### PR TITLE
[codex] refactor(nextcloud): extract shared integration layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Weave Repository Instructions
 
-Weave uses a feature-first clean architecture under `lib/features/<feature>/`. New work and refactors should follow this layout even where older features still use transitional folders like `models/` or top-level `providers/`.
+Weave uses a feature-first clean architecture under `lib/features/<feature>/`, with shared cross-feature protocol/platform code living under `lib/integrations/<integration>/`. New work and refactors should follow those ownership boundaries even where older code still uses transitional folders like `models/` or top-level `providers/`.
 
 Placement rules:
 - `presentation/` for screens, widgets, and feature UI composition
@@ -8,9 +8,15 @@ Placement rules:
 - `domain/` for entities, use cases, and repository contracts
 - `data/` for repository implementations, datasources, and DTOs
 
+Integration placement:
+- use `lib/integrations/<integration>/` for reusable auth/session/capability/protocol logic that is shared by multiple features
+- keep the same `presentation/`, `domain/`, and `data/` split inside integrations so shared boundaries stay predictable
+- move feature-specific transport mapping back into the owning feature once the code stops being reusable across features
+
 Feature boundaries:
-- Features may depend on `core/` and shared reusable UI, but must not import another feature's `data/` layer directly.
+- Features may depend on `core/`, shared reusable UI, and `lib/integrations/`, but must not import another feature's `data/` layer directly.
 - Cross-feature integration should go through domain contracts, app-level orchestration, or shared core abstractions.
+- Integrations may depend on shared app foundations such as `core/`, `features/auth/`, and `features/server_config/`, but must not depend on feature presentation code or feature-specific entities they are meant to serve.
 
 Accessibility is mandatory:
 - interactive controls must provide at least `48x48` logical touch targets

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ lib/
 │   ├── router/       # go_router setup and route constants
 │   ├── theme/
 │   └── widgets/
+├── integrations/
+│   └── nextcloud/    # Shared Nextcloud auth/session/platform boundary
 └── features/
     ├── auth/
     ├── calendar/
@@ -62,6 +64,14 @@ Inside each feature:
 - `presentation/` contains screens, widgets, and Riverpod UI state
 - `domain/` contains entities and repository contracts
 - `data/` contains repository implementations, persistence adapters, DTOs, and protocol/service clients
+
+Inside each shared integration:
+
+- `presentation/` contains reusable Riverpod providers and composition for the integration stack
+- `domain/` contains shared entities, failures, and service/repository contracts
+- `data/` contains persistence, protocol clients, and integration-level orchestration
+
+Today, Nextcloud auth, session persistence, login-flow handling, bearer fallback, and connection lifecycle live under `lib/integrations/nextcloud/`, while `features/files/` stays focused on DAV directory browsing and file-domain mapping.
 
 See [docs/architecture.md](docs/architecture.md) for the detailed design notes.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,7 +1,7 @@
 # Weave Architecture
 
 ## Overview
-Weave uses a feature-first clean architecture with deterministic bootstrap before routing. App-level OIDC bootstrap is resolved before navigation, while protocol-specific sessions such as Matrix remain inside their owning feature.
+Weave uses a feature-first clean architecture with deterministic bootstrap before routing. App-level OIDC bootstrap is resolved before navigation, while protocol-specific or platform-specific code lives either inside the owning feature or in `lib/integrations/<integration>/` when the boundary is shared across multiple features.
 
 ## App startup
 The app now resolves bootstrap before `MaterialApp.router` is built.
@@ -74,9 +74,9 @@ This is intentionally simple, explicit, and easy to change later. It is a conven
 Persistence is split by responsibility:
 
 - `PreferencesStore` for harmless configuration and future non-sensitive flags
-- `SecureStore` as the future boundary for tokens and secrets
+- `SecureStore` for tokens, sensitive protocol credentials, and persisted sessions that should not live in preferences
 
-This task does not add real secure storage yet. The interface exists so auth work can plug into a dedicated sensitive path later without refactoring unrelated features.
+Current secure-storage usage includes app-auth session persistence and the shared Nextcloud session store.
 
 ## Failure model
 `AppFailure` is the shared app-level failure model used across bootstrap, storage, and repositories. Presentation should respond to `AppFailure` rather than raw package exceptions.
@@ -88,30 +88,42 @@ Current failure types:
 - `validation`
 - `unknown`
 
-## Feature layering
+## Feature and integration layering
 Each feature follows the same three layers:
 
 - `presentation/`
 - `domain/`
 - `data/`
 
+Shared integrations follow the same layering under `lib/integrations/<integration>/` when multiple features need the same protocol/platform boundary.
+
 Current repository-first stub boundaries:
 
 - `auth` -> `AuthSessionRepository` + `OidcClient`
 - `chat` -> `ChatRepository` + `MatrixClient`
-- `files` -> `FilesRepository` + `NextcloudAuthClient` + `NextcloudClient`
+- `integrations/nextcloud` -> `NextcloudConnectionService` + `NextcloudAuthClient` + `NextcloudSessionRepository` + shared providers
+- `files` -> `FilesRepository` + `NextcloudDavClient`
 - `calendar` -> `CalendarRepository` + `CalDavClient`
 - `deck` -> `DeckRepository` + `DeckClient`
 
 Presentation depends on repository contracts and Riverpod providers only. It does not own storage or protocol logic.
 
+Boundary rule:
+
+- feature-specific mapping stays in the feature
+- reusable external-service auth/session/orchestration belongs in an integration layer
+- features may depend on integrations, but integrations must not depend on feature presentation state or feature-owned transport mappings they are meant to support
+
 ## Session separation
-App auth and Matrix auth are intentionally separate concerns:
+App auth, Matrix auth, and shared Nextcloud session handling are intentionally separate concerns:
 
 - `auth/` owns the app-level OIDC session that decides whether the shell is reachable
 - `chat/` owns Matrix protocol discovery, Matrix Native OAuth 2.0 login, refresh, logout, and SDK persistence
+- `integrations/nextcloud/` consumes app-auth state when available, but owns Nextcloud bearer/app-password selection, secure Nextcloud session persistence, reconnect rules, and app-password revocation
 - the app does not assume an app-level OIDC access token is also a Matrix access token
+- the app does not assume an app-level OIDC token can be persisted as a raw Nextcloud bearer session; persisted Nextcloud bearer sessions are stored as tokenless markers and rehydrated from app auth state
 - changing the Matrix homeserver invalidates the Matrix session without redesigning bootstrap
+- changing the configured Nextcloud base URL invalidates the persisted Nextcloud session without requiring feature-owned cleanup logic
 
 Matrix E2EE state also stays inside `features/chat/`:
 
@@ -130,6 +142,14 @@ The current Matrix integration uses:
 - Matrix Native OAuth 2.0 when `/_matrix/client/v1/auth_metadata` is available
 - a typed unsupported-configuration failure when the homeserver only exposes legacy login
 - Matrix SDK crypto setup helpers for first-device bootstrap, recovery reconnect, and self-verification continuation
+
+## Nextcloud integration split
+Nextcloud is now split into:
+
+- `integrations/nextcloud/` for shared auth, session, account validation, login-flow handling, revoke policy, provider wiring, and connection lifecycle orchestration
+- `features/files/` for DAV directory browsing, file-entry mapping, and file-facing presentation/state
+
+This keeps the current Files UX intact while making the same Nextcloud platform layer reusable for future Calendar or Deck work without importing `features/files/`.
 
 ## Onboarding and settings
 Onboarding setup and Settings share:

--- a/lib/features/auth/AGENTS.md
+++ b/lib/features/auth/AGENTS.md
@@ -17,3 +17,5 @@ Session expectations:
 - refresh proactively when expiry is known and a request would otherwise fail
 - treat refresh failure as an invalid session and collapse cleanly to signed-out state
 - keep auth reusable for setup and later authenticated features without coupling it to `onboarding`
+- downstream integrations may consume restored app OIDC sessions to derive their own protocol access, but auth still owns token refresh, storage, and validity decisions
+- do not let non-auth features or integrations persist duplicate copies of app OIDC tokens

--- a/lib/features/files/AGENTS.md
+++ b/lib/features/files/AGENTS.md
@@ -1,17 +1,24 @@
 # Files Feature Instructions
 
-`files` owns WebDAV modeling and the translation from DAV responses into internal file entities and view state.
+`files` owns WebDAV modeling, directory browsing behavior, and the translation from DAV responses into internal file entities and view state. Shared Nextcloud auth, session, and connection lifecycle concerns now live in `lib/integrations/nextcloud/`.
 
 Rules:
 - keep WebDAV parsing and DTOs in `data/`
 - distinguish files from directories in feature models, not by ad hoc widget logic
 - maintain stable path and identifier semantics for navigation, selection, and refresh
 - keep expansion, loading, and error state for directory trees out of raw transport objects
+- depend on reusable Nextcloud contracts from `lib/integrations/nextcloud/` instead of re-implementing auth/session/orchestration inside `files`
+- keep file-specific failure mapping and directory state in `files`, even when the underlying session comes from the shared Nextcloud integration layer
 
 Directory tree behavior:
 - recursive tree behavior must be driven by feature state, not by widgets walking raw DAV payloads
 - avoid importing another feature to resolve file metadata or storage concerns
 - preserve predictable parent/child relationships when refreshing nested folders
+
+Boundary reminders:
+- `NextcloudDavClient` is the file-focused protocol client for DAV directory access
+- bearer/app-password selection, persisted Nextcloud sessions, app-password revocation, and configured-base-URL matching belong to `integrations/nextcloud`, not `files`
+- future Nextcloud-backed features should be able to reuse the same platform layer without importing `features/files/`
 
 Accessibility:
 - each file row should be understandable as one unit when appropriate

--- a/lib/features/files/data/repositories/nextcloud_files_repository.dart
+++ b/lib/features/files/data/repositories/nextcloud_files_repository.dart
@@ -1,325 +1,124 @@
-import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
-import 'package:weave/features/auth/domain/entities/auth_session.dart';
-import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
-import 'package:weave/features/files/data/services/nextcloud_auth_client.dart';
-import 'package:weave/features/files/data/services/nextcloud_client.dart';
+import 'package:weave/features/files/data/services/nextcloud_dav_client.dart';
 import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/files_connection_state.dart';
 import 'package:weave/features/files/domain/entities/files_failure.dart';
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
-import 'package:weave/features/files/domain/repositories/nextcloud_session_repository.dart';
-import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
-import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_connection_state.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/domain/services/nextcloud_connection_service.dart';
 
 class NextcloudFilesRepository implements FilesRepository {
   const NextcloudFilesRepository({
-    required NextcloudAuthClient authClient,
-    required NextcloudClient client,
-    required AuthSessionRepository authSessionRepository,
-    required NextcloudSessionRepository sessionRepository,
-    required ServerConfigurationRepository serverConfigurationRepository,
-  }) : _authClient = authClient,
-       _client = client,
-       _authSessionRepository = authSessionRepository,
-       _sessionRepository = sessionRepository,
-       _serverConfigurationRepository = serverConfigurationRepository;
+    required NextcloudConnectionService connectionService,
+    required NextcloudDavClient client,
+  }) : _connectionService = connectionService,
+       _client = client;
 
-  final NextcloudAuthClient _authClient;
-  final NextcloudClient _client;
-  final AuthSessionRepository _authSessionRepository;
-  final NextcloudSessionRepository _sessionRepository;
-  final ServerConfigurationRepository _serverConfigurationRepository;
+  final NextcloudConnectionService _connectionService;
+  final NextcloudDavClient _client;
 
   @override
   Future<FilesConnectionState> restoreConnection() async {
-    final configuration = await _loadConfiguration();
-    if (configuration == null) {
-      return const FilesConnectionState.misconfigured(
-        message: 'Finish server setup before connecting Nextcloud.',
-      );
+    try {
+      return _mapConnectionState(await _connectionService.restoreConnection());
+    } on NextcloudFailure catch (failure) {
+      throw _mapFailure(failure);
     }
-
-    if (!_usesHttps(configuration.serviceEndpoints.nextcloudBaseUrl)) {
-      return const FilesConnectionState.misconfigured(
-        message: 'Use an HTTPS Nextcloud URL before connecting files.',
-      );
-    }
-
-    final configuredBaseUrl = configuration.serviceEndpoints.nextcloudBaseUrl;
-    final storedSession = await _readStoredSession(configuredBaseUrl);
-    if (storedSession == null) {
-      return FilesConnectionState.disconnected(baseUrl: configuredBaseUrl);
-    }
-
-    final bearerSession = await _tryResolveBearerSession(
-      configuration,
-      validateDavAccess: true,
-      accountLabelHint: storedSession.accountLabel,
-    );
-    if (bearerSession != null) {
-      await _replaceStoredSession(
-        previousSession: storedSession,
-        nextSession: bearerSession.toPersistedSession(),
-      );
-      return FilesConnectionState.connected(
-        baseUrl: bearerSession.baseUrl,
-        accountLabel: bearerSession.accountLabel,
-      );
-    }
-
-    if (storedSession.usesOidcBearer) {
-      await _sessionRepository.clearSession();
-      return FilesConnectionState.disconnected(baseUrl: configuredBaseUrl);
-    }
-
-    return FilesConnectionState.connected(
-      baseUrl: storedSession.baseUrl,
-      accountLabel: storedSession.accountLabel,
-    );
   }
 
   @override
   Future<FilesConnectionState> connect() async {
-    final configuration = await _loadConfiguration();
-    if (configuration == null) {
-      throw const FilesFailure.configuration(
-        'Finish server setup before connecting Nextcloud.',
-      );
+    try {
+      return _mapConnectionState(await _connectionService.connect());
+    } on NextcloudFailure catch (failure) {
+      throw _mapFailure(failure);
     }
-
-    if (!_usesHttps(configuration.serviceEndpoints.nextcloudBaseUrl)) {
-      throw const FilesFailure.configuration(
-        'Use an HTTPS Nextcloud URL before connecting files.',
-      );
-    }
-
-    final configuredBaseUrl = configuration.serviceEndpoints.nextcloudBaseUrl;
-    final previousSession = await _readStoredSession(configuredBaseUrl);
-    final bearerSession = await _tryResolveBearerSession(
-      configuration,
-      validateDavAccess: true,
-      accountLabelHint: previousSession?.accountLabel,
-    );
-    if (bearerSession != null) {
-      await _replaceStoredSession(
-        previousSession: previousSession,
-        nextSession: bearerSession.toPersistedSession(),
-      );
-      return FilesConnectionState.connected(
-        baseUrl: bearerSession.baseUrl,
-        accountLabel: bearerSession.accountLabel,
-      );
-    }
-
-    final fallbackSession = await _authClient.connect(configuredBaseUrl);
-    await _replaceStoredSession(
-      previousSession: previousSession,
-      nextSession: fallbackSession.toPersistedSession(),
-    );
-    return FilesConnectionState.connected(
-      baseUrl: fallbackSession.baseUrl,
-      accountLabel: fallbackSession.accountLabel,
-    );
   }
 
   @override
   Future<void> disconnect() async {
-    final session = await _sessionRepository.readSession();
-    await _sessionRepository.clearSession();
-
-    if (session != null && session.usesAppPassword) {
-      await _authClient.revokeAppPassword(session);
+    try {
+      await _connectionService.disconnect();
+    } on NextcloudFailure catch (failure) {
+      throw _mapFailure(failure);
     }
   }
 
   @override
   Future<DirectoryListing> listDirectory(String path) async {
-    final configuration = await _requireConfiguration();
-    final storedSession = await _requireStoredSession(
-      configuration.serviceEndpoints.nextcloudBaseUrl,
-    );
-    final liveSession = await _resolveLiveSession(configuration, storedSession);
+    late NextcloudSession liveSession;
+    try {
+      liveSession = await _connectionService.requireLiveSession();
+    } on NextcloudFailure catch (failure) {
+      throw _mapFailure(failure);
+    }
 
     try {
       return await _client.listDirectory(liveSession, path);
-    } on FilesFailure catch (failure) {
-      if (failure.type == FilesFailureType.invalidCredentials) {
-        await _clearStoredSession(storedSession);
+    } on NextcloudFailure catch (failure) {
+      if (failure.type == NextcloudFailureType.invalidCredentials) {
+        try {
+          await _connectionService.invalidateSession(liveSession);
+        } on NextcloudFailure catch (clearFailure) {
+          throw _mapFailure(clearFailure);
+        }
       }
-      rethrow;
+      throw _mapFailure(failure);
     }
   }
 
-  Future<ServerConfiguration> _requireConfiguration() async {
-    final configuration = await _loadConfiguration();
-    if (configuration == null) {
-      throw const FilesFailure.configuration(
-        'Finish server setup before browsing Nextcloud files.',
-      );
-    }
-
-    if (!_usesHttps(configuration.serviceEndpoints.nextcloudBaseUrl)) {
-      throw const FilesFailure.configuration(
-        'Use an HTTPS Nextcloud URL before browsing Nextcloud files.',
-      );
-    }
-
-    return configuration;
-  }
-
-  Future<NextcloudSession> _requireStoredSession(Uri configuredBaseUrl) async {
-    final session = await _readStoredSession(configuredBaseUrl);
-    if (session == null) {
-      throw const FilesFailure.sessionRequired(
-        'Connect Nextcloud before browsing files.',
-      );
-    }
-
-    return session;
-  }
-
-  Future<NextcloudSession> _resolveLiveSession(
-    ServerConfiguration configuration,
-    NextcloudSession storedSession,
-  ) async {
-    if (storedSession.usesAppPassword) {
-      return storedSession;
-    }
-
-    final bearerSession = await _tryResolveBearerSession(
-      configuration,
-      validateDavAccess: false,
-      accountLabelHint: storedSession.accountLabel,
-    );
-    if (bearerSession != null) {
-      return bearerSession;
-    }
-
-    await _sessionRepository.clearSession();
-    throw const FilesFailure.invalidCredentials(
-      'Reconnect Nextcloud because bearer-token access is no longer available.',
-    );
-  }
-
-  Future<NextcloudSession?> _readStoredSession(Uri configuredBaseUrl) async {
-    final session = await _sessionRepository.readSession();
-    if (session == null) {
-      return null;
-    }
-
-    if (!session.matchesBaseUrl(configuredBaseUrl)) {
-      await _clearStoredSession(session);
-      return null;
-    }
-
-    return session;
-  }
-
-  Future<void> _replaceStoredSession({
-    required NextcloudSession? previousSession,
-    required NextcloudSession nextSession,
-  }) async {
-    try {
-      await _sessionRepository.saveSession(nextSession);
-    } on FilesFailure {
-      if (nextSession.usesAppPassword) {
-        await _authClient.revokeAppPassword(nextSession);
-      }
-      rethrow;
-    }
-
-    if (previousSession != null &&
-        previousSession.usesAppPassword &&
-        (nextSession.usesOidcBearer ||
-            previousSession.appPassword != nextSession.appPassword)) {
-      await _authClient.revokeAppPassword(previousSession);
-    }
-  }
-
-  Future<void> _clearStoredSession(NextcloudSession session) async {
-    await _sessionRepository.clearSession();
-    if (session.usesAppPassword) {
-      await _authClient.revokeAppPassword(session);
-    }
-  }
-
-  Future<NextcloudSession?> _tryResolveBearerSession(
-    ServerConfiguration configuration, {
-    required bool validateDavAccess,
-    String? accountLabelHint,
-  }) async {
-    if (!configuration.hasCompleteAuthConfiguration) {
-      return null;
-    }
-
-    final authState = await _authSessionRepository.restoreSession(
-      AuthConfiguration(
-        issuer: configuration.oidcIssuerUrl,
-        clientId: configuration.oidcClientRegistration.clientId.trim(),
+  FilesConnectionState _mapConnectionState(NextcloudConnectionState state) {
+    return switch (state.status) {
+      NextcloudConnectionStatus.misconfigured =>
+        FilesConnectionState.misconfigured(message: state.message),
+      NextcloudConnectionStatus.disconnected =>
+        FilesConnectionState.disconnected(
+          baseUrl: state.baseUrl,
+          message: state.message,
+        ),
+      NextcloudConnectionStatus.connected => FilesConnectionState.connected(
+        baseUrl: state.baseUrl!,
+        accountLabel: state.accountLabel!,
       ),
-    );
-    final authSession = authState.session;
-    if (!authState.isAuthenticated || authSession == null) {
-      return null;
-    }
-
-    final configuredBaseUrl = configuration.serviceEndpoints.nextcloudBaseUrl;
-    for (final token in _bearerTokenCandidates(authSession)) {
-      try {
-        final bearerSession = await _authClient.createBearerSession(
-          configuredBaseUrl: configuredBaseUrl,
-          bearerToken: token,
-          accountLabelHint: accountLabelHint,
-        );
-        if (validateDavAccess) {
-          await _client.listDirectory(bearerSession, '/');
-        }
-        return bearerSession;
-      } on FilesFailure catch (failure) {
-        if (failure.type == FilesFailureType.invalidCredentials ||
-            failure.type == FilesFailureType.protocol) {
-          continue;
-        }
-        rethrow;
-      }
-    }
-
-    return null;
+      NextcloudConnectionStatus.invalid => FilesConnectionState.invalid(
+        baseUrl: state.baseUrl!,
+        accountLabel: state.accountLabel,
+        message: state.message,
+      ),
+    };
   }
 
-  List<String> _bearerTokenCandidates(AuthSession authSession) {
-    final candidates = <String>[];
-    final idToken = authSession.idToken?.trim();
-    if (idToken != null && idToken.isNotEmpty) {
-      // Nextcloud's OCS docs show bearer ID tokens explicitly, with access
-      // tokens also supported by user_oidc when the deployment enables it.
-      candidates.add(idToken);
-    }
-
-    final accessToken = authSession.accessToken.trim();
-    if (accessToken.isNotEmpty && !candidates.contains(accessToken)) {
-      candidates.add(accessToken);
-    }
-    return candidates;
+  FilesFailure _mapFailure(NextcloudFailure failure) {
+    return switch (failure.type) {
+      NextcloudFailureType.cancelled => FilesFailure.cancelled(
+        failure.message,
+        cause: failure.cause,
+      ),
+      NextcloudFailureType.configuration => FilesFailure.configuration(
+        failure.message,
+        cause: failure.cause,
+      ),
+      NextcloudFailureType.sessionRequired => FilesFailure.sessionRequired(
+        failure.message,
+        cause: failure.cause,
+      ),
+      NextcloudFailureType.invalidCredentials =>
+        FilesFailure.invalidCredentials(failure.message, cause: failure.cause),
+      NextcloudFailureType.protocol => FilesFailure.protocol(
+        failure.message,
+        cause: failure.cause,
+      ),
+      NextcloudFailureType.storage => FilesFailure.storage(
+        failure.message,
+        cause: failure.cause,
+      ),
+      NextcloudFailureType.unsupportedPlatform =>
+        FilesFailure.unsupportedPlatform(failure.message, cause: failure.cause),
+      NextcloudFailureType.unknown => FilesFailure.unknown(
+        failure.message,
+        cause: failure.cause,
+      ),
+    };
   }
-
-  Future<ServerConfiguration?> _loadConfiguration() async {
-    final configuration = await _serverConfigurationRepository
-        .loadConfiguration();
-    if (configuration == null) {
-      return null;
-    }
-
-    final nextcloudUrl = configuration.serviceEndpoints.nextcloudBaseUrl
-        .toString()
-        .trim();
-    if (nextcloudUrl.isEmpty) {
-      return null;
-    }
-
-    return configuration;
-  }
-
-  bool _usesHttps(Uri uri) => uri.scheme.toLowerCase() == 'https';
 }

--- a/lib/features/files/data/services/nextcloud_dav_client.dart
+++ b/lib/features/files/data/services/nextcloud_dav_client.dart
@@ -1,17 +1,17 @@
-import 'dart:convert';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
-import 'package:weave/features/files/data/services/nextcloud_auth_client.dart';
 import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/file_entry.dart';
-import 'package:weave/features/files/domain/entities/files_failure.dart';
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_auth_headers.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/presentation/providers/nextcloud_provider.dart';
 import 'package:xml/xml.dart';
 
-class NextcloudClient {
-  NextcloudClient({required http.Client httpClient}) : _httpClient = httpClient;
+class NextcloudDavClient {
+  NextcloudDavClient({required http.Client httpClient})
+    : _httpClient = httpClient;
 
   final http.Client _httpClient;
   static final DateFormat _modifiedDateFormat = DateFormat(
@@ -28,7 +28,7 @@ class NextcloudClient {
     final uri = _buildDirectoryUri(session, normalizedPath);
     final request = http.Request('PROPFIND', uri)
       ..headers.addAll({
-        ..._authHeaders(session),
+        ...buildNextcloudAuthHeaders(session),
         'Depth': '1',
         'Content-Type': 'application/xml; charset=utf-8',
       })
@@ -38,7 +38,7 @@ class NextcloudClient {
     try {
       response = await _httpClient.send(request);
     } catch (error) {
-      throw FilesFailure.unknown(
+      throw NextcloudFailure.unknown(
         'Unable to load the Nextcloud directory.',
         cause: error,
       );
@@ -46,13 +46,13 @@ class NextcloudClient {
 
     final body = await response.stream.bytesToString();
     if (response.statusCode == 401 || response.statusCode == 403) {
-      throw const FilesFailure.invalidCredentials(
+      throw const NextcloudFailure.invalidCredentials(
         'The saved Nextcloud credentials are no longer valid.',
       );
     }
 
     if (response.statusCode != 207) {
-      throw FilesFailure.protocol(
+      throw NextcloudFailure.protocol(
         'Nextcloud returned an unexpected WebDAV status (${response.statusCode}).',
       );
     }
@@ -115,7 +115,7 @@ class NextcloudClient {
 
   void _ensureHttpsSession(NextcloudSession session) {
     if (session.baseUrl.scheme.toLowerCase() != 'https') {
-      throw const FilesFailure.configuration(
+      throw const NextcloudFailure.configuration(
         'Use an HTTPS Nextcloud URL before browsing files.',
       );
     }
@@ -125,7 +125,7 @@ class NextcloudClient {
     try {
       return XmlDocument.parse(raw);
     } catch (error) {
-      throw FilesFailure.protocol(
+      throw NextcloudFailure.protocol(
         'Nextcloud returned an invalid WebDAV response.',
         cause: error,
       );
@@ -192,7 +192,7 @@ class NextcloudClient {
         ? davRootPath.substring(0, davRootPath.length - 1)
         : davRootPath;
     if (!decodedPath.startsWith(rootPath)) {
-      throw const FilesFailure.protocol(
+      throw const NextcloudFailure.protocol(
         'Nextcloud returned a WebDAV entry outside the configured account root.',
       );
     }
@@ -242,7 +242,7 @@ class NextcloudClient {
   }
 
   Uri _buildDirectoryUri(NextcloudSession session, String path) {
-    final normalizedBaseUrl = _normalizeBaseUrl(session.baseUrl);
+    final normalizedBaseUrl = normalizeNextcloudBaseUrl(session.baseUrl);
     final encodedUserId = Uri.encodeComponent(session.userId);
     final encodedSegments = _normalizePath(path)
         .split('/')
@@ -253,37 +253,6 @@ class NextcloudClient {
         ? 'remote.php/dav/files/$encodedUserId/'
         : 'remote.php/dav/files/$encodedUserId/$encodedSegments';
     return normalizedBaseUrl.resolve(relativePath);
-  }
-
-  Uri _normalizeBaseUrl(Uri uri) {
-    final path = uri.path.endsWith('/') ? uri.path : '${uri.path}/';
-    return uri.replace(path: path, query: null, fragment: null);
-  }
-
-  Map<String, String> _authHeaders(NextcloudSession session) {
-    if (session.usesOidcBearer) {
-      final bearerToken = session.bearerToken;
-      if (bearerToken == null || bearerToken.isEmpty) {
-        throw const FilesFailure.sessionRequired(
-          'Reconnect Nextcloud because the saved bearer session is incomplete.',
-        );
-      }
-      return {'Authorization': 'Bearer $bearerToken'};
-    }
-
-    final loginName = session.loginName;
-    final appPassword = session.appPassword;
-    if (loginName == null ||
-        loginName.isEmpty ||
-        appPassword == null ||
-        appPassword.isEmpty) {
-      throw const FilesFailure.sessionRequired(
-        'Reconnect Nextcloud because the saved app password is incomplete.',
-      );
-    }
-
-    final encoded = base64Encode(utf8.encode('$loginName:$appPassword'));
-    return {'Authorization': 'Basic $encoded'};
   }
 }
 
@@ -299,6 +268,6 @@ const _propfindBody = '''<?xml version="1.0"?>
 </d:propfind>
 ''';
 
-final nextcloudClientProvider = Provider<NextcloudClient>((ref) {
-  return NextcloudClient(httpClient: ref.watch(nextcloudHttpClientProvider));
+final nextcloudDavClientProvider = Provider<NextcloudDavClient>((ref) {
+  return NextcloudDavClient(httpClient: ref.watch(nextcloudHttpClientProvider));
 });

--- a/lib/features/files/data/services/nextcloud_dav_client.dart
+++ b/lib/features/files/data/services/nextcloud_dav_client.dart
@@ -37,6 +37,8 @@ class NextcloudDavClient {
     late http.StreamedResponse response;
     try {
       response = await _httpClient.send(request);
+    } on NextcloudFailure {
+      rethrow;
     } catch (error) {
       throw NextcloudFailure.unknown(
         'Unable to load the Nextcloud directory.',

--- a/lib/features/files/presentation/providers/files_repository_provider.dart
+++ b/lib/features/files/presentation/providers/files_repository_provider.dart
@@ -1,20 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:weave/features/auth/presentation/providers/auth_session_repository_provider.dart';
 import 'package:weave/features/files/data/repositories/nextcloud_files_repository.dart';
-import 'package:weave/features/files/data/repositories/secure_nextcloud_session_repository.dart';
-import 'package:weave/features/files/data/services/nextcloud_auth_client.dart';
-import 'package:weave/features/files/data/services/nextcloud_client.dart';
+import 'package:weave/features/files/data/services/nextcloud_dav_client.dart';
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
-import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/nextcloud/presentation/providers/nextcloud_provider.dart';
 
 final filesRepositoryProvider = Provider<FilesRepository>((ref) {
   return NextcloudFilesRepository(
-    authClient: ref.watch(nextcloudAuthClientProvider),
-    client: ref.watch(nextcloudClientProvider),
-    authSessionRepository: ref.watch(authSessionRepositoryProvider),
-    sessionRepository: ref.watch(nextcloudSessionRepositoryProvider),
-    serverConfigurationRepository: ref.watch(
-      serverConfigurationRepositoryProvider,
-    ),
+    connectionService: ref.watch(nextcloudConnectionServiceProvider),
+    client: ref.watch(nextcloudDavClientProvider),
   );
 });

--- a/lib/integrations/AGENTS.md
+++ b/lib/integrations/AGENTS.md
@@ -1,0 +1,14 @@
+# Integrations Instructions
+
+`lib/integrations/` hosts reusable external-service boundaries that are shared across multiple features.
+
+Rules:
+- place cross-feature auth, session, capability, and shared protocol orchestration here instead of inside a feature
+- keep the same clean-architecture split inside each integration: `presentation/`, `domain/`, and `data/`
+- expose reusable contracts/providers that features can consume without importing another feature's internals
+- do not let integrations depend on feature presentation code or feature-owned domain models they are meant to serve
+
+Ownership guidance:
+- keep feature-specific mapping and user-facing state inside the owning feature
+- keep server/session/account lifecycle rules in the integration when those rules are not feature-specific
+- if a new integration becomes large enough to guide contributors, add an `AGENTS.md` inside that integration subtree

--- a/lib/integrations/nextcloud/AGENTS.md
+++ b/lib/integrations/nextcloud/AGENTS.md
@@ -1,0 +1,21 @@
+# Nextcloud Integration Instructions
+
+`integrations/nextcloud` owns reusable Nextcloud platform concerns that can be shared by Files today and Calendar or Deck later.
+
+Own here:
+- Nextcloud session entities and auth-method semantics
+- secure Nextcloud session persistence
+- login flow v2, bearer-session resolution, account validation, and app-password revocation
+- configured-base-URL normalization, session replacement rules, reconnect rules, and connection lifecycle orchestration
+- shared Riverpod providers for the reusable Nextcloud platform stack
+
+Do not own here:
+- file-domain entities or WebDAV-to-file mapping
+- feature presentation state for files, calendars, or boards
+- UI-specific failure wording that only makes sense in one feature when the underlying failure is still shared
+
+Boundary rules:
+- consume app-level OIDC state from `features/auth/`, but do not take ownership of app-auth token refresh or persistence
+- keep persisted bearer sessions tokenless; only live bearer sessions should carry an in-memory bearer token
+- preserve current app-password revocation and stale-session invalidation behavior when refactoring
+- shared Nextcloud protocol code should become more reusable here, while DAV parsing that is still file-specific should remain in `features/files/`

--- a/lib/integrations/nextcloud/data/dtos/nextcloud_session_dto.dart
+++ b/lib/integrations/nextcloud/data/dtos/nextcloud_session_dto.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
 
 class NextcloudSessionDto {
   const NextcloudSessionDto({

--- a/lib/integrations/nextcloud/data/repositories/secure_nextcloud_session_repository.dart
+++ b/lib/integrations/nextcloud/data/repositories/secure_nextcloud_session_repository.dart
@@ -1,10 +1,8 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:weave/core/persistence/flutter_secure_store.dart';
 import 'package:weave/core/persistence/secure_store.dart';
-import 'package:weave/features/files/data/dtos/nextcloud_session_dto.dart';
-import 'package:weave/features/files/domain/entities/files_failure.dart';
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
-import 'package:weave/features/files/domain/repositories/nextcloud_session_repository.dart';
+import 'package:weave/integrations/nextcloud/data/dtos/nextcloud_session_dto.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/domain/repositories/nextcloud_session_repository.dart';
 
 const nextcloudSessionStorageKey = 'nextcloud_session_v1';
 
@@ -24,7 +22,7 @@ class SecureNextcloudSessionRepository implements NextcloudSessionRepository {
 
       return NextcloudSessionDto.decode(raw).toSession();
     } catch (error) {
-      throw FilesFailure.storage(
+      throw NextcloudFailure.storage(
         'Unable to read the saved Nextcloud session.',
         cause: error,
       );
@@ -39,7 +37,7 @@ class SecureNextcloudSessionRepository implements NextcloudSessionRepository {
         NextcloudSessionDto.fromSession(session).encode(),
       );
     } catch (error) {
-      throw FilesFailure.storage(
+      throw NextcloudFailure.storage(
         'Unable to save the Nextcloud session.',
         cause: error,
       );
@@ -51,18 +49,10 @@ class SecureNextcloudSessionRepository implements NextcloudSessionRepository {
     try {
       await _secureStore.delete(nextcloudSessionStorageKey);
     } catch (error) {
-      throw FilesFailure.storage(
+      throw NextcloudFailure.storage(
         'Unable to clear the saved Nextcloud session.',
         cause: error,
       );
     }
   }
 }
-
-final nextcloudSessionRepositoryProvider = Provider<NextcloudSessionRepository>(
-  (ref) {
-    return SecureNextcloudSessionRepository(
-      secureStore: ref.watch(secureStoreProvider),
-    );
-  },
-);

--- a/lib/integrations/nextcloud/data/services/default_nextcloud_connection_service.dart
+++ b/lib/integrations/nextcloud/data/services/default_nextcloud_connection_service.dart
@@ -1,0 +1,320 @@
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_session.dart';
+import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_auth_client.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_dav_access_validator.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_connection_state.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/domain/repositories/nextcloud_session_repository.dart';
+import 'package:weave/integrations/nextcloud/domain/services/nextcloud_connection_service.dart';
+
+class DefaultNextcloudConnectionService implements NextcloudConnectionService {
+  const DefaultNextcloudConnectionService({
+    required NextcloudAuthClient authClient,
+    required NextcloudDavAccessValidator davAccessValidator,
+    required AuthSessionRepository authSessionRepository,
+    required NextcloudSessionRepository sessionRepository,
+    required ServerConfigurationRepository serverConfigurationRepository,
+  }) : _authClient = authClient,
+       _davAccessValidator = davAccessValidator,
+       _authSessionRepository = authSessionRepository,
+       _sessionRepository = sessionRepository,
+       _serverConfigurationRepository = serverConfigurationRepository;
+
+  final NextcloudAuthClient _authClient;
+  final NextcloudDavAccessValidator _davAccessValidator;
+  final AuthSessionRepository _authSessionRepository;
+  final NextcloudSessionRepository _sessionRepository;
+  final ServerConfigurationRepository _serverConfigurationRepository;
+
+  @override
+  Future<NextcloudConnectionState> restoreConnection() async {
+    final configuration = await _loadConfiguration();
+    if (configuration == null) {
+      return const NextcloudConnectionState.misconfigured(
+        message: 'Finish server setup before connecting Nextcloud.',
+      );
+    }
+
+    if (!_usesHttps(configuration.serviceEndpoints.nextcloudBaseUrl)) {
+      return const NextcloudConnectionState.misconfigured(
+        message: 'Use an HTTPS Nextcloud URL before connecting files.',
+      );
+    }
+
+    final configuredBaseUrl = configuration.serviceEndpoints.nextcloudBaseUrl;
+    final storedSession = await _readStoredSession(configuredBaseUrl);
+    if (storedSession == null) {
+      return NextcloudConnectionState.disconnected(baseUrl: configuredBaseUrl);
+    }
+
+    final bearerSession = await _tryResolveBearerSession(
+      configuration,
+      validateDavAccess: true,
+      accountLabelHint: storedSession.accountLabel,
+    );
+    if (bearerSession != null) {
+      await _replaceStoredSession(
+        previousSession: storedSession,
+        nextSession: bearerSession.toPersistedSession(),
+      );
+      return NextcloudConnectionState.connected(
+        baseUrl: bearerSession.baseUrl,
+        accountLabel: bearerSession.accountLabel,
+      );
+    }
+
+    if (storedSession.usesOidcBearer) {
+      await _sessionRepository.clearSession();
+      return NextcloudConnectionState.disconnected(baseUrl: configuredBaseUrl);
+    }
+
+    return NextcloudConnectionState.connected(
+      baseUrl: storedSession.baseUrl,
+      accountLabel: storedSession.accountLabel,
+    );
+  }
+
+  @override
+  Future<NextcloudConnectionState> connect() async {
+    final configuration = await _loadConfiguration();
+    if (configuration == null) {
+      throw const NextcloudFailure.configuration(
+        'Finish server setup before connecting Nextcloud.',
+      );
+    }
+
+    if (!_usesHttps(configuration.serviceEndpoints.nextcloudBaseUrl)) {
+      throw const NextcloudFailure.configuration(
+        'Use an HTTPS Nextcloud URL before connecting files.',
+      );
+    }
+
+    final configuredBaseUrl = configuration.serviceEndpoints.nextcloudBaseUrl;
+    final previousSession = await _readStoredSession(configuredBaseUrl);
+    final bearerSession = await _tryResolveBearerSession(
+      configuration,
+      validateDavAccess: true,
+      accountLabelHint: previousSession?.accountLabel,
+    );
+    if (bearerSession != null) {
+      await _replaceStoredSession(
+        previousSession: previousSession,
+        nextSession: bearerSession.toPersistedSession(),
+      );
+      return NextcloudConnectionState.connected(
+        baseUrl: bearerSession.baseUrl,
+        accountLabel: bearerSession.accountLabel,
+      );
+    }
+
+    final fallbackSession = await _authClient.connect(configuredBaseUrl);
+    await _replaceStoredSession(
+      previousSession: previousSession,
+      nextSession: fallbackSession.toPersistedSession(),
+    );
+    return NextcloudConnectionState.connected(
+      baseUrl: fallbackSession.baseUrl,
+      accountLabel: fallbackSession.accountLabel,
+    );
+  }
+
+  @override
+  Future<void> disconnect() async {
+    final session = await _sessionRepository.readSession();
+    await _sessionRepository.clearSession();
+
+    if (session != null && session.usesAppPassword) {
+      await _authClient.revokeAppPassword(session);
+    }
+  }
+
+  @override
+  Future<NextcloudSession> requireLiveSession() async {
+    final configuration = await _requireConfiguration();
+    final storedSession = await _requireStoredSession(
+      configuration.serviceEndpoints.nextcloudBaseUrl,
+    );
+    return _resolveLiveSession(configuration, storedSession);
+  }
+
+  @override
+  Future<void> invalidateSession(NextcloudSession session) {
+    return _clearStoredSession(session);
+  }
+
+  Future<ServerConfiguration> _requireConfiguration() async {
+    final configuration = await _loadConfiguration();
+    if (configuration == null) {
+      throw const NextcloudFailure.configuration(
+        'Finish server setup before browsing Nextcloud files.',
+      );
+    }
+
+    if (!_usesHttps(configuration.serviceEndpoints.nextcloudBaseUrl)) {
+      throw const NextcloudFailure.configuration(
+        'Use an HTTPS Nextcloud URL before browsing Nextcloud files.',
+      );
+    }
+
+    return configuration;
+  }
+
+  Future<NextcloudSession> _requireStoredSession(Uri configuredBaseUrl) async {
+    final session = await _readStoredSession(configuredBaseUrl);
+    if (session == null) {
+      throw const NextcloudFailure.sessionRequired(
+        'Connect Nextcloud before browsing files.',
+      );
+    }
+
+    return session;
+  }
+
+  Future<NextcloudSession> _resolveLiveSession(
+    ServerConfiguration configuration,
+    NextcloudSession storedSession,
+  ) async {
+    if (storedSession.usesAppPassword) {
+      return storedSession;
+    }
+
+    final bearerSession = await _tryResolveBearerSession(
+      configuration,
+      validateDavAccess: false,
+      accountLabelHint: storedSession.accountLabel,
+    );
+    if (bearerSession != null) {
+      return bearerSession;
+    }
+
+    await _sessionRepository.clearSession();
+    throw const NextcloudFailure.invalidCredentials(
+      'Reconnect Nextcloud because bearer-token access is no longer available.',
+    );
+  }
+
+  Future<NextcloudSession?> _readStoredSession(Uri configuredBaseUrl) async {
+    final session = await _sessionRepository.readSession();
+    if (session == null) {
+      return null;
+    }
+
+    if (!session.matchesBaseUrl(configuredBaseUrl)) {
+      await _clearStoredSession(session);
+      return null;
+    }
+
+    return session;
+  }
+
+  Future<void> _replaceStoredSession({
+    required NextcloudSession? previousSession,
+    required NextcloudSession nextSession,
+  }) async {
+    try {
+      await _sessionRepository.saveSession(nextSession);
+    } on NextcloudFailure {
+      if (nextSession.usesAppPassword) {
+        await _authClient.revokeAppPassword(nextSession);
+      }
+      rethrow;
+    }
+
+    if (previousSession != null &&
+        previousSession.usesAppPassword &&
+        (nextSession.usesOidcBearer ||
+            previousSession.appPassword != nextSession.appPassword)) {
+      await _authClient.revokeAppPassword(previousSession);
+    }
+  }
+
+  Future<void> _clearStoredSession(NextcloudSession session) async {
+    await _sessionRepository.clearSession();
+    if (session.usesAppPassword) {
+      await _authClient.revokeAppPassword(session);
+    }
+  }
+
+  Future<NextcloudSession?> _tryResolveBearerSession(
+    ServerConfiguration configuration, {
+    required bool validateDavAccess,
+    String? accountLabelHint,
+  }) async {
+    if (!configuration.hasCompleteAuthConfiguration) {
+      return null;
+    }
+
+    final authState = await _authSessionRepository.restoreSession(
+      AuthConfiguration(
+        issuer: configuration.oidcIssuerUrl,
+        clientId: configuration.oidcClientRegistration.clientId.trim(),
+      ),
+    );
+    final authSession = authState.session;
+    if (!authState.isAuthenticated || authSession == null) {
+      return null;
+    }
+
+    final configuredBaseUrl = configuration.serviceEndpoints.nextcloudBaseUrl;
+    for (final token in _bearerTokenCandidates(authSession)) {
+      try {
+        final bearerSession = await _authClient.createBearerSession(
+          configuredBaseUrl: configuredBaseUrl,
+          bearerToken: token,
+          accountLabelHint: accountLabelHint,
+        );
+        if (validateDavAccess) {
+          await _davAccessValidator.validateRootAccess(bearerSession);
+        }
+        return bearerSession;
+      } on NextcloudFailure catch (failure) {
+        if (failure.type == NextcloudFailureType.invalidCredentials ||
+            failure.type == NextcloudFailureType.protocol) {
+          continue;
+        }
+        rethrow;
+      }
+    }
+
+    return null;
+  }
+
+  List<String> _bearerTokenCandidates(AuthSession authSession) {
+    final candidates = <String>[];
+    final idToken = authSession.idToken?.trim();
+    if (idToken != null && idToken.isNotEmpty) {
+      // Nextcloud's OCS docs show bearer ID tokens explicitly, with access
+      // tokens also supported by user_oidc when the deployment enables it.
+      candidates.add(idToken);
+    }
+
+    final accessToken = authSession.accessToken.trim();
+    if (accessToken.isNotEmpty && !candidates.contains(accessToken)) {
+      candidates.add(accessToken);
+    }
+    return candidates;
+  }
+
+  Future<ServerConfiguration?> _loadConfiguration() async {
+    final configuration = await _serverConfigurationRepository
+        .loadConfiguration();
+    if (configuration == null) {
+      return null;
+    }
+
+    final nextcloudUrl = configuration.serviceEndpoints.nextcloudBaseUrl
+        .toString()
+        .trim();
+    if (nextcloudUrl.isEmpty) {
+      return null;
+    }
+
+    return configuration;
+  }
+
+  bool _usesHttps(Uri uri) => uri.scheme.toLowerCase() == 'https';
+}

--- a/lib/integrations/nextcloud/data/services/nextcloud_auth_client.dart
+++ b/lib/integrations/nextcloud/data/services/nextcloud_auth_client.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
-import 'package:weave/features/files/data/services/nextcloud_login_launcher.dart';
-import 'package:weave/features/files/domain/entities/files_failure.dart';
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_login_launcher.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
 
 class NextcloudAuthClient {
   NextcloudAuthClient({
@@ -28,7 +27,7 @@ class NextcloudAuthClient {
     required String bearerToken,
     String? accountLabelHint,
   }) async {
-    final normalizedBaseUrl = _normalizeBaseUrl(configuredBaseUrl);
+    final normalizedBaseUrl = normalizeNextcloudBaseUrl(configuredBaseUrl);
     _ensureHttpsBaseUrl(
       normalizedBaseUrl,
       message: 'Use an HTTPS Nextcloud URL before validating bearer access.',
@@ -48,7 +47,7 @@ class NextcloudAuthClient {
   }
 
   Future<NextcloudSession> connect(Uri configuredBaseUrl) async {
-    final normalizedBaseUrl = _normalizeBaseUrl(configuredBaseUrl);
+    final normalizedBaseUrl = normalizeNextcloudBaseUrl(configuredBaseUrl);
     _ensureHttpsBaseUrl(
       normalizedBaseUrl,
       message: 'Use an HTTPS Nextcloud URL before starting the login flow.',
@@ -62,7 +61,7 @@ class NextcloudAuthClient {
     );
 
     if (startResponse.statusCode != 200) {
-      throw FilesFailure.protocol(
+      throw NextcloudFailure.protocol(
         'Nextcloud rejected the login flow request (${startResponse.statusCode}).',
       );
     }
@@ -70,7 +69,7 @@ class NextcloudAuthClient {
     final startPayload = _decodeJson(startResponse.body);
     final poll = startPayload['poll'];
     if (poll is! Map<String, dynamic>) {
-      throw const FilesFailure.protocol(
+      throw const NextcloudFailure.protocol(
         'Nextcloud returned an invalid login flow response.',
       );
     }
@@ -81,7 +80,7 @@ class NextcloudAuthClient {
     if (loginValue is! String ||
         endpointValue is! String ||
         tokenValue is! String) {
-      throw const FilesFailure.protocol(
+      throw const NextcloudFailure.protocol(
         'Nextcloud returned incomplete login flow data.',
       );
     }
@@ -142,7 +141,7 @@ class NextcloudAuthClient {
       }
 
       if (response.statusCode != 200) {
-        throw FilesFailure.protocol(
+        throw NextcloudFailure.protocol(
           'Nextcloud returned an unexpected login status (${response.statusCode}).',
         );
       }
@@ -154,19 +153,19 @@ class NextcloudAuthClient {
       if (serverValue is! String ||
           loginNameValue is! String ||
           appPasswordValue is! String) {
-        throw const FilesFailure.protocol(
+        throw const NextcloudFailure.protocol(
           'Nextcloud returned incomplete app credentials.',
         );
       }
 
-      final serverUrl = _normalizeBaseUrl(Uri.parse(serverValue));
+      final serverUrl = normalizeNextcloudBaseUrl(Uri.parse(serverValue));
       _ensureHttpsBaseUrl(
         serverUrl,
         message:
             'Nextcloud returned app credentials for a non-HTTPS server, which Weave will not use.',
       );
       if (serverUrl != configuredBaseUrl) {
-        throw const FilesFailure.configuration(
+        throw const NextcloudFailure.configuration(
           'The Nextcloud login flow completed for a different server than the one configured in Weave.',
         );
       }
@@ -184,7 +183,7 @@ class NextcloudAuthClient {
       );
     }
 
-    throw const FilesFailure.cancelled(
+    throw const NextcloudFailure.cancelled(
       'The Nextcloud login flow did not finish before it timed out.',
     );
   }
@@ -210,13 +209,13 @@ class NextcloudAuthClient {
     );
 
     if (response.statusCode == 401 || response.statusCode == 403) {
-      throw const FilesFailure.invalidCredentials(
+      throw const NextcloudFailure.invalidCredentials(
         'The saved Nextcloud credentials are no longer valid.',
       );
     }
 
     if (response.statusCode != 200) {
-      throw FilesFailure.protocol(
+      throw NextcloudFailure.protocol(
         'Nextcloud returned an unexpected account lookup status (${response.statusCode}).',
       );
     }
@@ -224,21 +223,21 @@ class NextcloudAuthClient {
     final payload = _decodeJson(response.body);
     final ocs = payload['ocs'];
     if (ocs is! Map<String, dynamic>) {
-      throw const FilesFailure.protocol(
+      throw const NextcloudFailure.protocol(
         'Nextcloud returned an invalid account response.',
       );
     }
 
     final data = ocs['data'];
     if (data is! Map<String, dynamic>) {
-      throw const FilesFailure.protocol(
+      throw const NextcloudFailure.protocol(
         'Nextcloud returned incomplete account data.',
       );
     }
 
     final userId = (data['id'] as String?)?.trim();
     if (userId == null || userId.isEmpty) {
-      throw const FilesFailure.protocol(
+      throw const NextcloudFailure.protocol(
         'Nextcloud did not provide a usable account identifier.',
       );
     }
@@ -252,10 +251,10 @@ class NextcloudAuthClient {
   }) async {
     try {
       return await request();
-    } on FilesFailure {
+    } on NextcloudFailure {
       rethrow;
     } catch (error) {
-      throw FilesFailure.unknown(fallbackMessage, cause: error);
+      throw NextcloudFailure.unknown(fallbackMessage, cause: error);
     }
   }
 
@@ -272,46 +271,28 @@ class NextcloudAuthClient {
     try {
       final decoded = jsonDecode(raw);
       if (decoded is! Map<String, dynamic>) {
-        throw const FilesFailure.protocol(
+        throw const NextcloudFailure.protocol(
           'Nextcloud returned an invalid JSON payload.',
         );
       }
       return decoded;
-    } on FilesFailure {
+    } on NextcloudFailure {
       rethrow;
     } catch (error) {
-      throw FilesFailure.protocol(
+      throw NextcloudFailure.protocol(
         'Nextcloud returned an invalid JSON payload.',
         cause: error,
       );
     }
   }
 
-  Uri _normalizeBaseUrl(Uri uri) {
-    final path = uri.path.endsWith('/') ? uri.path : '${uri.path}/';
-    return uri.replace(path: path, query: null, fragment: null);
-  }
-
   Uri _resolve(Uri baseUrl, String relativePath) {
-    return _normalizeBaseUrl(baseUrl).resolve(relativePath);
+    return normalizeNextcloudBaseUrl(baseUrl).resolve(relativePath);
   }
 
   void _ensureHttpsBaseUrl(Uri baseUrl, {required String message}) {
     if (baseUrl.scheme.toLowerCase() != 'https') {
-      throw FilesFailure.configuration(message);
+      throw NextcloudFailure.configuration(message);
     }
   }
 }
-
-final nextcloudHttpClientProvider = Provider<http.Client>((ref) {
-  final client = http.Client();
-  ref.onDispose(client.close);
-  return client;
-});
-
-final nextcloudAuthClientProvider = Provider<NextcloudAuthClient>((ref) {
-  return NextcloudAuthClient(
-    httpClient: ref.watch(nextcloudHttpClientProvider),
-    loginLauncher: ref.watch(nextcloudLoginLauncherProvider),
-  );
-});

--- a/lib/integrations/nextcloud/data/services/nextcloud_auth_headers.dart
+++ b/lib/integrations/nextcloud/data/services/nextcloud_auth_headers.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+
+Map<String, String> buildNextcloudAuthHeaders(NextcloudSession session) {
+  if (session.usesOidcBearer) {
+    final bearerToken = session.bearerToken;
+    if (bearerToken == null || bearerToken.isEmpty) {
+      throw const NextcloudFailure.sessionRequired(
+        'Reconnect Nextcloud because the saved bearer session is incomplete.',
+      );
+    }
+    return {'Authorization': 'Bearer $bearerToken'};
+  }
+
+  final loginName = session.loginName;
+  final appPassword = session.appPassword;
+  if (loginName == null ||
+      loginName.isEmpty ||
+      appPassword == null ||
+      appPassword.isEmpty) {
+    throw const NextcloudFailure.sessionRequired(
+      'Reconnect Nextcloud because the saved app password is incomplete.',
+    );
+  }
+
+  final encoded = base64Encode(utf8.encode('$loginName:$appPassword'));
+  return {'Authorization': 'Basic $encoded'};
+}

--- a/lib/integrations/nextcloud/data/services/nextcloud_dav_access_validator.dart
+++ b/lib/integrations/nextcloud/data/services/nextcloud_dav_access_validator.dart
@@ -1,0 +1,78 @@
+import 'package:http/http.dart' as http;
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_auth_headers.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+
+abstract interface class NextcloudDavAccessValidator {
+  Future<void> validateRootAccess(NextcloudSession session);
+}
+
+class HttpNextcloudDavAccessValidator implements NextcloudDavAccessValidator {
+  HttpNextcloudDavAccessValidator({required http.Client httpClient})
+    : _httpClient = httpClient;
+
+  final http.Client _httpClient;
+
+  @override
+  Future<void> validateRootAccess(NextcloudSession session) async {
+    _ensureHttpsSession(session);
+    final request =
+        http.Request(
+            'PROPFIND',
+            normalizeNextcloudBaseUrl(session.baseUrl).resolve(
+              'remote.php/dav/files/${Uri.encodeComponent(session.userId)}/',
+            ),
+          )
+          ..headers.addAll({
+            ...buildNextcloudAuthHeaders(session),
+            'Depth': '1',
+            'Content-Type': 'application/xml; charset=utf-8',
+          })
+          ..body = _propfindBody;
+
+    late http.StreamedResponse response;
+    try {
+      response = await _httpClient.send(request);
+    } on NextcloudFailure {
+      rethrow;
+    } catch (error) {
+      throw NextcloudFailure.unknown(
+        'Unable to validate Nextcloud WebDAV access.',
+        cause: error,
+      );
+    }
+
+    await response.stream.drain<void>();
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw const NextcloudFailure.invalidCredentials(
+        'The saved Nextcloud credentials are no longer valid.',
+      );
+    }
+
+    if (response.statusCode != 207) {
+      throw NextcloudFailure.protocol(
+        'Nextcloud returned an unexpected WebDAV status (${response.statusCode}).',
+      );
+    }
+  }
+
+  void _ensureHttpsSession(NextcloudSession session) {
+    if (session.baseUrl.scheme.toLowerCase() != 'https') {
+      throw const NextcloudFailure.configuration(
+        'Use an HTTPS Nextcloud URL before validating WebDAV access.',
+      );
+    }
+  }
+}
+
+const _propfindBody = '''<?xml version="1.0"?>
+<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+  <d:prop>
+    <d:displayname />
+    <d:getlastmodified />
+    <d:getcontentlength />
+    <d:resourcetype />
+    <oc:fileid />
+  </d:prop>
+</d:propfind>
+''';

--- a/lib/integrations/nextcloud/data/services/nextcloud_login_launcher.dart
+++ b/lib/integrations/nextcloud/data/services/nextcloud_login_launcher.dart
@@ -1,6 +1,5 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:weave/features/files/domain/entities/files_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
 
 abstract interface class NextcloudLoginLauncher {
   Future<void> launch(Uri loginUri);
@@ -17,21 +16,17 @@ class UrlLauncherNextcloudLoginLauncher implements NextcloudLoginLauncher {
         mode: LaunchMode.externalApplication,
       );
       if (!didLaunch) {
-        throw const FilesFailure.unsupportedPlatform(
+        throw const NextcloudFailure.unsupportedPlatform(
           'Unable to open the Nextcloud login page on this device.',
         );
       }
-    } on FilesFailure {
+    } on NextcloudFailure {
       rethrow;
     } catch (error) {
-      throw FilesFailure.unknown(
+      throw NextcloudFailure.unknown(
         'Unable to open the Nextcloud login page.',
         cause: error,
       );
     }
   }
 }
-
-final nextcloudLoginLauncherProvider = Provider<NextcloudLoginLauncher>((ref) {
-  return const UrlLauncherNextcloudLoginLauncher();
-});

--- a/lib/integrations/nextcloud/domain/entities/nextcloud_connection_state.dart
+++ b/lib/integrations/nextcloud/domain/entities/nextcloud_connection_state.dart
@@ -1,0 +1,52 @@
+enum NextcloudConnectionStatus {
+  misconfigured,
+  disconnected,
+  connected,
+  invalid,
+}
+
+class NextcloudConnectionState {
+  const NextcloudConnectionState({
+    required this.status,
+    this.baseUrl,
+    this.accountLabel,
+    this.message,
+  });
+
+  const NextcloudConnectionState.misconfigured({String? message})
+    : this(status: NextcloudConnectionStatus.misconfigured, message: message);
+
+  const NextcloudConnectionState.disconnected({Uri? baseUrl, String? message})
+    : this(
+        status: NextcloudConnectionStatus.disconnected,
+        baseUrl: baseUrl,
+        message: message,
+      );
+
+  const NextcloudConnectionState.connected({
+    required Uri baseUrl,
+    required String accountLabel,
+  }) : this(
+         status: NextcloudConnectionStatus.connected,
+         baseUrl: baseUrl,
+         accountLabel: accountLabel,
+       );
+
+  const NextcloudConnectionState.invalid({
+    required Uri baseUrl,
+    String? accountLabel,
+    String? message,
+  }) : this(
+         status: NextcloudConnectionStatus.invalid,
+         baseUrl: baseUrl,
+         accountLabel: accountLabel,
+         message: message,
+       );
+
+  final NextcloudConnectionStatus status;
+  final Uri? baseUrl;
+  final String? accountLabel;
+  final String? message;
+
+  bool get isConnected => status == NextcloudConnectionStatus.connected;
+}

--- a/lib/integrations/nextcloud/domain/entities/nextcloud_failure.dart
+++ b/lib/integrations/nextcloud/domain/entities/nextcloud_failure.dart
@@ -1,0 +1,69 @@
+enum NextcloudFailureType {
+  cancelled,
+  configuration,
+  sessionRequired,
+  invalidCredentials,
+  protocol,
+  storage,
+  unsupportedPlatform,
+  unknown,
+}
+
+class NextcloudFailure implements Exception {
+  const NextcloudFailure({
+    required this.type,
+    required this.message,
+    this.cause,
+  });
+
+  const NextcloudFailure.cancelled(String message, {Object? cause})
+    : this(
+        type: NextcloudFailureType.cancelled,
+        message: message,
+        cause: cause,
+      );
+
+  const NextcloudFailure.configuration(String message, {Object? cause})
+    : this(
+        type: NextcloudFailureType.configuration,
+        message: message,
+        cause: cause,
+      );
+
+  const NextcloudFailure.sessionRequired(String message, {Object? cause})
+    : this(
+        type: NextcloudFailureType.sessionRequired,
+        message: message,
+        cause: cause,
+      );
+
+  const NextcloudFailure.invalidCredentials(String message, {Object? cause})
+    : this(
+        type: NextcloudFailureType.invalidCredentials,
+        message: message,
+        cause: cause,
+      );
+
+  const NextcloudFailure.protocol(String message, {Object? cause})
+    : this(type: NextcloudFailureType.protocol, message: message, cause: cause);
+
+  const NextcloudFailure.storage(String message, {Object? cause})
+    : this(type: NextcloudFailureType.storage, message: message, cause: cause);
+
+  const NextcloudFailure.unsupportedPlatform(String message, {Object? cause})
+    : this(
+        type: NextcloudFailureType.unsupportedPlatform,
+        message: message,
+        cause: cause,
+      );
+
+  const NextcloudFailure.unknown(String message, {Object? cause})
+    : this(type: NextcloudFailureType.unknown, message: message, cause: cause);
+
+  final NextcloudFailureType type;
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => 'NextcloudFailure(type: $type, message: $message)';
+}

--- a/lib/integrations/nextcloud/domain/entities/nextcloud_session.dart
+++ b/lib/integrations/nextcloud/domain/entities/nextcloud_session.dart
@@ -1,5 +1,10 @@
 enum NextcloudSessionAuthMethod { oidcBearer, appPassword }
 
+Uri normalizeNextcloudBaseUrl(Uri uri) {
+  final path = uri.path.endsWith('/') ? uri.path : '${uri.path}/';
+  return uri.replace(path: path, query: null, fragment: null);
+}
+
 class NextcloudSession {
   const NextcloudSession._({
     required this.baseUrl,
@@ -79,11 +84,7 @@ class NextcloudSession {
   }
 
   bool matchesBaseUrl(Uri configuredBaseUrl) {
-    return _normalizeBaseUrl(baseUrl) == _normalizeBaseUrl(configuredBaseUrl);
-  }
-
-  static Uri _normalizeBaseUrl(Uri uri) {
-    final path = uri.path.endsWith('/') ? uri.path : '${uri.path}/';
-    return uri.replace(path: path, query: null, fragment: null);
+    return normalizeNextcloudBaseUrl(baseUrl) ==
+        normalizeNextcloudBaseUrl(configuredBaseUrl);
   }
 }

--- a/lib/integrations/nextcloud/domain/repositories/nextcloud_session_repository.dart
+++ b/lib/integrations/nextcloud/domain/repositories/nextcloud_session_repository.dart
@@ -1,4 +1,4 @@
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
 
 abstract interface class NextcloudSessionRepository {
   Future<NextcloudSession?> readSession();

--- a/lib/integrations/nextcloud/domain/services/nextcloud_connection_service.dart
+++ b/lib/integrations/nextcloud/domain/services/nextcloud_connection_service.dart
@@ -1,0 +1,14 @@
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_connection_state.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+
+abstract interface class NextcloudConnectionService {
+  Future<NextcloudConnectionState> restoreConnection();
+
+  Future<NextcloudConnectionState> connect();
+
+  Future<void> disconnect();
+
+  Future<NextcloudSession> requireLiveSession();
+
+  Future<void> invalidateSession(NextcloudSession session);
+}

--- a/lib/integrations/nextcloud/presentation/providers/nextcloud_provider.dart
+++ b/lib/integrations/nextcloud/presentation/providers/nextcloud_provider.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:weave/core/persistence/flutter_secure_store.dart';
+import 'package:weave/features/auth/presentation/providers/auth_session_repository_provider.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/nextcloud/data/repositories/secure_nextcloud_session_repository.dart';
+import 'package:weave/integrations/nextcloud/data/services/default_nextcloud_connection_service.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_auth_client.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_dav_access_validator.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_login_launcher.dart';
+import 'package:weave/integrations/nextcloud/domain/repositories/nextcloud_session_repository.dart';
+import 'package:weave/integrations/nextcloud/domain/services/nextcloud_connection_service.dart';
+
+final nextcloudHttpClientProvider = Provider<http.Client>((ref) {
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return client;
+});
+
+final nextcloudLoginLauncherProvider = Provider<NextcloudLoginLauncher>((ref) {
+  return const UrlLauncherNextcloudLoginLauncher();
+});
+
+final nextcloudAuthClientProvider = Provider<NextcloudAuthClient>((ref) {
+  return NextcloudAuthClient(
+    httpClient: ref.watch(nextcloudHttpClientProvider),
+    loginLauncher: ref.watch(nextcloudLoginLauncherProvider),
+  );
+});
+
+final nextcloudSessionRepositoryProvider = Provider<NextcloudSessionRepository>(
+  (ref) {
+    return SecureNextcloudSessionRepository(
+      secureStore: ref.watch(secureStoreProvider),
+    );
+  },
+);
+
+final nextcloudDavAccessValidatorProvider =
+    Provider<NextcloudDavAccessValidator>((ref) {
+      return HttpNextcloudDavAccessValidator(
+        httpClient: ref.watch(nextcloudHttpClientProvider),
+      );
+    });
+
+final nextcloudConnectionServiceProvider = Provider<NextcloudConnectionService>(
+  (ref) {
+    return DefaultNextcloudConnectionService(
+      authClient: ref.watch(nextcloudAuthClientProvider),
+      davAccessValidator: ref.watch(nextcloudDavAccessValidatorProvider),
+      authSessionRepository: ref.watch(authSessionRepositoryProvider),
+      sessionRepository: ref.watch(nextcloudSessionRepositoryProvider),
+      serverConfigurationRepository: ref.watch(
+        serverConfigurationRepositoryProvider,
+      ),
+    );
+  },
+);

--- a/test/features/files/data/repositories/nextcloud_files_repository_test.dart
+++ b/test/features/files/data/repositories/nextcloud_files_repository_test.dart
@@ -1,23 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
-import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
-import 'package:weave/features/auth/domain/entities/auth_state.dart';
-import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
 import 'package:weave/features/files/data/repositories/nextcloud_files_repository.dart';
-import 'package:weave/features/files/data/services/nextcloud_auth_client.dart';
-import 'package:weave/features/files/data/services/nextcloud_client.dart';
-import 'package:weave/features/files/data/services/nextcloud_login_launcher.dart';
+import 'package:weave/features/files/data/services/nextcloud_dav_client.dart';
 import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/file_entry.dart';
 import 'package:weave/features/files/domain/entities/files_connection_state.dart';
 import 'package:weave/features/files/domain/entities/files_failure.dart';
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
-import 'package:weave/features/files/domain/repositories/nextcloud_session_repository.dart';
-import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
-import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
-
-import '../../../../helpers/auth_test_data.dart';
-import '../../../../helpers/server_config_test_data.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_connection_state.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/domain/services/nextcloud_connection_service.dart';
 
 class _NoopHttpClient extends http.BaseClient {
   @override
@@ -26,91 +18,75 @@ class _NoopHttpClient extends http.BaseClient {
   }
 }
 
-class _FakeAuthSessionRepository implements AuthSessionRepository {
-  AuthState state = const AuthState.signedOut();
+class _FakeNextcloudConnectionService implements NextcloudConnectionService {
+  NextcloudConnectionState restoreState =
+      const NextcloudConnectionState.disconnected();
+  NextcloudConnectionState connectState =
+      const NextcloudConnectionState.disconnected();
+  NextcloudFailure? restoreFailure;
+  NextcloudFailure? connectFailure;
+  NextcloudFailure? disconnectFailure;
+  NextcloudFailure? liveSessionFailure;
+  NextcloudSession? liveSession;
   int restoreCalls = 0;
-
-  @override
-  Future<void> clearLocalSession() async {}
-
-  @override
-  Future<AuthState> refreshSession(AuthConfiguration configuration) async =>
-      state;
-
-  @override
-  Future<AuthState> restoreSession(AuthConfiguration configuration) async {
-    restoreCalls++;
-    return state;
-  }
-
-  @override
-  Future<AuthState> signIn(AuthConfiguration configuration) async => state;
-
-  @override
-  Future<void> signOut(AuthConfiguration configuration) async {}
-}
-
-class _FakeNextcloudAuthClient extends NextcloudAuthClient {
-  _FakeNextcloudAuthClient()
-    : super(
-        httpClient: _NoopHttpClient(),
-        loginLauncher: _FakeNextcloudLoginLauncher(),
-      );
-
-  NextcloudSession? appPasswordSessionToReturn;
-  final Map<String, NextcloudSession> bearerSessionsByToken =
-      <String, NextcloudSession>{};
-  final Map<String, FilesFailure> bearerFailuresByToken =
-      <String, FilesFailure>{};
   int connectCalls = 0;
-  int createBearerSessionCalls = 0;
-  int revokeCalls = 0;
-  final List<NextcloudSession> revokedSessions = <NextcloudSession>[];
+  int disconnectCalls = 0;
+  int requireLiveSessionCalls = 0;
+  int invalidateCalls = 0;
+  final List<NextcloudSession> invalidatedSessions = <NextcloudSession>[];
 
   @override
-  Future<NextcloudSession> connect(Uri configuredBaseUrl) async {
+  Future<NextcloudConnectionState> connect() async {
     connectCalls++;
-    final session = appPasswordSessionToReturn;
-    if (session == null) {
-      throw const FilesFailure.protocol('No app-password session configured.');
-    }
-    return session;
-  }
-
-  @override
-  Future<NextcloudSession> createBearerSession({
-    required Uri configuredBaseUrl,
-    required String bearerToken,
-    String? accountLabelHint,
-  }) async {
-    createBearerSessionCalls++;
-    final failure = bearerFailuresByToken[bearerToken];
+    final failure = connectFailure;
     if (failure != null) {
       throw failure;
     }
-
-    final session = bearerSessionsByToken[bearerToken];
-    if (session == null) {
-      throw const FilesFailure.invalidCredentials(
-        'The saved Nextcloud credentials are no longer valid.',
-      );
-    }
-    return session;
+    return connectState;
   }
 
   @override
-  Future<void> revokeAppPassword(NextcloudSession session) async {
-    revokeCalls++;
-    revokedSessions.add(session);
+  Future<void> disconnect() async {
+    disconnectCalls++;
+    final failure = disconnectFailure;
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  @override
+  Future<void> invalidateSession(NextcloudSession session) async {
+    invalidateCalls++;
+    invalidatedSessions.add(session);
+  }
+
+  @override
+  Future<NextcloudSession> requireLiveSession() async {
+    requireLiveSessionCalls++;
+    final failure = liveSessionFailure;
+    if (failure != null) {
+      throw failure;
+    }
+    return liveSession!;
+  }
+
+  @override
+  Future<NextcloudConnectionState> restoreConnection() async {
+    restoreCalls++;
+    final failure = restoreFailure;
+    if (failure != null) {
+      throw failure;
+    }
+    return restoreState;
   }
 }
 
-class _FakeNextcloudClient extends NextcloudClient {
-  _FakeNextcloudClient() : super(httpClient: _NoopHttpClient());
+class _FakeNextcloudDavClient extends NextcloudDavClient {
+  _FakeNextcloudDavClient() : super(httpClient: _NoopHttpClient());
 
   final Map<String, DirectoryListing> listingsByPath =
       <String, DirectoryListing>{};
-  FilesFailure? directoryFailure;
+  NextcloudFailure? directoryFailure;
   final List<NextcloudSession> sessions = <NextcloudSession>[];
   final List<String> paths = <String>[];
 
@@ -128,84 +104,25 @@ class _FakeNextcloudClient extends NextcloudClient {
 
     final listing = listingsByPath[path];
     if (listing == null) {
-      throw const FilesFailure.protocol('No listing configured for the test.');
+      throw const NextcloudFailure.protocol(
+        'No listing configured for the test.',
+      );
     }
     return listing;
   }
 }
 
-class _FakeNextcloudLoginLauncher implements NextcloudLoginLauncher {
-  @override
-  Future<void> launch(Uri loginUri) async {}
-}
-
-class _FakeNextcloudSessionRepository implements NextcloudSessionRepository {
-  NextcloudSession? session;
-  int clearCalls = 0;
-  int saveCalls = 0;
-  FilesFailure? saveFailure;
-
-  @override
-  Future<void> clearSession() async {
-    clearCalls++;
-    session = null;
-  }
-
-  @override
-  Future<NextcloudSession?> readSession() async => session;
-
-  @override
-  Future<void> saveSession(NextcloudSession session) async {
-    final failure = saveFailure;
-    if (failure != null) {
-      throw failure;
-    }
-
-    saveCalls++;
-    this.session = session;
-  }
-}
-
-class _FakeServerConfigurationRepository
-    implements ServerConfigurationRepository {
-  _FakeServerConfigurationRepository(this.configuration);
-
-  ServerConfiguration? configuration;
-
-  @override
-  Future<void> clearConfiguration() async {
-    configuration = null;
-  }
-
-  @override
-  Future<ServerConfiguration?> loadConfiguration() async => configuration;
-
-  @override
-  Future<void> saveConfiguration(ServerConfiguration configuration) async {
-    this.configuration = configuration;
-  }
-}
-
 void main() {
   group('NextcloudFilesRepository', () {
-    late _FakeAuthSessionRepository authSessionRepository;
-    late _FakeNextcloudAuthClient authClient;
-    late _FakeNextcloudClient client;
-    late _FakeNextcloudSessionRepository sessionRepository;
-    late _FakeServerConfigurationRepository configurationRepository;
+    late _FakeNextcloudConnectionService connectionService;
+    late _FakeNextcloudDavClient davClient;
     late NextcloudFilesRepository repository;
 
-    final bearerSession = NextcloudSession.oidcBearer(
+    final liveSession = NextcloudSession.oidcBearer(
       baseUrl: Uri.parse('https://nextcloud.home.internal/'),
       userId: 'alice',
-      accountLabel: 'alice',
-      bearerToken: 'id-token',
-    );
-    final appPasswordSession = NextcloudSession.appPassword(
-      baseUrl: Uri.parse('https://nextcloud.home.internal/'),
-      loginName: 'alice@example.com',
-      userId: 'alice',
-      appPassword: 'app-password',
+      accountLabel: 'Alice',
+      bearerToken: 'live-token',
     );
     const rootListing = DirectoryListing(
       path: '/',
@@ -220,182 +137,81 @@ void main() {
     );
 
     setUp(() {
-      authSessionRepository = _FakeAuthSessionRepository();
-      authClient = _FakeNextcloudAuthClient();
-      client = _FakeNextcloudClient()..listingsByPath['/'] = rootListing;
-      sessionRepository = _FakeNextcloudSessionRepository();
-      configurationRepository = _FakeServerConfigurationRepository(
-        buildTestConfiguration(),
-      );
+      connectionService = _FakeNextcloudConnectionService()
+        ..restoreState = NextcloudConnectionState.connected(
+          baseUrl: Uri.parse('https://nextcloud.home.internal'),
+          accountLabel: 'Alice',
+        )
+        ..connectState = NextcloudConnectionState.connected(
+          baseUrl: Uri.parse('https://nextcloud.home.internal'),
+          accountLabel: 'Alice',
+        )
+        ..liveSession = liveSession;
+      davClient = _FakeNextcloudDavClient()..listingsByPath['/'] = rootListing;
       repository = NextcloudFilesRepository(
-        authClient: authClient,
-        client: client,
-        authSessionRepository: authSessionRepository,
-        sessionRepository: sessionRepository,
-        serverConfigurationRepository: configurationRepository,
+        connectionService: connectionService,
+        client: davClient,
       );
     });
 
     test(
-      'restoreConnection returns disconnected when no files session is stored',
+      'restoreConnection maps shared connection state into files state',
       () async {
         final state = await repository.restoreConnection();
 
-        expect(state.status, FilesConnectionStatus.disconnected);
+        expect(state.status, FilesConnectionStatus.connected);
         expect(state.baseUrl, Uri.parse('https://nextcloud.home.internal'));
+        expect(state.accountLabel, 'Alice');
+        expect(connectionService.restoreCalls, 1);
       },
     );
 
-    test(
-      'connect stores a bearer-mode files session when OIDC bearer access works',
-      () async {
-        authSessionRepository.state = AuthState.authenticated(
-          buildTestAuthSession(),
-        );
-        authClient.bearerSessionsByToken['id-token'] = bearerSession;
-
-        final state = await repository.connect();
-
-        expect(state.status, FilesConnectionStatus.connected);
-        expect(authClient.connectCalls, 0);
-        expect(sessionRepository.saveCalls, 1);
-        expect(sessionRepository.session?.usesOidcBearer, isTrue);
-        expect(sessionRepository.session?.bearerToken, isNull);
-        expect(client.paths, ['/']);
-      },
-    );
-
-    test(
-      'connect falls back to the Login Flow when bearer DAV access is unavailable',
-      () async {
-        authSessionRepository.state = AuthState.authenticated(
-          buildTestAuthSession(),
-        );
-        authClient.bearerFailuresByToken['id-token'] =
-            const FilesFailure.invalidCredentials(
-              'The saved Nextcloud credentials are no longer valid.',
-            );
-        authClient.bearerFailuresByToken['access-token'] =
-            const FilesFailure.protocol(
-              'Nextcloud returned an unexpected WebDAV status (401).',
-            );
-        authClient.appPasswordSessionToReturn = appPasswordSession;
-
-        final state = await repository.connect();
-
-        expect(state.status, FilesConnectionStatus.connected);
-        expect(authClient.connectCalls, 1);
-        expect(sessionRepository.session?.usesAppPassword, isTrue);
-        expect(sessionRepository.session?.appPassword, 'app-password');
-      },
-    );
-
-    test(
-      'restoreConnection migrates a saved app-password session to bearer mode when bearer works',
-      () async {
-        sessionRepository.session = appPasswordSession;
-        authSessionRepository.state = AuthState.authenticated(
-          buildTestAuthSession(),
-        );
-        authClient.bearerSessionsByToken['id-token'] = bearerSession;
-
-        final state = await repository.restoreConnection();
-
-        expect(state.status, FilesConnectionStatus.connected);
-        expect(sessionRepository.session?.usesOidcBearer, isTrue);
-        expect(authClient.revokeCalls, 1);
-        expect(authClient.revokedSessions.single.appPassword, 'app-password');
-      },
-    );
-
-    test(
-      'restoreConnection keeps a saved app-password session when bearer is unavailable',
-      () async {
-        sessionRepository.session = appPasswordSession;
-        authSessionRepository.state = AuthState.authenticated(
-          buildTestAuthSession(),
-        );
-        authClient.bearerFailuresByToken['id-token'] =
-            const FilesFailure.invalidCredentials(
-              'The saved Nextcloud credentials are no longer valid.',
-            );
-        authClient.bearerFailuresByToken['access-token'] =
-            const FilesFailure.protocol(
-              'Nextcloud returned an unexpected WebDAV status (401).',
-            );
-
-        final state = await repository.restoreConnection();
-
-        expect(state.status, FilesConnectionStatus.connected);
-        expect(sessionRepository.session?.usesAppPassword, isTrue);
-        expect(authClient.revokeCalls, 0);
-      },
-    );
-
-    test(
-      'listDirectory resolves a live bearer session for a stored bearer marker',
-      () async {
-        sessionRepository.session = bearerSession.toPersistedSession();
-        authSessionRepository.state = AuthState.authenticated(
-          buildTestAuthSession(),
-        );
-        authClient.bearerSessionsByToken['id-token'] = bearerSession;
-
-        final listing = await repository.listDirectory('/');
-
-        expect(listing.entries.single.name, 'Documents');
-        expect(client.sessions.single.usesOidcBearer, isTrue);
-        expect(client.sessions.single.bearerToken, 'id-token');
-      },
-    );
-
-    test('listDirectory clears an invalid app-password session', () async {
-      sessionRepository.session = appPasswordSession;
-      client.directoryFailure = const FilesFailure.invalidCredentials(
-        'The saved Nextcloud credentials are no longer valid.',
+    test('connect maps shared failures into files failures', () async {
+      connectionService.connectFailure = const NextcloudFailure.configuration(
+        'Finish server setup before connecting Nextcloud.',
       );
 
       await expectLater(
-        repository.listDirectory('/'),
+        repository.connect(),
         throwsA(
           isA<FilesFailure>().having(
             (failure) => failure.type,
             'type',
-            FilesFailureType.invalidCredentials,
+            FilesFailureType.configuration,
           ),
         ),
       );
+    });
 
-      expect(sessionRepository.session, isNull);
-      expect(authClient.revokeCalls, 1);
+    test('listDirectory uses the shared live session and DAV client', () async {
+      final listing = await repository.listDirectory('/');
+
+      expect(listing.entries.single.name, 'Documents');
+      expect(connectionService.requireLiveSessionCalls, 1);
+      expect(davClient.sessions.single.bearerToken, 'live-token');
+      expect(davClient.paths.single, '/');
     });
 
     test(
-      'disconnect clears a stored bearer marker without revoking an app password',
+      'listDirectory invalidates the shared session on invalid credentials',
       () async {
-        sessionRepository.session = bearerSession.toPersistedSession();
-
-        await repository.disconnect();
-
-        expect(sessionRepository.session, isNull);
-        expect(authClient.revokeCalls, 0);
-      },
-    );
-
-    test(
-      'restoreConnection clears a stale session when the configured server changes',
-      () async {
-        sessionRepository.session = appPasswordSession;
-        configurationRepository.configuration = buildTestConfiguration(
-          nextcloudBaseUrl: 'https://other-nextcloud.home.internal',
+        davClient.directoryFailure = const NextcloudFailure.invalidCredentials(
+          'The saved Nextcloud credentials are no longer valid.',
         );
 
-        final state = await repository.restoreConnection();
+        await expectLater(
+          repository.listDirectory('/'),
+          throwsA(
+            isA<FilesFailure>().having(
+              (failure) => failure.type,
+              'type',
+              FilesFailureType.invalidCredentials,
+            ),
+          ),
+        );
 
-        expect(state.status, FilesConnectionStatus.disconnected);
-        expect(sessionRepository.clearCalls, 1);
-        expect(sessionRepository.session, isNull);
-        expect(authClient.revokeCalls, 1);
+        expect(connectionService.invalidateCalls, 1);
+        expect(connectionService.invalidatedSessions.single, same(liveSession));
       },
     );
   });

--- a/test/features/files/data/services/nextcloud_dav_client_test.dart
+++ b/test/features/files/data/services/nextcloud_dav_client_test.dart
@@ -1,14 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:weave/features/files/data/services/nextcloud_client.dart';
-import 'package:weave/features/files/domain/entities/files_failure.dart';
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
+import 'package:weave/features/files/data/services/nextcloud_dav_client.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
 
 void main() {
-  group('NextcloudClient', () {
+  group('NextcloudDavClient', () {
     test('listDirectory maps WebDAV responses into file entries', () async {
-      final client = NextcloudClient(
+      final client = NextcloudDavClient(
         httpClient: MockClient((request) async {
           expect(request.method, 'PROPFIND');
           expect(request.headers['Authorization'], startsWith('Basic '));
@@ -35,7 +35,7 @@ void main() {
     });
 
     test('listDirectory supports OIDC bearer authorization', () async {
-      final client = NextcloudClient(
+      final client = NextcloudDavClient(
         httpClient: MockClient((request) async {
           expect(request.headers['Authorization'], 'Bearer oidc-access-token');
           return http.Response(_multistatusResponse, 207);
@@ -55,7 +55,7 @@ void main() {
     });
 
     test('listDirectory surfaces invalid credentials from WebDAV', () async {
-      final client = NextcloudClient(
+      final client = NextcloudDavClient(
         httpClient: MockClient((request) async => http.Response('', 401)),
       );
 
@@ -70,10 +70,10 @@ void main() {
           '/',
         ),
         throwsA(
-          isA<FilesFailure>().having(
+          isA<NextcloudFailure>().having(
             (failure) => failure.type,
             'type',
-            FilesFailureType.invalidCredentials,
+            NextcloudFailureType.invalidCredentials,
           ),
         ),
       );

--- a/test/features/files/data/services/nextcloud_dav_client_test.dart
+++ b/test/features/files/data/services/nextcloud_dav_client_test.dart
@@ -5,6 +5,17 @@ import 'package:weave/features/files/data/services/nextcloud_dav_client.dart';
 import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
 import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
 
+class _ThrowingHttpClient extends http.BaseClient {
+  _ThrowingHttpClient(this.error);
+
+  final Object error;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return Future<http.StreamedResponse>.error(error);
+  }
+}
+
 void main() {
   group('NextcloudDavClient', () {
     test('listDirectory maps WebDAV responses into file entries', () async {
@@ -78,6 +89,35 @@ void main() {
         ),
       );
     });
+
+    test(
+      'listDirectory preserves typed Nextcloud failures from custom transports',
+      () async {
+        const failure = NextcloudFailure.sessionRequired(
+          'Reconnect Nextcloud because the saved app password is incomplete.',
+        );
+        final client = NextcloudDavClient(
+          httpClient: _ThrowingHttpClient(failure),
+        );
+
+        await expectLater(
+          client.listDirectory(
+            NextcloudSession.appPassword(
+              baseUrl: Uri.parse('https://nextcloud.home.internal/'),
+              loginName: 'alice@example.com',
+              userId: 'alice',
+              appPassword: 'app-password',
+            ),
+            '/',
+          ),
+          throwsA(
+            isA<NextcloudFailure>()
+                .having((value) => value.type, 'type', failure.type)
+                .having((value) => value.message, 'message', failure.message),
+          ),
+        );
+      },
+    );
   });
 }
 

--- a/test/integrations/nextcloud/data/repositories/secure_nextcloud_session_repository_test.dart
+++ b/test/integrations/nextcloud/data/repositories/secure_nextcloud_session_repository_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:weave/features/files/data/repositories/secure_nextcloud_session_repository.dart';
-import 'package:weave/features/files/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/data/repositories/secure_nextcloud_session_repository.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
 
 import '../../../../helpers/in_memory_stores.dart';
 

--- a/test/integrations/nextcloud/data/services/default_nextcloud_connection_service_test.dart
+++ b/test/integrations/nextcloud/data/services/default_nextcloud_connection_service_test.dart
@@ -1,0 +1,388 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_state.dart';
+import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/integrations/nextcloud/data/services/default_nextcloud_connection_service.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_auth_client.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_dav_access_validator.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_login_launcher.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_connection_state.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_session.dart';
+import 'package:weave/integrations/nextcloud/domain/repositories/nextcloud_session_repository.dart';
+
+import '../../../../helpers/auth_test_data.dart';
+import '../../../../helpers/server_config_test_data.dart';
+
+class _NoopHttpClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    throw UnimplementedError();
+  }
+}
+
+class _FakeAuthSessionRepository implements AuthSessionRepository {
+  AuthState state = const AuthState.signedOut();
+  int restoreCalls = 0;
+
+  @override
+  Future<void> clearLocalSession() async {}
+
+  @override
+  Future<AuthState> refreshSession(AuthConfiguration configuration) async =>
+      state;
+
+  @override
+  Future<AuthState> restoreSession(AuthConfiguration configuration) async {
+    restoreCalls++;
+    return state;
+  }
+
+  @override
+  Future<AuthState> signIn(AuthConfiguration configuration) async => state;
+
+  @override
+  Future<void> signOut(AuthConfiguration configuration) async {}
+}
+
+class _FakeNextcloudAuthClient extends NextcloudAuthClient {
+  _FakeNextcloudAuthClient()
+    : super(
+        httpClient: _NoopHttpClient(),
+        loginLauncher: _FakeNextcloudLoginLauncher(),
+      );
+
+  NextcloudSession? appPasswordSessionToReturn;
+  final Map<String, NextcloudSession> bearerSessionsByToken =
+      <String, NextcloudSession>{};
+  final Map<String, NextcloudFailure> bearerFailuresByToken =
+      <String, NextcloudFailure>{};
+  int connectCalls = 0;
+  int createBearerSessionCalls = 0;
+  int revokeCalls = 0;
+  final List<NextcloudSession> revokedSessions = <NextcloudSession>[];
+
+  @override
+  Future<NextcloudSession> connect(Uri configuredBaseUrl) async {
+    connectCalls++;
+    final session = appPasswordSessionToReturn;
+    if (session == null) {
+      throw const NextcloudFailure.protocol(
+        'No app-password session configured.',
+      );
+    }
+    return session;
+  }
+
+  @override
+  Future<NextcloudSession> createBearerSession({
+    required Uri configuredBaseUrl,
+    required String bearerToken,
+    String? accountLabelHint,
+  }) async {
+    createBearerSessionCalls++;
+    final failure = bearerFailuresByToken[bearerToken];
+    if (failure != null) {
+      throw failure;
+    }
+
+    final session = bearerSessionsByToken[bearerToken];
+    if (session == null) {
+      throw const NextcloudFailure.invalidCredentials(
+        'The saved Nextcloud credentials are no longer valid.',
+      );
+    }
+    return session;
+  }
+
+  @override
+  Future<void> revokeAppPassword(NextcloudSession session) async {
+    revokeCalls++;
+    revokedSessions.add(session);
+  }
+}
+
+class _FakeNextcloudDavAccessValidator implements NextcloudDavAccessValidator {
+  final Map<String, NextcloudFailure> failuresByToken =
+      <String, NextcloudFailure>{};
+  final List<NextcloudSession> sessions = <NextcloudSession>[];
+
+  @override
+  Future<void> validateRootAccess(NextcloudSession session) async {
+    sessions.add(session);
+    final token = session.bearerToken;
+    final failure = token == null ? null : failuresByToken[token];
+    if (failure != null) {
+      throw failure;
+    }
+  }
+}
+
+class _FakeNextcloudLoginLauncher implements NextcloudLoginLauncher {
+  @override
+  Future<void> launch(Uri loginUri) async {}
+}
+
+class _FakeNextcloudSessionRepository implements NextcloudSessionRepository {
+  NextcloudSession? session;
+  int clearCalls = 0;
+  int saveCalls = 0;
+  NextcloudFailure? saveFailure;
+
+  @override
+  Future<void> clearSession() async {
+    clearCalls++;
+    session = null;
+  }
+
+  @override
+  Future<NextcloudSession?> readSession() async => session;
+
+  @override
+  Future<void> saveSession(NextcloudSession session) async {
+    final failure = saveFailure;
+    if (failure != null) {
+      throw failure;
+    }
+
+    saveCalls++;
+    this.session = session;
+  }
+}
+
+class _FakeServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _FakeServerConfigurationRepository(this.configuration);
+
+  ServerConfiguration? configuration;
+
+  @override
+  Future<void> clearConfiguration() async {
+    configuration = null;
+  }
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    this.configuration = configuration;
+  }
+}
+
+void main() {
+  group('DefaultNextcloudConnectionService', () {
+    late _FakeAuthSessionRepository authSessionRepository;
+    late _FakeNextcloudAuthClient authClient;
+    late _FakeNextcloudDavAccessValidator davAccessValidator;
+    late _FakeNextcloudSessionRepository sessionRepository;
+    late _FakeServerConfigurationRepository configurationRepository;
+    late DefaultNextcloudConnectionService service;
+
+    final bearerSession = NextcloudSession.oidcBearer(
+      baseUrl: Uri.parse('https://nextcloud.home.internal/'),
+      userId: 'alice',
+      accountLabel: 'alice',
+      bearerToken: 'id-token',
+    );
+    final appPasswordSession = NextcloudSession.appPassword(
+      baseUrl: Uri.parse('https://nextcloud.home.internal/'),
+      loginName: 'alice@example.com',
+      userId: 'alice',
+      appPassword: 'app-password',
+    );
+
+    setUp(() {
+      authSessionRepository = _FakeAuthSessionRepository();
+      authClient = _FakeNextcloudAuthClient();
+      davAccessValidator = _FakeNextcloudDavAccessValidator();
+      sessionRepository = _FakeNextcloudSessionRepository();
+      configurationRepository = _FakeServerConfigurationRepository(
+        buildTestConfiguration(),
+      );
+      service = DefaultNextcloudConnectionService(
+        authClient: authClient,
+        davAccessValidator: davAccessValidator,
+        authSessionRepository: authSessionRepository,
+        sessionRepository: sessionRepository,
+        serverConfigurationRepository: configurationRepository,
+      );
+    });
+
+    test(
+      'restoreConnection returns disconnected when no session is stored',
+      () async {
+        final state = await service.restoreConnection();
+
+        expect(state.status, NextcloudConnectionStatus.disconnected);
+        expect(state.baseUrl, Uri.parse('https://nextcloud.home.internal'));
+      },
+    );
+
+    test(
+      'connect stores a bearer-mode session when OIDC bearer access works',
+      () async {
+        authSessionRepository.state = AuthState.authenticated(
+          buildTestAuthSession(),
+        );
+        authClient.bearerSessionsByToken['id-token'] = bearerSession;
+
+        final state = await service.connect();
+
+        expect(state.status, NextcloudConnectionStatus.connected);
+        expect(authClient.connectCalls, 0);
+        expect(sessionRepository.saveCalls, 1);
+        expect(sessionRepository.session?.usesOidcBearer, isTrue);
+        expect(sessionRepository.session?.bearerToken, isNull);
+        expect(davAccessValidator.sessions.single.bearerToken, 'id-token');
+      },
+    );
+
+    test(
+      'connect falls back to the Login Flow when bearer DAV access is unavailable',
+      () async {
+        authSessionRepository.state = AuthState.authenticated(
+          buildTestAuthSession(),
+        );
+        authClient.bearerFailuresByToken['id-token'] =
+            const NextcloudFailure.invalidCredentials(
+              'The saved Nextcloud credentials are no longer valid.',
+            );
+        authClient.bearerFailuresByToken['access-token'] =
+            const NextcloudFailure.protocol(
+              'Nextcloud returned an unexpected WebDAV status (401).',
+            );
+        authClient.appPasswordSessionToReturn = appPasswordSession;
+
+        final state = await service.connect();
+
+        expect(state.status, NextcloudConnectionStatus.connected);
+        expect(authClient.connectCalls, 1);
+        expect(sessionRepository.session?.usesAppPassword, isTrue);
+        expect(sessionRepository.session?.appPassword, 'app-password');
+      },
+    );
+
+    test(
+      'restoreConnection migrates a saved app-password session to bearer mode when bearer works',
+      () async {
+        sessionRepository.session = appPasswordSession;
+        authSessionRepository.state = AuthState.authenticated(
+          buildTestAuthSession(),
+        );
+        authClient.bearerSessionsByToken['id-token'] = bearerSession;
+
+        final state = await service.restoreConnection();
+
+        expect(state.status, NextcloudConnectionStatus.connected);
+        expect(sessionRepository.session?.usesOidcBearer, isTrue);
+        expect(authClient.revokeCalls, 1);
+        expect(authClient.revokedSessions.single.appPassword, 'app-password');
+      },
+    );
+
+    test(
+      'restoreConnection keeps a saved app-password session when bearer is unavailable',
+      () async {
+        sessionRepository.session = appPasswordSession;
+        authSessionRepository.state = AuthState.authenticated(
+          buildTestAuthSession(),
+        );
+        authClient.bearerFailuresByToken['id-token'] =
+            const NextcloudFailure.invalidCredentials(
+              'The saved Nextcloud credentials are no longer valid.',
+            );
+        authClient.bearerFailuresByToken['access-token'] =
+            const NextcloudFailure.protocol(
+              'Nextcloud returned an unexpected WebDAV status (401).',
+            );
+
+        final state = await service.restoreConnection();
+
+        expect(state.status, NextcloudConnectionStatus.connected);
+        expect(sessionRepository.session?.usesAppPassword, isTrue);
+        expect(authClient.revokeCalls, 0);
+      },
+    );
+
+    test(
+      'requireLiveSession resolves a live bearer session for a stored bearer marker',
+      () async {
+        sessionRepository.session = bearerSession.toPersistedSession();
+        authSessionRepository.state = AuthState.authenticated(
+          buildTestAuthSession(),
+        );
+        authClient.bearerSessionsByToken['id-token'] = bearerSession;
+
+        final session = await service.requireLiveSession();
+
+        expect(session.usesOidcBearer, isTrue);
+        expect(session.bearerToken, 'id-token');
+      },
+    );
+
+    test(
+      'requireLiveSession clears a stored bearer marker when bearer access is unavailable',
+      () async {
+        sessionRepository.session = bearerSession.toPersistedSession();
+
+        await expectLater(
+          service.requireLiveSession(),
+          throwsA(
+            isA<NextcloudFailure>().having(
+              (failure) => failure.type,
+              'type',
+              NextcloudFailureType.invalidCredentials,
+            ),
+          ),
+        );
+
+        expect(sessionRepository.session, isNull);
+      },
+    );
+
+    test(
+      'invalidateSession clears and revokes an app-password session',
+      () async {
+        sessionRepository.session = appPasswordSession;
+
+        await service.invalidateSession(appPasswordSession);
+
+        expect(sessionRepository.session, isNull);
+        expect(authClient.revokeCalls, 1);
+      },
+    );
+
+    test(
+      'disconnect clears a stored bearer marker without revoking an app password',
+      () async {
+        sessionRepository.session = bearerSession.toPersistedSession();
+
+        await service.disconnect();
+
+        expect(sessionRepository.session, isNull);
+        expect(authClient.revokeCalls, 0);
+      },
+    );
+
+    test(
+      'restoreConnection clears a stale session when the configured server changes',
+      () async {
+        sessionRepository.session = appPasswordSession;
+        configurationRepository.configuration = buildTestConfiguration(
+          nextcloudBaseUrl: 'https://other-nextcloud.home.internal',
+        );
+
+        final state = await service.restoreConnection();
+
+        expect(state.status, NextcloudConnectionStatus.disconnected);
+        expect(sessionRepository.clearCalls, 1);
+        expect(sessionRepository.session, isNull);
+        expect(authClient.revokeCalls, 1);
+      },
+    );
+  });
+}

--- a/test/integrations/nextcloud/data/services/nextcloud_auth_client_test.dart
+++ b/test/integrations/nextcloud/data/services/nextcloud_auth_client_test.dart
@@ -3,9 +3,9 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
-import 'package:weave/features/files/data/services/nextcloud_auth_client.dart';
-import 'package:weave/features/files/data/services/nextcloud_login_launcher.dart';
-import 'package:weave/features/files/domain/entities/files_failure.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_auth_client.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_login_launcher.dart';
+import 'package:weave/integrations/nextcloud/domain/entities/nextcloud_failure.dart';
 
 class _FakeNextcloudLoginLauncher implements NextcloudLoginLauncher {
   Uri? launchedUri;
@@ -160,10 +160,10 @@ void main() {
         await expectLater(
           authClient.connect(Uri.parse('https://nextcloud.home.internal')),
           throwsA(
-            isA<FilesFailure>().having(
+            isA<NextcloudFailure>().having(
               (failure) => failure.type,
               'type',
-              FilesFailureType.configuration,
+              NextcloudFailureType.configuration,
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- extract a feature-neutral Nextcloud integration layer under `lib/integrations/nextcloud`
- move auth, session persistence, login flow, bearer fallback, and connection lifecycle orchestration into a shared connection service
- slim Files down to DAV browsing plus file-facing connection and failure mapping, with tests split between shared integration behavior and file-specific DAV behavior

## Testing
- `flutter pub get`
- `flutter gen-l10n`
- `dart run build_runner build --delete-conflicting-outputs`
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze --fatal-infos`
- `flutter test`

Refs #13
