### PR TITLE
Consume backend workspace capabilities

### DIFF
--- a/lib/features/app/presentation/providers/workspace_connection_provider.dart
+++ b/lib/features/app/presentation/providers/workspace_connection_provider.dart
@@ -13,6 +13,7 @@ import 'package:weave/features/files/domain/entities/files_connection_state.dart
 import 'package:weave/features/files/domain/entities/files_failure.dart';
 import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 
 final appAuthIntegrationConnectionProvider =
     Provider<AsyncValue<IntegrationConnectionState>>((ref) {
@@ -119,7 +120,32 @@ final workspaceConnectionStateProvider =
 final workspaceCapabilitySnapshotProvider =
     Provider<AsyncValue<WorkspaceCapabilitySnapshot>>((ref) {
       final workspace = ref.watch(workspaceConnectionStateProvider);
-      return workspace.whenData(_mapWorkspaceCapabilitySnapshot);
+      final backendCapabilities = ref.watch(
+        weaveApiWorkspaceCapabilitySnapshotProvider,
+      );
+
+      if (workspace.hasError) {
+        return AsyncError(workspace.error!, workspace.stackTrace!);
+      }
+      if (workspace.isLoading) {
+        return const AsyncLoading();
+      }
+
+      final localSnapshot = _mapWorkspaceCapabilitySnapshot(
+        workspace.requireValue,
+      );
+
+      return switch (backendCapabilities) {
+        AsyncData(value: final snapshot) => AsyncData(
+          snapshot == null
+              ? localSnapshot
+              : _mergeWorkspaceCapabilitySnapshots(
+                  localSnapshot: localSnapshot,
+                  backendSnapshot: snapshot,
+                ),
+        ),
+        AsyncLoading() || AsyncError() => AsyncData(localSnapshot),
+      };
     });
 
 IntegrationConnectionState _mapAppAuthConnectionState(
@@ -333,6 +359,46 @@ WorkspaceCapabilitySnapshot _mapWorkspaceCapabilitySnapshot(
       capability: WorkspaceCapability.boards,
       shellAccess: connection.appAuth,
     ),
+  );
+}
+
+WorkspaceCapabilitySnapshot _mergeWorkspaceCapabilitySnapshots({
+  required WorkspaceCapabilitySnapshot localSnapshot,
+  required WorkspaceCapabilitySnapshot backendSnapshot,
+}) {
+  return WorkspaceCapabilitySnapshot(
+    shellAccess: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.shellAccess,
+      backend: backendSnapshot.shellAccess,
+    ),
+    chat: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.chat,
+      backend: backendSnapshot.chat,
+    ),
+    files: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.files,
+      backend: backendSnapshot.files,
+    ),
+    calendar: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.calendar,
+      backend: backendSnapshot.calendar,
+    ),
+    boards: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.boards,
+      backend: backendSnapshot.boards,
+    ),
+  );
+}
+
+WorkspaceCapabilityState _mergeWorkspaceCapabilityState({
+  required WorkspaceCapabilityState local,
+  required WorkspaceCapabilityState backend,
+}) {
+  return WorkspaceCapabilityState(
+    capability: local.capability,
+    readiness: backend.readiness,
+    connectionStatus: local.connectionStatus,
+    recoveryRequirement: local.recoveryRequirement,
   );
 }
 

--- a/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
@@ -1,0 +1,110 @@
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+
+class WorkspaceCapabilitiesResponseDto {
+  const WorkspaceCapabilitiesResponseDto({
+    required this.shellAccess,
+    required this.chat,
+    required this.files,
+    required this.calendar,
+    required this.boards,
+  });
+
+  factory WorkspaceCapabilitiesResponseDto.fromJson(Map<String, dynamic> json) {
+    return WorkspaceCapabilitiesResponseDto(
+      shellAccess: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'shellAccess'),
+      ),
+      chat: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'chat'),
+      ),
+      files: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'files'),
+      ),
+      calendar: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'calendar'),
+      ),
+      boards: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'boards'),
+      ),
+    );
+  }
+
+  final WorkspaceCapabilityStatusDto shellAccess;
+  final WorkspaceCapabilityStatusDto chat;
+  final WorkspaceCapabilityStatusDto files;
+  final WorkspaceCapabilityStatusDto calendar;
+  final WorkspaceCapabilityStatusDto boards;
+
+  WorkspaceCapabilitySnapshot toSnapshot() {
+    return WorkspaceCapabilitySnapshot(
+      shellAccess: shellAccess.toCapabilityState(
+        WorkspaceCapability.shellAccess,
+      ),
+      chat: chat.toCapabilityState(WorkspaceCapability.chat),
+      files: files.toCapabilityState(WorkspaceCapability.files),
+      calendar: calendar.toCapabilityState(WorkspaceCapability.calendar),
+      boards: boards.toCapabilityState(WorkspaceCapability.boards),
+    );
+  }
+
+  static Map<String, dynamic> _readNestedJson(
+    Map<String, dynamic> json,
+    String key,
+  ) {
+    final value = json[key];
+    if (value is Map<String, dynamic>) {
+      return value;
+    }
+
+    throw AppFailure.unknown(
+      'The backend returned an invalid workspace capabilities response.',
+      cause: 'Expected an object for "$key".',
+    );
+  }
+}
+
+class WorkspaceCapabilityStatusDto {
+  const WorkspaceCapabilityStatusDto({
+    required this.enabled,
+    required this.readiness,
+  });
+
+  factory WorkspaceCapabilityStatusDto.fromJson(Map<String, dynamic> json) {
+    final enabled = json['enabled'];
+    final readiness = json['readiness'];
+
+    if (enabled is! bool || readiness is! String) {
+      throw AppFailure.unknown(
+        'The backend returned an invalid workspace capability item.',
+      );
+    }
+
+    return WorkspaceCapabilityStatusDto(enabled: enabled, readiness: readiness);
+  }
+
+  final bool enabled;
+  final String readiness;
+
+  WorkspaceCapabilityState toCapabilityState(WorkspaceCapability capability) {
+    return WorkspaceCapabilityState(
+      capability: capability,
+      readiness: enabled
+          ? _parseReadiness(readiness)
+          : WorkspaceCapabilityReadiness.unavailable,
+    );
+  }
+
+  WorkspaceCapabilityReadiness _parseReadiness(String rawValue) {
+    return switch (rawValue.trim()) {
+      'ready' => WorkspaceCapabilityReadiness.ready,
+      'degraded' => WorkspaceCapabilityReadiness.degraded,
+      'blocked' => WorkspaceCapabilityReadiness.blocked,
+      'unavailable' => WorkspaceCapabilityReadiness.unavailable,
+      _ => throw AppFailure.unknown(
+        'The backend returned an unknown workspace capability readiness.',
+        cause: rawValue,
+      ),
+    };
+  }
+}

--- a/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
@@ -75,7 +75,7 @@ class WorkspaceCapabilityStatusDto {
     final readiness = json['readiness'];
 
     if (enabled is! bool || readiness is! String) {
-      throw AppFailure.unknown(
+      throw const AppFailure.unknown(
         'The backend returned an invalid workspace capability item.',
       );
     }

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -23,7 +23,7 @@ class HttpWeaveApiClient implements WeaveApiClient {
     required Uri baseUrl,
     required String accessToken,
   }) async {
-    final requestUri = baseUrl.resolve('/api/v1/workspace/capabilities');
+    final requestUri = _workspaceCapabilitiesUri(baseUrl);
 
     late http.Response response;
     try {
@@ -71,5 +71,17 @@ class HttpWeaveApiClient implements WeaveApiClient {
         cause: error,
       );
     }
+  }
+
+  Uri _workspaceCapabilitiesUri(Uri baseUrl) {
+    return baseUrl.replace(
+      pathSegments: [
+        ...baseUrl.pathSegments.where((segment) => segment.isNotEmpty),
+        'api',
+        'v1',
+        'workspace',
+        'capabilities',
+      ],
+    );
   }
 }

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart';
+
+abstract interface class WeaveApiClient {
+  Future<WorkspaceCapabilitySnapshot> fetchWorkspaceCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  });
+}
+
+class HttpWeaveApiClient implements WeaveApiClient {
+  HttpWeaveApiClient({required http.Client httpClient})
+    : _httpClient = httpClient;
+
+  final http.Client _httpClient;
+
+  @override
+  Future<WorkspaceCapabilitySnapshot> fetchWorkspaceCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    final requestUri = baseUrl.resolve('/api/v1/workspace/capabilities');
+
+    late http.Response response;
+    try {
+      response = await _httpClient.get(
+        requestUri,
+        headers: {
+          'accept': 'application/json',
+          'authorization': 'Bearer $accessToken',
+        },
+      );
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to reach the Weave backend right now.',
+        cause: error,
+      );
+    }
+
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw const AppFailure.unknown(
+        'The Weave backend rejected the current session.',
+      );
+    }
+
+    if (response.statusCode != 200) {
+      throw AppFailure.unknown(
+        'The Weave backend failed to return workspace capabilities.',
+        cause: response.statusCode,
+      );
+    }
+
+    try {
+      final payload = jsonDecode(response.body);
+      if (payload is! Map<String, dynamic>) {
+        throw const AppFailure.unknown(
+          'The Weave backend returned an invalid workspace capabilities payload.',
+        );
+      }
+
+      return WorkspaceCapabilitiesResponseDto.fromJson(payload).toSnapshot();
+    } on AppFailure {
+      rethrow;
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to decode workspace capabilities from the Weave backend.',
+        cause: error,
+      );
+    }
+  }
+}

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -30,8 +30,8 @@ class HttpWeaveApiClient implements WeaveApiClient {
       response = await _httpClient.get(
         requestUri,
         headers: {
-          'accept': 'application/json',
-          'authorization': 'Bearer $accessToken',
+          'Accept': 'application/json',
+          'Authorization': 'Bearer $accessToken',
         },
       );
     } catch (error) {

--- a/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
+++ b/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
+import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_failure.dart';
+import 'package:weave/features/auth/presentation/providers/auth_session_repository_provider.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+
+final weaveApiHttpClientProvider = Provider<http.Client>((ref) {
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return client;
+});
+
+final weaveApiClientProvider = Provider<WeaveApiClient>((ref) {
+  return HttpWeaveApiClient(httpClient: ref.watch(weaveApiHttpClientProvider));
+});
+
+final weaveApiWorkspaceCapabilitySnapshotProvider =
+    FutureProvider<WorkspaceCapabilitySnapshot?>((ref) async {
+      final configuration = await ref.watch(
+        savedServerConfigurationProvider.future,
+      );
+      if (configuration == null) {
+        return null;
+      }
+
+      final bootstrapState = await ref.watch(appBootstrapProvider.future);
+      if (bootstrapState.phase != BootstrapPhase.ready) {
+        return null;
+      }
+
+      try {
+        final authState = await ref
+            .read(authSessionRepositoryProvider)
+            .restoreSession(
+              AuthConfiguration(
+                issuer: configuration.oidcIssuerUrl,
+                clientId: configuration.oidcClientRegistration.clientId.trim(),
+              ),
+            );
+        final session = authState.session;
+        if (!authState.isAuthenticated || session == null) {
+          return null;
+        }
+
+        return ref
+            .read(weaveApiClientProvider)
+            .fetchWorkspaceCapabilities(
+              baseUrl: configuration.serviceEndpoints.backendApiBaseUrl,
+              accessToken: session.accessToken,
+            );
+      } on AuthFailure {
+        return null;
+      } on AppFailure {
+        return null;
+      } catch (_) {
+        return null;
+      }
+    });

--- a/test/features/app/presentation/providers/workspace_connection_provider_test.dart
+++ b/test/features/app/presentation/providers/workspace_connection_provider_test.dart
@@ -15,6 +15,7 @@ import 'package:weave/features/files/domain/entities/files_connection_state.dart
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
 import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 
 import '../../../../helpers/fake_chat_security_repository.dart';
 import '../../../../helpers/server_config_test_data.dart';
@@ -277,6 +278,97 @@ void main() {
         expect(
           capabilities.requireValue.files.readiness,
           WorkspaceCapabilityReadiness.ready,
+        );
+      },
+    );
+
+    test(
+      'prefers backend capability readiness when a backend snapshot exists',
+      () async {
+        final container = ProviderContainer.test(
+          overrides: [
+            appBootstrapProvider.overrideWith(
+              () => _FakeAppBootstrap(const BootstrapState.ready()),
+            ),
+            savedServerConfigurationProvider.overrideWith(
+              (ref) async => buildTestConfiguration(),
+            ),
+            chatSecurityRepositoryProvider.overrideWithValue(
+              FakeChatSecurityRepository(
+                loadSecurityStateHandler: ({bool refresh = false}) async {
+                  return const ChatSecurityState(
+                    isMatrixSignedIn: true,
+                    bootstrapState:
+                        ChatSecurityBootstrapState.partiallyInitialized,
+                    accountVerificationState:
+                        ChatAccountVerificationState.verificationRequired,
+                    deviceVerificationState:
+                        ChatDeviceVerificationState.unverified,
+                    keyBackupState: ChatKeyBackupState.missing,
+                    roomEncryptionReadiness:
+                        ChatRoomEncryptionReadiness.encryptedRoomsNeedAttention,
+                    secretStorageReady: false,
+                    crossSigningReady: false,
+                    hasEncryptedConversations: true,
+                    verificationSession: ChatVerificationSession.none(),
+                  );
+                },
+              ),
+            ),
+            filesRepositoryProvider.overrideWithValue(
+              _FakeFilesRepository(
+                connectionState: FilesConnectionState.connected(
+                  baseUrl: Uri.parse('https://nextcloud.home.internal'),
+                  accountLabel: 'alice',
+                ),
+              ),
+            ),
+            weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+              (ref) async => const WorkspaceCapabilitySnapshot(
+                shellAccess: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.shellAccess,
+                  readiness: WorkspaceCapabilityReadiness.ready,
+                ),
+                chat: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.chat,
+                  readiness: WorkspaceCapabilityReadiness.ready,
+                ),
+                files: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.files,
+                  readiness: WorkspaceCapabilityReadiness.blocked,
+                ),
+                calendar: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.calendar,
+                  readiness: WorkspaceCapabilityReadiness.unavailable,
+                ),
+                boards: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.boards,
+                  readiness: WorkspaceCapabilityReadiness.unavailable,
+                ),
+              ),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(appBootstrapProvider.future);
+        await container.read(matrixIntegrationConnectionProvider.future);
+        await container.read(nextcloudIntegrationConnectionProvider.future);
+        await container.read(
+          weaveApiWorkspaceCapabilitySnapshotProvider.future,
+        );
+
+        final capabilities = container.read(
+          workspaceCapabilitySnapshotProvider,
+        );
+
+        expect(
+          capabilities.requireValue.chat.readiness,
+          WorkspaceCapabilityReadiness.ready,
+        );
+        expect(
+          capabilities.requireValue.files.readiness,
+          WorkspaceCapabilityReadiness.blocked,
         );
       },
     );

--- a/test/features/app/weave_app_backend_capability_flow_test.dart
+++ b/test/features/app/weave_app_backend_capability_flow_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/core/persistence/flutter_secure_store.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/features/auth/data/dtos/auth_session_dto.dart';
+import 'package:weave/features/auth/data/repositories/oidc_auth_session_repository.dart';
+import 'package:weave/features/auth/data/services/flutter_appauth_oidc_client.dart';
+import 'package:weave/features/auth/data/services/oidc_client.dart';
+import 'package:weave/features/chat/domain/entities/chat_security_state.dart';
+import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
+import 'package:weave/features/chat/presentation/providers/chat_security_repository_provider.dart';
+import 'package:weave/features/files/domain/entities/directory_listing.dart';
+import 'package:weave/features/files/domain/entities/files_connection_state.dart';
+import 'package:weave/features/files/domain/repositories/files_repository.dart';
+import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
+import 'package:weave/main.dart';
+
+import '../../helpers/auth_test_data.dart';
+import '../../helpers/fake_chat_repository.dart';
+import '../../helpers/fake_chat_security_repository.dart';
+import '../../helpers/in_memory_stores.dart';
+import '../../helpers/server_config_test_data.dart';
+
+class _FakeServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _FakeServerConfigurationRepository({required this.configuration});
+
+  ServerConfiguration? configuration;
+
+  @override
+  Future<void> clearConfiguration() async {
+    configuration = null;
+  }
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    this.configuration = configuration;
+  }
+}
+
+class _FakeOidcClient implements OidcClient {
+  @override
+  Future<OidcTokenBundle> authorizeAndExchangeCode(configuration) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> endSession(configuration, {required String idTokenHint}) async {}
+
+  @override
+  Future<OidcTokenBundle> refresh(
+    configuration, {
+    required String refreshToken,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+class _FakeFilesRepository implements FilesRepository {
+  _FakeFilesRepository({required this.connectionState});
+
+  final FilesConnectionState connectionState;
+
+  @override
+  Future<FilesConnectionState> connect() async => connectionState;
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<DirectoryListing> listDirectory(String path) async {
+    return DirectoryListing(path: path, entries: const []);
+  }
+
+  @override
+  Future<FilesConnectionState> restoreConnection() async => connectionState;
+}
+
+class _RecordingWeaveApiClient implements WeaveApiClient {
+  _RecordingWeaveApiClient({required this.snapshot});
+
+  final WorkspaceCapabilitySnapshot snapshot;
+  Uri? lastBaseUrl;
+  String? lastAccessToken;
+  int callCount = 0;
+
+  @override
+  Future<WorkspaceCapabilitySnapshot> fetchWorkspaceCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    callCount++;
+    lastBaseUrl = baseUrl;
+    lastAccessToken = accessToken;
+    return snapshot;
+  }
+}
+
+void main() {
+  testWidgets(
+    'consumes backend capabilities and reflects merged readiness in settings',
+    (tester) async {
+      final weaveApiClient = _RecordingWeaveApiClient(
+        snapshot: const WorkspaceCapabilitySnapshot(
+          shellAccess: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.shellAccess,
+            readiness: WorkspaceCapabilityReadiness.ready,
+          ),
+          chat: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.chat,
+            readiness: WorkspaceCapabilityReadiness.ready,
+          ),
+          files: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.files,
+            readiness: WorkspaceCapabilityReadiness.blocked,
+          ),
+          calendar: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.calendar,
+            readiness: WorkspaceCapabilityReadiness.unavailable,
+          ),
+          boards: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.boards,
+            readiness: WorkspaceCapabilityReadiness.unavailable,
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) => _FakeServerConfigurationRepository(
+                configuration: buildTestConfiguration(),
+              ),
+            ),
+            secureStoreProvider.overrideWithValue(
+              InMemorySecureStore({
+                authSessionStorageKey: AuthSessionDto.fromSession(
+                  buildTestAuthSession(accessToken: 'backend-boundary-token'),
+                ).encode(),
+              }),
+            ),
+            oidcClientProvider.overrideWithValue(_FakeOidcClient()),
+            chatRepositoryProvider.overrideWithValue(FakeChatRepository()),
+            chatSecurityRepositoryProvider.overrideWithValue(
+              FakeChatSecurityRepository(
+                loadSecurityStateHandler: ({bool refresh = false}) async {
+                  return const ChatSecurityState(
+                    isMatrixSignedIn: true,
+                    bootstrapState:
+                        ChatSecurityBootstrapState.partiallyInitialized,
+                    accountVerificationState:
+                        ChatAccountVerificationState.verificationRequired,
+                    deviceVerificationState:
+                        ChatDeviceVerificationState.unverified,
+                    keyBackupState: ChatKeyBackupState.missing,
+                    roomEncryptionReadiness:
+                        ChatRoomEncryptionReadiness.encryptedRoomsNeedAttention,
+                    secretStorageReady: false,
+                    crossSigningReady: false,
+                    hasEncryptedConversations: true,
+                    verificationSession: ChatVerificationSession.none(),
+                  );
+                },
+              ),
+            ),
+            filesRepositoryProvider.overrideWithValue(
+              _FakeFilesRepository(
+                connectionState: FilesConnectionState.connected(
+                  baseUrl: Uri.parse('https://nextcloud.home.internal'),
+                  accountLabel: 'alice',
+                ),
+              ),
+            ),
+            weaveApiClientProvider.overrideWithValue(weaveApiClient),
+          ],
+          child: const WeaveApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NavigationBar), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.settings_outlined));
+      await tester.pumpAndSettle();
+
+      expect(weaveApiClient.callCount, 1);
+      expect(
+        weaveApiClient.lastBaseUrl,
+        Uri.parse('https://api.home.internal'),
+      );
+      expect(weaveApiClient.lastAccessToken, 'backend-boundary-token');
+
+      expect(find.text('Workspace Readiness'), findsOneWidget);
+      expect(
+        find.text(
+          'Shell access is ready, but one or more services still need attention.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Server Configuration'), findsOneWidget);
+      expect(
+        find.text('Readiness: Ready', findRichText: true),
+        findsNWidgets(2),
+      );
+      expect(
+        find.text('Readiness: Blocked', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Connection: Degraded', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Connection: Connected', findRichText: true),
+        findsNWidgets(2),
+      );
+    },
+  );
+}

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -68,6 +68,32 @@ void main() {
       );
     });
 
+    test('preserves a base path when building the workspace endpoint', () async {
+      late http.BaseRequest capturedRequest;
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          capturedRequest = request;
+          return _jsonResponse({
+            'shellAccess': {'enabled': true, 'readiness': 'ready'},
+            'chat': {'enabled': true, 'readiness': 'ready'},
+            'files': {'enabled': true, 'readiness': 'ready'},
+            'calendar': {'enabled': true, 'readiness': 'ready'},
+            'boards': {'enabled': true, 'readiness': 'ready'},
+          });
+        }),
+      );
+
+      await client.fetchWorkspaceCapabilities(
+        baseUrl: Uri.parse('https://api.home.internal/service/root'),
+        accessToken: 'token-123',
+      );
+
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.home.internal/service/root/api/v1/workspace/capabilities',
+      );
+    });
+
     test(
       'rejects unauthorized backend sessions with a dedicated failure',
       () async {

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+
+class _RecordingHttpClient extends http.BaseClient {
+  _RecordingHttpClient(this._handler);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+  _handler;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _handler(request);
+  }
+}
+
+http.StreamedResponse _jsonResponse(
+  Map<String, Object?> json, {
+  int statusCode = 200,
+}) {
+  return http.StreamedResponse(
+    Stream.value(utf8.encode(jsonEncode(json))),
+    statusCode,
+    headers: {'content-type': 'application/json'},
+  );
+}
+
+void main() {
+  group('HttpWeaveApiClient', () {
+    test('fetches workspace capabilities with a bearer token', () async {
+      late http.BaseRequest capturedRequest;
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          capturedRequest = request;
+          return _jsonResponse({
+            'shellAccess': {'enabled': true, 'readiness': 'ready'},
+            'chat': {'enabled': true, 'readiness': 'degraded'},
+            'files': {'enabled': true, 'readiness': 'ready'},
+            'calendar': {'enabled': false, 'readiness': 'unavailable'},
+            'boards': {'enabled': false, 'readiness': 'unavailable'},
+          });
+        }),
+      );
+
+      final snapshot = await client.fetchWorkspaceCapabilities(
+        baseUrl: Uri.parse('https://api.home.internal'),
+        accessToken: 'token-123',
+      );
+
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.home.internal/api/v1/workspace/capabilities',
+      );
+      expect(capturedRequest.headers['authorization'], 'Bearer token-123');
+      expect(
+        snapshot.shellAccess.readiness,
+        WorkspaceCapabilityReadiness.ready,
+      );
+      expect(snapshot.chat.readiness, WorkspaceCapabilityReadiness.degraded);
+      expect(
+        snapshot.calendar.readiness,
+        WorkspaceCapabilityReadiness.unavailable,
+      );
+    });
+
+    test('throws when the backend returns a non-success response', () async {
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          return _jsonResponse({'error': 'boom'}, statusCode: 503);
+        }),
+      );
+
+      await expectLater(
+        () => client.fetchWorkspaceCapabilities(
+          baseUrl: Uri.parse('https://api.home.internal'),
+          accessToken: 'token-123',
+        ),
+        throwsA(isA<AppFailure>()),
+      );
+    });
+  });
+}

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -55,7 +55,8 @@ void main() {
         capturedRequest.url.toString(),
         'https://api.home.internal/api/v1/workspace/capabilities',
       );
-      expect(capturedRequest.headers['authorization'], 'Bearer token-123');
+      expect(capturedRequest.headers['Accept'], 'application/json');
+      expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
       expect(
         snapshot.shellAccess.readiness,
         WorkspaceCapabilityReadiness.ready,
@@ -66,6 +67,35 @@ void main() {
         WorkspaceCapabilityReadiness.unavailable,
       );
     });
+
+    test(
+      'rejects unauthorized backend sessions with a dedicated failure',
+      () async {
+        for (final statusCode in [401, 403]) {
+          final client = HttpWeaveApiClient(
+            httpClient: _RecordingHttpClient((request) async {
+              return _jsonResponse({
+                'error': 'unauthorized',
+              }, statusCode: statusCode);
+            }),
+          );
+
+          await expectLater(
+            () => client.fetchWorkspaceCapabilities(
+              baseUrl: Uri.parse('https://api.home.internal'),
+              accessToken: 'token-123',
+            ),
+            throwsA(
+              isA<AppFailure>().having(
+                (failure) => failure.message,
+                'message',
+                contains('rejected the current session'),
+              ),
+            ),
+          );
+        }
+      },
+    );
 
     test('throws when the backend returns a non-success response', () async {
       final client = HttpWeaveApiClient(


### PR DESCRIPTION
Refs #22
Depends on #23

## What changed
- added a dedicated `lib/integrations/weave_api/` boundary for backend-owned HTTP contracts
- added a typed client for `GET /api/v1/workspace/capabilities`
- taught the workspace capability provider to prefer backend readiness when available while keeping the existing local mapping as a fallback
- added client and provider tests for the new integration path

## Why
- this keeps Matrix and Nextcloud user-session flows inside the client while giving the backend a clean product-API boundary
- stacking this PR on top of #23 keeps the review focused on the backend integration layer instead of mixing it with the earlier config-contract work

## Validation
- `flutter test test/integrations/weave_api/data/services/weave_api_client_test.dart test/features/app/presentation/providers/workspace_connection_provider_test.dart test/features/settings/settings_screen_test.dart`
- `flutter test`
