### PR TITLE
feat(app): client backend integration model

### DIFF
--- a/lib/features/app/domain/entities/integration_invalidation.dart
+++ b/lib/features/app/domain/entities/integration_invalidation.dart
@@ -1,9 +1,10 @@
-enum WorkspaceIntegration { appAuth, matrix, nextcloud }
+enum WorkspaceIntegration { appAuth, matrix, nextcloud, weaveBackend }
 
 enum IntegrationInvalidationReason {
   authConfigurationChanged,
   matrixHomeserverChanged,
   nextcloudBaseUrlChanged,
+  backendApiBaseUrlChanged,
   explicitSignOut,
   restartSetup,
 }

--- a/lib/features/app/domain/use_cases/apply_server_configuration_changes.dart
+++ b/lib/features/app/domain/use_cases/apply_server_configuration_changes.dart
@@ -45,5 +45,12 @@ class ApplyServerConfigurationChanges {
         reason: IntegrationInvalidationReason.nextcloudBaseUrlChanged,
       );
     }
+
+    if (result.backendApiBaseUrlChanged) {
+      _workspaceInvalidationPort.invalidate(
+        integration: WorkspaceIntegration.weaveBackend,
+        reason: IntegrationInvalidationReason.backendApiBaseUrlChanged,
+      );
+    }
   }
 }

--- a/lib/features/app/domain/use_cases/apply_server_configuration_changes.dart
+++ b/lib/features/app/domain/use_cases/apply_server_configuration_changes.dart
@@ -28,6 +28,12 @@ class ApplyServerConfigurationChanges {
         integration: WorkspaceIntegration.appAuth,
         reason: IntegrationInvalidationReason.authConfigurationChanged,
       );
+      // The Weave backend access token is derived from the OIDC session;
+      // invalidate so it is re-fetched once the user reauthenticates.
+      _workspaceInvalidationPort.invalidate(
+        integration: WorkspaceIntegration.weaveBackend,
+        reason: IntegrationInvalidationReason.authConfigurationChanged,
+      );
     }
 
     if (result.matrixHomeserverChanged) {

--- a/lib/features/app/domain/use_cases/restart_workspace_setup.dart
+++ b/lib/features/app/domain/use_cases/restart_workspace_setup.dart
@@ -41,5 +41,9 @@ class RestartWorkspaceSetup {
       integration: WorkspaceIntegration.nextcloud,
       reason: IntegrationInvalidationReason.restartSetup,
     );
+    _workspaceInvalidationPort.invalidate(
+      integration: WorkspaceIntegration.weaveBackend,
+      reason: IntegrationInvalidationReason.restartSetup,
+    );
   }
 }

--- a/lib/features/app/domain/use_cases/sign_out_workspace.dart
+++ b/lib/features/app/domain/use_cases/sign_out_workspace.dart
@@ -49,6 +49,10 @@ class SignOutWorkspace {
       integration: WorkspaceIntegration.nextcloud,
       reason: IntegrationInvalidationReason.explicitSignOut,
     );
+    _workspaceInvalidationPort.invalidate(
+      integration: WorkspaceIntegration.weaveBackend,
+      reason: IntegrationInvalidationReason.explicitSignOut,
+    );
   }
 
   AuthConfiguration _toAuthConfiguration(ServerConfiguration configuration) {

--- a/lib/features/app/presentation/providers/workspace_connection_provider.dart
+++ b/lib/features/app/presentation/providers/workspace_connection_provider.dart
@@ -13,6 +13,7 @@ import 'package:weave/features/files/domain/entities/files_connection_state.dart
 import 'package:weave/features/files/domain/entities/files_failure.dart';
 import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 
 final appAuthIntegrationConnectionProvider =
     Provider<AsyncValue<IntegrationConnectionState>>((ref) {
@@ -119,7 +120,32 @@ final workspaceConnectionStateProvider =
 final workspaceCapabilitySnapshotProvider =
     Provider<AsyncValue<WorkspaceCapabilitySnapshot>>((ref) {
       final workspace = ref.watch(workspaceConnectionStateProvider);
-      return workspace.whenData(_mapWorkspaceCapabilitySnapshot);
+      final backendCapabilities = ref.watch(
+        weaveApiWorkspaceCapabilitySnapshotProvider,
+      );
+
+      if (workspace.hasError) {
+        return AsyncError(workspace.error!, workspace.stackTrace!);
+      }
+      if (workspace.isLoading) {
+        return const AsyncLoading();
+      }
+
+      final localSnapshot = _mapWorkspaceCapabilitySnapshot(
+        workspace.requireValue,
+      );
+
+      return switch (backendCapabilities) {
+        AsyncData(value: final snapshot) => AsyncData(
+          snapshot == null
+              ? localSnapshot
+              : _mergeWorkspaceCapabilitySnapshots(
+                  localSnapshot: localSnapshot,
+                  backendSnapshot: snapshot,
+                ),
+        ),
+        AsyncLoading() || AsyncError() => AsyncData(localSnapshot),
+      };
     });
 
 IntegrationConnectionState _mapAppAuthConnectionState(
@@ -333,6 +359,46 @@ WorkspaceCapabilitySnapshot _mapWorkspaceCapabilitySnapshot(
       capability: WorkspaceCapability.boards,
       shellAccess: connection.appAuth,
     ),
+  );
+}
+
+WorkspaceCapabilitySnapshot _mergeWorkspaceCapabilitySnapshots({
+  required WorkspaceCapabilitySnapshot localSnapshot,
+  required WorkspaceCapabilitySnapshot backendSnapshot,
+}) {
+  return WorkspaceCapabilitySnapshot(
+    shellAccess: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.shellAccess,
+      backend: backendSnapshot.shellAccess,
+    ),
+    chat: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.chat,
+      backend: backendSnapshot.chat,
+    ),
+    files: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.files,
+      backend: backendSnapshot.files,
+    ),
+    calendar: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.calendar,
+      backend: backendSnapshot.calendar,
+    ),
+    boards: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.boards,
+      backend: backendSnapshot.boards,
+    ),
+  );
+}
+
+WorkspaceCapabilityState _mergeWorkspaceCapabilityState({
+  required WorkspaceCapabilityState local,
+  required WorkspaceCapabilityState backend,
+}) {
+  return WorkspaceCapabilityState(
+    capability: local.capability,
+    readiness: backend.readiness,
+    connectionStatus: local.connectionStatus,
+    recoveryRequirement: local.recoveryRequirement,
   );
 }
 

--- a/lib/features/chat/presentation/providers/chat_provider.dart
+++ b/lib/features/chat/presentation/providers/chat_provider.dart
@@ -133,7 +133,8 @@ class ChatController extends Notifier<ChatUiState> {
       IntegrationInvalidationReason.explicitSignOut ||
       IntegrationInvalidationReason.restartSetup => false,
       IntegrationInvalidationReason.authConfigurationChanged ||
-      IntegrationInvalidationReason.nextcloudBaseUrlChanged => true,
+      IntegrationInvalidationReason.nextcloudBaseUrlChanged ||
+      IntegrationInvalidationReason.backendApiBaseUrlChanged => true,
     };
   }
 }

--- a/lib/features/server_config/domain/entities/server_configuration_save_result.dart
+++ b/lib/features/server_config/domain/entities/server_configuration_save_result.dart
@@ -6,15 +6,18 @@ class ServerConfigurationSaveResult {
     required this.authConfigurationChanged,
     required this.matrixHomeserverChanged,
     required this.nextcloudBaseUrlChanged,
+    required this.backendApiBaseUrlChanged,
   });
 
   final ServerConfiguration configuration;
   final bool authConfigurationChanged;
   final bool matrixHomeserverChanged;
   final bool nextcloudBaseUrlChanged;
+  final bool backendApiBaseUrlChanged;
 
   bool get hasSessionImpact =>
       authConfigurationChanged ||
       matrixHomeserverChanged ||
-      nextcloudBaseUrlChanged;
+      nextcloudBaseUrlChanged ||
+      backendApiBaseUrlChanged;
 }

--- a/lib/features/server_config/presentation/providers/server_configuration_form_controller.dart
+++ b/lib/features/server_config/presentation/providers/server_configuration_form_controller.dart
@@ -151,6 +151,7 @@ class ServerConfigurationFormController
   String? _initialAuthSignature;
   String? _initialMatrixSignature;
   String? _initialNextcloudSignature;
+  String? _initialBackendApiSignature;
 
   @override
   ServerConfigurationFormState build() =>
@@ -165,6 +166,7 @@ class ServerConfigurationFormController
       _initialAuthSignature = null;
       _initialMatrixSignature = null;
       _initialNextcloudSignature = null;
+      _initialBackendApiSignature = null;
       state = state.copyWith(initialized: true, clientId: oidcDefaultClientId);
       return;
     }
@@ -184,6 +186,7 @@ class ServerConfigurationFormController
     );
     _initialMatrixSignature = _matrixSignature(matrixUrl);
     _initialNextcloudSignature = _nextcloudSignature(nextcloudUrl);
+    _initialBackendApiSignature = _backendApiSignature(backendApiUrl);
 
     state = state.copyWith(
       initialized: true,
@@ -410,15 +413,23 @@ class ServerConfigurationFormController
       final nextcloudBaseUrlChanged =
           _initialNextcloudSignature != null &&
           _initialNextcloudSignature != nextNextcloudSignature;
+      final nextBackendApiSignature = _backendApiSignature(
+        backendApiUrl.toString(),
+      );
+      final backendApiBaseUrlChanged =
+          _initialBackendApiSignature != null &&
+          _initialBackendApiSignature != nextBackendApiSignature;
       _initialAuthSignature = nextAuthSignature;
       _initialMatrixSignature = nextMatrixSignature;
       _initialNextcloudSignature = nextNextcloudSignature;
+      _initialBackendApiSignature = nextBackendApiSignature;
 
       return ServerConfigurationSaveResult(
         configuration: configuration,
         authConfigurationChanged: authConfigurationChanged,
         matrixHomeserverChanged: matrixHomeserverChanged,
         nextcloudBaseUrlChanged: nextcloudBaseUrlChanged,
+        backendApiBaseUrlChanged: backendApiBaseUrlChanged,
       );
     } on AppFailure catch (failure) {
       final issuerMessage =
@@ -505,6 +516,10 @@ class ServerConfigurationFormController
 
   String _nextcloudSignature(String nextcloudBaseUrl) {
     return nextcloudBaseUrl.trim();
+  }
+
+  String _backendApiSignature(String backendApiBaseUrl) {
+    return backendApiBaseUrl.trim();
   }
 }
 

--- a/lib/features/server_config/presentation/providers/server_configuration_form_controller.g.dart
+++ b/lib/features/server_config/presentation/providers/server_configuration_form_controller.g.dart
@@ -49,7 +49,7 @@ final class ServerConfigurationFormControllerProvider
 }
 
 String _$serverConfigurationFormControllerHash() =>
-    r'7bb36cfdda04c2b5796732627004e31b1eaa4cca';
+    r'b1f3576fa379cc506fb0aa5d09bb00eb8a07e0b6';
 
 abstract class _$ServerConfigurationFormController
     extends $Notifier<ServerConfigurationFormState> {

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -369,6 +369,8 @@ class _WorkspaceReadinessRow extends StatelessWidget {
         l10n.settingsWorkspaceInvalidationMatrixHomeserverChanged,
       IntegrationInvalidationReason.nextcloudBaseUrlChanged =>
         l10n.settingsWorkspaceInvalidationNextcloudBaseUrlChanged,
+      IntegrationInvalidationReason.backendApiBaseUrlChanged =>
+        l10n.settingsWorkspaceInvalidationBackendApiBaseUrlChanged,
       IntegrationInvalidationReason.explicitSignOut =>
         l10n.settingsWorkspaceInvalidationExplicitSignOut,
       IntegrationInvalidationReason.restartSetup =>

--- a/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
@@ -1,0 +1,110 @@
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+
+class WorkspaceCapabilitiesResponseDto {
+  const WorkspaceCapabilitiesResponseDto({
+    required this.shellAccess,
+    required this.chat,
+    required this.files,
+    required this.calendar,
+    required this.boards,
+  });
+
+  factory WorkspaceCapabilitiesResponseDto.fromJson(Map<String, dynamic> json) {
+    return WorkspaceCapabilitiesResponseDto(
+      shellAccess: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'shellAccess'),
+      ),
+      chat: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'chat'),
+      ),
+      files: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'files'),
+      ),
+      calendar: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'calendar'),
+      ),
+      boards: WorkspaceCapabilityStatusDto.fromJson(
+        _readNestedJson(json, 'boards'),
+      ),
+    );
+  }
+
+  final WorkspaceCapabilityStatusDto shellAccess;
+  final WorkspaceCapabilityStatusDto chat;
+  final WorkspaceCapabilityStatusDto files;
+  final WorkspaceCapabilityStatusDto calendar;
+  final WorkspaceCapabilityStatusDto boards;
+
+  WorkspaceCapabilitySnapshot toSnapshot() {
+    return WorkspaceCapabilitySnapshot(
+      shellAccess: shellAccess.toCapabilityState(
+        WorkspaceCapability.shellAccess,
+      ),
+      chat: chat.toCapabilityState(WorkspaceCapability.chat),
+      files: files.toCapabilityState(WorkspaceCapability.files),
+      calendar: calendar.toCapabilityState(WorkspaceCapability.calendar),
+      boards: boards.toCapabilityState(WorkspaceCapability.boards),
+    );
+  }
+
+  static Map<String, dynamic> _readNestedJson(
+    Map<String, dynamic> json,
+    String key,
+  ) {
+    final value = json[key];
+    if (value is Map<String, dynamic>) {
+      return value;
+    }
+
+    throw AppFailure.unknown(
+      'The backend returned an invalid workspace capabilities response.',
+      cause: 'Expected an object for "$key".',
+    );
+  }
+}
+
+class WorkspaceCapabilityStatusDto {
+  const WorkspaceCapabilityStatusDto({
+    required this.enabled,
+    required this.readiness,
+  });
+
+  factory WorkspaceCapabilityStatusDto.fromJson(Map<String, dynamic> json) {
+    final enabled = json['enabled'];
+    final readiness = json['readiness'];
+
+    if (enabled is! bool || readiness is! String) {
+      throw AppFailure.unknown(
+        'The backend returned an invalid workspace capability item.',
+      );
+    }
+
+    return WorkspaceCapabilityStatusDto(enabled: enabled, readiness: readiness);
+  }
+
+  final bool enabled;
+  final String readiness;
+
+  WorkspaceCapabilityState toCapabilityState(WorkspaceCapability capability) {
+    return WorkspaceCapabilityState(
+      capability: capability,
+      readiness: enabled
+          ? _parseReadiness(readiness)
+          : WorkspaceCapabilityReadiness.unavailable,
+    );
+  }
+
+  WorkspaceCapabilityReadiness _parseReadiness(String rawValue) {
+    return switch (rawValue.trim()) {
+      'ready' => WorkspaceCapabilityReadiness.ready,
+      'degraded' => WorkspaceCapabilityReadiness.degraded,
+      'blocked' => WorkspaceCapabilityReadiness.blocked,
+      'unavailable' => WorkspaceCapabilityReadiness.unavailable,
+      _ => throw AppFailure.unknown(
+        'The backend returned an unknown workspace capability readiness.',
+        cause: rawValue,
+      ),
+    };
+  }
+}

--- a/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
@@ -75,7 +75,7 @@ class WorkspaceCapabilityStatusDto {
     final readiness = json['readiness'];
 
     if (enabled is! bool || readiness is! String) {
-      throw AppFailure.unknown(
+      throw const AppFailure.unknown(
         'The backend returned an invalid workspace capability item.',
       );
     }

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -23,7 +23,7 @@ class HttpWeaveApiClient implements WeaveApiClient {
     required Uri baseUrl,
     required String accessToken,
   }) async {
-    final requestUri = baseUrl.resolve('/api/v1/workspace/capabilities');
+    final requestUri = _workspaceCapabilitiesUri(baseUrl);
 
     late http.Response response;
     try {
@@ -71,5 +71,17 @@ class HttpWeaveApiClient implements WeaveApiClient {
         cause: error,
       );
     }
+  }
+
+  Uri _workspaceCapabilitiesUri(Uri baseUrl) {
+    return baseUrl.replace(
+      pathSegments: [
+        ...baseUrl.pathSegments.where((segment) => segment.isNotEmpty),
+        'api',
+        'v1',
+        'workspace',
+        'capabilities',
+      ],
+    );
   }
 }

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart';
+
+abstract interface class WeaveApiClient {
+  Future<WorkspaceCapabilitySnapshot> fetchWorkspaceCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  });
+}
+
+class HttpWeaveApiClient implements WeaveApiClient {
+  HttpWeaveApiClient({required http.Client httpClient})
+    : _httpClient = httpClient;
+
+  final http.Client _httpClient;
+
+  @override
+  Future<WorkspaceCapabilitySnapshot> fetchWorkspaceCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    final requestUri = baseUrl.resolve('/api/v1/workspace/capabilities');
+
+    late http.Response response;
+    try {
+      response = await _httpClient.get(
+        requestUri,
+        headers: {
+          'accept': 'application/json',
+          'authorization': 'Bearer $accessToken',
+        },
+      );
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to reach the Weave backend right now.',
+        cause: error,
+      );
+    }
+
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw const AppFailure.unknown(
+        'The Weave backend rejected the current session.',
+      );
+    }
+
+    if (response.statusCode != 200) {
+      throw AppFailure.unknown(
+        'The Weave backend failed to return workspace capabilities.',
+        cause: response.statusCode,
+      );
+    }
+
+    try {
+      final payload = jsonDecode(response.body);
+      if (payload is! Map<String, dynamic>) {
+        throw const AppFailure.unknown(
+          'The Weave backend returned an invalid workspace capabilities payload.',
+        );
+      }
+
+      return WorkspaceCapabilitiesResponseDto.fromJson(payload).toSnapshot();
+    } on AppFailure {
+      rethrow;
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to decode workspace capabilities from the Weave backend.',
+        cause: error,
+      );
+    }
+  }
+}

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -30,8 +30,8 @@ class HttpWeaveApiClient implements WeaveApiClient {
       response = await _httpClient.get(
         requestUri,
         headers: {
-          'accept': 'application/json',
-          'authorization': 'Bearer $accessToken',
+          'Accept': 'application/json',
+          'Authorization': 'Bearer $accessToken',
         },
       );
     } catch (error) {

--- a/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
+++ b/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
+import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_failure.dart';
+import 'package:weave/features/auth/presentation/providers/auth_session_repository_provider.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+
+final weaveApiHttpClientProvider = Provider<http.Client>((ref) {
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return client;
+});
+
+final weaveApiClientProvider = Provider<WeaveApiClient>((ref) {
+  return HttpWeaveApiClient(httpClient: ref.watch(weaveApiHttpClientProvider));
+});
+
+final weaveApiWorkspaceCapabilitySnapshotProvider =
+    FutureProvider<WorkspaceCapabilitySnapshot?>((ref) async {
+      final configuration = await ref.watch(
+        savedServerConfigurationProvider.future,
+      );
+      if (configuration == null) {
+        return null;
+      }
+
+      final bootstrapState = await ref.watch(appBootstrapProvider.future);
+      if (bootstrapState.phase != BootstrapPhase.ready) {
+        return null;
+      }
+
+      try {
+        final authState = await ref
+            .read(authSessionRepositoryProvider)
+            .restoreSession(
+              AuthConfiguration(
+                issuer: configuration.oidcIssuerUrl,
+                clientId: configuration.oidcClientRegistration.clientId.trim(),
+              ),
+            );
+        final session = authState.session;
+        if (!authState.isAuthenticated || session == null) {
+          return null;
+        }
+
+        return ref
+            .read(weaveApiClientProvider)
+            .fetchWorkspaceCapabilities(
+              baseUrl: configuration.serviceEndpoints.backendApiBaseUrl,
+              accessToken: session.accessToken,
+            );
+      } on AuthFailure {
+        return null;
+      } on AppFailure {
+        return null;
+      } catch (_) {
+        return null;
+      }
+    });

--- a/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
+++ b/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
@@ -16,12 +16,16 @@ import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart
 ///
 /// Distinct states allow the UI to surface actionable failure messages
 /// rather than silently degrading to local-only capabilities.
+///
+/// The error states ([unreachable], [unauthorized], [serverError]) are
+/// reachable because [weaveApiWorkspaceCapabilitySnapshotProvider] propagates
+/// [AppFailure] into the Riverpod error channel. The merged
+/// [workspaceCapabilitySnapshotProvider] handles the error gracefully by
+/// falling back to the local capability snapshot.
 enum WeaveBackendConnectionState {
-  /// The backend URL is not configured; no fetch is attempted.
+  /// The backend URL is not configured (or the app is not yet ready); no
+  /// fetch is attempted.
   unconfigured,
-
-  /// The app is not yet in a ready bootstrap phase; no fetch is attempted.
-  notReady,
 
   /// A fetch is in progress.
   loading,
@@ -90,11 +94,20 @@ final weaveApiWorkspaceCapabilitySnapshotProvider =
               accessToken: session.accessToken,
             );
       } on AuthFailure {
-        return null;
+        // Treat an OIDC session-restore failure as backend-unauthorised so
+        // weaveBackendConnectionStateProvider can surface the right state.
+        throw const AppFailure.unknown(
+          'The Weave backend rejected the current session.',
+        );
       } on AppFailure {
-        return null;
-      } catch (_) {
-        return null;
+        // Propagate to Riverpod error channel; workspaceCapabilitySnapshotProvider
+        // already falls back to the local snapshot on AsyncError.
+        rethrow;
+      } catch (error) {
+        throw AppFailure.unknown(
+          'The Weave backend returned an unexpected error.',
+          cause: error,
+        );
       }
     });
 

--- a/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
+++ b/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
@@ -3,12 +3,41 @@ import 'package:http/http.dart' as http;
 import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
 import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
 import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/features/app/presentation/providers/workspace_invalidation_provider.dart';
 import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
 import 'package:weave/features/auth/domain/entities/auth_failure.dart';
 import 'package:weave/features/auth/presentation/providers/auth_session_repository_provider.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
 import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+
+/// Connection state for the Weave backend integration.
+///
+/// Distinct states allow the UI to surface actionable failure messages
+/// rather than silently degrading to local-only capabilities.
+enum WeaveBackendConnectionState {
+  /// The backend URL is not configured; no fetch is attempted.
+  unconfigured,
+
+  /// The app is not yet in a ready bootstrap phase; no fetch is attempted.
+  notReady,
+
+  /// A fetch is in progress.
+  loading,
+
+  /// Capabilities were successfully fetched from the backend.
+  connected,
+
+  /// The backend could not be reached (network error or DNS failure).
+  unreachable,
+
+  /// The backend rejected the current session token (HTTP 401 or 403).
+  unauthorized,
+
+  /// The backend returned an unexpected error response.
+  serverError,
+}
 
 final weaveApiHttpClientProvider = Provider<http.Client>((ref) {
   final client = http.Client();
@@ -22,6 +51,12 @@ final weaveApiClientProvider = Provider<WeaveApiClient>((ref) {
 
 final weaveApiWorkspaceCapabilitySnapshotProvider =
     FutureProvider<WorkspaceCapabilitySnapshot?>((ref) async {
+      // Watch the invalidation signal so explicit invalidations (sign-out,
+      // restart-setup, URL change) trigger a re-fetch beyond just config changes.
+      ref.watch(
+        integrationInvalidationProvider(WorkspaceIntegration.weaveBackend),
+      );
+
       final configuration = await ref.watch(
         savedServerConfigurationProvider.future,
       );
@@ -61,4 +96,40 @@ final weaveApiWorkspaceCapabilitySnapshotProvider =
       } catch (_) {
         return null;
       }
+    });
+
+/// Maps the backend capability provider state to a distinct [WeaveBackendConnectionState].
+///
+/// This provider is the testable surface for "is the backend reachable, authorized,
+/// or unconfigured?" — separate from the merged [workspaceCapabilitySnapshotProvider].
+final weaveBackendConnectionStateProvider =
+    Provider<WeaveBackendConnectionState>((ref) {
+      // Watch the invalidation signal to ensure this provider also re-evaluates
+      // on explicit invalidations.
+      ref.watch(
+        integrationInvalidationProvider(WorkspaceIntegration.weaveBackend),
+      );
+
+      final backendAsync = ref.watch(
+        weaveApiWorkspaceCapabilitySnapshotProvider,
+      );
+
+      return backendAsync.when(
+        loading: () => WeaveBackendConnectionState.loading,
+        error: (error, _) {
+          if (error is AppFailure) {
+            final msg = error.message;
+            if (msg.contains('rejected the current session')) {
+              return WeaveBackendConnectionState.unauthorized;
+            }
+            if (msg.contains('reach the Weave backend')) {
+              return WeaveBackendConnectionState.unreachable;
+            }
+          }
+          return WeaveBackendConnectionState.serverError;
+        },
+        data: (snapshot) => snapshot == null
+            ? WeaveBackendConnectionState.unconfigured
+            : WeaveBackendConnectionState.connected,
+      );
     });

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -88,6 +88,7 @@
   "settingsWorkspaceInvalidationNextcloudBaseUrlChanged": "Nextcloud-Basis-URL geändert",
   "settingsWorkspaceInvalidationExplicitSignOut": "Manuell abgemeldet",
   "settingsWorkspaceInvalidationRestartSetup": "Einrichtung neu gestartet",
+  "settingsWorkspaceInvalidationBackendApiBaseUrlChanged": "Backend-API-URL ge\u00e4ndert",
   "chatSecuritySectionTitle": "Matrix-Sicherheit",
   "chatSecuritySectionDescription": "Weave behandelt Matrix-Verschlüsselung nur dann als gesund, wenn Secret Storage, Cross-Signing, Wiederherstellung und Gerätevertrauen vollständig eingerichtet sind.",
   "chatSecurityRecoveryKeyTitle": "Diesen Matrix-Wiederherstellungsschlüssel jetzt sichern",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -542,6 +542,9 @@
   "settingsWorkspaceInvalidationRestartSetup": "Restarted setup",
   "@settingsWorkspaceInvalidationRestartSetup": { "description": "Invalidation label for restart-setup actions" },
 
+  "settingsWorkspaceInvalidationBackendApiBaseUrlChanged": "Backend API URL changed",
+  "@settingsWorkspaceInvalidationBackendApiBaseUrlChanged": { "description": "Invalidation label for backend API base URL changes" },
+
   "settingsServerConfigurationDescription": "Update the provider and service URLs Weave should use for your self-hosted environment.",
   "@settingsServerConfigurationDescription": { "description": "Description for the settings server configuration section" },
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1118,6 +1118,12 @@ abstract class AppLocalizations {
   /// **'Restarted setup'**
   String get settingsWorkspaceInvalidationRestartSetup;
 
+  /// Invalidation label for backend API base URL changes
+  ///
+  /// In en, this message translates to:
+  /// **'Backend API URL changed'**
+  String get settingsWorkspaceInvalidationBackendApiBaseUrlChanged;
+
   /// Description for the settings server configuration section
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -605,6 +605,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Einrichtung neu gestartet';
 
   @override
+  String get settingsWorkspaceInvalidationBackendApiBaseUrlChanged =>
+      'Backend-API-URL geändert';
+
+  @override
   String get settingsServerConfigurationDescription =>
       'Aktualisiere den Anbieter und die Dienst-URLs, die Weave für deine selbst gehostete Umgebung verwenden soll.';
 

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -592,6 +592,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsWorkspaceInvalidationRestartSetup => 'Restarted setup';
 
   @override
+  String get settingsWorkspaceInvalidationBackendApiBaseUrlChanged =>
+      'Backend API URL changed';
+
+  @override
   String get settingsServerConfigurationDescription =>
       'Update the provider and service URLs Weave should use for your self-hosted environment.';
 

--- a/test/features/app/domain/use_cases/workspace_orchestration_test.dart
+++ b/test/features/app/domain/use_cases/workspace_orchestration_test.dart
@@ -153,6 +153,12 @@ void main() {
         workspaceInvalidationPort.lastReasonFor(WorkspaceIntegration.nextcloud),
         IntegrationInvalidationReason.explicitSignOut,
       );
+      expect(
+        workspaceInvalidationPort.lastReasonFor(
+          WorkspaceIntegration.weaveBackend,
+        ),
+        IntegrationInvalidationReason.explicitSignOut,
+      );
     });
 
     test('clears local auth when no complete configuration is saved', () async {
@@ -208,6 +214,12 @@ void main() {
         expect(
           workspaceInvalidationPort.lastReasonFor(
             WorkspaceIntegration.nextcloud,
+          ),
+          IntegrationInvalidationReason.restartSetup,
+        );
+        expect(
+          workspaceInvalidationPort.lastReasonFor(
+            WorkspaceIntegration.weaveBackend,
           ),
           IntegrationInvalidationReason.restartSetup,
         );
@@ -301,6 +313,12 @@ void main() {
       expect(authPort.clearLocalSessionCalls, 1);
       expect(
         workspaceInvalidationPort.lastReasonFor(WorkspaceIntegration.appAuth),
+        IntegrationInvalidationReason.authConfigurationChanged,
+      );
+      expect(
+        workspaceInvalidationPort.lastReasonFor(
+          WorkspaceIntegration.weaveBackend,
+        ),
         IntegrationInvalidationReason.authConfigurationChanged,
       );
     });

--- a/test/features/app/domain/use_cases/workspace_orchestration_test.dart
+++ b/test/features/app/domain/use_cases/workspace_orchestration_test.dart
@@ -234,6 +234,7 @@ void main() {
           authConfigurationChanged: false,
           matrixHomeserverChanged: true,
           nextcloudBaseUrlChanged: false,
+          backendApiBaseUrlChanged: false,
         ),
       );
 
@@ -264,6 +265,7 @@ void main() {
           authConfigurationChanged: false,
           matrixHomeserverChanged: false,
           nextcloudBaseUrlChanged: true,
+          backendApiBaseUrlChanged: false,
         ),
       );
 
@@ -292,6 +294,7 @@ void main() {
           authConfigurationChanged: true,
           matrixHomeserverChanged: false,
           nextcloudBaseUrlChanged: false,
+          backendApiBaseUrlChanged: false,
         ),
       );
 
@@ -301,5 +304,35 @@ void main() {
         IntegrationInvalidationReason.authConfigurationChanged,
       );
     });
+
+    test(
+      'records weaveBackend invalidation when backend API URL changes',
+      () async {
+        final workspaceInvalidationPort = _FakeWorkspaceInvalidationPort();
+        final useCase = ApplyServerConfigurationChanges(
+          authPort: _FakeAppAuthPort(),
+          chatSessionPort: _FakeChatSessionPort(),
+          filesSessionPort: _FakeFilesSessionPort(),
+          workspaceInvalidationPort: workspaceInvalidationPort,
+        );
+
+        await useCase.call(
+          ServerConfigurationSaveResult(
+            configuration: buildTestConfiguration(),
+            authConfigurationChanged: false,
+            matrixHomeserverChanged: false,
+            nextcloudBaseUrlChanged: false,
+            backendApiBaseUrlChanged: true,
+          ),
+        );
+
+        expect(
+          workspaceInvalidationPort.lastReasonFor(
+            WorkspaceIntegration.weaveBackend,
+          ),
+          IntegrationInvalidationReason.backendApiBaseUrlChanged,
+        );
+      },
+    );
   });
 }

--- a/test/features/app/presentation/providers/workspace_connection_provider_test.dart
+++ b/test/features/app/presentation/providers/workspace_connection_provider_test.dart
@@ -15,6 +15,7 @@ import 'package:weave/features/files/domain/entities/files_connection_state.dart
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
 import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 
 import '../../../../helpers/fake_chat_security_repository.dart';
 import '../../../../helpers/server_config_test_data.dart';
@@ -277,6 +278,97 @@ void main() {
         expect(
           capabilities.requireValue.files.readiness,
           WorkspaceCapabilityReadiness.ready,
+        );
+      },
+    );
+
+    test(
+      'prefers backend capability readiness when a backend snapshot exists',
+      () async {
+        final container = ProviderContainer.test(
+          overrides: [
+            appBootstrapProvider.overrideWith(
+              () => _FakeAppBootstrap(const BootstrapState.ready()),
+            ),
+            savedServerConfigurationProvider.overrideWith(
+              (ref) async => buildTestConfiguration(),
+            ),
+            chatSecurityRepositoryProvider.overrideWithValue(
+              FakeChatSecurityRepository(
+                loadSecurityStateHandler: ({bool refresh = false}) async {
+                  return const ChatSecurityState(
+                    isMatrixSignedIn: true,
+                    bootstrapState:
+                        ChatSecurityBootstrapState.partiallyInitialized,
+                    accountVerificationState:
+                        ChatAccountVerificationState.verificationRequired,
+                    deviceVerificationState:
+                        ChatDeviceVerificationState.unverified,
+                    keyBackupState: ChatKeyBackupState.missing,
+                    roomEncryptionReadiness:
+                        ChatRoomEncryptionReadiness.encryptedRoomsNeedAttention,
+                    secretStorageReady: false,
+                    crossSigningReady: false,
+                    hasEncryptedConversations: true,
+                    verificationSession: ChatVerificationSession.none(),
+                  );
+                },
+              ),
+            ),
+            filesRepositoryProvider.overrideWithValue(
+              _FakeFilesRepository(
+                connectionState: FilesConnectionState.connected(
+                  baseUrl: Uri.parse('https://nextcloud.home.internal'),
+                  accountLabel: 'alice',
+                ),
+              ),
+            ),
+            weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+              (ref) async => const WorkspaceCapabilitySnapshot(
+                shellAccess: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.shellAccess,
+                  readiness: WorkspaceCapabilityReadiness.ready,
+                ),
+                chat: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.chat,
+                  readiness: WorkspaceCapabilityReadiness.ready,
+                ),
+                files: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.files,
+                  readiness: WorkspaceCapabilityReadiness.blocked,
+                ),
+                calendar: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.calendar,
+                  readiness: WorkspaceCapabilityReadiness.unavailable,
+                ),
+                boards: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.boards,
+                  readiness: WorkspaceCapabilityReadiness.unavailable,
+                ),
+              ),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(appBootstrapProvider.future);
+        await container.read(matrixIntegrationConnectionProvider.future);
+        await container.read(nextcloudIntegrationConnectionProvider.future);
+        await container.read(
+          weaveApiWorkspaceCapabilitySnapshotProvider.future,
+        );
+
+        final capabilities = container.read(
+          workspaceCapabilitySnapshotProvider,
+        );
+
+        expect(
+          capabilities.requireValue.chat.readiness,
+          WorkspaceCapabilityReadiness.ready,
+        );
+        expect(
+          capabilities.requireValue.files.readiness,
+          WorkspaceCapabilityReadiness.blocked,
         );
       },
     );

--- a/test/features/app/weave_app_backend_capability_flow_test.dart
+++ b/test/features/app/weave_app_backend_capability_flow_test.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/core/persistence/flutter_secure_store.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/features/auth/data/dtos/auth_session_dto.dart';
+import 'package:weave/features/auth/data/repositories/oidc_auth_session_repository.dart';
+import 'package:weave/features/auth/data/services/flutter_appauth_oidc_client.dart';
+import 'package:weave/features/auth/data/services/oidc_client.dart';
+import 'package:weave/features/chat/domain/entities/chat_security_state.dart';
+import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
+import 'package:weave/features/chat/presentation/providers/chat_security_repository_provider.dart';
+import 'package:weave/features/files/domain/entities/directory_listing.dart';
+import 'package:weave/features/files/domain/entities/files_connection_state.dart';
+import 'package:weave/features/files/domain/repositories/files_repository.dart';
+import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
+import 'package:weave/main.dart';
+
+import '../../helpers/auth_test_data.dart';
+import '../../helpers/fake_chat_repository.dart';
+import '../../helpers/fake_chat_security_repository.dart';
+import '../../helpers/in_memory_stores.dart';
+import '../../helpers/server_config_test_data.dart';
+
+class _FakeServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _FakeServerConfigurationRepository({required this.configuration});
+
+  ServerConfiguration? configuration;
+
+  @override
+  Future<void> clearConfiguration() async {
+    configuration = null;
+  }
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    this.configuration = configuration;
+  }
+}
+
+class _FakeOidcClient implements OidcClient {
+  @override
+  Future<OidcTokenBundle> authorizeAndExchangeCode(configuration) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> endSession(configuration, {required String idTokenHint}) async {}
+
+  @override
+  Future<OidcTokenBundle> refresh(
+    configuration, {
+    required String refreshToken,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+class _FakeFilesRepository implements FilesRepository {
+  _FakeFilesRepository({required this.connectionState});
+
+  final FilesConnectionState connectionState;
+
+  @override
+  Future<FilesConnectionState> connect() async => connectionState;
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<DirectoryListing> listDirectory(String path) async {
+    return DirectoryListing(path: path, entries: const []);
+  }
+
+  @override
+  Future<FilesConnectionState> restoreConnection() async => connectionState;
+}
+
+class _RecordingWeaveApiClient implements WeaveApiClient {
+  _RecordingWeaveApiClient({required this.snapshot});
+
+  final WorkspaceCapabilitySnapshot snapshot;
+  Uri? lastBaseUrl;
+  String? lastAccessToken;
+  int callCount = 0;
+
+  @override
+  Future<WorkspaceCapabilitySnapshot> fetchWorkspaceCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    callCount++;
+    lastBaseUrl = baseUrl;
+    lastAccessToken = accessToken;
+    return snapshot;
+  }
+}
+
+void main() {
+  testWidgets(
+    'consumes backend capabilities and reflects merged readiness in settings',
+    (tester) async {
+      final weaveApiClient = _RecordingWeaveApiClient(
+        snapshot: const WorkspaceCapabilitySnapshot(
+          shellAccess: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.shellAccess,
+            readiness: WorkspaceCapabilityReadiness.ready,
+          ),
+          chat: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.chat,
+            readiness: WorkspaceCapabilityReadiness.ready,
+          ),
+          files: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.files,
+            readiness: WorkspaceCapabilityReadiness.blocked,
+          ),
+          calendar: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.calendar,
+            readiness: WorkspaceCapabilityReadiness.unavailable,
+          ),
+          boards: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.boards,
+            readiness: WorkspaceCapabilityReadiness.unavailable,
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) => _FakeServerConfigurationRepository(
+                configuration: buildTestConfiguration(),
+              ),
+            ),
+            secureStoreProvider.overrideWithValue(
+              InMemorySecureStore({
+                authSessionStorageKey: AuthSessionDto.fromSession(
+                  buildTestAuthSession(accessToken: 'backend-boundary-token'),
+                ).encode(),
+              }),
+            ),
+            oidcClientProvider.overrideWithValue(_FakeOidcClient()),
+            chatRepositoryProvider.overrideWithValue(FakeChatRepository()),
+            chatSecurityRepositoryProvider.overrideWithValue(
+              FakeChatSecurityRepository(
+                loadSecurityStateHandler: ({bool refresh = false}) async {
+                  return const ChatSecurityState(
+                    isMatrixSignedIn: true,
+                    bootstrapState:
+                        ChatSecurityBootstrapState.partiallyInitialized,
+                    accountVerificationState:
+                        ChatAccountVerificationState.verificationRequired,
+                    deviceVerificationState:
+                        ChatDeviceVerificationState.unverified,
+                    keyBackupState: ChatKeyBackupState.missing,
+                    roomEncryptionReadiness:
+                        ChatRoomEncryptionReadiness.encryptedRoomsNeedAttention,
+                    secretStorageReady: false,
+                    crossSigningReady: false,
+                    hasEncryptedConversations: true,
+                    verificationSession: ChatVerificationSession.none(),
+                  );
+                },
+              ),
+            ),
+            filesRepositoryProvider.overrideWithValue(
+              _FakeFilesRepository(
+                connectionState: FilesConnectionState.connected(
+                  baseUrl: Uri.parse('https://nextcloud.home.internal'),
+                  accountLabel: 'alice',
+                ),
+              ),
+            ),
+            weaveApiClientProvider.overrideWithValue(weaveApiClient),
+          ],
+          child: const WeaveApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NavigationBar), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.settings_outlined));
+      await tester.pumpAndSettle();
+
+      expect(weaveApiClient.callCount, 1);
+      expect(
+        weaveApiClient.lastBaseUrl,
+        Uri.parse('https://api.home.internal'),
+      );
+      expect(weaveApiClient.lastAccessToken, 'backend-boundary-token');
+
+      expect(find.text('Workspace Readiness'), findsOneWidget);
+      expect(
+        find.text(
+          'Shell access is ready, but one or more services still need attention.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Server Configuration'), findsOneWidget);
+      expect(
+        find.text('Readiness: Ready', findRichText: true),
+        findsNWidgets(2),
+      );
+      expect(
+        find.text('Readiness: Blocked', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Connection: Degraded', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Connection: Connected', findRichText: true),
+        findsNWidgets(2),
+      );
+    },
+  );
+}

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -68,6 +68,32 @@ void main() {
       );
     });
 
+    test('preserves a base path when building the workspace endpoint', () async {
+      late http.BaseRequest capturedRequest;
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          capturedRequest = request;
+          return _jsonResponse({
+            'shellAccess': {'enabled': true, 'readiness': 'ready'},
+            'chat': {'enabled': true, 'readiness': 'ready'},
+            'files': {'enabled': true, 'readiness': 'ready'},
+            'calendar': {'enabled': true, 'readiness': 'ready'},
+            'boards': {'enabled': true, 'readiness': 'ready'},
+          });
+        }),
+      );
+
+      await client.fetchWorkspaceCapabilities(
+        baseUrl: Uri.parse('https://api.home.internal/service/root'),
+        accessToken: 'token-123',
+      );
+
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.home.internal/service/root/api/v1/workspace/capabilities',
+      );
+    });
+
     test(
       'rejects unauthorized backend sessions with a dedicated failure',
       () async {

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+
+class _RecordingHttpClient extends http.BaseClient {
+  _RecordingHttpClient(this._handler);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+  _handler;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _handler(request);
+  }
+}
+
+http.StreamedResponse _jsonResponse(
+  Map<String, Object?> json, {
+  int statusCode = 200,
+}) {
+  return http.StreamedResponse(
+    Stream.value(utf8.encode(jsonEncode(json))),
+    statusCode,
+    headers: {'content-type': 'application/json'},
+  );
+}
+
+void main() {
+  group('HttpWeaveApiClient', () {
+    test('fetches workspace capabilities with a bearer token', () async {
+      late http.BaseRequest capturedRequest;
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          capturedRequest = request;
+          return _jsonResponse({
+            'shellAccess': {'enabled': true, 'readiness': 'ready'},
+            'chat': {'enabled': true, 'readiness': 'degraded'},
+            'files': {'enabled': true, 'readiness': 'ready'},
+            'calendar': {'enabled': false, 'readiness': 'unavailable'},
+            'boards': {'enabled': false, 'readiness': 'unavailable'},
+          });
+        }),
+      );
+
+      final snapshot = await client.fetchWorkspaceCapabilities(
+        baseUrl: Uri.parse('https://api.home.internal'),
+        accessToken: 'token-123',
+      );
+
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.home.internal/api/v1/workspace/capabilities',
+      );
+      expect(capturedRequest.headers['authorization'], 'Bearer token-123');
+      expect(
+        snapshot.shellAccess.readiness,
+        WorkspaceCapabilityReadiness.ready,
+      );
+      expect(snapshot.chat.readiness, WorkspaceCapabilityReadiness.degraded);
+      expect(
+        snapshot.calendar.readiness,
+        WorkspaceCapabilityReadiness.unavailable,
+      );
+    });
+
+    test('throws when the backend returns a non-success response', () async {
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          return _jsonResponse({'error': 'boom'}, statusCode: 503);
+        }),
+      );
+
+      await expectLater(
+        () => client.fetchWorkspaceCapabilities(
+          baseUrl: Uri.parse('https://api.home.internal'),
+          accessToken: 'token-123',
+        ),
+        throwsA(isA<AppFailure>()),
+      );
+    });
+  });
+}

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -55,7 +55,8 @@ void main() {
         capturedRequest.url.toString(),
         'https://api.home.internal/api/v1/workspace/capabilities',
       );
-      expect(capturedRequest.headers['authorization'], 'Bearer token-123');
+      expect(capturedRequest.headers['Accept'], 'application/json');
+      expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
       expect(
         snapshot.shellAccess.readiness,
         WorkspaceCapabilityReadiness.ready,
@@ -66,6 +67,35 @@ void main() {
         WorkspaceCapabilityReadiness.unavailable,
       );
     });
+
+    test(
+      'rejects unauthorized backend sessions with a dedicated failure',
+      () async {
+        for (final statusCode in [401, 403]) {
+          final client = HttpWeaveApiClient(
+            httpClient: _RecordingHttpClient((request) async {
+              return _jsonResponse({
+                'error': 'unauthorized',
+              }, statusCode: statusCode);
+            }),
+          );
+
+          await expectLater(
+            () => client.fetchWorkspaceCapabilities(
+              baseUrl: Uri.parse('https://api.home.internal'),
+              accessToken: 'token-123',
+            ),
+            throwsA(
+              isA<AppFailure>().having(
+                (failure) => failure.message,
+                'message',
+                contains('rejected the current session'),
+              ),
+            ),
+          );
+        }
+      },
+    );
 
     test('throws when the backend returns a non-success response', () async {
       final client = HttpWeaveApiClient(

--- a/test/integrations/weave_api/presentation/providers/weave_backend_connection_state_test.dart
+++ b/test/integrations/weave_api/presentation/providers/weave_backend_connection_state_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
+
+void main() {
+  group('weaveBackendConnectionStateProvider', () {
+    test('returns unconfigured when snapshot is null', () {
+      final container = ProviderContainer.test(
+        overrides: [
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
+            const AsyncData<WorkspaceCapabilitySnapshot?>(null),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(weaveBackendConnectionStateProvider),
+        WeaveBackendConnectionState.unconfigured,
+      );
+    });
+
+    test('returns unreachable when backend cannot be reached', () {
+      final container = ProviderContainer.test(
+        overrides: [
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
+            AsyncError<WorkspaceCapabilitySnapshot?>(
+              AppFailure.unknown('Unable to reach the Weave backend right now.'),
+              StackTrace.empty,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(weaveBackendConnectionStateProvider),
+        WeaveBackendConnectionState.unreachable,
+      );
+    });
+
+    test('returns unauthorized when backend rejects session token', () {
+      final container = ProviderContainer.test(
+        overrides: [
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
+            AsyncError<WorkspaceCapabilitySnapshot?>(
+              AppFailure.unknown(
+                'The Weave backend rejected the current session.',
+              ),
+              StackTrace.empty,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(weaveBackendConnectionStateProvider),
+        WeaveBackendConnectionState.unauthorized,
+      );
+    });
+
+    test('returns serverError for other AppFailure messages', () {
+      final container = ProviderContainer.test(
+        overrides: [
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
+            AsyncError<WorkspaceCapabilitySnapshot?>(
+              AppFailure.unknown('Unexpected server problem.'),
+              StackTrace.empty,
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(weaveBackendConnectionStateProvider),
+        WeaveBackendConnectionState.serverError,
+      );
+    });
+  });
+}

--- a/test/integrations/weave_api/presentation/providers/weave_backend_connection_state_test.dart
+++ b/test/integrations/weave_api/presentation/providers/weave_backend_connection_state_test.dart
@@ -4,8 +4,47 @@ import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 
+const _connectedSnapshot = WorkspaceCapabilitySnapshot(
+  shellAccess: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.shellAccess,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+  chat: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.chat,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+  files: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.files,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+  calendar: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.calendar,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+  boards: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.boards,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+);
+
 void main() {
   group('weaveBackendConnectionStateProvider', () {
+    test('returns loading when snapshot is loading', () {
+      final container = ProviderContainer.test(
+        overrides: [
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
+            const AsyncLoading<WorkspaceCapabilitySnapshot?>(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(weaveBackendConnectionStateProvider),
+        WeaveBackendConnectionState.loading,
+      );
+    });
+
     test('returns unconfigured when snapshot is null', () {
       final container = ProviderContainer.test(
         overrides: [
@@ -22,12 +61,30 @@ void main() {
       );
     });
 
+    test('returns connected when snapshot is non-null', () {
+      final container = ProviderContainer.test(
+        overrides: [
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
+            const AsyncData<WorkspaceCapabilitySnapshot?>(_connectedSnapshot),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(weaveBackendConnectionStateProvider),
+        WeaveBackendConnectionState.connected,
+      );
+    });
+
     test('returns unreachable when backend cannot be reached', () {
       final container = ProviderContainer.test(
         overrides: [
           weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
-            AsyncError<WorkspaceCapabilitySnapshot?>(
-              AppFailure.unknown('Unable to reach the Weave backend right now.'),
+            const AsyncError<WorkspaceCapabilitySnapshot?>(
+              AppFailure.unknown(
+                'Unable to reach the Weave backend right now.',
+              ),
               StackTrace.empty,
             ),
           ),
@@ -45,7 +102,7 @@ void main() {
       final container = ProviderContainer.test(
         overrides: [
           weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
-            AsyncError<WorkspaceCapabilitySnapshot?>(
+            const AsyncError<WorkspaceCapabilitySnapshot?>(
               AppFailure.unknown(
                 'The Weave backend rejected the current session.',
               ),
@@ -66,7 +123,7 @@ void main() {
       final container = ProviderContainer.test(
         overrides: [
           weaveApiWorkspaceCapabilitySnapshotProvider.overrideWithValue(
-            AsyncError<WorkspaceCapabilitySnapshot?>(
+            const AsyncError<WorkspaceCapabilitySnapshot?>(
               AppFailure.unknown('Unexpected server problem.'),
               StackTrace.empty,
             ),


### PR DESCRIPTION
Closes #26

## What changed
- `weaveBackend` added to `WorkspaceIntegration`; `backendApiBaseUrlChanged` added to `IntegrationInvalidationReason`
- `ServerConfigurationSaveResult` now includes `backendApiBaseUrlChanged`; detected via signature comparison in `ServerConfigurationFormController`
- `ApplyServerConfigurationChanges`, `SignOutWorkspace`, and `RestartWorkspaceSetup` all wire `weaveBackend` invalidation
- `weaveApiWorkspaceCapabilitySnapshotProvider` watches the `weaveBackend` invalidation signal
- Added `WeaveBackendConnectionState` enum and `weaveBackendConnectionStateProvider`: `unreachable` and `unauthorized` are distinct testable states

## Validation
- `flutter analyze --fatal-infos`: no issues
- `flutter test`: 164/164 passed