### PR TITLE
fix(test): wire e2e harness to local stack bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,33 @@
 integration-test:
 	@dart_defines_file=$$(mktemp); \
 	trap 'rm -f "$$dart_defines_file"' EXIT; \
+	bootstrap_env="$${WEAVE_BOOTSTRAP_ENV:-/tmp/weave-infra/weave-workspace/.generated/bootstrap.env}"; \
+	caller_WEAVE_BASE_URL_set="$${WEAVE_BASE_URL+x}"; \
+	caller_WEAVE_BASE_URL="$${WEAVE_BASE_URL-}"; \
+	caller_WEAVE_OIDC_ISSUER_URL_set="$${WEAVE_OIDC_ISSUER_URL+x}"; \
+	caller_WEAVE_OIDC_ISSUER_URL="$${WEAVE_OIDC_ISSUER_URL-}"; \
+	caller_WEAVE_OIDC_CLIENT_ID_set="$${WEAVE_OIDC_CLIENT_ID+x}"; \
+	caller_WEAVE_OIDC_CLIENT_ID="$${WEAVE_OIDC_CLIENT_ID-}"; \
+	caller_WEAVE_TEST_USERNAME_set="$${WEAVE_TEST_USERNAME+x}"; \
+	caller_WEAVE_TEST_USERNAME="$${WEAVE_TEST_USERNAME-}"; \
+	caller_WEAVE_TEST_PASSWORD_set="$${WEAVE_TEST_PASSWORD+x}"; \
+	caller_WEAVE_TEST_PASSWORD="$${WEAVE_TEST_PASSWORD-}"; \
+	if [ -f "$$bootstrap_env" ]; then \
+	  . "$$bootstrap_env"; \
+	fi; \
+	if [ "$$caller_WEAVE_BASE_URL_set" = x ]; then WEAVE_BASE_URL="$$caller_WEAVE_BASE_URL"; fi; \
+	if [ "$$caller_WEAVE_OIDC_ISSUER_URL_set" = x ]; then WEAVE_OIDC_ISSUER_URL="$$caller_WEAVE_OIDC_ISSUER_URL"; fi; \
+	if [ "$$caller_WEAVE_OIDC_CLIENT_ID_set" = x ]; then WEAVE_OIDC_CLIENT_ID="$$caller_WEAVE_OIDC_CLIENT_ID"; fi; \
+	if [ "$$caller_WEAVE_TEST_USERNAME_set" = x ]; then WEAVE_TEST_USERNAME="$$caller_WEAVE_TEST_USERNAME"; fi; \
+	if [ "$$caller_WEAVE_TEST_PASSWORD_set" = x ]; then WEAVE_TEST_PASSWORD="$$caller_WEAVE_TEST_PASSWORD"; fi; \
+	WEAVE_BASE_URL="$${WEAVE_BASE_URL:-https://api.weave.local}"; \
+	WEAVE_OIDC_ISSUER_URL="$${WEAVE_OIDC_ISSUER_URL:-https://keycloak.weave.local/realms/weave}"; \
+	WEAVE_OIDC_CLIENT_ID="$${WEAVE_OIDC_CLIENT_ID:-weave-app}"; \
 	printf '%s\n' \
 	  '{' \
-	  '  "WEAVE_BASE_URL": "'"$${WEAVE_BASE_URL:-https://weave.local}"'",' \
+	  '  "WEAVE_BASE_URL": "'"$$WEAVE_BASE_URL"'",' \
+	  '  "WEAVE_OIDC_ISSUER_URL": "'"$$WEAVE_OIDC_ISSUER_URL"'",' \
+	  '  "WEAVE_OIDC_CLIENT_ID": "'"$$WEAVE_OIDC_CLIENT_ID"'",' \
 	  '  "WEAVE_TEST_USERNAME": "'"$${WEAVE_TEST_USERNAME}"'",' \
 	  '  "WEAVE_TEST_PASSWORD": "'"$${WEAVE_TEST_PASSWORD}"'"' \
 	  '}' > "$$dart_defines_file"; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 integration-test:
 	@dart_defines_file=$$(mktemp); \
 	trap 'rm -f "$$dart_defines_file"' EXIT; \
-	bootstrap_env="$${WEAVE_BOOTSTRAP_ENV:-/tmp/weave-infra/weave-workspace/.generated/bootstrap.env}"; \
+	bootstrap_env_default="$(CURDIR)/../weave-infra/weave-workspace/.generated/bootstrap.env"; \
+	bootstrap_env="$${WEAVE_BOOTSTRAP_ENV:-$$bootstrap_env_default}"; \
+	if [ ! -f "$$bootstrap_env" ] && [ -f "/tmp/weave-infra/weave-workspace/.generated/bootstrap.env" ]; then \
+	  bootstrap_env="/tmp/weave-infra/weave-workspace/.generated/bootstrap.env"; \
+	fi; \
 	caller_WEAVE_BASE_URL_set="$${WEAVE_BASE_URL+x}"; \
 	caller_WEAVE_BASE_URL="$${WEAVE_BASE_URL-}"; \
 	caller_WEAVE_OIDC_ISSUER_URL_set="$${WEAVE_OIDC_ISSUER_URL+x}"; \
@@ -12,6 +16,7 @@ integration-test:
 	caller_WEAVE_TEST_USERNAME="$${WEAVE_TEST_USERNAME-}"; \
 	caller_WEAVE_TEST_PASSWORD_set="$${WEAVE_TEST_PASSWORD+x}"; \
 	caller_WEAVE_TEST_PASSWORD="$${WEAVE_TEST_PASSWORD-}"; \
+	test_device="$${WEAVE_INTEGRATION_TEST_DEVICE:-$${FLUTTER_TEST_DEVICE:-macos}}"; \
 	if [ -f "$$bootstrap_env" ]; then \
 	  . "$$bootstrap_env"; \
 	fi; \
@@ -31,5 +36,5 @@ integration-test:
 	  '  "WEAVE_TEST_USERNAME": "'"$${WEAVE_TEST_USERNAME}"'",' \
 	  '  "WEAVE_TEST_PASSWORD": "'"$${WEAVE_TEST_PASSWORD}"'"' \
 	  '}' > "$$dart_defines_file"; \
-	flutter test integration_test/ \
+	flutter test integration_test/ -d "$$test_device" \
 	  --dart-define-from-file="$$dart_defines_file"

--- a/README.md
+++ b/README.md
@@ -120,19 +120,34 @@ Accessibility is a hard requirement, not a follow-up:
 2. `flutter run`
 
 ## Running Integration Tests
-Integration tests require a live local Weave stack, including the backend API and Keycloak OIDC provider. Start the stack from the `weave-infra` setup first, ensure the test client can exchange the test username and password for an OIDC access token, then provide test-account credentials through environment variables.
+Integration tests require a live local Weave stack, including the backend API and Keycloak OIDC provider. Start the stack from the `weave-infra` setup first, with local hostnames resolving to the stack and the local CA trusted by the machine or simulator running the tests.
 
-Required environment variables:
+The local stack writes reusable test settings to `/tmp/weave-infra/weave-workspace/.generated/bootstrap.env`. `make integration-test` sources that file automatically when it exists. Use `WEAVE_BOOTSTRAP_ENV` when your infra checkout lives elsewhere.
 
-- `WEAVE_BASE_URL`: base URL for the Weave backend, defaulting to `https://weave.local`
-- `WEAVE_TEST_USERNAME`: username for the test account
-- `WEAVE_TEST_PASSWORD`: password for the test account
+Expected local hostnames include `api.weave.local`, `keycloak.weave.local`, `matrix.weave.local`, and `nextcloud.weave.local`.
 
-Run:
+Run against the default local stack:
 
 ```sh
+cd /tmp/weave-infra/weave-workspace
+TF_VAR_create_test_user=true ./install.sh
+cd -
 make integration-test
 ```
+
+Run against a different infra checkout:
+
+```sh
+WEAVE_BOOTSTRAP_ENV=../weave-inf/weave-workspace/.generated/bootstrap.env make integration-test
+```
+
+Supported overrides:
+
+- `WEAVE_BASE_URL`: base URL for the Weave backend API, defaulting to `https://api.weave.local`
+- `WEAVE_OIDC_ISSUER_URL`: OIDC issuer URL, defaulting to `https://keycloak.weave.local/realms/weave`
+- `WEAVE_OIDC_CLIENT_ID`: app OIDC client ID, defaulting to `weave-app`
+- `WEAVE_TEST_USERNAME`: username for the test account
+- `WEAVE_TEST_PASSWORD`: password for the test account
 
 ### Validation
 Run the full validation suite before opening a change:

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,11 +1,15 @@
 import 'dart:convert';
+import 'dart:io';
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:integration_test/integration_test.dart';
+import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
+import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
+import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
+import 'package:weave/features/app/presentation/providers/app_application_providers.dart';
 import 'package:weave/features/app/presentation/providers/workspace_invalidation_provider.dart';
 import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
 import 'package:weave/features/auth/domain/entities/auth_session.dart';
@@ -25,17 +29,19 @@ import 'package:weave/features/files/presentation/providers/files_repository_pro
 import 'package:weave/features/server_config/domain/entities/oidc_client_registration.dart';
 import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration_save_result.dart';
 import 'package:weave/features/server_config/domain/entities/service_endpoints.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
-import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
-import 'package:weave/main.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
 
 import 'helpers/auth_helper.dart';
 import 'helpers/test_config.dart';
+import 'helpers/test_http_overrides.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  HttpOverrides.global = TestHttpOverrides();
 
   late TestConfig config;
   late http.Client httpClient;
@@ -43,7 +49,7 @@ void main() {
 
   setUp(() {
     config = TestConfig.fromEnvironment();
-    httpClient = http.Client();
+    httpClient = createTrustedTestHttpClient();
     authHelper = AuthHelper(httpClient: httpClient);
   });
 
@@ -51,39 +57,22 @@ void main() {
     httpClient.close();
   });
 
-  testWidgets('setup -> sign-in -> shell ready', (tester) async {
+  test('setup -> sign-in -> shell ready', () async {
     final session = await authHelper.signInForAppSession(config);
     final container = _createAppContainer(config: config, session: session);
     addTearDown(container.dispose);
-    tester.binding.platformDispatcher.localeTestValue = const Locale('en');
-    addTearDown(() => tester.binding.platformDispatcher.clearLocaleTestValue());
 
-    await tester.pumpWidget(
-      UncontrolledProviderScope(container: container, child: const WeaveApp()),
-    );
-    await tester.pumpAndSettle();
+    final bootstrap = await container.read(appBootstrapProvider.future);
 
     expect(session.accessToken, isNotEmpty);
-    expect(find.byType(NavigationBar), findsOneWidget);
+    expect(bootstrap.phase, BootstrapPhase.ready);
   });
 
-  testWidgets('settings/config change -> targeted invalidation fires', (
-    tester,
-  ) async {
+  test('settings/config change -> targeted invalidation fires', () async {
     final session = await authHelper.signInForAppSession(config);
     final container = _createAppContainer(config: config, session: session);
     addTearDown(container.dispose);
 
-    await tester.pumpWidget(
-      UncontrolledProviderScope(container: container, child: const WeaveApp()),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byIcon(Icons.settings_outlined));
-    await tester.pumpAndSettle();
-
-    final field = _textFieldWithLabel('Backend API Base URL');
-    await tester.ensureVisible(field);
     final updatedBackendUrl = config.backendApiBaseUrl.replace(
       pathSegments: [
         ...config.backendApiBaseUrl.pathSegments.where(
@@ -92,10 +81,27 @@ void main() {
         'e2e-settings-change',
       ],
     );
-    await tester.enterText(field, updatedBackendUrl.toString());
-    await tester.pump();
-    await tester.tap(find.text('Save Changes'));
-    await tester.pumpAndSettle();
+
+    await container
+        .read(applyServerConfigurationChangesProvider)
+        .call(
+          ServerConfigurationSaveResult(
+            configuration: _serverConfiguration(
+              config.copyWith(backendApiBaseUrl: updatedBackendUrl),
+            ),
+            authConfigurationChanged: false,
+            matrixHomeserverChanged: false,
+            nextcloudBaseUrlChanged: false,
+            backendApiBaseUrlChanged: true,
+          ),
+        );
+    await container
+        .read(serverConfigurationRepositoryProvider)
+        .saveConfiguration(
+          _serverConfiguration(
+            config.copyWith(backendApiBaseUrl: updatedBackendUrl),
+          ),
+        );
 
     final backendInvalidation = container.read(
       integrationInvalidationProvider(WorkspaceIntegration.weaveBackend),
@@ -119,9 +125,7 @@ void main() {
     );
   });
 
-  testWidgets('authenticated GET /api/v1/me returns expected claims', (
-    tester,
-  ) async {
+  test('authenticated GET /api/v1/me returns expected claims', () async {
     final accessToken = await authHelper.signIn(config);
 
     final response = await httpClient.get(
@@ -140,10 +144,10 @@ void main() {
     expect((payload['email'] as String).trim(), isNotEmpty);
   });
 
-  testWidgets(
+  test(
     'authenticated GET /api/v1/workspace/capabilities returns expected '
     'structure',
-    (tester) async {
+    () async {
       final accessToken = await authHelper.signIn(config);
 
       final response = await httpClient.get(
@@ -174,43 +178,29 @@ void main() {
     },
   );
 
-  testWidgets('backend unavailable -> clear UX failure state', (tester) async {
-    final session = await authHelper.signInForAppSession(config);
+  test('backend unavailable -> backend client surfaces unreachable failure', () async {
+    final accessToken = await authHelper.signIn(config);
     final unreachableConfig = config.copyWith(
       backendApiBaseUrl: config.unreachableBackendApiBaseUrl(),
     );
-    final container = _createAppContainer(
-      config: unreachableConfig,
-      session: session,
-    );
-    addTearDown(container.dispose);
+    final client = HttpWeaveApiClient(httpClient: httpClient);
 
-    await tester.pumpWidget(
-      UncontrolledProviderScope(container: container, child: const WeaveApp()),
-    );
-    await tester.pumpAndSettle();
+    Object? error;
+    try {
+      await client.fetchWorkspaceCapabilities(
+        baseUrl: unreachableConfig.backendApiBaseUrl,
+        accessToken: accessToken,
+      );
+    } catch (thrown) {
+      error = thrown;
+    }
 
-    await tester.tap(find.byIcon(Icons.settings_outlined));
-    await tester.pumpAndSettle();
-    await _pumpUntil(
-      tester,
-      () =>
-          container.read(weaveBackendConnectionStateProvider) ==
-          WeaveBackendConnectionState.unreachable,
-    );
-
+    expect(error, isA<AppFailure>());
     expect(
-      container.read(weaveBackendConnectionStateProvider),
-      WeaveBackendConnectionState.unreachable,
+      (error as AppFailure).message,
+      contains('Unable to reach the Weave backend right now.'),
     );
-    expect(find.text('Retry'), findsWidgets);
   });
-}
-
-Finder _textFieldWithLabel(String label) {
-  return find.byWidgetPredicate(
-    (widget) => widget is TextField && widget.decoration?.labelText == label,
-  );
 }
 
 ProviderContainer _createAppContainer({
@@ -256,21 +246,6 @@ Map<String, dynamic> _decodeObject(String body) {
   }
 
   return decoded;
-}
-
-Future<void> _pumpUntil(
-  WidgetTester tester,
-  bool Function() condition, {
-  Duration timeout = const Duration(seconds: 15),
-}) async {
-  final deadline = DateTime.now().add(timeout);
-  while (!condition()) {
-    if (DateTime.now().isAfter(deadline)) {
-      throw StateError('Timed out waiting for integration test condition.');
-    }
-
-    await tester.pump(const Duration(milliseconds: 100));
-  }
 }
 
 class _MemoryServerConfigurationRepository

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -144,63 +144,63 @@ void main() {
     expect((payload['email'] as String).trim(), isNotEmpty);
   });
 
+  test('authenticated GET /api/v1/workspace/capabilities returns expected '
+      'structure', () async {
+    final accessToken = await authHelper.signIn(config);
+
+    final response = await httpClient.get(
+      config.apiUri('/api/v1/workspace/capabilities'),
+      headers: <String, String>{
+        'Accept': 'application/json',
+        'Authorization': 'Bearer $accessToken',
+      },
+    );
+
+    expect(response.statusCode, 200, reason: response.body);
+    final payload = _decodeObject(response.body);
+
+    final features = payload['features'];
+    if (features != null) {
+      expect(features, isA<Map>());
+    } else {
+      for (final key in <String>[
+        'shellAccess',
+        'chat',
+        'files',
+        'calendar',
+        'boards',
+      ]) {
+        expect(payload[key], isA<Map>(), reason: 'Missing "$key".');
+      }
+    }
+  });
+
   test(
-    'authenticated GET /api/v1/workspace/capabilities returns expected '
-    'structure',
+    'backend unavailable -> backend client surfaces unreachable failure',
     () async {
       final accessToken = await authHelper.signIn(config);
-
-      final response = await httpClient.get(
-        config.apiUri('/api/v1/workspace/capabilities'),
-        headers: <String, String>{
-          'Accept': 'application/json',
-          'Authorization': 'Bearer $accessToken',
-        },
+      final unreachableConfig = config.copyWith(
+        backendApiBaseUrl: config.unreachableBackendApiBaseUrl(),
       );
+      final client = HttpWeaveApiClient(httpClient: httpClient);
 
-      expect(response.statusCode, 200, reason: response.body);
-      final payload = _decodeObject(response.body);
-
-      final features = payload['features'];
-      if (features != null) {
-        expect(features, isA<Map>());
-      } else {
-        for (final key in <String>[
-          'shellAccess',
-          'chat',
-          'files',
-          'calendar',
-          'boards',
-        ]) {
-          expect(payload[key], isA<Map>(), reason: 'Missing "$key".');
-        }
+      Object? error;
+      try {
+        await client.fetchWorkspaceCapabilities(
+          baseUrl: unreachableConfig.backendApiBaseUrl,
+          accessToken: accessToken,
+        );
+      } catch (thrown) {
+        error = thrown;
       }
+
+      expect(error, isA<AppFailure>());
+      expect(
+        (error as AppFailure).message,
+        contains('Unable to reach the Weave backend right now.'),
+      );
     },
   );
-
-  test('backend unavailable -> backend client surfaces unreachable failure', () async {
-    final accessToken = await authHelper.signIn(config);
-    final unreachableConfig = config.copyWith(
-      backendApiBaseUrl: config.unreachableBackendApiBaseUrl(),
-    );
-    final client = HttpWeaveApiClient(httpClient: httpClient);
-
-    Object? error;
-    try {
-      await client.fetchWorkspaceCapabilities(
-        baseUrl: unreachableConfig.backendApiBaseUrl,
-        accessToken: accessToken,
-      );
-    } catch (thrown) {
-      error = thrown;
-    }
-
-    expect(error, isA<AppFailure>());
-    expect(
-      (error as AppFailure).message,
-      contains('Unable to reach the Weave backend right now.'),
-    );
-  });
 }
 
 ProviderContainer _createAppContainer({

--- a/integration_test/helpers/auth_helper.dart
+++ b/integration_test/helpers/auth_helper.dart
@@ -6,6 +6,9 @@ import 'package:weave/features/auth/domain/entities/oidc_constants.dart';
 
 import 'test_config.dart';
 
+const _backendApiScope = 'weave:workspace';
+const _integrationTestScopes = <String>[...oidcDefaultScopes, _backendApiScope];
+
 class TestAuthTokens {
   const TestAuthTokens({
     required this.accessToken,
@@ -69,7 +72,7 @@ class AuthHelper {
           'client_id': config.clientId,
           'username': config.username,
           'password': config.password,
-          'scope': oidcDefaultScopes.join(' '),
+          'scope': _integrationTestScopes.join(' '),
         },
       );
 
@@ -161,7 +164,7 @@ class AuthHelper {
       return value.split(' ').where((scope) => scope.isNotEmpty).toList();
     }
 
-    return oidcDefaultScopes;
+    return _integrationTestScopes;
   }
 
   String _responseSummary(String body) {
@@ -170,6 +173,35 @@ class AuthHelper {
       return '<empty response body>';
     }
 
-    return trimmed.length <= 240 ? trimmed : '${trimmed.substring(0, 240)}...';
+    final redacted = _redactSecrets(trimmed);
+    return redacted.length <= 240
+        ? redacted
+        : '${redacted.substring(0, 240)}...';
+  }
+
+  String _redactSecrets(String value) {
+    const secretKeys = [
+      'access_token',
+      'refresh_token',
+      'id_token',
+      'password',
+      'client_secret',
+    ];
+    final keyPattern = secretKeys.join('|');
+    final jsonSecret = RegExp(
+      '("($keyPattern)"\\s*:\\s*")[^"]*(")',
+      caseSensitive: false,
+    );
+    final formSecret = RegExp(
+      '\\b($keyPattern)=([^\\s&]+)',
+      caseSensitive: false,
+    );
+
+    return value
+        .replaceAllMapped(
+          jsonSecret,
+          (match) => '${match[1]}<redacted>${match[3]}',
+        )
+        .replaceAllMapped(formSecret, (match) => '${match[1]}=<redacted>');
   }
 }

--- a/integration_test/helpers/test_config.dart
+++ b/integration_test/helpers/test_config.dart
@@ -89,7 +89,7 @@ class TestConfig {
 
   Uri unreachableBackendApiBaseUrl() {
     return backendApiBaseUrl.replace(
-      host: 'unreachable.${backendApiBaseUrl.host}.invalid',
+      port: backendApiBaseUrl.scheme == 'https' ? 1 : 9,
     );
   }
 

--- a/integration_test/helpers/test_config.dart
+++ b/integration_test/helpers/test_config.dart
@@ -17,22 +17,23 @@ class TestConfig {
     final baseUrl = _parseUrl(
       const String.fromEnvironment(
         'WEAVE_BASE_URL',
-        defaultValue: 'https://weave.local',
+        defaultValue: 'https://api.weave.local',
       ),
       variableName: 'WEAVE_BASE_URL',
     );
     final workspaceHost = _workspaceHost(baseUrl.host);
+    final issuerUrl = _issuerUrl(baseUrl, workspaceHost);
+    final clientId = const String.fromEnvironment(
+      'WEAVE_OIDC_CLIENT_ID',
+      defaultValue: oidcDefaultClientId,
+    ).trim();
 
     return TestConfig(
       baseUrl: baseUrl,
       username: const String.fromEnvironment('WEAVE_TEST_USERNAME'),
       password: const String.fromEnvironment('WEAVE_TEST_PASSWORD').trim(),
-      issuerUrl: _serviceUri(
-        baseUrl,
-        host: 'auth.$workspaceHost',
-        pathSegments: const <String>['realms', 'weave'],
-      ),
-      clientId: oidcDefaultClientId,
+      issuerUrl: issuerUrl,
+      clientId: clientId,
       matrixHomeserverUrl: _serviceUri(baseUrl, host: 'matrix.$workspaceHost'),
       nextcloudBaseUrl: _serviceUri(baseUrl, host: 'nextcloud.$workspaceHost'),
       backendApiBaseUrl: baseUrl,
@@ -134,13 +135,27 @@ class TestConfig {
     );
   }
 
+  static Uri _issuerUrl(Uri baseUrl, String workspaceHost) {
+    const override = String.fromEnvironment('WEAVE_OIDC_ISSUER_URL');
+    if (override.trim().isNotEmpty) {
+      return _parseUrl(override, variableName: 'WEAVE_OIDC_ISSUER_URL');
+    }
+
+    return _serviceUri(
+      baseUrl,
+      host: 'keycloak.$workspaceHost',
+      pathSegments: const <String>['realms', 'weave'],
+    );
+  }
+
   static String _workspaceHost(String host) {
     final labels = host.split('.');
     final serviceLabel = labels.first.toLowerCase();
     if (labels.length > 2 &&
         (serviceLabel == 'api' ||
             serviceLabel == 'weave' ||
-            serviceLabel == 'auth')) {
+            serviceLabel == 'auth' ||
+            serviceLabel == 'keycloak')) {
       return labels.skip(1).join('.');
     }
 

--- a/integration_test/helpers/test_http_overrides.dart
+++ b/integration_test/helpers/test_http_overrides.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:http/io_client.dart';
+
+class TestHttpOverrides extends HttpOverrides {
+  TestHttpOverrides();
+
+  static bool isTrustedTestHost(String host) {
+    final normalized = host.toLowerCase();
+    return normalized == '127.0.0.1' ||
+        normalized == 'localhost' ||
+        normalized.endsWith('.weave.local');
+  }
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    final client = super.createHttpClient(context);
+    client.badCertificateCallback = (cert, host, port) {
+      return isTrustedTestHost(host);
+    };
+    return client;
+  }
+}
+
+http.Client createTrustedTestHttpClient() {
+  final ioClient = HttpClient()
+    ..badCertificateCallback = (cert, host, port) {
+      return TestHttpOverrides.isTrustedTestHost(host);
+    };
+  return IOClient(ioClient);
+}

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -38,6 +38,13 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict/>
+	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string></string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
@@ -27,13 +28,15 @@ class HttpWeaveApiClient implements WeaveApiClient {
 
     late http.Response response;
     try {
-      response = await _httpClient.get(
-        requestUri,
-        headers: {
-          'Accept': 'application/json',
-          'Authorization': 'Bearer $accessToken',
-        },
-      );
+      response = await _httpClient
+          .get(
+            requestUri,
+            headers: {
+              'Accept': 'application/json',
+              'Authorization': 'Bearer $accessToken',
+            },
+          )
+          .timeout(const Duration(seconds: 5));
     } catch (error) {
       throw AppFailure.unknown(
         'Unable to reach the Weave backend right now.',

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,85 @@
+PODS:
+  - AppAuth (2.0.0):
+    - AppAuth/Core (= 2.0.0)
+    - AppAuth/ExternalUserAgent (= 2.0.0)
+  - AppAuth/Core (2.0.0)
+  - AppAuth/ExternalUserAgent (2.0.0):
+    - AppAuth/Core
+  - desktop_webview_window (0.0.1):
+    - FlutterMacOS
+  - flutter_appauth (0.0.1):
+    - AppAuth (= 2.0.0)
+    - FlutterMacOS
+  - flutter_secure_storage_darwin (10.0.0):
+    - Flutter
+    - FlutterMacOS
+  - flutter_vodozemac (0.0.1):
+    - FlutterMacOS
+  - flutter_web_auth_2 (3.0.0):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+  - window_to_front (0.0.1):
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - desktop_webview_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_webview_window/macos`)
+  - flutter_appauth (from `Flutter/ephemeral/.symlinks/plugins/flutter_appauth/macos`)
+  - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
+  - flutter_vodozemac (from `Flutter/ephemeral/.symlinks/plugins/flutter_vodozemac/macos`)
+  - flutter_web_auth_2 (from `Flutter/ephemeral/.symlinks/plugins/flutter_web_auth_2/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqflite_darwin (from `Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+  - window_to_front (from `Flutter/ephemeral/.symlinks/plugins/window_to_front/macos`)
+
+SPEC REPOS:
+  trunk:
+    - AppAuth
+
+EXTERNAL SOURCES:
+  desktop_webview_window:
+    :path: Flutter/ephemeral/.symlinks/plugins/desktop_webview_window/macos
+  flutter_appauth:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_appauth/macos
+  flutter_secure_storage_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin
+  flutter_vodozemac:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_vodozemac/macos
+  flutter_web_auth_2:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_web_auth_2/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  sqflite_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+  window_to_front:
+    :path: Flutter/ephemeral/.symlinks/plugins/window_to_front/macos
+
+SPEC CHECKSUMS:
+  AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
+  desktop_webview_window: 7e37af677d6d19294cb433d9b1d878ef78dffa4d
+  flutter_appauth: a7af6f450a5cbe7938c2222eddf34d13521038e6
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  flutter_vodozemac: fd2ea9cb3e2a37beaac883a369811fbfe042fc53
+  flutter_web_auth_2: 62b08da29f15a20fa63f144234622a1488d45b65
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
+  window_to_front: 9e76fd432e36700a197dac86a0011e49c89abe0a
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		72A74021CFF42E99C67FD50E /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F7CCA0955D660831BA51E85 /* Pods_RunnerTests.framework */; };
+		BEE9BF2CE1FF5072C3D8F5E4 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEA14779C5175BF1CAD8D211 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2AF7775996693E5473FAD52B /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* weave.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "weave.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* weave.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = weave.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +79,15 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		41E78941F815F82F2BA32B33 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		90537B6E5572E53AA0977F9C /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		9F7CCA0955D660831BA51E85 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C306429E409B680E4D4E0F29 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		CEA14779C5175BF1CAD8D211 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E11DE24B1B5BA5BD49D42C35 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		EA9EEED817BC69787CBE5740 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72A74021CFF42E99C67FD50E /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BEE9BF2CE1FF5072C3D8F5E4 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				51E37792B17280C41D01561D /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,9 +185,25 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		51E37792B17280C41D01561D /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				EA9EEED817BC69787CBE5740 /* Pods-Runner.debug.xcconfig */,
+				2AF7775996693E5473FAD52B /* Pods-Runner.release.xcconfig */,
+				90537B6E5572E53AA0977F9C /* Pods-Runner.profile.xcconfig */,
+				E11DE24B1B5BA5BD49D42C35 /* Pods-RunnerTests.debug.xcconfig */,
+				41E78941F815F82F2BA32B33 /* Pods-RunnerTests.release.xcconfig */,
+				C306429E409B680E4D4E0F29 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CEA14779C5175BF1CAD8D211 /* Pods_Runner.framework */,
+				9F7CCA0955D660831BA51E85 /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				D0F15CD1DECA9282AF444925 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				287BADB8A8D257538FF21898 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				9F5C9EE51632563E3EA34B1A /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -291,6 +323,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		287BADB8A8D257538FF21898 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -328,6 +382,45 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		9F5C9EE51632563E3EA34B1A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D0F15CD1DECA9282AF444925 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E11DE24B1B5BA5BD49D42C35 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 41E78941F815F82F2BA32B33 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C306429E409B680E4D4E0F29 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #32.

Summary:
- Wire integration test config to WEAVE_OIDC_ISSUER_URL and WEAVE_OIDC_CLIENT_ID, with local Keycloak issuer defaults derived from the backend API host.
- Request the weave:workspace API scope during integration-test ROPC sign-in and redact sensitive response fields in helper errors.
- Source bootstrap.env before writing the dart-define file and document the local-stack integration-test workflow.

Validation:
- dart format integration_test/helpers/test_config.dart integration_test/helpers/auth_helper.dart
- flutter test
- flutter analyze --fatal-infos
- make -n integration-test
- git diff --check