### PR TITLE
test: cover release-one golden paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 Weave is an accessibility-first Flutter client for self-hosted collaboration stacks. It is being built around a repository-first, feature-first architecture so future protocol integrations can land behind stable domain boundaries instead of leaking transport logic into presentation code.
 
 ## Vision
-Weave aims to unify the core mobile workflows for self-hosted environments:
+Weave aims to unify the core mobile workflows for self-hosted environments.
 
-- Identity through OIDC providers such as Authentik and Keycloak
-- Communication through Matrix
-- Files, calendars, and deck-style planning through Nextcloud-backed services
+Release 1 is intentionally narrower:
+
+- identity through OIDC providers such as Authentik and Keycloak
+- communication through Matrix
+- files through Nextcloud-backed services
+
+Calendar and Deck remain future product areas, not Release 1 promises.
 
 ## Current foundation
 The app now starts through an explicit bootstrap phase before the router is built. Startup resolves into one of:
@@ -85,6 +89,11 @@ Inside each shared integration:
 Today, Nextcloud auth, session persistence, login-flow handling, bearer fallback, and connection lifecycle live under `lib/integrations/nextcloud/`, while `features/files/` stays focused on DAV directory browsing and file-domain mapping.
 
 See [docs/architecture.md](docs/architecture.md) for the detailed design notes.
+
+## Release 1 boundary
+The first public release only presents Chat, Files, and Settings in the main app shell.
+
+Calendar and Deck code may still exist behind the scenes while those features are under construction, but they are not presented as release-ready surfaces.
 
 ## Matrix Chat
 Chat is the first real post-auth product slice in the app shell:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,8 +41,8 @@ Shell destinations:
 
 - Chat
 - Files
-- Calendar
-- Deck
+- Calendar (future, not part of Release 1 navigation)
+- Deck (future, not part of Release 1 navigation)
 - Settings
 
 ## Shared server configuration

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -5,9 +5,7 @@ import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
 import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
 import 'package:weave/core/router/app_routes.dart';
 import 'package:weave/features/auth/presentation/sign_in_screen.dart';
-import 'package:weave/features/calendar/presentation/calendar_screen.dart';
 import 'package:weave/features/chat/presentation/chat_screen.dart';
-import 'package:weave/features/deck/presentation/deck_screen.dart';
 import 'package:weave/features/files/presentation/files_screen.dart';
 import 'package:weave/features/onboarding/presentation/setup_flow.dart';
 import 'package:weave/features/onboarding/presentation/welcome_screen.dart';
@@ -33,6 +31,13 @@ GoRouter appRouter(Ref ref) {
           state.matchedLocation == AppRoutes.welcome ||
           state.matchedLocation == AppRoutes.setup;
       final onSignIn = state.matchedLocation == AppRoutes.signIn;
+      final onHiddenReleaseOneRoute =
+          state.matchedLocation == AppRoutes.calendar ||
+          state.matchedLocation == AppRoutes.deck;
+
+      if (onHiddenReleaseOneRoute) {
+        return AppRoutes.chat;
+      }
 
       switch (bootstrapState.phase) {
         case BootstrapPhase.loading:
@@ -76,22 +81,6 @@ GoRouter appRouter(Ref ref) {
               GoRoute(
                 path: AppRoutes.files,
                 builder: (context, state) => const FilesScreen(),
-              ),
-            ],
-          ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: AppRoutes.calendar,
-                builder: (context, state) => const CalendarScreen(),
-              ),
-            ],
-          ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: AppRoutes.deck,
-                builder: (context, state) => const DeckScreen(),
               ),
             ],
           ),

--- a/lib/features/shell/presentation/app_shell.dart
+++ b/lib/features/shell/presentation/app_shell.dart
@@ -50,28 +50,6 @@ class AppShell extends StatelessWidget {
           ),
           NavigationDestination(
             icon: Icon(
-              Icons.calendar_today_outlined,
-              semanticLabel: l10n.semanticCalendarIcon,
-            ),
-            selectedIcon: Icon(
-              Icons.calendar_month,
-              semanticLabel: l10n.semanticCalendarIcon,
-            ),
-            label: l10n.navCalendar,
-          ),
-          NavigationDestination(
-            icon: Icon(
-              Icons.dashboard_outlined,
-              semanticLabel: l10n.semanticDeckIcon,
-            ),
-            selectedIcon: Icon(
-              Icons.dashboard,
-              semanticLabel: l10n.semanticDeckIcon,
-            ),
-            label: l10n.navDeck,
-          ),
-          NavigationDestination(
-            icon: Icon(
               Icons.settings_outlined,
               semanticLabel: l10n.semanticSettingsIcon,
             ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6,7 +6,7 @@
   "welcomeTitle": "Welcome to Weave",
   "@welcomeTitle": { "description": "Main heading on the welcome screen" },
 
-  "welcomeSubtitle": "Your unified collaboration hub — messaging, files, and calendar in one place.",
+  "welcomeSubtitle": "Your unified collaboration hub for messaging, files, and secure self-hosted access.",
   "@welcomeSubtitle": { "description": "Subtitle text below the welcome heading" },
 
   "continueButton": "Get Started",
@@ -207,7 +207,7 @@
   "settingsScreenTitle": "Settings",
   "@settingsScreenTitle": { "description": "Title for the settings screen app bar" },
 
-  "settingsBrandSectionDescription": "Weave brings messaging, files, and calendar into one workspace while this screen manages the server connection behind it.",
+  "settingsBrandSectionDescription": "Weave Release 1 focuses on messaging, files, and the server connection that holds them together.",
   "@settingsBrandSectionDescription": { "description": "Subtle branded copy shown in the settings header card" },
 
   "chatSecuritySectionTitle": "Matrix security",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -113,7 +113,7 @@ abstract class AppLocalizations {
   /// Subtitle text below the welcome heading
   ///
   /// In en, this message translates to:
-  /// **'Your unified collaboration hub — messaging, files, and calendar in one place.'**
+  /// **'Your unified collaboration hub for messaging, files, and secure self-hosted access.'**
   String get welcomeSubtitle;
 
   /// Label for the primary CTA on the welcome screen
@@ -461,7 +461,7 @@ abstract class AppLocalizations {
   /// Subtle branded copy shown in the settings header card
   ///
   /// In en, this message translates to:
-  /// **'Weave brings messaging, files, and calendar into one workspace while this screen manages the server connection behind it.'**
+  /// **'Weave Release 1 focuses on messaging, files, and the server connection that holds them together.'**
   String get settingsBrandSectionDescription;
 
   /// Section title for Matrix security status and actions in settings

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -16,7 +16,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get welcomeSubtitle =>
-      'Your unified collaboration hub — messaging, files, and calendar in one place.';
+      'Your unified collaboration hub for messaging, files, and secure self-hosted access.';
 
   @override
   String get continueButton => 'Get Started';
@@ -208,7 +208,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsBrandSectionDescription =>
-      'Weave brings messaging, files, and calendar into one workspace while this screen manages the server connection behind it.';
+      'Weave Release 1 focuses on messaging, files, and the server connection that holds them together.';
 
   @override
   String get chatSecuritySectionTitle => 'Matrix security';

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -145,6 +145,34 @@ void main() {
       expect(find.byType(ChatScreen), findsOneWidget);
     });
 
+    testWidgets('redirects hidden release-one routes back to chat when ready', (
+      tester,
+    ) async {
+      final secureStore = InMemorySecureStore();
+      await secureStore.write(
+        authSessionStorageKey,
+        AuthSessionDto.fromSession(buildTestAuthSession()).encode(),
+      );
+      final container = createContainer(
+        configuration: buildTestConfiguration(),
+        secureStore: secureStore,
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const WeaveApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      container.read(appRouterProvider).go(AppRoutes.calendar);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ChatScreen), findsOneWidget);
+    });
+
     testWidgets('redirects shell routes back to welcome when setup is needed', (
       tester,
     ) async {

--- a/test/features/app/release_golden_paths_test.dart
+++ b/test/features/app/release_golden_paths_test.dart
@@ -1,0 +1,616 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
+import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
+import 'package:weave/core/persistence/flutter_secure_store.dart';
+import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
+import 'package:weave/features/app/presentation/providers/workspace_connection_provider.dart';
+import 'package:weave/features/auth/data/dtos/auth_session_dto.dart';
+import 'package:weave/features/auth/data/repositories/oidc_auth_session_repository.dart';
+import 'package:weave/features/auth/data/services/flutter_appauth_oidc_client.dart';
+import 'package:weave/features/auth/data/services/oidc_client.dart';
+import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
+import 'package:weave/features/chat/domain/entities/chat_failure.dart';
+import 'package:weave/features/chat/domain/entities/chat_security_state.dart';
+import 'package:weave/features/chat/domain/repositories/chat_repository.dart';
+import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
+import 'package:weave/features/chat/presentation/providers/chat_security_repository_provider.dart';
+import 'package:weave/features/files/domain/entities/directory_listing.dart';
+import 'package:weave/features/files/domain/entities/file_entry.dart';
+import 'package:weave/features/files/domain/entities/files_connection_state.dart';
+import 'package:weave/features/files/domain/repositories/files_repository.dart';
+import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration_save_result.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/features/auth/presentation/providers/auth_flow_controller.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
+import 'package:weave/main.dart';
+
+import '../../helpers/auth_test_data.dart';
+import '../../helpers/fake_chat_security_repository.dart';
+import '../../helpers/in_memory_stores.dart';
+import '../../helpers/server_config_test_data.dart';
+
+class _FakeServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _FakeServerConfigurationRepository({required this.configuration});
+
+  ServerConfiguration? configuration;
+
+  @override
+  Future<void> clearConfiguration() async {
+    configuration = null;
+  }
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    this.configuration = configuration;
+  }
+}
+
+class _FakeOidcClient implements OidcClient {
+  _FakeOidcClient({this.authorizeHandler, this.refreshHandler});
+
+  Future<OidcTokenBundle> Function()? authorizeHandler;
+  Future<OidcTokenBundle> Function(String refreshToken)? refreshHandler;
+
+  @override
+  Future<OidcTokenBundle> authorizeAndExchangeCode(configuration) async {
+    final handler = authorizeHandler;
+    if (handler == null) {
+      throw UnimplementedError();
+    }
+
+    return handler();
+  }
+
+  @override
+  Future<void> endSession(configuration, {required String idTokenHint}) async {}
+
+  @override
+  Future<OidcTokenBundle> refresh(
+    configuration, {
+    required String refreshToken,
+  }) async {
+    final handler = refreshHandler;
+    if (handler == null) {
+      throw UnimplementedError();
+    }
+
+    return handler(refreshToken);
+  }
+}
+
+class _MutableFilesRepository implements FilesRepository {
+  _MutableFilesRepository({
+    required FilesConnectionState initialConnectionState,
+    required Map<String, DirectoryListing> listings,
+    FilesConnectionState? connectedState,
+  }) : _connectionState = initialConnectionState,
+       _listings = listings,
+       _connectedState =
+           connectedState ??
+           FilesConnectionState.connected(
+             baseUrl: Uri.parse('https://nextcloud.home.internal'),
+             accountLabel: 'alice',
+           );
+
+  FilesConnectionState _connectionState;
+  final Map<String, DirectoryListing> _listings;
+  final FilesConnectionState _connectedState;
+  int connectCalls = 0;
+  int disconnectCalls = 0;
+  final List<String> listedPaths = <String>[];
+
+  @override
+  Future<FilesConnectionState> connect() async {
+    connectCalls++;
+    _connectionState = _connectedState;
+    return _connectionState;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    disconnectCalls++;
+    _connectionState = FilesConnectionState.disconnected(
+      baseUrl: _connectionState.baseUrl,
+    );
+  }
+
+  @override
+  Future<DirectoryListing> listDirectory(String path) async {
+    listedPaths.add(path);
+    final listing = _listings[path];
+    if (listing == null) {
+      throw StateError('Missing fake listing for $path');
+    }
+
+    return listing;
+  }
+
+  @override
+  Future<FilesConnectionState> restoreConnection() async => _connectionState;
+}
+
+class _MutableChatRepository implements ChatRepository {
+  _MutableChatRepository({required this.conversations});
+
+  final List<ChatConversation> conversations;
+  bool isConnected = false;
+  int connectCalls = 0;
+  int signOutCalls = 0;
+  int clearSessionCalls = 0;
+  int loadCalls = 0;
+
+  @override
+  Future<void> clearSession() async {
+    clearSessionCalls++;
+    isConnected = false;
+  }
+
+  @override
+  Future<void> connect() async {
+    connectCalls++;
+    isConnected = true;
+  }
+
+  @override
+  Future<List<ChatConversation>> loadConversations() async {
+    loadCalls++;
+    if (!isConnected) {
+      throw const ChatFailure.sessionRequired('Matrix sign-in required.');
+    }
+
+    return conversations;
+  }
+
+  @override
+  Future<void> signOut() async {
+    signOutCalls++;
+    isConnected = false;
+  }
+}
+
+class _StaticWeaveApiClient implements WeaveApiClient {
+  const _StaticWeaveApiClient(this.snapshot);
+
+  final WorkspaceCapabilitySnapshot snapshot;
+
+  @override
+  Future<WorkspaceCapabilitySnapshot> fetchWorkspaceCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return snapshot;
+  }
+}
+
+void main() {
+  group('Release golden paths', () {
+    testWidgets('sign-in journey reaches the ready shell', (tester) async {
+      final secureStore = InMemorySecureStore();
+      final configurationRepository = _FakeServerConfigurationRepository(
+        configuration: buildTestConfiguration(),
+      );
+      final oidcClient = _FakeOidcClient(
+        authorizeHandler: () async => OidcTokenBundle(
+          accessToken: 'fresh-access-token',
+          refreshToken: 'fresh-refresh-token',
+          idToken: 'fresh-id-token',
+          expiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+          tokenType: 'Bearer',
+          scopes: const ['openid', 'profile', 'email'],
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) => configurationRepository,
+            ),
+            secureStoreProvider.overrideWithValue(secureStore),
+            oidcClientProvider.overrideWithValue(oidcClient),
+            chatRepositoryProvider.overrideWithValue(
+              _MutableChatRepository(conversations: const <ChatConversation>[]),
+            ),
+            chatSecurityRepositoryProvider.overrideWithValue(
+              FakeChatSecurityRepository(),
+            ),
+            filesRepositoryProvider.overrideWithValue(
+              _MutableFilesRepository(
+                initialConnectionState:
+                    const FilesConnectionState.disconnected(),
+                listings: const <String, DirectoryListing>{
+                  '/': DirectoryListing(path: '/', entries: <FileEntry>[]),
+                },
+              ),
+            ),
+            weaveApiClientProvider.overrideWithValue(
+              const _StaticWeaveApiClient(
+                WorkspaceCapabilitySnapshot(
+                  shellAccess: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.shellAccess,
+                    readiness: WorkspaceCapabilityReadiness.ready,
+                  ),
+                  chat: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.chat,
+                    readiness: WorkspaceCapabilityReadiness.blocked,
+                  ),
+                  files: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.files,
+                    readiness: WorkspaceCapabilityReadiness.blocked,
+                  ),
+                  calendar: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.calendar,
+                    readiness: WorkspaceCapabilityReadiness.unavailable,
+                  ),
+                  boards: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.boards,
+                    readiness: WorkspaceCapabilityReadiness.unavailable,
+                  ),
+                ),
+              ),
+            ),
+          ],
+          child: const WeaveApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Sign In'), findsAtLeastNWidgets(1));
+
+      final signInButton = find.widgetWithText(FilledButton, 'Sign In');
+      await tester.scrollUntilVisible(signInButton, 300);
+      await tester.tap(signInButton);
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(WeaveApp)),
+      );
+      expect(
+        container.read(appBootstrapProvider).requireValue.phase,
+        BootstrapPhase.ready,
+      );
+      expect(find.byType(NavigationBar), findsOneWidget);
+      expect(
+        await secureStore.read(authSessionStorageKey),
+        contains('fresh-access-token'),
+      );
+    });
+
+    testWidgets(
+      'files-first journey connects Nextcloud, browses folders, and keeps chat reachable',
+      (tester) async {
+        final secureStore = InMemorySecureStore({
+          authSessionStorageKey: AuthSessionDto.fromSession(
+            buildTestAuthSession(),
+          ).encode(),
+        });
+        final filesRepository = _MutableFilesRepository(
+          initialConnectionState: FilesConnectionState.disconnected(
+            baseUrl: Uri.parse('https://nextcloud.home.internal'),
+          ),
+          listings: <String, DirectoryListing>{
+            '/': DirectoryListing(
+              path: '/',
+              entries: const <FileEntry>[
+                FileEntry(
+                  id: 'projects',
+                  name: 'Projects',
+                  path: '/Projects',
+                  isDirectory: true,
+                ),
+              ],
+            ),
+            '/Projects': DirectoryListing(
+              path: '/Projects',
+              entries: const <FileEntry>[
+                FileEntry(
+                  id: 'roadmap',
+                  name: 'roadmap.md',
+                  path: '/Projects/roadmap.md',
+                  isDirectory: false,
+                  sizeInBytes: 2048,
+                ),
+              ],
+            ),
+          },
+        );
+        final chatRepository = _MutableChatRepository(
+          conversations: const <ChatConversation>[
+            ChatConversation(
+              id: '!weave:home.internal',
+              title: 'Weave Core',
+              previewType: ChatConversationPreviewType.text,
+              previewText: 'Golden path looks healthy.',
+              unreadCount: 2,
+              isInvite: false,
+              isDirectMessage: false,
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              serverConfigurationRepositoryProvider.overrideWith(
+                (ref) => _FakeServerConfigurationRepository(
+                  configuration: buildTestConfiguration(),
+                ),
+              ),
+              secureStoreProvider.overrideWithValue(secureStore),
+              oidcClientProvider.overrideWithValue(_FakeOidcClient()),
+              chatRepositoryProvider.overrideWithValue(chatRepository),
+              chatSecurityRepositoryProvider.overrideWithValue(
+                FakeChatSecurityRepository(),
+              ),
+              filesRepositoryProvider.overrideWithValue(filesRepository),
+              weaveApiClientProvider.overrideWithValue(
+                const _StaticWeaveApiClient(
+                  WorkspaceCapabilitySnapshot(
+                    shellAccess: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.shellAccess,
+                      readiness: WorkspaceCapabilityReadiness.ready,
+                    ),
+                    chat: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.chat,
+                      readiness: WorkspaceCapabilityReadiness.ready,
+                    ),
+                    files: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.files,
+                      readiness: WorkspaceCapabilityReadiness.ready,
+                    ),
+                    calendar: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.calendar,
+                      readiness: WorkspaceCapabilityReadiness.unavailable,
+                    ),
+                    boards: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.boards,
+                      readiness: WorkspaceCapabilityReadiness.unavailable,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+            child: const WeaveApp(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(chatRepository.connectCalls, 1);
+        expect(find.text('Weave Core'), findsOneWidget);
+
+        await tester.tap(find.byIcon(Icons.folder_outlined));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Connect Nextcloud'), findsWidgets);
+
+        await tester.tap(find.text('Connect Nextcloud').first);
+        await tester.pumpAndSettle();
+
+        expect(filesRepository.connectCalls, 1);
+        expect(find.text('Projects'), findsOneWidget);
+
+        await tester.tap(find.text('Projects'));
+        await tester.pumpAndSettle();
+
+        expect(
+          filesRepository.listedPaths,
+          containsAllInOrder(<String>['/', '/Projects']),
+        );
+        expect(find.text('roadmap.md'), findsOneWidget);
+
+        await tester.tap(find.text('Chat'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Weave Core'), findsOneWidget);
+        expect(find.text('Golden path looks healthy.'), findsOneWidget);
+      },
+    );
+
+    testWidgets('settings sign-out returns the app to sign-in', (tester) async {
+      final secureStore = InMemorySecureStore({
+        authSessionStorageKey: AuthSessionDto.fromSession(
+          buildTestAuthSession(),
+        ).encode(),
+      });
+      final filesRepository = _MutableFilesRepository(
+        initialConnectionState: FilesConnectionState.connected(
+          baseUrl: Uri.parse('https://nextcloud.home.internal'),
+          accountLabel: 'alice',
+        ),
+        listings: const <String, DirectoryListing>{
+          '/': DirectoryListing(path: '/', entries: <FileEntry>[]),
+        },
+      );
+      final chatRepository = _MutableChatRepository(conversations: const []);
+      chatRepository.isConnected = true;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) => _FakeServerConfigurationRepository(
+                configuration: buildTestConfiguration(),
+              ),
+            ),
+            secureStoreProvider.overrideWithValue(secureStore),
+            oidcClientProvider.overrideWithValue(_FakeOidcClient()),
+            chatRepositoryProvider.overrideWithValue(chatRepository),
+            chatSecurityRepositoryProvider.overrideWithValue(
+              FakeChatSecurityRepository(),
+            ),
+            filesRepositoryProvider.overrideWithValue(filesRepository),
+            weaveApiClientProvider.overrideWithValue(
+              const _StaticWeaveApiClient(
+                WorkspaceCapabilitySnapshot(
+                  shellAccess: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.shellAccess,
+                    readiness: WorkspaceCapabilityReadiness.ready,
+                  ),
+                  chat: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.chat,
+                    readiness: WorkspaceCapabilityReadiness.ready,
+                  ),
+                  files: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.files,
+                    readiness: WorkspaceCapabilityReadiness.ready,
+                  ),
+                  calendar: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.calendar,
+                    readiness: WorkspaceCapabilityReadiness.unavailable,
+                  ),
+                  boards: WorkspaceCapabilityState(
+                    capability: WorkspaceCapability.boards,
+                    readiness: WorkspaceCapabilityReadiness.unavailable,
+                  ),
+                ),
+              ),
+            ),
+          ],
+          child: const WeaveApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.settings_outlined));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(WeaveApp)),
+      );
+      await container.read(authFlowControllerProvider.notifier).signOut();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Sign In'), findsAtLeastNWidgets(1));
+      expect(await secureStore.read(authSessionStorageKey), isNull);
+      expect(chatRepository.signOutCalls, 1);
+      expect(filesRepository.disconnectCalls, 1);
+    });
+
+    testWidgets(
+      'changed Nextcloud server marks files as needing recovery without dropping shell access',
+      (tester) async {
+        final secureStore = InMemorySecureStore({
+          authSessionStorageKey: AuthSessionDto.fromSession(
+            buildTestAuthSession(),
+          ).encode(),
+        });
+        final configurationRepository = _FakeServerConfigurationRepository(
+          configuration: buildTestConfiguration(),
+        );
+        final filesRepository = _MutableFilesRepository(
+          initialConnectionState: FilesConnectionState.connected(
+            baseUrl: Uri.parse('https://nextcloud.home.internal'),
+            accountLabel: 'alice',
+          ),
+          listings: const <String, DirectoryListing>{
+            '/': DirectoryListing(path: '/', entries: <FileEntry>[]),
+          },
+        );
+        final chatRepository = _MutableChatRepository(conversations: const []);
+        chatRepository.isConnected = true;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              serverConfigurationRepositoryProvider.overrideWith(
+                (ref) => configurationRepository,
+              ),
+              secureStoreProvider.overrideWithValue(secureStore),
+              oidcClientProvider.overrideWithValue(_FakeOidcClient()),
+              chatRepositoryProvider.overrideWithValue(chatRepository),
+              chatSecurityRepositoryProvider.overrideWithValue(
+                FakeChatSecurityRepository(),
+              ),
+              filesRepositoryProvider.overrideWithValue(filesRepository),
+              weaveApiClientProvider.overrideWithValue(
+                const _StaticWeaveApiClient(
+                  WorkspaceCapabilitySnapshot(
+                    shellAccess: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.shellAccess,
+                      readiness: WorkspaceCapabilityReadiness.ready,
+                    ),
+                    chat: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.chat,
+                      readiness: WorkspaceCapabilityReadiness.ready,
+                    ),
+                    files: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.files,
+                      readiness: WorkspaceCapabilityReadiness.blocked,
+                    ),
+                    calendar: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.calendar,
+                      readiness: WorkspaceCapabilityReadiness.unavailable,
+                    ),
+                    boards: WorkspaceCapabilityState(
+                      capability: WorkspaceCapability.boards,
+                      readiness: WorkspaceCapabilityReadiness.unavailable,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+            child: const WeaveApp(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.settings_outlined));
+        await tester.pumpAndSettle();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(WeaveApp)),
+        );
+        final updatedConfiguration = buildTestConfiguration(
+          nextcloudBaseUrl: 'https://files-2.home.internal',
+        );
+        await configurationRepository.saveConfiguration(updatedConfiguration);
+        await container
+            .read(authFlowControllerProvider.notifier)
+            .handleConfigurationSaved(
+              ServerConfigurationSaveResult(
+                configuration: updatedConfiguration,
+                authConfigurationChanged: false,
+                matrixHomeserverChanged: false,
+                nextcloudBaseUrlChanged: true,
+                backendApiBaseUrlChanged: false,
+              ),
+            );
+        await tester.pumpAndSettle();
+
+        final workspace = container
+            .read(workspaceConnectionStateProvider)
+            .requireValue;
+        final capabilities = container
+            .read(workspaceCapabilitySnapshotProvider)
+            .requireValue;
+
+        expect(workspace.shellAccessReady, isTrue);
+        expect(
+          workspace.nextcloud.status,
+          IntegrationConnectionStatus.disconnected,
+        );
+        expect(
+          workspace.nextcloud.lastInvalidation?.reason,
+          IntegrationInvalidationReason.nextcloudBaseUrlChanged,
+        );
+        expect(
+          capabilities.files.readiness,
+          WorkspaceCapabilityReadiness.blocked,
+        );
+        expect(filesRepository.disconnectCalls, 1);
+      },
+    );
+  });
+}

--- a/test/features/app/release_golden_paths_test.dart
+++ b/test/features/app/release_golden_paths_test.dart
@@ -14,7 +14,6 @@ import 'package:weave/features/auth/data/services/flutter_appauth_oidc_client.da
 import 'package:weave/features/auth/data/services/oidc_client.dart';
 import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 import 'package:weave/features/chat/domain/entities/chat_failure.dart';
-import 'package:weave/features/chat/domain/entities/chat_security_state.dart';
 import 'package:weave/features/chat/domain/repositories/chat_repository.dart';
 import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
 import 'package:weave/features/chat/presentation/providers/chat_security_repository_provider.dart';
@@ -58,10 +57,9 @@ class _FakeServerConfigurationRepository
 }
 
 class _FakeOidcClient implements OidcClient {
-  _FakeOidcClient({this.authorizeHandler, this.refreshHandler});
+  _FakeOidcClient({this.authorizeHandler});
 
   Future<OidcTokenBundle> Function()? authorizeHandler;
-  Future<OidcTokenBundle> Function(String refreshToken)? refreshHandler;
 
   @override
   Future<OidcTokenBundle> authorizeAndExchangeCode(configuration) async {
@@ -81,12 +79,7 @@ class _FakeOidcClient implements OidcClient {
     configuration, {
     required String refreshToken,
   }) async {
-    final handler = refreshHandler;
-    if (handler == null) {
-      throw UnimplementedError();
-    }
-
-    return handler(refreshToken);
+    throw UnimplementedError();
   }
 }
 
@@ -301,9 +294,9 @@ void main() {
             baseUrl: Uri.parse('https://nextcloud.home.internal'),
           ),
           listings: <String, DirectoryListing>{
-            '/': DirectoryListing(
+            '/': const DirectoryListing(
               path: '/',
-              entries: const <FileEntry>[
+              entries: <FileEntry>[
                 FileEntry(
                   id: 'projects',
                   name: 'Projects',
@@ -312,9 +305,9 @@ void main() {
                 ),
               ],
             ),
-            '/Projects': DirectoryListing(
+            '/Projects': const DirectoryListing(
               path: '/Projects',
-              entries: const <FileEntry>[
+              entries: <FileEntry>[
                 FileEntry(
                   id: 'roadmap',
                   name: 'roadmap.md',

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -147,7 +147,7 @@ void main() {
       expect(find.byType(WeaveLogo), findsOneWidget);
       expect(
         find.text(
-          'Weave brings messaging, files, and calendar into one workspace while this screen manages the server connection behind it.',
+          'Weave Release 1 focuses on messaging, files, and the server connection that holds them together.',
         ),
         findsOneWidget,
       );

--- a/test/features/shell/app_shell_test.dart
+++ b/test/features/shell/app_shell_test.dart
@@ -84,7 +84,9 @@ void main() {
       );
     }
 
-    testWidgets('renders the Release 1 bottom navigation destinations', (tester) async {
+    testWidgets('renders the Release 1 bottom navigation destinations', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();
 

--- a/test/features/shell/app_shell_test.dart
+++ b/test/features/shell/app_shell_test.dart
@@ -84,16 +84,16 @@ void main() {
       );
     }
 
-    testWidgets('renders five bottom navigation destinations', (tester) async {
+    testWidgets('renders the Release 1 bottom navigation destinations', (tester) async {
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();
 
       expect(find.byType(NavigationBar), findsOneWidget);
       expect(find.byIcon(Icons.chat_bubble), findsOneWidget);
       expect(find.byIcon(Icons.folder_outlined), findsOneWidget);
-      expect(find.byIcon(Icons.calendar_today_outlined), findsOneWidget);
-      expect(find.byIcon(Icons.dashboard_outlined), findsOneWidget);
       expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.calendar_today_outlined), findsNothing);
+      expect(find.byIcon(Icons.dashboard_outlined), findsNothing);
     });
 
     testWidgets('navigates to settings from the bottom navigation bar', (


### PR DESCRIPTION
## Summary
- add a release golden-path widget suite for sign-in, files-first browsing, sign-out, and changed-server recovery
- hide calendar and deck from the Release 1 shell/router and document that narrower release boundary
- align Release 1 copy/tests with the current product reality and fix the recovery contract usage to `IntegrationRecoveryRequirement.reauthenticate`

## Testing
- flutter test test/features/app/release_golden_paths_test.dart test/core/router/app_router_test.dart test/features/shell/app_shell_test.dart test/features/settings/settings_screen_test.dart