### PR TITLE
test: lock release 1 boundary golden path coverage

### DIFF
--- a/lib/core/router/app_router.g.dart
+++ b/lib/core/router/app_router.g.dart
@@ -55,4 +55,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'c52f19723d468c150d8172554a56a404d9d11362';
+String _$appRouterHash() => r'744700c15a75ed3974c7ed054c66613abce532b5';


### PR DESCRIPTION
## Summary
- finish the release-1 boundary slice on the current branch by repairing the release golden path test doubles after the chat MVP contract changes
- keep the router-generated provider file in sync so the branch is reviewable as-is
- preserve the already-landed product boundary behavior: chat, files, and settings remain the only visible Release 1 shell surfaces while legacy calendar and deck routes stay hidden

## Testing
- flutter analyze
- flutter test test/core/router/app_router_test.dart test/features/shell/app_shell_test.dart test/release_1/release_golden_paths_test.dart