### PR TITLE
feat(files): add breadcrumb navigation in browser

### DIFF
--- a/lib/features/files/presentation/files_screen.dart
+++ b/lib/features/files/presentation/files_screen.dart
@@ -5,6 +5,7 @@ import 'package:weave/core/a11y/semantic_button.dart';
 import 'package:weave/core/widgets/empty_state.dart';
 import 'package:weave/core/widgets/error_state.dart';
 import 'package:weave/core/widgets/loading_state.dart';
+import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/file_entry.dart';
 import 'package:weave/features/files/domain/entities/files_connection_state.dart';
 import 'package:weave/features/files/presentation/providers/files_provider.dart';
@@ -53,7 +54,6 @@ class FilesScreen extends ConsumerWidget {
     AppLocalizations l10n,
     FilesViewState state,
   ) {
-    final theme = Theme.of(context);
     final slivers = <Widget>[
       SliverPadding(
         padding: const EdgeInsets.fromLTRB(24, 0, 24, 16),
@@ -65,40 +65,7 @@ class FilesScreen extends ConsumerWidget {
       slivers.add(
         SliverPadding(
           padding: const EdgeInsets.fromLTRB(24, 0, 24, 16),
-          sliver: SliverToBoxAdapter(
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    state.currentPath,
-                    style: theme.textTheme.titleMedium,
-                  ),
-                ),
-                if (!(state.directoryListing?.isRoot ?? true))
-                  AccessibleButton(
-                    outlined: true,
-                    onPressed: state.isBusy
-                        ? null
-                        : () {
-                            ref.read(filesProvider.notifier).goUp();
-                          },
-                    semanticLabel: l10n.filesOpenParentSemantic,
-                    child: Text(l10n.filesUpButton),
-                  ),
-                const SizedBox(width: 12),
-                AccessibleButton(
-                  outlined: true,
-                  onPressed: state.isBusy
-                      ? null
-                      : () {
-                          ref.read(filesProvider.notifier).refresh();
-                        },
-                  semanticLabel: l10n.filesRefreshCurrentFolderSemantic,
-                  child: Text(l10n.filesRefreshButton),
-                ),
-              ],
-            ),
-          ),
+          sliver: SliverToBoxAdapter(child: _DirectoryToolbar(state: state)),
         ),
       );
     }
@@ -186,15 +153,19 @@ class FilesScreen extends ConsumerWidget {
         return SliverPadding(
           padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
           sliver: SliverList(
-            delegate: SliverChildBuilderDelegate((context, index) {
-              if (index.isOdd) {
-                return const Divider(height: 1);
-              }
+            delegate: SliverChildListDelegate.fixed([
+              _DirectorySummary(listing: listing),
+              const SizedBox(height: 12),
+              ...List<Widget>.generate(listing.entries.length * 2 - 1, (index) {
+                if (index.isOdd) {
+                  return const Divider(height: 1);
+                }
 
-              final entryIndex = index ~/ 2;
-              final entry = listing.entries[entryIndex];
-              return _FileEntryTile(entry: entry, isBusy: state.isBusy);
-            }, childCount: listing.entries.length * 2 - 1),
+                final entryIndex = index ~/ 2;
+                final entry = listing.entries[entryIndex];
+                return _FileEntryTile(entry: entry, isBusy: state.isBusy);
+              }),
+            ]),
           ),
         );
     }
@@ -204,6 +175,144 @@ class FilesScreen extends ConsumerWidget {
     return SliverPadding(
       padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
       sliver: SliverFillRemaining(hasScrollBody: false, child: child),
+    );
+  }
+}
+
+class _DirectoryToolbar extends ConsumerWidget {
+  const _DirectoryToolbar({required this.state});
+
+  final FilesViewState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final listing = state.directoryListing;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _PathBreadcrumbs(path: state.currentPath, isBusy: state.isBusy),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            Text(state.currentPath, style: theme.textTheme.titleMedium),
+            if (!(listing?.isRoot ?? true))
+              AccessibleButton(
+                outlined: true,
+                onPressed: state.isBusy
+                    ? null
+                    : () {
+                        ref.read(filesProvider.notifier).goUp();
+                      },
+                semanticLabel: l10n.filesOpenParentSemantic,
+                child: Text(l10n.filesUpButton),
+              ),
+            AccessibleButton(
+              outlined: true,
+              onPressed: state.isBusy
+                  ? null
+                  : () {
+                      ref.read(filesProvider.notifier).refresh();
+                    },
+              semanticLabel: l10n.filesRefreshCurrentFolderSemantic,
+              child: Text(l10n.filesRefreshButton),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _PathBreadcrumbs extends ConsumerWidget {
+  const _PathBreadcrumbs({required this.path, required this.isBusy});
+
+  final String path;
+  final bool isBusy;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final segments = path.split('/')..removeWhere((segment) => segment.isEmpty);
+    final crumbs = <Widget>[
+      _BreadcrumbChip(
+        label: l10n.filesRootBreadcrumb,
+        onPressed: path == '/' || isBusy
+            ? null
+            : () {
+                ref.read(filesProvider.notifier).openDirectory('/');
+              },
+      ),
+    ];
+
+    for (var index = 0; index < segments.length; index++) {
+      final crumbPath = '/${segments.take(index + 1).join('/')}';
+      final isCurrent = crumbPath == path;
+      crumbs
+        ..add(
+          ExcludeSemantics(
+            child: Icon(
+              Icons.chevron_right,
+              size: 18,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        )
+        ..add(
+          _BreadcrumbChip(
+            label: segments[index],
+            onPressed: isCurrent || isBusy
+                ? null
+                : () {
+                    ref.read(filesProvider.notifier).openDirectory(crumbPath);
+                  },
+          ),
+        );
+    }
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(children: crumbs),
+    );
+  }
+}
+
+class _BreadcrumbChip extends StatelessWidget {
+  const _BreadcrumbChip({required this.label, required this.onPressed});
+
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ActionChip(label: Text(label), onPressed: onPressed);
+  }
+}
+
+class _DirectorySummary extends StatelessWidget {
+  const _DirectorySummary({required this.listing});
+
+  final DirectoryListing listing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final folderCount = listing.entries
+        .where((entry) => entry.isDirectory)
+        .length;
+    final fileCount = listing.entries.length - folderCount;
+
+    return Text(
+      l10n.filesDirectorySummary(folderCount, fileCount),
+      style: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
     );
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -46,6 +46,8 @@
   "filesDisconnectButton": "Trennen",
   "filesRefreshButton": "Aktualisieren",
   "filesUpButton": "Nach oben",
+  "filesRootBreadcrumb": "Root",
+  "filesDirectorySummary": "{folderCount, plural, =0{Keine Ordner} one{1 Ordner} other{{folderCount} Ordner}} • {fileCount, plural, =0{keine Dateien} one{1 Datei} other{{fileCount} Dateien}}",
   "filesDisconnectedMessage": "Verbinde Nextcloud, um deine Dateien zu durchsuchen.",
   "filesInvalidSessionMessage": "Verbinde Nextcloud erneut, weil die gespeicherte Sitzung nicht mehr gültig ist.",
   "filesMisconfiguredMessage": "Konfiguriere zuerst eine Nextcloud-URL, bevor du Dateien verbindest.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -144,6 +144,18 @@
   "filesUpButton": "Up",
   "@filesUpButton": { "description": "Button label used to open the parent Nextcloud directory" },
 
+  "filesRootBreadcrumb": "Root",
+  "@filesRootBreadcrumb": { "description": "Label for the root breadcrumb in the files browser" },
+
+  "filesDirectorySummary": "{folderCount, plural, =0{No folders} one{1 folder} other{{folderCount} folders}} • {fileCount, plural, =0{no files} one{1 file} other{{fileCount} files}}",
+  "@filesDirectorySummary": {
+    "description": "Summary for the current directory contents",
+    "placeholders": {
+      "folderCount": { "type": "int" },
+      "fileCount": { "type": "int" }
+    }
+  },
+
   "filesDisconnectedMessage": "Connect Nextcloud to browse your files.",
   "@filesDisconnectedMessage": { "description": "Message shown when the Files screen is disconnected from Nextcloud" },
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -374,6 +374,18 @@ abstract class AppLocalizations {
   /// **'Up'**
   String get filesUpButton;
 
+  /// Label for the root breadcrumb in the files browser
+  ///
+  /// In en, this message translates to:
+  /// **'Root'**
+  String get filesRootBreadcrumb;
+
+  /// Summary for the current directory contents
+  ///
+  /// In en, this message translates to:
+  /// **'{folderCount, plural, =0{No folders} one{1 folder} other{{folderCount} folders}} • {fileCount, plural, =0{no files} one{1 file} other{{fileCount} files}}'**
+  String filesDirectorySummary(int folderCount, int fileCount);
+
   /// Message shown when the Files screen is disconnected from Nextcloud
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -154,6 +154,28 @@ class AppLocalizationsDe extends AppLocalizations {
   String get filesUpButton => 'Nach oben';
 
   @override
+  String get filesRootBreadcrumb => 'Root';
+
+  @override
+  String filesDirectorySummary(int folderCount, int fileCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      folderCount,
+      locale: localeName,
+      other: '$folderCount Ordner',
+      one: '1 Ordner',
+      zero: 'Keine Ordner',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      fileCount,
+      locale: localeName,
+      other: '$fileCount Dateien',
+      one: '1 Datei',
+      zero: 'keine Dateien',
+    );
+    return '$_temp0 • $_temp1';
+  }
+
+  @override
   String get filesDisconnectedMessage =>
       'Verbinde Nextcloud, um deine Dateien zu durchsuchen.';
 

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -153,6 +153,28 @@ class AppLocalizationsEn extends AppLocalizations {
   String get filesUpButton => 'Up';
 
   @override
+  String get filesRootBreadcrumb => 'Root';
+
+  @override
+  String filesDirectorySummary(int folderCount, int fileCount) {
+    String _temp0 = intl.Intl.pluralLogic(
+      folderCount,
+      locale: localeName,
+      other: '$folderCount folders',
+      one: '1 folder',
+      zero: 'No folders',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      fileCount,
+      locale: localeName,
+      other: '$fileCount files',
+      one: '1 file',
+      zero: 'no files',
+    );
+    return '$_temp0 • $_temp1';
+  }
+
+  @override
   String get filesDisconnectedMessage =>
       'Connect Nextcloud to browse your files.';
 

--- a/test/features/app/release_golden_paths_test.dart
+++ b/test/features/app/release_golden_paths_test.dart
@@ -409,6 +409,12 @@ void main() {
         expect(filesRepository.connectCalls, 1);
         expect(find.text('Projects'), findsOneWidget);
 
+        await tester.drag(
+          find.byType(CustomScrollView).last,
+          const Offset(0, -120),
+        );
+        await tester.pumpAndSettle();
+
         await tester.tap(find.text('Projects'));
         await tester.pumpAndSettle();
 

--- a/test/features/files/files_screen_test.dart
+++ b/test/features/files/files_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/file_entry.dart';
@@ -110,9 +111,26 @@ void main() {
             path: '/Documents',
             entries: [
               FileEntry(
+                id: 'folder-2',
+                name: 'Reports',
+                path: '/Documents/Reports',
+                isDirectory: true,
+              ),
+              FileEntry(
                 id: 'file-1',
                 name: 'Notes.txt',
                 path: '/Documents/Notes.txt',
+                isDirectory: false,
+              ),
+            ],
+          ),
+          '/Documents/Reports': DirectoryListing(
+            path: '/Documents/Reports',
+            entries: [
+              FileEntry(
+                id: 'file-2',
+                name: 'Q2.pdf',
+                path: '/Documents/Reports/Q2.pdf',
                 isDirectory: false,
               ),
             ],
@@ -134,17 +152,38 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Documents'), findsOneWidget);
+      expect(find.text('Documents'), findsAtLeastNWidgets(1));
 
-      await tester.tap(find.text('Documents'));
+      await tester.tap(
+        find.ancestor(
+          of: find.text('Documents').first,
+          matching: find.byType(InkWell),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.ancestor(
+          of: find.text('Reports').first,
+          matching: find.byType(InkWell),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Documents').last);
       await tester.pumpAndSettle();
 
       expect(
         repository.requestedPaths,
-        containsAllInOrder(['/', '/Documents']),
+        containsAllInOrder([
+          '/',
+          '/Documents',
+          '/Documents/Reports',
+          '/Documents',
+        ]),
       );
       expect(find.text('Notes.txt'), findsOneWidget);
+      expect(find.text('1 folder • 1 file'), findsOneWidget);
       expect(find.text('Up'), findsOneWidget);
+      expect(find.text('Root'), findsOneWidget);
     });
 
     testWidgets('meets androidTapTargetGuideline', (tester) async {


### PR DESCRIPTION
## Summary
- add clickable breadcrumbs to the Files browser so users can jump back to any parent folder
- show a folder/file summary for the current directory to improve browsing context
- extend release-path and Files screen tests to cover the new navigation flow

## Verification
- flutter analyze
- flutter test test/features/files/files_screen_test.dart test/features/app/release_golden_paths_test.dart