### PR TITLE
fix(matrix): use loopback OIDC on native platforms

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,12 +33,6 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="com.massimotter.weave" />
             </intent-filter>
-            <intent-filter android:label="flutter_web_auth_2">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="com.massimotter.weave.matrix" />
-            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -1,0 +1,638 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:weave/features/auth/data/services/oidc_client.dart';
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_failure.dart';
+import 'package:weave/features/auth/domain/entities/oidc_constants.dart';
+import 'package:weave/features/chat/data/services/matrix_auth_browser.dart';
+
+import 'test_config.dart';
+
+class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
+  LiveOidcTestDriver({required TestConfig config}) : _config = config;
+
+  final TestConfig _config;
+
+  @override
+  Future<OidcTokenBundle> authorizeAndExchangeCode(
+    AuthConfiguration configuration,
+  ) async {
+    try {
+      final discovery = await _readDiscovery(configuration.issuer);
+      final authorizationEndpoint = _requireAbsoluteUri(
+        discovery,
+        'authorization_endpoint',
+      );
+      final tokenEndpoint = _requireAbsoluteUri(discovery, 'token_endpoint');
+      final codeVerifier = _randomUrlSafe(64);
+      final state = _randomUrlSafe(32);
+      final nonce = _randomUrlSafe(32);
+      final callbackUri = await _authenticateInBrowserLikeFlow(
+        authorizationUri: authorizationEndpoint.replace(
+          queryParameters: <String, String>{
+            'client_id': configuration.clientId,
+            'redirect_uri': oidcRedirectUri,
+            'response_type': 'code',
+            'scope': oidcDefaultScopes.join(' '),
+            'state': state,
+            'nonce': nonce,
+            'code_challenge': _sha256UrlSafe(codeVerifier),
+            'code_challenge_method': 'S256',
+          },
+        ),
+        redirectUri: Uri.parse(oidcRedirectUri),
+      );
+      final code = callbackUri.queryParameters['code']?.trim();
+      final returnedState = callbackUri.queryParameters['state']?.trim();
+      if (code == null || code.isEmpty) {
+        throw const AuthFailure.protocol(
+          'OIDC sign-in callback did not include an authorization code.',
+        );
+      }
+      if (returnedState != state) {
+        throw const AuthFailure.protocol(
+          'OIDC sign-in callback returned an unexpected state value.',
+        );
+      }
+
+      final tokenResponse = await _sendForm(tokenEndpoint, <String, String>{
+        'grant_type': 'authorization_code',
+        'client_id': configuration.clientId,
+        'code': code,
+        'redirect_uri': oidcRedirectUri,
+        'code_verifier': codeVerifier,
+      });
+      if (tokenResponse.statusCode != 200) {
+        throw AuthFailure.protocol(
+          'OIDC token exchange failed with HTTP ${tokenResponse.statusCode}.',
+        );
+      }
+      final payload = _decodeObject(tokenResponse.body, 'OIDC token response');
+      return _bundleFromTokenPayload(payload);
+    } on AuthFailure {
+      rethrow;
+    } catch (error) {
+      throw AuthFailure.unknown('Unable to complete sign-in.', cause: error);
+    }
+  }
+
+  @override
+  Future<OidcTokenBundle> refresh(
+    AuthConfiguration configuration, {
+    required String refreshToken,
+  }) async {
+    final discovery = await _readDiscovery(configuration.issuer);
+    final tokenEndpoint = _requireAbsoluteUri(discovery, 'token_endpoint');
+    final response = await _sendForm(tokenEndpoint, <String, String>{
+      'grant_type': 'refresh_token',
+      'client_id': configuration.clientId,
+      'refresh_token': refreshToken,
+      'scope': oidcDefaultScopes.join(' '),
+    });
+    if (response.statusCode != 200) {
+      throw AuthFailure.protocol(
+        'OIDC refresh failed with HTTP ${response.statusCode}.',
+      );
+    }
+    final payload = _decodeObject(response.body, 'OIDC refresh response');
+    return _bundleFromTokenPayload(payload);
+  }
+
+  @override
+  Future<void> endSession(
+    AuthConfiguration configuration, {
+    required String idTokenHint,
+  }) async {
+    final discovery = await _readDiscovery(configuration.issuer);
+    final endSessionEndpoint = discovery['end_session_endpoint'];
+    if (endSessionEndpoint is! String || endSessionEndpoint.trim().isEmpty) {
+      return;
+    }
+    final uri = Uri.parse(endSessionEndpoint).replace(
+      queryParameters: <String, String>{
+        'client_id': configuration.clientId,
+        'id_token_hint': idTokenHint,
+        'post_logout_redirect_uri': oidcPostLogoutRedirectUri,
+      },
+    );
+    final client = _newHttpClient();
+    try {
+      final request = await client.getUrl(uri);
+      request.followRedirects = false;
+      final response = await request.close();
+      await response.drain<List<int>>();
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  @override
+  Future<Uri> authenticate({
+    required Uri authorizationUri,
+    required Uri redirectUri,
+  }) {
+    return _authenticateInBrowserLikeFlow(
+      authorizationUri: authorizationUri,
+      redirectUri: redirectUri,
+    );
+  }
+
+  Future<Uri> _authenticateInBrowserLikeFlow({
+    required Uri authorizationUri,
+    required Uri redirectUri,
+  }) async {
+    final client = _newHttpClient();
+    try {
+      final cookieJar = <_StoredCookie>[];
+      Uri? previousUri;
+      var nextUri = authorizationUri;
+      while (true) {
+        final response = await _open(client, nextUri, cookieJar);
+        final location = response.headers.value(HttpHeaders.locationHeader);
+        final body = await utf8.decodeStream(response);
+
+        if (_isRedirect(response.statusCode) && location != null) {
+          previousUri = nextUri;
+          final redirected = nextUri.resolve(location);
+          if (_matchesRedirect(redirected, redirectUri)) {
+            return redirected;
+          }
+          nextUri = redirected;
+          continue;
+        }
+
+        final loginForm = _tryParseLoginForm(body, nextUri);
+        if (loginForm != null) {
+          final postResponse = await _postForm(
+            client,
+            loginForm.action,
+            <String, String>{
+              ...loginForm.fields,
+              'username': _config.username,
+              'password': _config.password,
+              'credentialId': '',
+              'login': 'Sign In',
+            },
+            cookieJar,
+            referer: previousUri ?? nextUri,
+          );
+          final postLocation = postResponse.headers.value(
+            HttpHeaders.locationHeader,
+          );
+          final postBody = await utf8.decodeStream(postResponse);
+
+          if (_isRedirect(postResponse.statusCode) && postLocation != null) {
+            previousUri = loginForm.action;
+            final redirected = loginForm.action.resolve(postLocation);
+            if (_matchesRedirect(redirected, redirectUri)) {
+              return redirected;
+            }
+            nextUri = redirected;
+            continue;
+          }
+
+          if (postBody.contains('Invalid username or password') ||
+              postBody.contains('Sign in to your account')) {
+            throw StateError(
+              'Live browser login did not complete successfully.',
+            );
+          }
+
+          final followUpForm = _tryParseAutoSubmitForm(
+            postBody,
+            loginForm.action,
+          );
+          if (followUpForm != null) {
+            nextUri = followUpForm.action;
+            final followUpResponse = await _postForm(
+              client,
+              followUpForm.action,
+              followUpForm.fields,
+              cookieJar,
+              referer: loginForm.action,
+            );
+            final followUpLocation = followUpResponse.headers.value(
+              HttpHeaders.locationHeader,
+            );
+            await utf8.decodeStream(followUpResponse);
+            if (_isRedirect(followUpResponse.statusCode) &&
+                followUpLocation != null) {
+              previousUri = followUpForm.action;
+              final redirected = followUpForm.action.resolve(followUpLocation);
+              if (_matchesRedirect(redirected, redirectUri)) {
+                return redirected;
+              }
+              nextUri = redirected;
+              continue;
+            }
+          }
+
+          final snippet = postBody.replaceAll(RegExp(r'\s+'), ' ');
+          throw StateError(
+            'Unexpected response after submitting the login form '
+            'to ${loginForm.action}. Status=${postResponse.statusCode} '
+            'Body=${snippet.substring(0, snippet.length > 300 ? 300 : snippet.length)}',
+          );
+        }
+
+        final followUpForm = _tryParseAutoSubmitForm(body, nextUri);
+        if (followUpForm != null) {
+          final postResponse = await _postForm(
+            client,
+            followUpForm.action,
+            followUpForm.fields,
+            cookieJar,
+            referer: previousUri ?? nextUri,
+          );
+          final postLocation = postResponse.headers.value(
+            HttpHeaders.locationHeader,
+          );
+          await utf8.decodeStream(postResponse);
+          if (_isRedirect(postResponse.statusCode) && postLocation != null) {
+            previousUri = followUpForm.action;
+            final redirected = followUpForm.action.resolve(postLocation);
+            if (_matchesRedirect(redirected, redirectUri)) {
+              return redirected;
+            }
+            nextUri = redirected;
+            continue;
+          }
+        }
+
+        throw StateError(
+          'Unable to continue the live browser flow for $authorizationUri. '
+          'Expected a redirect or supported form on ${nextUri.toString()}.',
+        );
+      }
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  Future<Map<String, dynamic>> _readDiscovery(Uri issuer) async {
+    final client = _newHttpClient();
+    try {
+      final request = await client.getUrl(
+        issuer.replace(
+          pathSegments: [
+            ...issuer.pathSegments.where((segment) => segment.isNotEmpty),
+            '.well-known',
+            'openid-configuration',
+          ],
+        ),
+      );
+      final response = await request.close();
+      final body = await utf8.decodeStream(response);
+      if (response.statusCode != 200) {
+        throw AuthFailure.protocol(
+          'Unable to read OIDC discovery (HTTP ${response.statusCode}).',
+        );
+      }
+      return _decodeObject(body, 'OIDC discovery document');
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  Future<_SimpleHttpResponse> _sendForm(
+    Uri uri,
+    Map<String, String> body,
+  ) async {
+    final client = _newHttpClient();
+    try {
+      final response = await _postForm(client, uri, body, <_StoredCookie>[]);
+      final responseBody = await utf8.decodeStream(response);
+      return _SimpleHttpResponse(response.statusCode, responseBody);
+    } finally {
+      client.close(force: true);
+    }
+  }
+
+  Future<HttpClientResponse> _open(
+    HttpClient client,
+    Uri uri,
+    List<_StoredCookie> cookieJar,
+  ) async {
+    final request = await client.getUrl(uri);
+    request.followRedirects = false;
+    request.headers.set(HttpHeaders.acceptHeader, 'text/html,application/json');
+    request.headers.set(HttpHeaders.userAgentHeader, 'WeaveLiveOidcTest/1.0');
+    _applyCookies(request, uri, cookieJar);
+    final response = await request.close();
+    _storeCookies(response, uri, cookieJar);
+    return response;
+  }
+
+  Future<HttpClientResponse> _postForm(
+    HttpClient client,
+    Uri uri,
+    Map<String, String> fields,
+    List<_StoredCookie> cookieJar, {
+    Uri? referer,
+  }) async {
+    final request = await client.postUrl(uri);
+    request.followRedirects = false;
+    request.headers.set(
+      HttpHeaders.contentTypeHeader,
+      'application/x-www-form-urlencoded',
+    );
+    request.headers.set(HttpHeaders.acceptHeader, 'text/html,application/json');
+    request.headers.set(HttpHeaders.userAgentHeader, 'WeaveLiveOidcTest/1.0');
+    if (referer != null) {
+      request.headers.set(HttpHeaders.refererHeader, referer.toString());
+      request.headers.set('origin', referer.origin);
+    }
+    _applyCookies(request, uri, cookieJar);
+    request.write(_formEncode(fields));
+    final response = await request.close();
+    _storeCookies(response, uri, cookieJar);
+    return response;
+  }
+
+  void _applyCookies(
+    HttpClientRequest request,
+    Uri uri,
+    List<_StoredCookie> cookieJar,
+  ) {
+    for (final cookie in cookieJar) {
+      if (cookie.matches(uri)) {
+        request.cookies.add(cookie.toCookie());
+      }
+    }
+  }
+
+  void _storeCookies(
+    HttpClientResponse response,
+    Uri uri,
+    List<_StoredCookie> cookieJar,
+  ) {
+    for (final cookie in response.cookies) {
+      cookieJar.removeWhere(
+        (existing) =>
+            existing.name == cookie.name && existing.domain == cookie.domain,
+      );
+      cookieJar.add(_StoredCookie.fromCookie(cookie, uri));
+    }
+  }
+
+  HttpClient _newHttpClient() {
+    return HttpClient()
+      ..badCertificateCallback = (cert, host, port) =>
+          host == 'localhost' ||
+          host == '127.0.0.1' ||
+          host.endsWith('.weave.local');
+  }
+
+  bool _isRedirect(int statusCode) =>
+      statusCode == 301 ||
+      statusCode == 302 ||
+      statusCode == 303 ||
+      statusCode == 307 ||
+      statusCode == 308;
+
+  bool _matchesRedirect(Uri candidate, Uri expected) {
+    return candidate.scheme == expected.scheme &&
+        candidate.path == expected.path &&
+        (expected.host.isEmpty || candidate.host == expected.host);
+  }
+
+  Map<String, dynamic> _decodeObject(String body, String label) {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, dynamic>) {
+      throw StateError('$label was not a JSON object.');
+    }
+    return decoded;
+  }
+
+  Uri _requireAbsoluteUri(Map<String, dynamic> json, String key) {
+    final value = json[key];
+    if (value is! String || value.trim().isEmpty) {
+      throw StateError('Missing OIDC discovery field "$key".');
+    }
+    final uri = Uri.parse(value);
+    if (!uri.isAbsolute) {
+      throw StateError('OIDC discovery field "$key" was not absolute.');
+    }
+    return uri;
+  }
+
+  OidcTokenBundle _bundleFromTokenPayload(Map<String, dynamic> payload) {
+    final accessToken = payload['access_token'];
+    if (accessToken is! String || accessToken.isEmpty) {
+      throw const AuthFailure.protocol(
+        'OIDC response did not include an access token.',
+      );
+    }
+    final expiresIn = payload['expires_in'];
+    return OidcTokenBundle(
+      accessToken: accessToken,
+      refreshToken: payload['refresh_token'] as String?,
+      idToken: payload['id_token'] as String?,
+      expiresAt: expiresIn is int
+          ? DateTime.now().toUtc().add(Duration(seconds: expiresIn))
+          : null,
+      tokenType: payload['token_type'] as String?,
+      scopes: _scopesFrom(payload['scope']),
+    );
+  }
+
+  List<String> _scopesFrom(Object? value) {
+    if (value is String && value.trim().isNotEmpty) {
+      return value.split(' ').where((scope) => scope.isNotEmpty).toList();
+    }
+    return oidcDefaultScopes;
+  }
+
+  _ParsedLoginForm? _tryParseLoginForm(String html, Uri baseUri) {
+    final formMatch = RegExp(
+      r'<form([^>]*)>([\s\S]*?)</form>',
+      caseSensitive: false,
+    ).firstMatch(html);
+    if (formMatch == null) {
+      return null;
+    }
+    final formAttributes = formMatch.group(1) ?? '';
+    final formHtml = formMatch.group(0)!;
+    if (!formHtml.contains('name="username"') ||
+        !formHtml.contains('name="password"')) {
+      return null;
+    }
+    return _ParsedLoginForm(
+      action: _resolveFormAction(formAttributes, baseUri),
+      fields: _parseFormFields(formHtml),
+    );
+  }
+
+  _ParsedLoginForm? _tryParseAutoSubmitForm(String html, Uri baseUri) {
+    final formMatches = RegExp(
+      r'<form([^>]*)>([\s\S]*?)</form>',
+      caseSensitive: false,
+    ).allMatches(html);
+    for (final match in formMatches) {
+      final formAttributes = match.group(1) ?? '';
+      final formHtml = match.group(0)!;
+      if (formHtml.contains('name="username"') &&
+          formHtml.contains('name="password"')) {
+        continue;
+      }
+      final fields = _parseFormFields(formHtml);
+      if (fields.isEmpty) {
+        continue;
+      }
+      if (!RegExp(r'type="submit"', caseSensitive: false).hasMatch(formHtml) &&
+          !formHtml.contains('Create Account') &&
+          !formHtml.contains('Continue')) {
+        continue;
+      }
+      return _ParsedLoginForm(
+        action: _resolveFormAction(formAttributes, baseUri),
+        fields: fields,
+      );
+    }
+    return null;
+  }
+
+  Uri _resolveFormAction(String formAttributes, Uri baseUri) {
+    final actionMatch = RegExp(
+      r'action="([^"]*)"',
+      caseSensitive: false,
+    ).firstMatch(formAttributes);
+    final rawAction = _htmlDecode(actionMatch?.group(1) ?? '').trim();
+    if (rawAction.isEmpty) {
+      return baseUri;
+    }
+    return baseUri.resolve(rawAction);
+  }
+
+  Map<String, String> _parseFormFields(String formHtml) {
+    final fields = <String, String>{};
+    final inputMatches = RegExp(
+      r'<input([^>]*)>',
+      caseSensitive: false,
+    ).allMatches(formHtml);
+    for (final match in inputMatches) {
+      final attributes = match.group(1) ?? '';
+      final name = _extractHtmlAttribute(attributes, 'name');
+      if (name == null || name.isEmpty) {
+        continue;
+      }
+      final type = (_extractHtmlAttribute(attributes, 'type') ?? 'text')
+          .toLowerCase();
+      final isChecked = RegExp(
+        r'\schecked(?:\s|>|$)',
+        caseSensitive: false,
+      ).hasMatch(attributes);
+      if ((type == 'checkbox' || type == 'radio') && !isChecked) {
+        continue;
+      }
+      fields[name] = _extractHtmlAttribute(attributes, 'value') ?? 'on';
+    }
+    return fields;
+  }
+
+  String? _extractHtmlAttribute(String html, String name) {
+    final match = RegExp(
+      '$name="([^"]*)"',
+      caseSensitive: false,
+    ).firstMatch(html);
+    final value = match?.group(1);
+    if (value == null) {
+      return null;
+    }
+    return _htmlDecode(value);
+  }
+
+  String _formEncode(Map<String, String> fields) {
+    return fields.entries
+        .map(
+          (entry) =>
+              '${Uri.encodeQueryComponent(entry.key)}=${Uri.encodeQueryComponent(entry.value)}',
+        )
+        .join('&');
+  }
+
+  String _htmlDecode(String value) {
+    return value
+        .replaceAll('&amp;', '&')
+        .replaceAll('&#x2F;', '/')
+        .replaceAll('&quot;', '"')
+        .replaceAll('&#39;', "'");
+  }
+
+  String _randomUrlSafe(int length) {
+    const chars =
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+    final random = Random.secure();
+    return List<String>.generate(
+      length,
+      (_) => chars[random.nextInt(chars.length)],
+    ).join();
+  }
+
+  String _sha256UrlSafe(String input) {
+    final bytes = sha256.convert(utf8.encode(input)).bytes;
+    return base64UrlEncode(bytes).replaceAll('=', '');
+  }
+}
+
+class _ParsedLoginForm {
+  const _ParsedLoginForm({required this.action, required this.fields});
+
+  final Uri action;
+  final Map<String, String> fields;
+}
+
+class _SimpleHttpResponse {
+  const _SimpleHttpResponse(this.statusCode, this.body);
+
+  final int statusCode;
+  final String body;
+}
+
+class _StoredCookie {
+  const _StoredCookie({
+    required this.name,
+    required this.value,
+    required this.domain,
+    required this.path,
+    required this.secure,
+  });
+
+  factory _StoredCookie.fromCookie(Cookie cookie, Uri uri) {
+    return _StoredCookie(
+      name: cookie.name,
+      value: cookie.value,
+      domain: cookie.domain ?? uri.host,
+      path: cookie.path ?? '/',
+      secure: cookie.secure,
+    );
+  }
+
+  final String name;
+  final String value;
+  final String domain;
+  final String path;
+  final bool secure;
+
+  bool matches(Uri uri) {
+    final normalizedDomain = domain.startsWith('.')
+        ? domain.substring(1)
+        : domain;
+    final hostMatches =
+        uri.host == normalizedDomain || uri.host.endsWith('.$normalizedDomain');
+    final pathMatches = uri.path.startsWith(path);
+    final schemeMatches = !secure || uri.scheme == 'https';
+    return hostMatches && pathMatches && schemeMatches;
+  }
+
+  Cookie toCookie() {
+    final cookie = Cookie(name, value)
+      ..domain = domain
+      ..path = path
+      ..secure = secure;
+    return cookie;
+  }
+}

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -1,0 +1,258 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:integration_test/integration_test.dart';
+import 'package:weave/core/a11y/semantic_button.dart';
+import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
+import 'package:weave/core/persistence/flutter_secure_store.dart';
+import 'package:weave/core/persistence/secure_store.dart';
+import 'package:weave/features/auth/data/services/flutter_appauth_oidc_client.dart';
+import 'package:weave/features/chat/data/services/matrix_auth_browser.dart';
+import 'package:weave/features/chat/presentation/providers/chat_provider.dart';
+import 'package:weave/features/files/presentation/providers/files_provider.dart';
+import 'package:weave/features/server_config/domain/entities/oidc_client_registration.dart';
+import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/entities/service_endpoints.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/nextcloud/presentation/providers/nextcloud_provider.dart';
+import 'package:weave/main.dart';
+
+import 'helpers/live_oidc_test_driver.dart';
+import 'helpers/test_config.dart';
+import 'helpers/test_http_overrides.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  HttpOverrides.global = TestHttpOverrides();
+
+  late TestConfig config;
+  late LiveOidcTestDriver liveOidcDriver;
+  late http.Client nextcloudHttpClient;
+
+  setUp(() {
+    config = TestConfig.fromEnvironment();
+    config.requireCredentials();
+    liveOidcDriver = LiveOidcTestDriver(config: config);
+    nextcloudHttpClient = createTrustedTestHttpClient();
+  });
+
+  tearDown(() {
+    nextcloudHttpClient.close();
+  });
+
+  testWidgets('real live-stack sign-in, Matrix connect, and Nextcloud browse', (
+    tester,
+  ) async {
+    final serverConfig = ServerConfiguration(
+      providerType: OidcProviderType.keycloak,
+      oidcIssuerUrl: config.issuerUrl,
+      oidcClientRegistration: OidcClientRegistration.manual(
+        clientId: config.clientId,
+      ),
+      serviceEndpoints: ServiceEndpoints(
+        matrixHomeserverUrl: config.matrixHomeserverUrl,
+        nextcloudBaseUrl: config.nextcloudBaseUrl,
+        backendApiBaseUrl: config.backendApiBaseUrl,
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          secureStoreProvider.overrideWithValue(_MemorySecureStore()),
+          serverConfigurationRepositoryProvider.overrideWithValue(
+            _MemoryServerConfigurationRepository(serverConfig),
+          ),
+          oidcClientProvider.overrideWithValue(liveOidcDriver),
+          matrixAuthBrowserProvider.overrideWithValue(liveOidcDriver),
+          nextcloudHttpClientProvider.overrideWithValue(nextcloudHttpClient),
+        ],
+        child: const WeaveApp(),
+      ),
+    );
+
+    await _pumpUntilSettled(tester);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(WeaveApp)),
+    );
+
+    await _waitFor(
+      tester,
+      () => find.text('Anmelden').evaluate().isNotEmpty,
+      reason: 'App should reach the sign-in screen with the live config.',
+      diagnostics: () {
+        final bootstrap = container.read(appBootstrapProvider);
+        final texts = find
+            .byType(Text)
+            .evaluate()
+            .map((element) => (element.widget as Text).data)
+            .whereType<String>()
+            .join(' | ');
+        return 'bootstrap=$bootstrap\ntexts=$texts';
+      },
+    );
+
+    await tester.tap(find.widgetWithText(AccessibleButton, 'Anmelden').first);
+    await tester.pump();
+
+    container.read(chatProvider.notifier).connect();
+    await tester.pump();
+
+    await _waitFor(
+      tester,
+      () {
+        final state = container.read(chatProvider);
+        return state.phase == ChatViewPhase.empty ||
+            state.phase == ChatViewPhase.content ||
+            state.phase == ChatViewPhase.error ||
+            state.phase == ChatViewPhase.unsupported;
+      },
+      reason: 'Matrix chat should connect against the live homeserver.',
+      timeout: const Duration(minutes: 2),
+      diagnostics: () {
+        final state = container.read(chatProvider);
+        return 'chatPhase=${state.phase} '
+            'failure=${state.failure?.message} '
+            'cause=${state.failure?.cause} '
+            'conversations=${state.conversations.length}';
+      },
+    );
+
+    final chatState = container.read(chatProvider);
+    final matrixConnected =
+        chatState.phase == ChatViewPhase.empty ||
+        chatState.phase == ChatViewPhase.content;
+    // Keep the Matrix outcome visible while still validating the Nextcloud path.
+    // ignore: avoid_print
+    print(
+      'MATRIX_RESULT phase=${chatState.phase} '
+      'failure=${chatState.failure} '
+      'cause=${chatState.failure?.cause}',
+    );
+
+    await container.read(filesProvider.notifier).connect();
+    await tester.pump();
+
+    await _waitFor(
+      tester,
+      () {
+        final asyncState = container.read(filesProvider);
+        if (asyncState.hasError) {
+          return true;
+        }
+        if (!asyncState.hasValue) {
+          return false;
+        }
+        final state = asyncState.requireValue;
+        return state.connectionState.isConnected &&
+            state.directoryListing != null;
+      },
+      reason: 'Nextcloud should connect and return a real directory listing.',
+      timeout: const Duration(minutes: 1),
+      diagnostics: () {
+        final asyncState = container.read(filesProvider);
+        if (asyncState.hasError) {
+          return 'filesError=${asyncState.error}';
+        }
+        if (!asyncState.hasValue) {
+          return 'filesState=loading';
+        }
+        final state = asyncState.requireValue;
+        return 'filesConnected=${state.connectionState.isConnected} '
+            'filesStatus=${state.connectionState.status} '
+            'filesMessage=${state.connectionState.message} '
+            'hasListing=${state.directoryListing != null}';
+      },
+    );
+
+    final filesState = container.read(filesProvider).requireValue;
+    final nextcloudConnected =
+        filesState.connectionState.isConnected &&
+        filesState.directoryListing != null;
+
+    if (!matrixConnected || !nextcloudConnected) {
+      fail(
+        'live_e2e_result '
+        'authSignedIn=true '
+        'matrixConnected=$matrixConnected '
+        'matrixPhase=${chatState.phase} '
+        'matrixFailure=${chatState.failure} '
+        'matrixCause=${chatState.failure?.cause} '
+        'nextcloudConnected=$nextcloudConnected '
+        'nextcloudStatus=${filesState.connectionState.status} '
+        'nextcloudMessage=${filesState.connectionState.message} '
+        'nextcloudEntries=${filesState.directoryListing?.entries.length}',
+      );
+    }
+
+    expect(matrixConnected, isTrue);
+    expect(nextcloudConnected, isTrue);
+  });
+}
+
+Future<void> _pumpUntilSettled(WidgetTester tester) async {
+  for (var i = 0; i < 20; i++) {
+    await tester.pump(const Duration(milliseconds: 200));
+  }
+}
+
+Future<void> _waitFor(
+  WidgetTester tester,
+  bool Function() predicate, {
+  required String reason,
+  Duration timeout = const Duration(seconds: 30),
+  String Function()? diagnostics,
+}) async {
+  final end = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(end)) {
+    await tester.pump(const Duration(milliseconds: 250));
+    if (predicate()) {
+      return;
+    }
+  }
+  final details = diagnostics?.call();
+  fail(details == null ? reason : '$reason\n$details');
+}
+
+class _MemorySecureStore implements SecureStore {
+  final Map<String, String> _values = <String, String>{};
+
+  @override
+  Future<void> delete(String key) async {
+    _values.remove(key);
+  }
+
+  @override
+  Future<String?> read(String key) async => _values[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    _values[key] = value;
+  }
+}
+
+class _MemoryServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _MemoryServerConfigurationRepository(this._configuration);
+
+  ServerConfiguration? _configuration;
+
+  @override
+  Future<void> clearConfiguration() async {
+    _configuration = null;
+  }
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => _configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    _configuration = configuration;
+  }
+}

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -30,7 +30,6 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>com.massimotter.weave</string>
-				<string>com.massimotter.weave.matrix</string>
 			</array>
 		</dict>
 	</array>

--- a/lib/features/chat/data/services/matrix_auth_browser.dart
+++ b/lib/features/chat/data/services/matrix_auth_browser.dart
@@ -1,9 +1,8 @@
-import 'dart:async';
-
-import 'package:flutter/services.dart';
-import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
 import 'package:riverpod/riverpod.dart';
-import 'package:weave/features/chat/domain/entities/chat_failure.dart';
+
+import 'matrix_auth_browser_stub.dart'
+    if (dart.library.io) 'matrix_auth_browser_io.dart'
+    as impl;
 
 abstract interface class MatrixAuthBrowser {
   Future<Uri> authenticate({
@@ -12,50 +11,6 @@ abstract interface class MatrixAuthBrowser {
   });
 }
 
-class FlutterWebAuthMatrixAuthBrowser implements MatrixAuthBrowser {
-  const FlutterWebAuthMatrixAuthBrowser();
-
-  @override
-  Future<Uri> authenticate({
-    required Uri authorizationUri,
-    required Uri redirectUri,
-  }) async {
-    try {
-      final result = await FlutterWebAuth2.authenticate(
-        url: authorizationUri.toString(),
-        callbackUrlScheme: redirectUri.scheme,
-        options: redirectUri.scheme == 'https'
-            ? FlutterWebAuth2Options(
-                httpsHost: redirectUri.host,
-                httpsPath: redirectUri.path,
-              )
-            : const FlutterWebAuth2Options(),
-      );
-      return Uri.parse(result);
-    } on PlatformException catch (error) {
-      if (error.code == 'CANCELED') {
-        throw ChatFailure.cancelled(
-          'Matrix sign-in was cancelled before it completed.',
-          cause: error,
-        );
-      }
-
-      final message = error.message?.trim();
-      throw ChatFailure.protocol(
-        message == null || message.isEmpty
-            ? 'Unable to complete the Matrix browser sign-in flow.'
-            : message,
-        cause: error,
-      );
-    } catch (error) {
-      throw ChatFailure.unknown(
-        'Unable to complete the Matrix browser sign-in flow.',
-        cause: error,
-      );
-    }
-  }
-}
-
 final matrixAuthBrowserProvider = Provider<MatrixAuthBrowser>(
-  (ref) => const FlutterWebAuthMatrixAuthBrowser(),
+  (ref) => impl.createMatrixAuthBrowser(),
 );

--- a/lib/features/chat/data/services/matrix_auth_browser_io.dart
+++ b/lib/features/chat/data/services/matrix_auth_browser_io.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:url_launcher/url_launcher.dart';
+import 'package:weave/features/chat/data/services/matrix_auth_browser.dart';
+import 'package:weave/features/chat/data/services/matrix_auth_browser_stub.dart'
+    as stub;
+import 'package:weave/features/chat/domain/entities/chat_failure.dart';
+
+class FlutterWebAuthMatrixAuthBrowser implements MatrixAuthBrowser {
+  const FlutterWebAuthMatrixAuthBrowser();
+
+  @override
+  Future<Uri> authenticate({
+    required Uri authorizationUri,
+    required Uri redirectUri,
+  }) async {
+    if (redirectUri.scheme == 'http' && _isLoopbackHost(redirectUri.host)) {
+      return _authenticateWithLoopbackRedirect(
+        authorizationUri: authorizationUri,
+        redirectUri: redirectUri,
+      );
+    }
+
+    return const _StubMatrixAuthBrowser().authenticate(
+      authorizationUri: authorizationUri,
+      redirectUri: redirectUri,
+    );
+  }
+
+  Future<Uri> _authenticateWithLoopbackRedirect({
+    required Uri authorizationUri,
+    required Uri redirectUri,
+  }) async {
+    HttpServer? server;
+    try {
+      server = await HttpServer.bind(
+        InternetAddress.loopbackIPv4,
+        redirectUri.port,
+      );
+      final callbackFuture = server.first.timeout(const Duration(minutes: 2));
+      final launched = await launchUrl(
+        authorizationUri,
+        mode: LaunchMode.externalApplication,
+      );
+      if (!launched) {
+        throw const ChatFailure.protocol(
+          'Unable to open the browser for Matrix sign-in.',
+        );
+      }
+
+      final request = await callbackFuture;
+      final callbackUri = request.requestedUri;
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.contentType = ContentType.html
+        ..write(_loopbackCompletionPage);
+      await request.response.close();
+      return callbackUri;
+    } on TimeoutException catch (error) {
+      throw ChatFailure.cancelled(
+        'Matrix sign-in did not return to the app in time.',
+        cause: error,
+      );
+    } on ChatFailure {
+      rethrow;
+    } catch (error) {
+      throw ChatFailure.unknown(
+        'Unable to complete the Matrix browser sign-in flow.',
+        cause: error,
+      );
+    } finally {
+      await server?.close(force: true);
+    }
+  }
+
+  bool _isLoopbackHost(String host) {
+    return host == '127.0.0.1' || host == 'localhost';
+  }
+}
+
+typedef _StubMatrixAuthBrowser = stub.FlutterWebAuthMatrixAuthBrowser;
+
+MatrixAuthBrowser createMatrixAuthBrowser() {
+  return const FlutterWebAuthMatrixAuthBrowser();
+}
+
+const _loopbackCompletionPage = '''
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Weave sign-in complete</title>
+  </head>
+  <body>
+    <script>window.close();</script>
+    <p>You can return to Weave now.</p>
+  </body>
+</html>
+''';

--- a/lib/features/chat/data/services/matrix_auth_browser_stub.dart
+++ b/lib/features/chat/data/services/matrix_auth_browser_stub.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
+import 'package:weave/features/chat/data/services/matrix_auth_browser.dart';
+import 'package:weave/features/chat/domain/entities/chat_failure.dart';
+
+class FlutterWebAuthMatrixAuthBrowser implements MatrixAuthBrowser {
+  const FlutterWebAuthMatrixAuthBrowser();
+
+  @override
+  Future<Uri> authenticate({
+    required Uri authorizationUri,
+    required Uri redirectUri,
+  }) async {
+    try {
+      final result = await FlutterWebAuth2.authenticate(
+        url: authorizationUri.toString(),
+        callbackUrlScheme: redirectUri.scheme,
+        options: redirectUri.scheme == 'https'
+            ? FlutterWebAuth2Options(
+                httpsHost: redirectUri.host,
+                httpsPath: redirectUri.path,
+              )
+            : const FlutterWebAuth2Options(),
+      );
+      return Uri.parse(result);
+    } on PlatformException catch (error) {
+      if (error.code == 'CANCELED') {
+        throw ChatFailure.cancelled(
+          'Matrix sign-in was cancelled before it completed.',
+          cause: error,
+        );
+      }
+
+      final message = error.message?.trim();
+      throw ChatFailure.protocol(
+        message == null || message.isEmpty
+            ? 'Unable to complete the Matrix browser sign-in flow.'
+            : message,
+        cause: error,
+      );
+    } catch (error) {
+      throw ChatFailure.unknown(
+        'Unable to complete the Matrix browser sign-in flow.',
+        cause: error,
+      );
+    }
+  }
+}
+
+MatrixAuthBrowser createMatrixAuthBrowser() {
+  return const FlutterWebAuthMatrixAuthBrowser();
+}

--- a/lib/features/chat/data/services/matrix_service_types.dart
+++ b/lib/features/chat/data/services/matrix_service_types.dart
@@ -4,8 +4,9 @@
 
 const matrixOidcClientName = 'Weave';
 const matrixOidcClientUri = 'https://github.com/masssi164/weave';
-const matrixOidcRedirectScheme = 'com.massimotter.weave.matrix';
-const matrixOidcRedirectUri = '$matrixOidcRedirectScheme:/oauthredirect';
+const matrixOidcContact = 'support@weave.local';
+const matrixOidcLoopbackRedirectHost = '127.0.0.1';
+const matrixOidcRedirectPath = '/oauthredirect';
 
 enum MatrixRoomPreviewType { none, text, encrypted, unsupported }
 

--- a/lib/features/chat/data/services/matrix_session_service.dart
+++ b/lib/features/chat/data/services/matrix_session_service.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:math';
+
 import 'package:matrix/matrix.dart' as sdk;
 import 'package:riverpod/riverpod.dart';
 import 'package:weave/features/chat/data/services/matrix_auth_browser.dart';
@@ -32,7 +35,6 @@ class SdkMatrixSessionService implements MatrixSessionService {
   final MatrixClientFactory _factory;
   final MatrixAuthBrowser _authBrowser;
 
-  static final Uri _redirectUri = Uri.parse(matrixOidcRedirectUri);
   static final Uri _clientUri = Uri.parse(matrixOidcClientUri);
 
   @override
@@ -57,24 +59,26 @@ class SdkMatrixSessionService implements MatrixSessionService {
     }
 
     try {
-      final oidcClient = await client.registerOidcClient(
-        redirectUris: [_redirectUri],
-        applicationType: sdk.OidcApplicationType.native,
-        clientInformation: sdk.OidcClientInformation(
-          clientName: matrixOidcClientName,
-          clientUri: _clientUri,
-          logoUri: null,
-          tosUri: null,
-          policyUri: null,
-        ),
+      final redirectUri = _buildLoopbackRedirectUri();
+      final clientInformation = sdk.OidcClientInformation(
+        clientName: matrixOidcClientName,
+        clientUri: _clientUri,
+        logoUri: null,
+        tosUri: null,
+        policyUri: null,
+      );
+      final oidcClient = await _registerOidcClient(
+        client,
+        redirectUri: redirectUri,
+        clientInformation: clientInformation,
       );
       final session = await client.initOidcLoginSession(
         oidcClientData: oidcClient,
-        redirectUri: _redirectUri,
+        redirectUri: redirectUri,
       );
       final callbackUri = await _authBrowser.authenticate(
         authorizationUri: session.authenticationUri,
-        redirectUri: _redirectUri,
+        redirectUri: redirectUri,
       );
       final callbackParameters = _extractCallbackParameters(callbackUri);
       final code = callbackParameters['code']?.trim();
@@ -199,6 +203,73 @@ class SdkMatrixSessionService implements MatrixSessionService {
     }
 
     return Uri.splitQueryString(callbackUri.fragment);
+  }
+
+  Future<sdk.OidcClientData> _registerOidcClient(
+    sdk.Client client, {
+    required Uri redirectUri,
+    required sdk.OidcClientInformation clientInformation,
+  }) async {
+    final authMetadata = await client.getAuthMetadata();
+    final response = await client.httpClient.post(
+      authMetadata.registrationEndpoint,
+      body: jsonEncode({
+        'redirect_uris': [redirectUri.toString()],
+        'token_endpoint_auth_method': 'none',
+        'response_types': const ['code'],
+        'grant_types': const ['authorization_code', 'refresh_token'],
+        'application_type': sdk.OidcApplicationType.native.name,
+        ...clientInformation.toJson(),
+        'contacts': [matrixOidcContact],
+      }),
+      headers: const {'content-type': 'application/json'},
+    );
+    if (response.statusCode != 201) {
+      throw ChatFailure.protocol(
+        'Matrix OIDC client registration failed with HTTP '
+        '${response.statusCode}: ${utf8.decode(response.bodyBytes)}',
+      );
+    }
+
+    final json = jsonDecode(utf8.decode(response.bodyBytes));
+    if (json is! Map<String, Object?>) {
+      throw const ChatFailure.protocol(
+        'The Matrix OIDC client registration response was not a JSON object.',
+      );
+    }
+
+    final clientId = json['client_id'];
+    if (clientId is! String || clientId.isEmpty) {
+      throw const ChatFailure.protocol(
+        'The Matrix OIDC client registration response did not include a client_id.',
+      );
+    }
+
+    final issuedAtRaw = json['client_id_issued_at'];
+    final issuedAt = switch (issuedAtRaw) {
+      int value when value > 9999999999 => DateTime.fromMillisecondsSinceEpoch(
+        value,
+      ),
+      int value => DateTime.fromMillisecondsSinceEpoch(value * 1000),
+      _ => null,
+    };
+
+    return sdk.OidcClientData(
+      clientId: clientId,
+      clientIdIssuedAt: issuedAt,
+      clientInformation: clientInformation,
+      additionalProperties: json,
+    );
+  }
+
+  Uri _buildLoopbackRedirectUri() {
+    final port = 20000 + Random.secure().nextInt(30000);
+    return Uri(
+      scheme: 'http',
+      host: matrixOidcLoopbackRedirectHost,
+      port: port,
+      path: matrixOidcRedirectPath,
+    );
   }
 
   Uri _normalizeUri(Uri uri) {

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -10,7 +10,6 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>com.massimotter.weave</string>
-				<string>com.massimotter.weave.matrix</string>
 			</array>
 		</dict>
 	</array>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -210,7 +210,7 @@ packages:
     source: hosted
     version: "1.15.0"
   crypto:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+  crypto: ^3.0.7
   flutter_lints: ^4.0.0
   build_runner: ^2.5.0
   riverpod_generator: ^4.0.3

--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## Summary
- replace the Matrix native auth callback scheme flow with dynamic loopback redirects on IO platforms
- register Matrix OIDC clients with loopback redirect URIs plus contact metadata
- add a live stack integration test that signs in, connects Matrix, and browses Nextcloud against the local stack

## Validation
- flutter test
- flutter test integration_test/live_stack_app_e2e_test.dart -d macos with WEAVE_* dart-defines from weave-infra bootstrap env

## Cross-repo
- depends on matching MAS/infrastructure changes from weave-infra PR and backend auth contract cleanup from weave-backend PR
