### PR TITLE
ci: run live stack e2e on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
       WEAVE_INTEGRATION_TEST_DEVICE: macos
     steps:
       - uses: actions/checkout@v4
+      - name: Free disk space on self-hosted runner
+        run: |
+          rm -rf "$HOME/Library/Developer/Xcode/DerivedData"
+          rm -rf "$GITHUB_WORKSPACE/build"
       - name: Verify local live-stack bootstrap env
         run: |
           test -f /tmp/weave-infra/weave-workspace/.generated/bootstrap.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,25 @@ jobs:
       - run: flutter test
 
   integration-test:
-    # Requires a publicly routable Weave stack or VPN/tunnel reachable from GitHub runners.
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
-    runs-on: ubuntu-latest
+    name: Live Stack Integration Test
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - weave-live
+    timeout-minutes: 45
     env:
       WEAVE_BASE_URL: ${{ inputs.WEAVE_BASE_URL }}
       WEAVE_TEST_USERNAME: ${{ inputs.WEAVE_TEST_USERNAME }}
       WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
+      WEAVE_BOOTSTRAP_ENV: /tmp/weave-infra/weave-workspace/.generated/bootstrap.env
+      WEAVE_INTEGRATION_TEST_DEVICE: macos
     steps:
       - uses: actions/checkout@v4
+      - name: Verify local live-stack bootstrap env
+        run: |
+          test -f /tmp/weave-infra/weave-workspace/.generated/bootstrap.env
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,8 @@ jobs:
       - name: Verify local live-stack bootstrap env
         run: |
           test -f /tmp/weave-infra/weave-workspace/.generated/bootstrap.env
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: stable
+      - name: Use host Flutter SDK
+        run: flutter --version
       - run: flutter pub get
       - run: flutter gen-l10n
       - run: dart run build_runner build --delete-conflicting-outputs

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ integration-test:
 	if [ -f "$$bootstrap_env" ]; then \
 	  . "$$bootstrap_env"; \
 	fi; \
-	if [ "$$caller_WEAVE_BASE_URL_set" = x ]; then WEAVE_BASE_URL="$$caller_WEAVE_BASE_URL"; fi; \
-	if [ "$$caller_WEAVE_OIDC_ISSUER_URL_set" = x ]; then WEAVE_OIDC_ISSUER_URL="$$caller_WEAVE_OIDC_ISSUER_URL"; fi; \
-	if [ "$$caller_WEAVE_OIDC_CLIENT_ID_set" = x ]; then WEAVE_OIDC_CLIENT_ID="$$caller_WEAVE_OIDC_CLIENT_ID"; fi; \
-	if [ "$$caller_WEAVE_TEST_USERNAME_set" = x ]; then WEAVE_TEST_USERNAME="$$caller_WEAVE_TEST_USERNAME"; fi; \
-	if [ "$$caller_WEAVE_TEST_PASSWORD_set" = x ]; then WEAVE_TEST_PASSWORD="$$caller_WEAVE_TEST_PASSWORD"; fi; \
+	if [ "$$caller_WEAVE_BASE_URL_set" = x ] && [ -n "$$caller_WEAVE_BASE_URL" ]; then WEAVE_BASE_URL="$$caller_WEAVE_BASE_URL"; fi; \
+	if [ "$$caller_WEAVE_OIDC_ISSUER_URL_set" = x ] && [ -n "$$caller_WEAVE_OIDC_ISSUER_URL" ]; then WEAVE_OIDC_ISSUER_URL="$$caller_WEAVE_OIDC_ISSUER_URL"; fi; \
+	if [ "$$caller_WEAVE_OIDC_CLIENT_ID_set" = x ] && [ -n "$$caller_WEAVE_OIDC_CLIENT_ID" ]; then WEAVE_OIDC_CLIENT_ID="$$caller_WEAVE_OIDC_CLIENT_ID"; fi; \
+	if [ "$$caller_WEAVE_TEST_USERNAME_set" = x ] && [ -n "$$caller_WEAVE_TEST_USERNAME" ]; then WEAVE_TEST_USERNAME="$$caller_WEAVE_TEST_USERNAME"; fi; \
+	if [ "$$caller_WEAVE_TEST_PASSWORD_set" = x ] && [ -n "$$caller_WEAVE_TEST_PASSWORD" ]; then WEAVE_TEST_PASSWORD="$$caller_WEAVE_TEST_PASSWORD"; fi; \
 	WEAVE_BASE_URL="$${WEAVE_BASE_URL:-https://api.weave.local}"; \
 	WEAVE_OIDC_ISSUER_URL="$${WEAVE_OIDC_ISSUER_URL:-https://keycloak.weave.local/realms/weave}"; \
 	WEAVE_OIDC_CLIENT_ID="$${WEAVE_OIDC_CLIENT_ID:-weave-app}"; \
@@ -36,5 +36,7 @@ integration-test:
 	  '  "WEAVE_TEST_USERNAME": "'"$${WEAVE_TEST_USERNAME}"'",' \
 	  '  "WEAVE_TEST_PASSWORD": "'"$${WEAVE_TEST_PASSWORD}"'"' \
 	  '}' > "$$dart_defines_file"; \
-	flutter test integration_test/ -d "$$test_device" \
-	  --dart-define-from-file="$$dart_defines_file"
+	for test_file in integration_test/app_test.dart integration_test/live_stack_app_e2e_test.dart; do \
+	  flutter test "$$test_file" -d "$$test_device" \
+	    --dart-define-from-file="$$dart_defines_file" || exit $$?; \
+	done

--- a/README.md
+++ b/README.md
@@ -131,16 +131,16 @@ Accessibility is a hard requirement, not a follow-up:
 ## Running Integration Tests
 Integration tests require a live local Weave stack, including the backend API and Keycloak OIDC provider. Start the stack from the `weave-infra` setup first, with local hostnames resolving to the stack and the local CA trusted by the machine or simulator running the tests.
 
-The local stack writes reusable test settings to `/tmp/weave-infra/weave-workspace/.generated/bootstrap.env`. `make integration-test` sources that file automatically when it exists. Use `WEAVE_BOOTSTRAP_ENV` when your infra checkout lives elsewhere.
+The local stack writes reusable test settings to `weave-infra/weave-workspace/.generated/bootstrap.env` and mirrors them to `/tmp/weave-infra/weave-workspace/.generated/bootstrap.env` for the self-hosted GitHub runner path. `make integration-test` sources the repo-local file first, then falls back to the `/tmp` mirror. Use `WEAVE_BOOTSTRAP_ENV` when your infra checkout lives elsewhere.
 
 Expected local hostnames include `api.weave.local`, `keycloak.weave.local`, `matrix.weave.local`, and `nextcloud.weave.local`.
 
 Run against the default local stack:
 
 ```sh
-cd /tmp/weave-infra/weave-workspace
+cd ../weave-infra/weave-workspace
 TF_VAR_create_test_user=true ./install.sh
-cd -
+cd ../../weave
 make integration-test
 ```
 
@@ -149,6 +149,8 @@ Run against a different infra checkout:
 ```sh
 WEAVE_BOOTSTRAP_ENV=../weave-inf/weave-workspace/.generated/bootstrap.env make integration-test
 ```
+
+The GitHub Actions live-stack job now runs on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner. That runner only needs the local stack bootstrapped once on the same machine because the workflow reads the mirrored `/tmp/weave-infra/.../bootstrap.env` file.
 
 Supported overrides:
 

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -144,7 +144,8 @@ void main() {
       waitForSync: true,
       federated: false,
     );
-    final sentMessage = 'live-e2e message ${DateTime.now().toUtc().toIso8601String()}';
+    final sentMessage =
+        'live-e2e message ${DateTime.now().toUtc().toIso8601String()}';
     await chatRepository.sendMessage(roomId: roomId, message: sentMessage);
     final timeline = await chatRepository.loadRoomTimeline(roomId);
     final deliveredMessage = timeline.messages
@@ -208,7 +209,8 @@ void main() {
     final nextcloudSession = await container
         .read(nextcloudConnectionServiceProvider)
         .requireLiveSession();
-    final seededFileName = 'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}.txt';
+    final seededFileName =
+        'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}.txt';
     final seededFileUri = nextcloudSession.baseUrl.resolve(
       'remote.php/dav/files/${Uri.encodeComponent(nextcloudSession.userId)}/$seededFileName',
     );
@@ -238,7 +240,8 @@ void main() {
         return listing != null &&
             listing.entries.any((entry) => entry.name == seededFileName);
       },
-      reason: 'Files view should show the file uploaded to the live Nextcloud WebDAV path.',
+      reason:
+          'Files view should show the file uploaded to the live Nextcloud WebDAV path.',
       timeout: const Duration(minutes: 1),
     );
 
@@ -254,7 +257,10 @@ void main() {
       'fileName=$seededFileName',
     );
 
-    if (!matrixConnected || !nextcloudConnected || deliveredMessage.isEmpty || matchedFiles.isEmpty) {
+    if (!matrixConnected ||
+        !nextcloudConnected ||
+        deliveredMessage.isEmpty ||
+        matchedFiles.isEmpty) {
       fail(
         'live_e2e_result '
         'authSignedIn=true '

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -11,7 +11,9 @@ import 'package:weave/core/persistence/flutter_secure_store.dart';
 import 'package:weave/core/persistence/secure_store.dart';
 import 'package:weave/features/auth/data/services/flutter_appauth_oidc_client.dart';
 import 'package:weave/features/chat/data/services/matrix_auth_browser.dart';
+import 'package:weave/features/chat/data/services/matrix_client_factory.dart';
 import 'package:weave/features/chat/presentation/providers/chat_provider.dart';
+import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
 import 'package:weave/features/files/presentation/providers/files_provider.dart';
 import 'package:weave/features/server_config/domain/entities/oidc_client_registration.dart';
 import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
@@ -19,6 +21,7 @@ import 'package:weave/features/server_config/domain/entities/server_configuratio
 import 'package:weave/features/server_config/domain/entities/service_endpoints.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_auth_headers.dart';
 import 'package:weave/integrations/nextcloud/presentation/providers/nextcloud_provider.dart';
 import 'package:weave/main.dart';
 
@@ -128,6 +131,32 @@ void main() {
     final matrixConnected =
         chatState.phase == ChatViewPhase.empty ||
         chatState.phase == ChatViewPhase.content;
+
+    final chatRepository = container.read(chatRepositoryProvider);
+    final matrixClientFactory = container.read(matrixClientFactoryProvider);
+    final matrixClient = await matrixClientFactory.getClientForHomeserver(
+      config.matrixHomeserverUrl,
+    );
+    final roomName = 'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}';
+    final roomId = await matrixClient.createGroupChat(
+      groupName: roomName,
+      enableEncryption: false,
+      waitForSync: true,
+      federated: false,
+    );
+    final sentMessage = 'live-e2e message ${DateTime.now().toUtc().toIso8601String()}';
+    await chatRepository.sendMessage(roomId: roomId, message: sentMessage);
+    final timeline = await chatRepository.loadRoomTimeline(roomId);
+    final deliveredMessage = timeline.messages
+        .where((message) => message.text == sentMessage)
+        .toList(growable: false);
+    // ignore: avoid_print
+    print(
+      'CHAT_RESULT roomId=$roomId roomName=$roomName '
+      'timelineMessages=${timeline.messages.length} '
+      'matchedMessages=${deliveredMessage.length}',
+    );
+
     // Keep the Matrix outcome visible while still validating the Nextcloud path.
     // ignore: avoid_print
     print(
@@ -176,7 +205,56 @@ void main() {
         filesState.connectionState.isConnected &&
         filesState.directoryListing != null;
 
-    if (!matrixConnected || !nextcloudConnected) {
+    final nextcloudSession = await container
+        .read(nextcloudConnectionServiceProvider)
+        .requireLiveSession();
+    final seededFileName = 'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}.txt';
+    final seededFileUri = nextcloudSession.baseUrl.resolve(
+      'remote.php/dav/files/${Uri.encodeComponent(nextcloudSession.userId)}/$seededFileName',
+    );
+    final putResponse = await nextcloudHttpClient.put(
+      seededFileUri,
+      headers: <String, String>{
+        ...buildNextcloudAuthHeaders(nextcloudSession),
+        HttpHeaders.contentTypeHeader: 'text/plain; charset=utf-8',
+      },
+      body: 'weave live e2e ${DateTime.now().toUtc().toIso8601String()}',
+    );
+    expect(
+      putResponse.statusCode,
+      anyOf(201, 204),
+      reason: 'Nextcloud WebDAV upload should succeed for the live session.',
+    );
+
+    await container.read(filesProvider.notifier).refresh();
+    await _waitFor(
+      tester,
+      () {
+        final state = container.read(filesProvider);
+        if (!state.hasValue) {
+          return false;
+        }
+        final listing = state.requireValue.directoryListing;
+        return listing != null &&
+            listing.entries.any((entry) => entry.name == seededFileName);
+      },
+      reason: 'Files view should show the file uploaded to the live Nextcloud WebDAV path.',
+      timeout: const Duration(minutes: 1),
+    );
+
+    final refreshedFilesState = container.read(filesProvider).requireValue;
+    final matchedFiles = refreshedFilesState.directoryListing!.entries
+        .where((entry) => entry.name == seededFileName)
+        .toList(growable: false);
+    // ignore: avoid_print
+    print(
+      'FILES_RESULT path=${refreshedFilesState.directoryListing!.path} '
+      'entries=${refreshedFilesState.directoryListing!.entries.length} '
+      'matchedFiles=${matchedFiles.length} '
+      'fileName=$seededFileName',
+    );
+
+    if (!matrixConnected || !nextcloudConnected || deliveredMessage.isEmpty || matchedFiles.isEmpty) {
       fail(
         'live_e2e_result '
         'authSignedIn=true '
@@ -184,15 +262,21 @@ void main() {
         'matrixPhase=${chatState.phase} '
         'matrixFailure=${chatState.failure} '
         'matrixCause=${chatState.failure?.cause} '
+        'chatRoomId=$roomId '
+        'chatMatchedMessages=${deliveredMessage.length} '
         'nextcloudConnected=$nextcloudConnected '
         'nextcloudStatus=${filesState.connectionState.status} '
         'nextcloudMessage=${filesState.connectionState.message} '
-        'nextcloudEntries=${filesState.directoryListing?.entries.length}',
+        'nextcloudEntries=${refreshedFilesState.directoryListing?.entries.length} '
+        'nextcloudMatchedFiles=${matchedFiles.length} '
+        'seededFileName=$seededFileName',
       );
     }
 
     expect(matrixConnected, isTrue);
+    expect(deliveredMessage, isNotEmpty);
     expect(nextcloudConnected, isTrue);
+    expect(matchedFiles, isNotEmpty);
   });
 }
 


### PR DESCRIPTION
## Summary
- run the live integration job on the dedicated self-hosted macOS runner for push, PR, and manual execution
- force the workflow onto the mirrored /tmp bootstrap env so GitHub jobs use the local stack credentials without paid infrastructure
- tighten the live integration assertions so chat delivery and Nextcloud upload are both proven in the same run

## Validation
- flutter pub get
- flutter gen-l10n
- dart run build_runner build --delete-conflicting-outputs
- WEAVE_BOOTSTRAP_ENV=/tmp/weave-infra/weave-workspace/.generated/bootstrap.env make integration-test