### PR TITLE
feat(files): polish breadcrumb accessibility

### DIFF
--- a/lib/features/files/presentation/files_screen.dart
+++ b/lib/features/files/presentation/files_screen.dart
@@ -242,6 +242,10 @@ class _PathBreadcrumbs extends ConsumerWidget {
     final crumbs = <Widget>[
       _BreadcrumbChip(
         label: l10n.filesRootBreadcrumb,
+        semanticLabel: path == '/'
+            ? l10n.filesCurrentFolderSemantic(l10n.filesRootBreadcrumb)
+            : l10n.filesOpenFolderSemantic(l10n.filesRootBreadcrumb),
+        isCurrent: path == '/',
         onPressed: path == '/' || isBusy
             ? null
             : () {
@@ -266,6 +270,10 @@ class _PathBreadcrumbs extends ConsumerWidget {
         ..add(
           _BreadcrumbChip(
             label: segments[index],
+            semanticLabel: isCurrent
+                ? l10n.filesCurrentFolderSemantic(segments[index])
+                : l10n.filesOpenFolderSemantic(segments[index]),
+            isCurrent: isCurrent,
             onPressed: isCurrent || isBusy
                 ? null
                 : () {
@@ -283,14 +291,33 @@ class _PathBreadcrumbs extends ConsumerWidget {
 }
 
 class _BreadcrumbChip extends StatelessWidget {
-  const _BreadcrumbChip({required this.label, required this.onPressed});
+  const _BreadcrumbChip({
+    required this.label,
+    required this.semanticLabel,
+    required this.isCurrent,
+    required this.onPressed,
+  });
 
   final String label;
+  final String semanticLabel;
+  final bool isCurrent;
   final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return ActionChip(label: Text(label), onPressed: onPressed);
+    return Semantics(
+      button: onPressed != null,
+      enabled: onPressed != null,
+      selected: isCurrent,
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: ActionChip(
+          avatar: isCurrent ? const Icon(Icons.place_outlined, size: 18) : null,
+          label: Text(label),
+          onPressed: onPressed,
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -47,6 +47,8 @@
   "filesRefreshButton": "Aktualisieren",
   "filesUpButton": "Nach oben",
   "filesRootBreadcrumb": "Root",
+  "filesOpenFolderSemantic": "Ordner öffnen: {name}",
+  "filesCurrentFolderSemantic": "Aktueller Ordner: {name}",
   "filesDirectorySummary": "{folderCount, plural, =0{Keine Ordner} one{1 Ordner} other{{folderCount} Ordner}} • {fileCount, plural, =0{keine Dateien} one{1 Datei} other{{fileCount} Dateien}}",
   "filesDisconnectedMessage": "Verbinde Nextcloud, um deine Dateien zu durchsuchen.",
   "filesInvalidSessionMessage": "Verbinde Nextcloud erneut, weil die gespeicherte Sitzung nicht mehr gültig ist.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -147,6 +147,22 @@
   "filesRootBreadcrumb": "Root",
   "@filesRootBreadcrumb": { "description": "Label for the root breadcrumb in the files browser" },
 
+  "filesOpenFolderSemantic": "Open folder: {name}",
+  "@filesOpenFolderSemantic": {
+    "description": "Semantic label for a breadcrumb that opens a folder in the files browser",
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+
+  "filesCurrentFolderSemantic": "Current folder: {name}",
+  "@filesCurrentFolderSemantic": {
+    "description": "Semantic label for the current breadcrumb in the files browser",
+    "placeholders": {
+      "name": { "type": "String" }
+    }
+  },
+
   "filesDirectorySummary": "{folderCount, plural, =0{No folders} one{1 folder} other{{folderCount} folders}} • {fileCount, plural, =0{no files} one{1 file} other{{fileCount} files}}",
   "@filesDirectorySummary": {
     "description": "Summary for the current directory contents",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -380,6 +380,18 @@ abstract class AppLocalizations {
   /// **'Root'**
   String get filesRootBreadcrumb;
 
+  /// Semantic label for a breadcrumb that opens a folder in the files browser
+  ///
+  /// In en, this message translates to:
+  /// **'Open folder: {name}'**
+  String filesOpenFolderSemantic(String name);
+
+  /// Semantic label for the current breadcrumb in the files browser
+  ///
+  /// In en, this message translates to:
+  /// **'Current folder: {name}'**
+  String filesCurrentFolderSemantic(String name);
+
   /// Summary for the current directory contents
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -157,6 +157,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get filesRootBreadcrumb => 'Root';
 
   @override
+  String filesOpenFolderSemantic(String name) {
+    return 'Ordner öffnen: $name';
+  }
+
+  @override
+  String filesCurrentFolderSemantic(String name) {
+    return 'Aktueller Ordner: $name';
+  }
+
+  @override
   String filesDirectorySummary(int folderCount, int fileCount) {
     String _temp0 = intl.Intl.pluralLogic(
       folderCount,

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -156,6 +156,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get filesRootBreadcrumb => 'Root';
 
   @override
+  String filesOpenFolderSemantic(String name) {
+    return 'Open folder: $name';
+  }
+
+  @override
+  String filesCurrentFolderSemantic(String name) {
+    return 'Current folder: $name';
+  }
+
+  @override
   String filesDirectorySummary(int folderCount, int fileCount) {
     String _temp0 = intl.Intl.pluralLogic(
       folderCount,

--- a/test/features/files/files_screen_test.dart
+++ b/test/features/files/files_screen_test.dart
@@ -186,6 +186,94 @@ void main() {
       expect(find.text('Root'), findsOneWidget);
     });
 
+    testWidgets('marks the current breadcrumb and lets users jump back home', (
+      tester,
+    ) async {
+      final repository = _FakeFilesRepository(
+        connectionState: FilesConnectionState.connected(
+          baseUrl: Uri.parse('https://nextcloud.home.internal'),
+          accountLabel: 'alice',
+        ),
+        listings: const {
+          '/': DirectoryListing(
+            path: '/',
+            entries: [
+              FileEntry(
+                id: 'folder-1',
+                name: 'Documents',
+                path: '/Documents',
+                isDirectory: true,
+              ),
+            ],
+          ),
+          '/Documents': DirectoryListing(
+            path: '/Documents',
+            entries: [
+              FileEntry(
+                id: 'folder-2',
+                name: 'Reports',
+                path: '/Documents/Reports',
+                isDirectory: true,
+              ),
+            ],
+          ),
+          '/Documents/Reports': DirectoryListing(
+            path: '/Documents/Reports',
+            entries: [
+              FileEntry(
+                id: 'file-2',
+                name: 'Q2.pdf',
+                path: '/Documents/Reports/Q2.pdf',
+                isDirectory: false,
+              ),
+            ],
+          ),
+        },
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          const FilesScreen(),
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.ancestor(
+          of: find.text('Documents').first,
+          matching: find.byType(InkWell),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.ancestor(
+          of: find.text('Reports').first,
+          matching: find.byType(InkWell),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final reportsChip = tester.widget<ActionChip>(
+        find.widgetWithText(ActionChip, 'Reports'),
+      );
+      expect(reportsChip.onPressed, isNull);
+      expect(find.bySemanticsLabel('Current folder: Reports'), findsOneWidget);
+      expect(find.bySemanticsLabel('Open folder: Root'), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(ActionChip, 'Root'));
+      await tester.pumpAndSettle();
+
+      expect(repository.requestedPaths.last, '/');
+      expect(find.text('Documents'), findsAtLeastNWidgets(1));
+    });
+
     testWidgets('meets androidTapTargetGuideline', (tester) async {
       final repository = _FakeFilesRepository(
         connectionState: FilesConnectionState.disconnected(


### PR DESCRIPTION
## Summary\n- make the current Files breadcrumb visually distinct and expose explicit breadcrumb semantics for screen readers\n- add localized semantic labels for opening folders versus announcing the current folder\n- cover current-crumb and jump-to-root behavior with a widget test\n\n## Validation\n- flutter test test/features/files/files_screen_test.dart\n- flutter analyze\n\nCloses #56