### PR TITLE
ci: declare reusable live-stack secret in workflow_call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,21 @@ jobs:
         run: |
           CA_FILE="$GITHUB_WORKSPACE/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/weave-local-ca.pem"
           security add-trusted-cert -d -r trustRoot -k "$HOME/Library/Keychains/login.keychain-db" "$CA_FILE" || true
+      - name: Ensure local Weave hostnames resolve on the runner
+        run: |
+          set -euo pipefail
+          hosts_line='127.0.0.1 keycloak.weave.local nextcloud.weave.local matrix.weave.local api.weave.local'
+          if grep -Fq "$hosts_line" /etc/hosts; then
+            exit 0
+          fi
+
+          if sudo -n true 2>/dev/null; then
+            printf '%s\n' "$hosts_line" | sudo tee -a /etc/hosts >/dev/null
+          else
+            echo "Missing passwordless sudo for /etc/hosts update on weave-live runner" >&2
+            echo "Pre-provision this hosts entry on the runner: $hosts_line" >&2
+            exit 1
+          fi
       - name: Verify local live-stack bootstrap env
         run: |
           test -f "$WEAVE_BOOTSTRAP_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       WEAVE_BASE_URL: ${{ inputs.WEAVE_BASE_URL }}
       WEAVE_TEST_USERNAME: ${{ inputs.WEAVE_TEST_USERNAME }}
       WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
+      TF_VAR_test_user_password: ${{ secrets.WEAVE_TEST_PASSWORD }}
       WEAVE_BOOTSTRAP_ENV: ${{ github.workspace }}/weave-infra/weave-workspace/.generated/bootstrap.env
       WEAVE_INTEGRATION_TEST_DEVICE: macos
       WEAVE_INFRA_REF: ${{ inputs.WEAVE_INFRA_REF || 'main' }}

--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -21,14 +21,13 @@ on:
         type: string
         required: false
         default: "main"
+    secrets:
+      WEAVE_TEST_PASSWORD:
+        required: true
 
 permissions:
   contents: read
   packages: read
-
-secrets:
-  WEAVE_TEST_PASSWORD:
-    required: true
 
 concurrency:
   group: weave-live-stack-self-hosted

--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -26,6 +26,10 @@ permissions:
   contents: read
   packages: read
 
+secrets:
+  WEAVE_TEST_PASSWORD:
+    required: true
+
 concurrency:
   group: weave-live-stack-self-hosted
   cancel-in-progress: false
@@ -42,6 +46,8 @@ jobs:
     env:
       WEAVE_BACKEND_IMAGE: ${{ inputs.weave_backend_image || github.event.inputs.weave_backend_image || 'ghcr.io/masssi164/weave-backend:latest' }}
       WEAVE_INFRA_REF: ${{ inputs.weave_infra_ref || github.event.inputs.weave_infra_ref || 'main' }}
+      WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
+      TF_VAR_test_user_password: ${{ secrets.WEAVE_TEST_PASSWORD }}
       TF_VAR_create_test_user: 'true'
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'


### PR DESCRIPTION
## Summary
- move `WEAVE_TEST_PASSWORD` secret declaration under `on.workflow_call.secrets`
- keep the reusable live-stack workflow valid while forwarding the test-user secret

## Why
The previous patch added a top-level `secrets:` block, which is not valid for reusable workflow secret declarations. GitHub rejected the workflow before jobs even started.

## Effect
Reusable live-stack calls can now receive `WEAVE_TEST_PASSWORD` correctly.
