### PR TITLE
ci: remove invalid top-level secrets from live-stack workflow

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -29,10 +29,6 @@ permissions:
   contents: read
   packages: read
 
-secrets:
-  WEAVE_TEST_PASSWORD:
-    required: true
-
 concurrency:
   group: weave-live-stack-self-hosted
   cancel-in-progress: false


### PR DESCRIPTION
## Summary
- remove the invalid top-level `secrets:` block from `live-stack-e2e.yml`
- keep reusable secret declaration only under `on.workflow_call.secrets`

## Why
GitHub rejects the workflow before jobs start when a top-level `secrets:` block is present here.
