### PR TITLE
ci: preseed live-stack bootstrap secrets for self-hosted runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,19 @@ jobs:
       WEAVE_TEST_USERNAME: ${{ inputs.WEAVE_TEST_USERNAME }}
       WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
       TF_VAR_test_user_password: ${{ secrets.WEAVE_TEST_PASSWORD }}
+      TF_VAR_db_admin_password: ci-db-admin-password
+      TF_VAR_keycloak_admin_password: ci-keycloak-admin-password
+      TF_VAR_keycloak_db_password: ci-keycloak-db-password
+      TF_VAR_mas_db_password: ci-mas-db-password
+      TF_VAR_synapse_db_password: ci-synapse-db-password
+      TF_VAR_nextcloud_db_password: ci-nextcloud-db-password
+      TF_VAR_nextcloud_admin_password: ci-nextcloud-admin-password
+      TF_VAR_matrix_mas_client_secret: ci-matrix-mas-client-secret
+      TF_VAR_mas_encryption_secret: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      TF_VAR_mas_matrix_secret: ci-mas-matrix-secret
+      TF_VAR_synapse_registration_shared_secret: ci-synapse-registration-shared-secret
+      TF_VAR_synapse_macaroon_secret_key: ci-synapse-macaroon-secret-key
+      TF_VAR_synapse_form_secret: ci-synapse-form-secret
       WEAVE_BOOTSTRAP_ENV: ${{ github.workspace }}/weave-infra/weave-workspace/.generated/bootstrap.env
       WEAVE_INTEGRATION_TEST_DEVICE: macos
       WEAVE_INFRA_REF: ${{ inputs.WEAVE_INFRA_REF || 'main' }}

--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -47,6 +47,19 @@ jobs:
       WEAVE_INFRA_REF: ${{ inputs.weave_infra_ref || github.event.inputs.weave_infra_ref || 'main' }}
       WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
       TF_VAR_test_user_password: ${{ secrets.WEAVE_TEST_PASSWORD }}
+      TF_VAR_db_admin_password: ci-db-admin-password
+      TF_VAR_keycloak_admin_password: ci-keycloak-admin-password
+      TF_VAR_keycloak_db_password: ci-keycloak-db-password
+      TF_VAR_mas_db_password: ci-mas-db-password
+      TF_VAR_synapse_db_password: ci-synapse-db-password
+      TF_VAR_nextcloud_db_password: ci-nextcloud-db-password
+      TF_VAR_nextcloud_admin_password: ci-nextcloud-admin-password
+      TF_VAR_matrix_mas_client_secret: ci-matrix-mas-client-secret
+      TF_VAR_mas_encryption_secret: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      TF_VAR_mas_matrix_secret: ci-mas-matrix-secret
+      TF_VAR_synapse_registration_shared_secret: ci-synapse-registration-shared-secret
+      TF_VAR_synapse_macaroon_secret_key: ci-synapse-macaroon-secret-key
+      TF_VAR_synapse_form_secret: ci-synapse-form-secret
       TF_VAR_create_test_user: 'true'
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'


### PR DESCRIPTION
## Strategy
The failure moved to bootstrap, specifically Terraform variable resolution before `install.sh` finishes generating defaults. Instead of relying on later in-script secret generation, preseed the required `TF_VAR_*` values in CI so bootstrap starts deterministically on the self-hosted runner.

## Changes
- preseed required bootstrap secrets in `CI`
- preseed the same values in reusable `live-stack-e2e`
- keep the test-user password flowing from `WEAVE_TEST_PASSWORD`

## Verification plan
- merge
- rerun `weave` main CI
- inspect whether bootstrap now passes and the run advances into readiness / Flutter / app E2E
