### PR TITLE
[codex] Align client platform contract baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
       WEAVE_BACKEND_IMAGE:
         description: "Backend image to boot inside the infra stack"
         required: false
-        default: "ghcr.io/masssi164/weave-backend:latest"
+        default: "weave-backend:live-stack-ci"
   workflow_call:
     inputs:
       WEAVE_BASE_URL:
@@ -43,7 +43,7 @@ on:
       WEAVE_BACKEND_IMAGE:
         type: string
         required: false
-        default: "ghcr.io/masssi164/weave-backend:latest"
+        default: "weave-backend:live-stack-ci"
     secrets:
       WEAVE_TEST_PASSWORD:
         required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Ensure local Weave hostnames resolve on the runner
         run: |
           set -euo pipefail
-          hosts_line='127.0.0.1 keycloak.weave.local nextcloud.weave.local matrix.weave.local api.weave.local'
+          hosts_line='127.0.0.1 weave.local auth.weave.local files.weave.local matrix.weave.local'
           if grep -Fq "$hosts_line" /etc/hosts; then
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
       WEAVE_REMOVE_VOLUMES: 'true'
       TF_VAR_create_test_user: 'true'
       TF_VAR_tenant_domain: 127.0.0.1.sslip.io
+      TF_VAR_caddy_tls_cert_file: ${{ github.workspace }}/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/127.0.0.1.sslip.io.pem
+      TF_VAR_caddy_tls_key_file: ${{ github.workspace }}/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/127.0.0.1.sslip.io-key.pem
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
       TF_VAR_keycloak_host_port: '48080'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,13 +195,6 @@ jobs:
         env:
           TF_VAR_weave_backend_image: ${{ env.WEAVE_BACKEND_IMAGE }}
         run: ./install.sh
-      - name: Verify stack readiness before Flutter work
-        working-directory: weave-infra/weave-workspace
-        run: bash ./operator-check.sh
-      - name: Trust local Weave CA for this runner user
-        run: |
-          CA_FILE="$GITHUB_WORKSPACE/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/weave-local-ca.pem"
-          security add-trusted-cert -d -r trustRoot -k "$HOME/Library/Keychains/login.keychain-db" "$CA_FILE" || true
       - name: Ensure local Weave hostnames resolve on the runner
         run: |
           set -euo pipefail
@@ -217,6 +210,13 @@ jobs:
             echo "Pre-provision this hosts entry on the runner: $hosts_line" >&2
             exit 1
           fi
+      - name: Verify stack readiness before Flutter work
+        working-directory: weave-infra/weave-workspace
+        run: bash ./operator-check.sh
+      - name: Trust local Weave CA for this runner user
+        run: |
+          CA_FILE="$GITHUB_WORKSPACE/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/weave-local-ca.pem"
+          security add-trusted-cert -d -r trustRoot -k "$HOME/Library/Keychains/login.keychain-db" "$CA_FILE" || true
       - name: Verify local live-stack bootstrap env
         run: |
           test -f "$WEAVE_BOOTSTRAP_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       REQUESTED_WEAVE_BACKEND_REF: ${{ inputs.WEAVE_BACKEND_REF || github.head_ref || github.ref_name || 'main' }}
       WEAVE_BACKEND_IMAGE: ${{ inputs.WEAVE_BACKEND_IMAGE || 'weave-backend:live-stack-ci' }}
       DOCKER_BUILDKIT: '1'
+      WEAVE_REMOVE_VOLUMES: 'true'
       TF_VAR_create_test_user: 'true'
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
         description: "Git ref to use for weave-infra"
         required: false
         default: "main"
+      WEAVE_BACKEND_REF:
+        description: "Git ref to use for weave-backend when building the live-stack backend image"
+        required: false
+        default: "main"
       WEAVE_BACKEND_IMAGE:
         description: "Backend image to boot inside the infra stack"
         required: false
@@ -29,6 +33,10 @@ on:
         type: string
         required: true
       WEAVE_INFRA_REF:
+        type: string
+        required: false
+        default: "main"
+      WEAVE_BACKEND_REF:
         type: string
         required: false
         default: "main"
@@ -95,8 +103,9 @@ jobs:
       TF_VAR_synapse_form_secret: ci-synapse-form-secret
       WEAVE_BOOTSTRAP_ENV: ${{ github.workspace }}/weave-infra/weave-workspace/.generated/bootstrap.env
       WEAVE_INTEGRATION_TEST_DEVICE: macos
-      WEAVE_INFRA_REF: ${{ inputs.WEAVE_INFRA_REF || 'main' }}
-      WEAVE_BACKEND_IMAGE: ${{ inputs.WEAVE_BACKEND_IMAGE || 'ghcr.io/masssi164/weave-backend:latest' }}
+      REQUESTED_WEAVE_INFRA_REF: ${{ inputs.WEAVE_INFRA_REF || github.head_ref || github.ref_name || 'main' }}
+      REQUESTED_WEAVE_BACKEND_REF: ${{ inputs.WEAVE_BACKEND_REF || github.head_ref || github.ref_name || 'main' }}
+      WEAVE_BACKEND_IMAGE: ${{ inputs.WEAVE_BACKEND_IMAGE || 'weave-backend:live-stack-ci' }}
       TF_VAR_create_test_user: 'true'
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
@@ -107,14 +116,46 @@ jobs:
       TF_VAR_backend_host_port: '48084'
       WEAVE_RUNNER_HYGIENE: 'true'
     steps:
+      - name: Resolve companion repository refs
+        id: companion_refs
+        run: |
+          set -euo pipefail
+
+          resolve_ref() {
+            local repo="$1"
+            local requested_ref="$2"
+
+            if git ls-remote --exit-code --heads "https://github.com/${repo}.git" "${requested_ref}" >/dev/null 2>&1; then
+              printf '%s' "${requested_ref}"
+            else
+              printf '%s' "main"
+            fi
+          }
+
+          infra_ref="$(resolve_ref masssi164/weave-infra "${REQUESTED_WEAVE_INFRA_REF}")"
+          backend_ref="$(resolve_ref masssi164/weave-backend "${REQUESTED_WEAVE_BACKEND_REF}")"
+
+          {
+            echo "infra_ref=${infra_ref}"
+            echo "backend_ref=${backend_ref}"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Using weave-infra ref: ${infra_ref}"
+          echo "Using weave-backend ref: ${backend_ref}"
+
       - uses: actions/checkout@v4
         with:
           path: weave
       - uses: actions/checkout@v4
         with:
           repository: masssi164/weave-infra
-          ref: ${{ env.WEAVE_INFRA_REF }}
+          ref: ${{ steps.companion_refs.outputs.infra_ref }}
           path: weave-infra
+      - uses: actions/checkout@v4
+        with:
+          repository: masssi164/weave-backend
+          ref: ${{ steps.companion_refs.outputs.backend_ref }}
+          path: weave-backend
       - name: Configure Docker auth without macOS Keychain
         shell: bash
         env:
@@ -131,8 +172,8 @@ jobs:
           chmod 600 "$DOCKER_CONFIG/config.json"
           echo "DOCKER_CONFIG=$DOCKER_CONFIG" >> "$GITHUB_ENV"
           docker --config "$DOCKER_CONFIG" info >/dev/null
-      - name: Pull backend image
-        run: docker pull "${WEAVE_BACKEND_IMAGE}"
+      - name: Build backend image
+        run: docker build -t "${WEAVE_BACKEND_IMAGE}" weave-backend
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       DOCKER_BUILDKIT: '1'
       WEAVE_REMOVE_VOLUMES: 'true'
       TF_VAR_create_test_user: 'true'
-      TF_VAR_tenant_domain: localhost
+      TF_VAR_tenant_domain: weave.local
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
       TF_VAR_keycloak_host_port: '48080'
@@ -196,10 +196,23 @@ jobs:
         env:
           TF_VAR_weave_backend_image: ${{ env.WEAVE_BACKEND_IMAGE }}
         run: ./install.sh
-      - name: Verify local test hostnames resolve on the runner
+      - name: Ensure local test hostnames resolve on the runner
         run: |
           set -euo pipefail
-          for host in localhost auth.localhost files.localhost matrix.localhost; do
+          hosts=(weave.local auth.weave.local files.weave.local matrix.weave.local)
+          missing=()
+          for host in "${hosts[@]}"; do
+            if ! dscacheutil -q host -a name "$host" | grep -q 'ip_address:'; then
+              missing+=("$host")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            line="127.0.0.1 ${missing[*]}"
+            echo "Adding local live-stack host entries: ${missing[*]}"
+            printf '%s\n' "$line" | sudo tee -a /etc/hosts >/dev/null
+            dscacheutil -flushcache || true
+          fi
+          for host in "${hosts[@]}"; do
             dscacheutil -q host -a name "$host" | grep -q 'ip_address:' || {
               echo "Runner cannot resolve $host to loopback" >&2
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
       REQUESTED_WEAVE_INFRA_REF: ${{ inputs.WEAVE_INFRA_REF || github.head_ref || github.ref_name || 'main' }}
       REQUESTED_WEAVE_BACKEND_REF: ${{ inputs.WEAVE_BACKEND_REF || github.head_ref || github.ref_name || 'main' }}
       WEAVE_BACKEND_IMAGE: ${{ inputs.WEAVE_BACKEND_IMAGE || 'weave-backend:live-stack-ci' }}
+      DOCKER_BUILDKIT: '1'
       TF_VAR_create_test_user: 'true'
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,10 @@ jobs:
           chmod 600 "$DOCKER_CONFIG/config.json"
           echo "DOCKER_CONFIG=$DOCKER_CONFIG" >> "$GITHUB_ENV"
           docker --config "$DOCKER_CONFIG" info >/dev/null
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build backend image
-        run: docker build -t "${WEAVE_BACKEND_IMAGE}" weave-backend
+        run: docker buildx build --load -t "${WEAVE_BACKEND_IMAGE}" weave-backend
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
       DOCKER_BUILDKIT: '1'
       WEAVE_REMOVE_VOLUMES: 'true'
       TF_VAR_create_test_user: 'true'
-      TF_VAR_tenant_domain: weave.local
+      TF_VAR_tenant_domain: 127.0.0.1.sslip.io
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
       TF_VAR_keycloak_host_port: '48080'
@@ -196,24 +196,12 @@ jobs:
         env:
           TF_VAR_weave_backend_image: ${{ env.WEAVE_BACKEND_IMAGE }}
         run: ./install.sh
-      - name: Ensure local test hostnames resolve on the runner
+      - name: Verify local test hostnames resolve on the runner
         run: |
           set -euo pipefail
-          hosts=(weave.local auth.weave.local files.weave.local matrix.weave.local)
-          missing=()
+          hosts=(127.0.0.1.sslip.io auth.127.0.0.1.sslip.io files.127.0.0.1.sslip.io matrix.127.0.0.1.sslip.io)
           for host in "${hosts[@]}"; do
-            if ! dscacheutil -q host -a name "$host" | grep -q 'ip_address:'; then
-              missing+=("$host")
-            fi
-          done
-          if (( ${#missing[@]} > 0 )); then
-            line="127.0.0.1 ${missing[*]}"
-            echo "Adding local live-stack host entries: ${missing[*]}"
-            printf '%s\n' "$line" | sudo tee -a /etc/hosts >/dev/null
-            dscacheutil -flushcache || true
-          fi
-          for host in "${hosts[@]}"; do
-            dscacheutil -q host -a name "$host" | grep -q 'ip_address:' || {
+            dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1' || {
               echo "Runner cannot resolve $host to loopback" >&2
               exit 1
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,7 @@ jobs:
       DOCKER_BUILDKIT: '1'
       WEAVE_REMOVE_VOLUMES: 'true'
       TF_VAR_create_test_user: 'true'
-      TF_VAR_tenant_domain: 127.0.0.1.sslip.io
-      TF_VAR_caddy_tls_cert_file: ${{ github.workspace }}/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/127.0.0.1.sslip.io.pem
-      TF_VAR_caddy_tls_key_file: ${{ github.workspace }}/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/127.0.0.1.sslip.io-key.pem
+      TF_VAR_tenant_domain: weave.local
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
       TF_VAR_keycloak_host_port: '48080'
@@ -190,6 +188,34 @@ jobs:
         run: |
           rm -rf "$HOME/Library/Developer/Xcode/DerivedData"
           rm -rf "$GITHUB_WORKSPACE/build"
+      - name: Ensure local Weave hostnames resolve on the runner
+        run: |
+          set -euo pipefail
+          hosts=(weave.local auth.weave.local files.weave.local matrix.weave.local)
+          missing=()
+          for host in "${hosts[@]}"; do
+            if ! dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1'; then
+              missing+=("$host")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            line="127.0.0.1 ${missing[*]}"
+            if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+              printf '%s\n' "$line" | sudo tee -a /etc/hosts >/dev/null
+              sudo dscacheutil -flushcache || true
+            else
+              echo "::error::Runner cannot resolve required Weave hostnames and passwordless sudo is unavailable. Add this /etc/hosts line before rerunning: $line" >&2
+              exit 1
+            fi
+          fi
+
+          for host in "${hosts[@]}"; do
+            dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1' || {
+              echo "::error::Runner still cannot resolve $host to 127.0.0.1" >&2
+              exit 1
+            }
+          done
       - name: Clean up stale stack state before bootstrap
         working-directory: weave-infra/weave-workspace
         run: bash ./teardown.sh
@@ -201,7 +227,7 @@ jobs:
       - name: Verify local test hostnames resolve on the runner
         run: |
           set -euo pipefail
-          hosts=(127.0.0.1.sslip.io auth.127.0.0.1.sslip.io files.127.0.0.1.sslip.io matrix.127.0.0.1.sslip.io)
+          hosts=(weave.local auth.weave.local files.weave.local matrix.weave.local)
           for host in "${hosts[@]}"; do
             dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1' || {
               echo "Runner cannot resolve $host to loopback" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
   integration-test:
     name: Live Stack Integration Test
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     concurrency:
       group: weave-live-stack-self-hosted
       cancel-in-progress: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,9 @@ jobs:
       DOCKER_BUILDKIT: '1'
       WEAVE_REMOVE_VOLUMES: 'true'
       TF_VAR_create_test_user: 'true'
-      TF_VAR_tenant_domain: weave.local
+      TF_VAR_tenant_domain: 127.0.0.1.sslip.io
+      TF_VAR_caddy_tls_cert_file: ${{ github.workspace }}/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/127.0.0.1.sslip.io.pem
+      TF_VAR_caddy_tls_key_file: ${{ github.workspace }}/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/127.0.0.1.sslip.io-key.pem
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
       TF_VAR_keycloak_host_port: '48080'
@@ -188,34 +190,6 @@ jobs:
         run: |
           rm -rf "$HOME/Library/Developer/Xcode/DerivedData"
           rm -rf "$GITHUB_WORKSPACE/build"
-      - name: Ensure local Weave hostnames resolve on the runner
-        run: |
-          set -euo pipefail
-          hosts=(weave.local auth.weave.local files.weave.local matrix.weave.local)
-          missing=()
-          for host in "${hosts[@]}"; do
-            if ! dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1'; then
-              missing+=("$host")
-            fi
-          done
-
-          if (( ${#missing[@]} > 0 )); then
-            line="127.0.0.1 ${missing[*]}"
-            if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-              printf '%s\n' "$line" | sudo tee -a /etc/hosts >/dev/null
-              sudo dscacheutil -flushcache || true
-            else
-              echo "::error::Runner cannot resolve required Weave hostnames and passwordless sudo is unavailable. Add this /etc/hosts line before rerunning: $line" >&2
-              exit 1
-            fi
-          fi
-
-          for host in "${hosts[@]}"; do
-            dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1' || {
-              echo "::error::Runner still cannot resolve $host to 127.0.0.1" >&2
-              exit 1
-            }
-          done
       - name: Clean up stale stack state before bootstrap
         working-directory: weave-infra/weave-workspace
         run: bash ./teardown.sh
@@ -227,7 +201,7 @@ jobs:
       - name: Verify local test hostnames resolve on the runner
         run: |
           set -euo pipefail
-          hosts=(weave.local auth.weave.local files.weave.local matrix.weave.local)
+          hosts=(127.0.0.1.sslip.io auth.127.0.0.1.sslip.io files.127.0.0.1.sslip.io matrix.127.0.0.1.sslip.io)
           for host in "${hosts[@]}"; do
             dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1' || {
               echo "Runner cannot resolve $host to loopback" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
       DOCKER_BUILDKIT: '1'
       WEAVE_REMOVE_VOLUMES: 'true'
       TF_VAR_create_test_user: 'true'
+      TF_VAR_tenant_domain: localhost
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
       TF_VAR_keycloak_host_port: '48080'
@@ -195,21 +196,15 @@ jobs:
         env:
           TF_VAR_weave_backend_image: ${{ env.WEAVE_BACKEND_IMAGE }}
         run: ./install.sh
-      - name: Ensure local Weave hostnames resolve on the runner
+      - name: Verify local test hostnames resolve on the runner
         run: |
           set -euo pipefail
-          hosts_line='127.0.0.1 weave.local auth.weave.local files.weave.local matrix.weave.local'
-          if grep -Fq "$hosts_line" /etc/hosts; then
-            exit 0
-          fi
-
-          if sudo -n true 2>/dev/null; then
-            printf '%s\n' "$hosts_line" | sudo tee -a /etc/hosts >/dev/null
-          else
-            echo "Missing passwordless sudo for /etc/hosts update on weave-live runner" >&2
-            echo "Pre-provision this hosts entry on the runner: $hosts_line" >&2
-            exit 1
-          fi
+          for host in localhost auth.localhost files.localhost matrix.localhost; do
+            dscacheutil -q host -a name "$host" | grep -q 'ip_address:' || {
+              echo "Runner cannot resolve $host to loopback" >&2
+              exit 1
+            }
+          done
       - name: Verify stack readiness before Flutter work
         working-directory: weave-infra/weave-workspace
         run: bash ./operator-check.sh

--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -70,7 +70,7 @@ jobs:
       TF_VAR_synapse_macaroon_secret_key: ci-synapse-macaroon-secret-key
       TF_VAR_synapse_form_secret: ci-synapse-form-secret
       TF_VAR_create_test_user: 'true'
-      TF_VAR_tenant_domain: localhost
+      TF_VAR_tenant_domain: weave.local
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
       TF_VAR_keycloak_host_port: '48080'
@@ -135,6 +135,35 @@ jobs:
           terraform_version: 1.9.8
           terraform_wrapper: false
 
+      - name: Ensure local Weave hostnames resolve on the runner
+        run: |
+          set -euo pipefail
+          hosts=(weave.local auth.weave.local files.weave.local matrix.weave.local)
+          missing=()
+          for host in "${hosts[@]}"; do
+            if ! dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1'; then
+              missing+=("$host")
+            fi
+          done
+
+          if (( ${#missing[@]} > 0 )); then
+            line="127.0.0.1 ${missing[*]}"
+            if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+              printf '%s\n' "$line" | sudo tee -a /etc/hosts >/dev/null
+              sudo dscacheutil -flushcache || true
+            else
+              echo "::error::Runner cannot resolve required Weave hostnames and passwordless sudo is unavailable. Add this /etc/hosts line before rerunning: $line" >&2
+              exit 1
+            fi
+          fi
+
+          for host in "${hosts[@]}"; do
+            dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1' || {
+              echo "::error::Runner still cannot resolve $host to 127.0.0.1" >&2
+              exit 1
+            }
+          done
+
       - name: Clean up stale stack state before bootstrap
         working-directory: weave-infra/weave-workspace
         run: bash ./teardown.sh
@@ -151,7 +180,7 @@ jobs:
       - name: Verify local test hostnames resolve on the runner
         run: |
           set -euo pipefail
-          for host in localhost auth.localhost files.localhost matrix.localhost; do
+          for host in weave.local auth.weave.local files.weave.local matrix.weave.local; do
             dscacheutil -q host -a name "$host" | grep -q 'ip_address:' || {
               echo "Runner cannot resolve $host to loopback" >&2
               exit 1

--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -6,7 +6,11 @@ on:
       weave_backend_image:
         description: "Backend image to boot inside the infra stack"
         required: false
-        default: "ghcr.io/masssi164/weave-backend:latest"
+        default: "weave-backend:live-stack-ci"
+      weave_backend_ref:
+        description: "Git ref to use for weave-backend when building the live-stack backend image"
+        required: false
+        default: "main"
       weave_infra_ref:
         description: "Git ref to use for weave-infra"
         required: false
@@ -16,7 +20,11 @@ on:
       weave_backend_image:
         type: string
         required: false
-        default: "ghcr.io/masssi164/weave-backend:latest"
+        default: "weave-backend:live-stack-ci"
+      weave_backend_ref:
+        type: string
+        required: false
+        default: "main"
       weave_infra_ref:
         type: string
         required: false
@@ -43,8 +51,9 @@ jobs:
       - weave-live
     timeout-minutes: 75
     env:
-      WEAVE_BACKEND_IMAGE: ${{ inputs.weave_backend_image || github.event.inputs.weave_backend_image || 'ghcr.io/masssi164/weave-backend:latest' }}
+      WEAVE_BACKEND_IMAGE: ${{ inputs.weave_backend_image || github.event.inputs.weave_backend_image || 'weave-backend:live-stack-ci' }}
       WEAVE_INFRA_REF: ${{ inputs.weave_infra_ref || github.event.inputs.weave_infra_ref || 'main' }}
+      WEAVE_BACKEND_REF: ${{ inputs.weave_backend_ref || github.event.inputs.weave_backend_ref || 'main' }}
       WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
       TF_VAR_test_user_password: ${{ secrets.WEAVE_TEST_PASSWORD }}
       TF_VAR_db_admin_password: ci-db-admin-password
@@ -61,6 +70,7 @@ jobs:
       TF_VAR_synapse_macaroon_secret_key: ci-synapse-macaroon-secret-key
       TF_VAR_synapse_form_secret: ci-synapse-form-secret
       TF_VAR_create_test_user: 'true'
+      TF_VAR_tenant_domain: localhost
       TF_VAR_proxy_http_host_port: '44080'
       TF_VAR_proxy_host_port: '44443'
       TF_VAR_keycloak_host_port: '48080'
@@ -88,6 +98,13 @@ jobs:
           ref: ${{ env.WEAVE_INFRA_REF }}
           path: weave-infra
 
+      - name: Check out weave-backend
+        uses: actions/checkout@v4
+        with:
+          repository: masssi164/weave-backend
+          ref: ${{ env.WEAVE_BACKEND_REF }}
+          path: weave-backend
+
       - name: Configure Docker auth without macOS Keychain
         env:
           GHCR_TOKEN: ${{ github.token }}
@@ -109,6 +126,9 @@ jobs:
         with:
           channel: stable
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v4
         with:
@@ -119,14 +139,24 @@ jobs:
         working-directory: weave-infra/weave-workspace
         run: bash ./teardown.sh
 
-      - name: Pull backend image
-        run: docker pull "${WEAVE_BACKEND_IMAGE}"
+      - name: Build backend image
+        run: docker buildx build --load -t "${WEAVE_BACKEND_IMAGE}" weave-backend
 
       - name: Bootstrap local stack
         working-directory: weave-infra/weave-workspace
         env:
           TF_VAR_weave_backend_image: ${{ env.WEAVE_BACKEND_IMAGE }}
         run: ./install.sh
+
+      - name: Verify local test hostnames resolve on the runner
+        run: |
+          set -euo pipefail
+          for host in localhost auth.localhost files.localhost matrix.localhost; do
+            dscacheutil -q host -a name "$host" | grep -q 'ip_address:' || {
+              echo "Runner cannot resolve $host to loopback" >&2
+              exit 1
+            }
+          done
 
       - name: Verify stack readiness before Flutter work
         working-directory: weave-infra/weave-workspace

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ integration-test:
 	caller_WEAVE_OIDC_ISSUER_URL="$${WEAVE_OIDC_ISSUER_URL-}"; \
 	caller_WEAVE_OIDC_CLIENT_ID_set="$${WEAVE_OIDC_CLIENT_ID+x}"; \
 	caller_WEAVE_OIDC_CLIENT_ID="$${WEAVE_OIDC_CLIENT_ID-}"; \
+	caller_WEAVE_NEXTCLOUD_BASE_URL_set="$${WEAVE_NEXTCLOUD_BASE_URL+x}"; \
+	caller_WEAVE_NEXTCLOUD_BASE_URL="$${WEAVE_NEXTCLOUD_BASE_URL-}"; \
+	caller_WEAVE_MATRIX_HOMESERVER_URL_set="$${WEAVE_MATRIX_HOMESERVER_URL+x}"; \
+	caller_WEAVE_MATRIX_HOMESERVER_URL="$${WEAVE_MATRIX_HOMESERVER_URL-}"; \
 	caller_WEAVE_TEST_USERNAME_set="$${WEAVE_TEST_USERNAME+x}"; \
 	caller_WEAVE_TEST_USERNAME="$${WEAVE_TEST_USERNAME-}"; \
 	caller_WEAVE_TEST_PASSWORD_set="$${WEAVE_TEST_PASSWORD+x}"; \
@@ -23,16 +27,22 @@ integration-test:
 	if [ "$$caller_WEAVE_BASE_URL_set" = x ] && [ -n "$$caller_WEAVE_BASE_URL" ]; then WEAVE_BASE_URL="$$caller_WEAVE_BASE_URL"; fi; \
 	if [ "$$caller_WEAVE_OIDC_ISSUER_URL_set" = x ] && [ -n "$$caller_WEAVE_OIDC_ISSUER_URL" ]; then WEAVE_OIDC_ISSUER_URL="$$caller_WEAVE_OIDC_ISSUER_URL"; fi; \
 	if [ "$$caller_WEAVE_OIDC_CLIENT_ID_set" = x ] && [ -n "$$caller_WEAVE_OIDC_CLIENT_ID" ]; then WEAVE_OIDC_CLIENT_ID="$$caller_WEAVE_OIDC_CLIENT_ID"; fi; \
+	if [ "$$caller_WEAVE_NEXTCLOUD_BASE_URL_set" = x ] && [ -n "$$caller_WEAVE_NEXTCLOUD_BASE_URL" ]; then WEAVE_NEXTCLOUD_BASE_URL="$$caller_WEAVE_NEXTCLOUD_BASE_URL"; fi; \
+	if [ "$$caller_WEAVE_MATRIX_HOMESERVER_URL_set" = x ] && [ -n "$$caller_WEAVE_MATRIX_HOMESERVER_URL" ]; then WEAVE_MATRIX_HOMESERVER_URL="$$caller_WEAVE_MATRIX_HOMESERVER_URL"; fi; \
 	if [ "$$caller_WEAVE_TEST_USERNAME_set" = x ] && [ -n "$$caller_WEAVE_TEST_USERNAME" ]; then WEAVE_TEST_USERNAME="$$caller_WEAVE_TEST_USERNAME"; fi; \
 	if [ "$$caller_WEAVE_TEST_PASSWORD_set" = x ] && [ -n "$$caller_WEAVE_TEST_PASSWORD" ]; then WEAVE_TEST_PASSWORD="$$caller_WEAVE_TEST_PASSWORD"; fi; \
 	WEAVE_BASE_URL="$${WEAVE_BASE_URL:-https://weave.local/api}"; \
 	WEAVE_OIDC_ISSUER_URL="$${WEAVE_OIDC_ISSUER_URL:-https://auth.weave.local/realms/weave}"; \
 	WEAVE_OIDC_CLIENT_ID="$${WEAVE_OIDC_CLIENT_ID:-weave-app}"; \
+	WEAVE_NEXTCLOUD_BASE_URL="$${WEAVE_NEXTCLOUD_BASE_URL:-$${WEAVE_NEXTCLOUD_URL:-}}"; \
+	WEAVE_MATRIX_HOMESERVER_URL="$${WEAVE_MATRIX_HOMESERVER_URL:-$${WEAVE_MATRIX_URL:-}}"; \
 	printf '%s\n' \
 	  '{' \
 	  '  "WEAVE_BASE_URL": "'"$$WEAVE_BASE_URL"'",' \
 	  '  "WEAVE_OIDC_ISSUER_URL": "'"$$WEAVE_OIDC_ISSUER_URL"'",' \
 	  '  "WEAVE_OIDC_CLIENT_ID": "'"$$WEAVE_OIDC_CLIENT_ID"'",' \
+	  '  "WEAVE_NEXTCLOUD_BASE_URL": "'"$$WEAVE_NEXTCLOUD_BASE_URL"'",' \
+	  '  "WEAVE_MATRIX_HOMESERVER_URL": "'"$$WEAVE_MATRIX_HOMESERVER_URL"'",' \
 	  '  "WEAVE_TEST_USERNAME": "'"$${WEAVE_TEST_USERNAME}"'",' \
 	  '  "WEAVE_TEST_PASSWORD": "'"$${WEAVE_TEST_PASSWORD}"'"' \
 	  '}' > "$$dart_defines_file"; \

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ integration-test:
 	if [ "$$caller_WEAVE_OIDC_CLIENT_ID_set" = x ] && [ -n "$$caller_WEAVE_OIDC_CLIENT_ID" ]; then WEAVE_OIDC_CLIENT_ID="$$caller_WEAVE_OIDC_CLIENT_ID"; fi; \
 	if [ "$$caller_WEAVE_TEST_USERNAME_set" = x ] && [ -n "$$caller_WEAVE_TEST_USERNAME" ]; then WEAVE_TEST_USERNAME="$$caller_WEAVE_TEST_USERNAME"; fi; \
 	if [ "$$caller_WEAVE_TEST_PASSWORD_set" = x ] && [ -n "$$caller_WEAVE_TEST_PASSWORD" ]; then WEAVE_TEST_PASSWORD="$$caller_WEAVE_TEST_PASSWORD"; fi; \
-	WEAVE_BASE_URL="$${WEAVE_BASE_URL:-https://api.weave.local}"; \
-	WEAVE_OIDC_ISSUER_URL="$${WEAVE_OIDC_ISSUER_URL:-https://keycloak.weave.local/realms/weave}"; \
+	WEAVE_BASE_URL="$${WEAVE_BASE_URL:-https://weave.local/api}"; \
+	WEAVE_OIDC_ISSUER_URL="$${WEAVE_OIDC_ISSUER_URL:-https://auth.weave.local/realms/weave}"; \
 	WEAVE_OIDC_CLIENT_ID="$${WEAVE_OIDC_CLIENT_ID:-weave-app}"; \
 	printf '%s\n' \
 	  '{' \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For the default homelab convention, Weave assumes:
 
 - OIDC issuer / auth provider: `https://auth.home.internal`
 - Matrix homeserver: `https://matrix.home.internal`
-- Raw Nextcloud fallback URL: `https://files.home.internal`
+- Canonical Nextcloud URL: `https://files.home.internal`
 - Backend API base URL: `https://home.internal/api`
 
 ## Architecture
@@ -147,7 +147,7 @@ make integration-test
 Run against a different infra checkout:
 
 ```sh
-WEAVE_BOOTSTRAP_ENV=../weave-inf/weave-workspace/.generated/bootstrap.env make integration-test
+WEAVE_BOOTSTRAP_ENV=../weave-infra/weave-workspace/.generated/bootstrap.env make integration-test
 ```
 
 The GitHub Actions live-stack job runs on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner. The job bootstraps a fresh local stack, builds the backend image from the selected backend ref, then reads the generated bootstrap env so the Flutter tests consume the exact API/Auth/Matrix/Nextcloud endpoints that infra exposed.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Run against a different infra checkout:
 WEAVE_BOOTSTRAP_ENV=../weave-infra/weave-workspace/.generated/bootstrap.env make integration-test
 ```
 
-The GitHub Actions live-stack job runs on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner. The job bootstraps a fresh local stack, builds the backend image from the selected backend ref, then reads the generated bootstrap env so the Flutter tests consume the exact API/Auth/Matrix/Nextcloud endpoints that infra exposed.
+The GitHub Actions live-stack job runs on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner. The job bootstraps a fresh local stack on the same canonical `*.weave.local` hostnames used by local developers, builds the backend image from the selected backend ref, then reads the generated bootstrap env so the Flutter tests consume the exact API/Auth/Matrix/Nextcloud endpoints that infra exposed. If the runner cannot resolve those hostnames and cannot update `/etc/hosts` non-interactively, the job fails fast with the exact host line to add.
 
 Supported overrides:
 

--- a/README.md
+++ b/README.md
@@ -150,13 +150,15 @@ Run against a different infra checkout:
 WEAVE_BOOTSTRAP_ENV=../weave-inf/weave-workspace/.generated/bootstrap.env make integration-test
 ```
 
-The GitHub Actions live-stack job now runs on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner. That runner only needs the local stack bootstrapped once on the same machine because the workflow reads the mirrored `/tmp/weave-infra/.../bootstrap.env` file.
+The GitHub Actions live-stack job runs on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner. The job bootstraps a fresh local stack, builds the backend image from the selected backend ref, then reads the generated bootstrap env so the Flutter tests consume the exact API/Auth/Matrix/Nextcloud endpoints that infra exposed.
 
 Supported overrides:
 
 - `WEAVE_BASE_URL`: base URL for the Weave backend API, defaulting to `https://weave.local/api`
 - `WEAVE_OIDC_ISSUER_URL`: OIDC issuer URL, defaulting to `https://auth.weave.local/realms/weave`
 - `WEAVE_OIDC_CLIENT_ID`: app OIDC client ID, defaulting to `weave-app`
+- `WEAVE_NEXTCLOUD_BASE_URL`: canonical Nextcloud URL, defaulting to `files.<workspace-host>` (legacy `WEAVE_NEXTCLOUD_URL` is also accepted)
+- `WEAVE_MATRIX_HOMESERVER_URL`: Matrix homeserver URL, defaulting to `matrix.<workspace-host>` (legacy `WEAVE_MATRIX_URL` is also accepted)
 - `WEAVE_TEST_USERNAME`: username for the test account
 - `WEAVE_TEST_PASSWORD`: password for the test account
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Run against a different infra checkout:
 WEAVE_BOOTSTRAP_ENV=../weave-infra/weave-workspace/.generated/bootstrap.env make integration-test
 ```
 
-The GitHub Actions live-stack job runs on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner. The job bootstraps a fresh local stack on the same canonical `*.weave.local` hostnames used by local developers, builds the backend image from the selected backend ref, then reads the generated bootstrap env so the Flutter tests consume the exact API/Auth/Matrix/Nextcloud endpoints that infra exposed. If the runner cannot resolve those hostnames and cannot update `/etc/hosts` non-interactively, the job fails fast with the exact host line to add.
+The GitHub Actions live-stack paths run on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner. Pull-request CI uses the loopback `127.0.0.1.sslip.io` tenant so shared runners do not need `/etc/hosts` mutation. The standalone Live Stack E2E workflow uses the canonical `*.weave.local` hostnames used by local developers; if that runner cannot resolve them and cannot update `/etc/hosts` non-interactively, the job fails fast with the exact host line to add. Both paths build the backend image from the selected backend ref and read the generated bootstrap env so Flutter tests consume the exact API/Auth/Matrix/Nextcloud endpoints that infra exposed.
 
 Supported overrides:
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ The local stack writes reusable test settings to `weave-infra/weave-workspace/.g
 
 Expected local hostnames include `weave.local`, `auth.weave.local`, `matrix.weave.local`, and `files.weave.local`.
 
+The live Nextcloud E2E helper currently follows the real Nextcloud OIDC/login-flow HTML pages so the MVP stack can prove the existing fallback path end to end. Treat that as an honest compatibility smoke, not the target product contract: longer term, Weave should prefer deterministic backend/API contracts for product files flows over brittle Flutter-side HTML scraping.
+
 Run against the default local stack:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ For the default homelab convention, Weave assumes:
 
 - OIDC issuer / auth provider: `https://auth.home.internal`
 - Matrix homeserver: `https://matrix.home.internal`
-- Nextcloud base URL: `https://nextcloud.home.internal`
-- Backend API base URL: `https://api.home.internal`
+- Raw Nextcloud fallback URL: `https://files.home.internal`
+- Backend API base URL: `https://home.internal/api`
 
 ## Architecture
 Weave follows a feature-first clean architecture layout:
@@ -133,7 +133,7 @@ Integration tests require a live local Weave stack, including the backend API an
 
 The local stack writes reusable test settings to `weave-infra/weave-workspace/.generated/bootstrap.env` and mirrors them to `/tmp/weave-infra/weave-workspace/.generated/bootstrap.env` for the self-hosted GitHub runner path. `make integration-test` sources the repo-local file first, then falls back to the `/tmp` mirror. Use `WEAVE_BOOTSTRAP_ENV` when your infra checkout lives elsewhere.
 
-Expected local hostnames include `api.weave.local`, `keycloak.weave.local`, `matrix.weave.local`, and `nextcloud.weave.local`.
+Expected local hostnames include `weave.local`, `auth.weave.local`, `matrix.weave.local`, and `files.weave.local`.
 
 Run against the default local stack:
 
@@ -154,8 +154,8 @@ The GitHub Actions live-stack job now runs on a dedicated `self-hosted`, `macOS`
 
 Supported overrides:
 
-- `WEAVE_BASE_URL`: base URL for the Weave backend API, defaulting to `https://api.weave.local`
-- `WEAVE_OIDC_ISSUER_URL`: OIDC issuer URL, defaulting to `https://keycloak.weave.local/realms/weave`
+- `WEAVE_BASE_URL`: base URL for the Weave backend API, defaulting to `https://weave.local/api`
+- `WEAVE_OIDC_ISSUER_URL`: OIDC issuer URL, defaulting to `https://auth.weave.local/realms/weave`
 - `WEAVE_OIDC_CLIENT_ID`: app OIDC client ID, defaulting to `weave-app`
 - `WEAVE_TEST_USERNAME`: username for the test account
 - `WEAVE_TEST_PASSWORD`: password for the test account

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,12 +63,12 @@ Derivation rule:
 - if the host has 3 or more labels, drop the first label
 - derive:
   - `https://matrix.<base-domain>`
-  - `https://nextcloud.<base-domain>`
-  - `https://api.<base-domain>`
+  - `https://files.<base-domain>`
+  - `https://<base-domain>/api`
 
 Example:
 
-- `https://auth.home.internal` becomes `https://matrix.home.internal`, `https://nextcloud.home.internal`, and `https://api.home.internal`
+- `https://auth.home.internal` becomes `https://matrix.home.internal`, `https://files.home.internal`, and `https://home.internal/api`
 
 This is intentionally simple, explicit, and easy to change later. It is a convenience default, not a hard rule. Users can edit the derived values during setup and in Settings.
 

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -126,11 +126,11 @@ void main() {
     );
   });
 
-  test('authenticated GET /api/v1/me returns expected claims', () async {
+  test('authenticated GET /api/me returns expected identity', () async {
     final accessToken = await authHelper.signIn(config);
 
     final response = await httpClient.get(
-      config.apiUri('/api/v1/me'),
+      config.apiUri('/api/me'),
       headers: <String, String>{
         'Accept': 'application/json',
         'Authorization': 'Bearer $accessToken',
@@ -139,8 +139,10 @@ void main() {
 
     expect(response.statusCode, 200, reason: response.body);
     final payload = _decodeObject(response.body);
-    expect(payload['sub'], isA<String>());
-    expect((payload['sub'] as String).trim(), isNotEmpty);
+    expect(payload['userId'], isA<String>());
+    expect((payload['userId'] as String).trim(), isNotEmpty);
+    expect(payload['username'], isA<String>());
+    expect((payload['username'] as String).trim(), isNotEmpty);
     expect(payload['email'], isA<String>());
     expect((payload['email'] as String).trim(), isNotEmpty);
   });

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -383,6 +383,7 @@ class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
       ..badCertificateCallback = (cert, host, port) =>
           host == 'localhost' ||
           host == '127.0.0.1' ||
+          host.endsWith('.localhost') ||
           host.endsWith('.weave.local');
   }
 

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -8,10 +8,12 @@ import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
 import 'package:weave/features/auth/domain/entities/auth_failure.dart';
 import 'package:weave/features/auth/domain/entities/oidc_constants.dart';
 import 'package:weave/features/chat/data/services/matrix_auth_browser.dart';
+import 'package:weave/integrations/nextcloud/data/services/nextcloud_login_launcher.dart';
 
 import 'test_config.dart';
 
-class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
+class LiveOidcTestDriver
+    implements OidcClient, MatrixAuthBrowser, NextcloudLoginLauncher {
   LiveOidcTestDriver({required TestConfig config}) : _config = config;
 
   final TestConfig _config;
@@ -140,24 +142,52 @@ class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
     );
   }
 
+  @override
+  Future<void> launch(Uri loginUri) async {
+    await _completeBrowserLikeFlow(loginUri);
+  }
+
   Future<Uri> _authenticateInBrowserLikeFlow({
     required Uri authorizationUri,
     required Uri redirectUri,
+  }) async {
+    final redirected = await _driveBrowserLikeFlow(
+      startUri: authorizationUri,
+      redirectUri: redirectUri,
+    );
+    if (redirected == null) {
+      throw StateError(
+        'Live browser flow for $authorizationUri completed without the expected redirect.',
+      );
+    }
+    return redirected;
+  }
+
+  Future<void> _completeBrowserLikeFlow(Uri startUri) async {
+    await _driveBrowserLikeFlow(startUri: startUri);
+  }
+
+  Future<Uri?> _driveBrowserLikeFlow({
+    required Uri startUri,
+    Uri? redirectUri,
   }) async {
     final client = _newHttpClient();
     try {
       final cookieJar = <_StoredCookie>[];
       Uri? previousUri;
-      var nextUri = authorizationUri;
+      var madeProgress = false;
+      var nextUri = startUri;
       while (true) {
         final response = await _open(client, nextUri, cookieJar);
         final location = response.headers.value(HttpHeaders.locationHeader);
         final body = await utf8.decodeStream(response);
 
         if (_isRedirect(response.statusCode) && location != null) {
+          madeProgress = true;
           previousUri = nextUri;
           final redirected = nextUri.resolve(location);
-          if (_matchesRedirect(redirected, redirectUri)) {
+          if (redirectUri != null &&
+              _matchesRedirect(redirected, redirectUri)) {
             return redirected;
           }
           nextUri = redirected;
@@ -166,6 +196,7 @@ class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
 
         final loginForm = _tryParseLoginForm(body, nextUri);
         if (loginForm != null) {
+          madeProgress = true;
           final postResponse = await _postForm(
             client,
             loginForm.action,
@@ -185,9 +216,11 @@ class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
           final postBody = await utf8.decodeStream(postResponse);
 
           if (_isRedirect(postResponse.statusCode) && postLocation != null) {
+            madeProgress = true;
             previousUri = loginForm.action;
             final redirected = loginForm.action.resolve(postLocation);
-            if (_matchesRedirect(redirected, redirectUri)) {
+            if (redirectUri != null &&
+                _matchesRedirect(redirected, redirectUri)) {
               return redirected;
             }
             nextUri = redirected;
@@ -220,14 +253,23 @@ class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
             await utf8.decodeStream(followUpResponse);
             if (_isRedirect(followUpResponse.statusCode) &&
                 followUpLocation != null) {
+              madeProgress = true;
               previousUri = followUpForm.action;
               final redirected = followUpForm.action.resolve(followUpLocation);
-              if (_matchesRedirect(redirected, redirectUri)) {
+              if (redirectUri != null &&
+                  _matchesRedirect(redirected, redirectUri)) {
                 return redirected;
               }
               nextUri = redirected;
               continue;
             }
+            if (redirectUri == null) {
+              return null;
+            }
+          }
+
+          if (redirectUri == null) {
+            return null;
           }
 
           final snippet = postBody.replaceAll(RegExp(r'\s+'), ' ');
@@ -240,6 +282,7 @@ class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
 
         final followUpForm = _tryParseAutoSubmitForm(body, nextUri);
         if (followUpForm != null) {
+          madeProgress = true;
           final postResponse = await _postForm(
             client,
             followUpForm.action,
@@ -252,9 +295,11 @@ class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
           );
           await utf8.decodeStream(postResponse);
           if (_isRedirect(postResponse.statusCode) && postLocation != null) {
+            madeProgress = true;
             previousUri = followUpForm.action;
             final redirected = followUpForm.action.resolve(postLocation);
-            if (_matchesRedirect(redirected, redirectUri)) {
+            if (redirectUri != null &&
+                _matchesRedirect(redirected, redirectUri)) {
               return redirected;
             }
             nextUri = redirected;
@@ -262,8 +307,12 @@ class LiveOidcTestDriver implements OidcClient, MatrixAuthBrowser {
           }
         }
 
+        if (redirectUri == null && madeProgress) {
+          return null;
+        }
+
         throw StateError(
-          'Unable to continue the live browser flow for $authorizationUri. '
+          'Unable to continue the live browser flow for $startUri. '
           'Expected a redirect or supported form on ${nextUri.toString()}.',
         );
       }

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -587,7 +587,8 @@ class LiveOidcTestDriver
           host == 'localhost' ||
           host == '127.0.0.1' ||
           host.endsWith('.localhost') ||
-          host.endsWith('.weave.local');
+          host.endsWith('.weave.local') ||
+          host.endsWith('.sslip.io');
   }
 
   bool _isRedirect(int statusCode) =>

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -194,6 +194,17 @@ class LiveOidcTestDriver
           continue;
         }
 
+        final nextcloudOidcLink = _tryParseNextcloudOidcProviderLink(
+          body,
+          nextUri,
+        );
+        if (nextcloudOidcLink != null && nextcloudOidcLink != nextUri) {
+          madeProgress = true;
+          previousUri = nextUri;
+          nextUri = nextcloudOidcLink;
+          continue;
+        }
+
         final loginForm = _tryParseLoginForm(body, nextUri);
         if (loginForm != null) {
           madeProgress = true;
@@ -496,6 +507,38 @@ class LiveOidcTestDriver
     return oidcDefaultScopes;
   }
 
+  Uri? _tryParseNextcloudOidcProviderLink(String html, Uri baseUri) {
+    final anchorMatches = RegExp(
+      r'<a([^>]*)>',
+      caseSensitive: false,
+    ).allMatches(html);
+    for (final match in anchorMatches) {
+      final attributes = match.group(1) ?? '';
+      final href = _extractHtmlAttribute(attributes, 'href')?.trim();
+      if (href == null || href.isEmpty) {
+        continue;
+      }
+      final decodedHref = _htmlDecode(href);
+      if (decodedHref.contains('/apps/user_oidc/login/')) {
+        return baseUri.resolve(decodedHref);
+      }
+    }
+
+    final formMatches = RegExp(
+      r'<form([^>]*)>',
+      caseSensitive: false,
+    ).allMatches(html);
+    for (final match in formMatches) {
+      final attributes = match.group(1) ?? '';
+      final action = _resolveFormAction(attributes, baseUri);
+      if (action.path.contains('/apps/user_oidc/login/')) {
+        return action;
+      }
+    }
+
+    return null;
+  }
+
   _ParsedLoginForm? _tryParseLoginForm(String html, Uri baseUri) {
     final formMatch = RegExp(
       r'<form([^>]*)>([\s\S]*?)</form>',
@@ -534,7 +577,9 @@ class LiveOidcTestDriver
       }
       if (!RegExp(r'type="submit"', caseSensitive: false).hasMatch(formHtml) &&
           !formHtml.contains('Create Account') &&
-          !formHtml.contains('Continue')) {
+          !formHtml.contains('Continue') &&
+          !formHtml.contains('Grant access') &&
+          !formHtml.contains('Authorize')) {
         continue;
       }
       return _ParsedLoginForm(

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -172,6 +172,7 @@ class LiveOidcTestDriver
     Uri? redirectUri,
     HttpClient? clientOverride,
     List<_StoredCookie>? cookieJarOverride,
+    void Function()? onNextcloudGrantSubmitted,
   }) async {
     final client = clientOverride ?? _newHttpClient();
     final ownsClient = clientOverride == null;
@@ -224,11 +225,14 @@ class LiveOidcTestDriver
         );
         if (nextcloudLoginFlowAuth != null && redirectUri == null) {
           madeProgress = true;
-          await _completeNextcloudLoginFlow(
+          final grantSubmitted = await _completeNextcloudLoginFlow(
             client,
             nextcloudLoginFlowAuth,
             cookieJar,
           );
+          if (grantSubmitted) {
+            onNextcloudGrantSubmitted?.call();
+          }
           return null;
         }
 
@@ -244,6 +248,7 @@ class LiveOidcTestDriver
             cookieJar,
             referer: previousUri ?? nextUri,
           );
+          onNextcloudGrantSubmitted?.call();
           return null;
         }
 
@@ -376,34 +381,49 @@ class LiveOidcTestDriver
     }
   }
 
-  Future<void> _completeNextcloudLoginFlow(
+  Future<bool> _completeNextcloudLoginFlow(
     HttpClient client,
     _NextcloudLoginFlowAuth auth,
     List<_StoredCookie> cookieJar,
   ) async {
-    var grantResponse = await _open(client, auth.loginRedirectUrl, cookieJar);
-    var grantBody = await utf8.decodeStream(grantResponse);
+    for (var attempt = 0; attempt < 3; attempt++) {
+      var grantUri = auth.loginRedirectUrl;
+      var grantResponse = await _open(client, grantUri, cookieJar);
+      var grantBody = await utf8.decodeStream(grantResponse);
 
-    if (grantResponse.statusCode == 401) {
-      await _signIntoNextcloud(client, auth.loginRedirectUrl, cookieJar);
-      grantResponse = await _open(client, auth.loginRedirectUrl, cookieJar);
-      grantBody = await utf8.decodeStream(grantResponse);
-    }
+      final grantLocation = grantResponse.headers.value(
+        HttpHeaders.locationHeader,
+      );
+      if (_isRedirect(grantResponse.statusCode) && grantLocation != null) {
+        grantUri = grantUri.resolve(grantLocation);
+        grantResponse = await _open(client, grantUri, cookieJar);
+        grantBody = await utf8.decodeStream(grantResponse);
+      }
 
-    final grantLocation = grantResponse.headers.value(
-      HttpHeaders.locationHeader,
-    );
-    if (_isRedirect(grantResponse.statusCode) && grantLocation != null) {
-      final redirected = auth.loginRedirectUrl.resolve(grantLocation);
-      grantResponse = await _open(client, redirected, cookieJar);
-      grantBody = await utf8.decodeStream(grantResponse);
-    }
+      if (grantResponse.statusCode == 401 ||
+          _hasNextcloudLoginAction(grantBody, grantUri)) {
+        final grantSubmitted = await _signIntoNextcloud(
+          client,
+          auth.loginRedirectUrl,
+          cookieJar,
+        );
+        if (grantSubmitted) {
+          return true;
+        }
+        continue;
+      }
 
-    final grant = _tryParseNextcloudLoginFlowGrant(
-      grantBody,
-      auth.loginRedirectUrl,
-    );
-    if (grant == null) {
+      final grant = _tryParseNextcloudLoginFlowGrant(grantBody, grantUri);
+      if (grant != null) {
+        await _submitNextcloudGrant(
+          client,
+          grant,
+          cookieJar,
+          referer: grantUri,
+        );
+        return true;
+      }
+
       final snippet = grantBody.replaceAll(RegExp(r'\s+'), ' ');
       throw StateError(
         'Nextcloud login flow did not expose a grant form after sign-in. '
@@ -411,15 +431,10 @@ class LiveOidcTestDriver
       );
     }
 
-    await _submitNextcloudGrant(
-      client,
-      grant,
-      cookieJar,
-      referer: auth.loginRedirectUrl,
-    );
+    throw StateError('Nextcloud login flow did not expose a grant form.');
   }
 
-  Future<void> _signIntoNextcloud(
+  Future<bool> _signIntoNextcloud(
     HttpClient client,
     Uri grantUri,
     List<_StoredCookie> cookieJar,
@@ -438,11 +453,16 @@ class LiveOidcTestDriver
       );
     }
 
+    var grantSubmitted = false;
     await _driveBrowserLikeFlow(
       startUri: oidcLogin,
       clientOverride: client,
       cookieJarOverride: cookieJar,
+      onNextcloudGrantSubmitted: () {
+        grantSubmitted = true;
+      },
     );
+    return grantSubmitted;
   }
 
   Future<void> _submitNextcloudGrant(
@@ -650,6 +670,12 @@ class LiveOidcTestDriver
       return value.split(' ').where((scope) => scope.isNotEmpty).toList();
     }
     return oidcDefaultScopes;
+  }
+
+  bool _hasNextcloudLoginAction(String html, Uri baseUri) {
+    return _tryParseNextcloudOidcProviderLink(html, baseUri) != null ||
+        _tryParseNextcloudAlternativeLoginLink(html, baseUri) != null ||
+        _tryParseLoginForm(html, baseUri) != null;
   }
 
   _NextcloudLoginFlowAuth? _tryParseNextcloudLoginFlowAuth(

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -386,26 +386,48 @@ class LiveOidcTestDriver
     _NextcloudLoginFlowAuth auth,
     List<_StoredCookie> cookieJar,
   ) async {
-    for (var attempt = 0; attempt < 3; attempt++) {
-      var grantUri = auth.loginRedirectUrl;
-      var grantResponse = await _open(client, grantUri, cookieJar);
-      var grantBody = await utf8.decodeStream(grantResponse);
-
-      final grantLocation = grantResponse.headers.value(
-        HttpHeaders.locationHeader,
+    var grantUri = auth.loginRedirectUrl;
+    var lastDiagnostic = 'not-opened';
+    for (var attempt = 0; attempt < 4; attempt++) {
+      final requestedGrantUri = grantUri;
+      final page = await _openFollowingRedirects(client, grantUri, cookieJar);
+      lastDiagnostic = _describeNextcloudPage(
+        page.body,
+        page.uri,
+        page.statusCode,
       );
-      if (_isRedirect(grantResponse.statusCode) && grantLocation != null) {
-        grantUri = grantUri.resolve(grantLocation);
-        grantResponse = await _open(client, grantUri, cookieJar);
-        grantBody = await utf8.decodeStream(grantResponse);
+      _logNextcloudFlow(
+        'NEXTCLOUD_LOGIN_FLOW_GRANT_PAGE attempt=$attempt $lastDiagnostic',
+      );
+
+      if (_isNextcloudLoginFlowDone(page.body)) {
+        return true;
       }
 
-      if (grantResponse.statusCode == 401 ||
-          _hasNextcloudLoginAction(grantBody, grantUri) ||
-          _isNextcloudLoginPage(grantBody, grantUri)) {
+      final grant = _tryParseNextcloudLoginFlowGrant(page.body, page.uri);
+      if (grant != null) {
+        await _submitNextcloudGrant(
+          client,
+          grant,
+          cookieJar,
+          referer: page.uri,
+        );
+        return true;
+      }
+
+      final nestedAuth = _tryParseNextcloudLoginFlowAuth(page.body, page.uri);
+      if (nestedAuth != null && nestedAuth.loginRedirectUrl != page.uri) {
+        grantUri = nestedAuth.loginRedirectUrl;
+      }
+      final loginGrantUri = nestedAuth?.loginRedirectUrl ?? requestedGrantUri;
+
+      if (page.statusCode == 401 ||
+          nestedAuth != null ||
+          _hasNextcloudLoginAction(page.body, page.uri) ||
+          _isNextcloudLoginPage(page.body, page.uri)) {
         final grantSubmitted = await _signIntoNextcloud(
           client,
-          grantUri,
+          loginGrantUri,
           cookieJar,
         );
         if (grantSubmitted) {
@@ -414,25 +436,16 @@ class LiveOidcTestDriver
         continue;
       }
 
-      final grant = _tryParseNextcloudLoginFlowGrant(grantBody, grantUri);
-      if (grant != null) {
-        await _submitNextcloudGrant(
-          client,
-          grant,
-          cookieJar,
-          referer: grantUri,
-        );
-        return true;
-      }
-
-      final snippet = grantBody.replaceAll(RegExp(r'\s+'), ' ');
       throw StateError(
         'Nextcloud login flow did not expose a grant form after sign-in. '
-        'Status=${grantResponse.statusCode} Body=${snippet.substring(0, snippet.length > 300 ? 300 : snippet.length)}',
+        '$lastDiagnostic',
       );
     }
 
-    throw StateError('Nextcloud login flow did not expose a grant form.');
+    throw StateError(
+      'Nextcloud login flow did not expose a grant form after retries. '
+      '$lastDiagnostic',
+    );
   }
 
   Future<bool> _signIntoNextcloud(
@@ -441,16 +454,34 @@ class LiveOidcTestDriver
     List<_StoredCookie> cookieJar,
   ) async {
     final loginUri = _nextcloudLoginUriForGrant(grantUri);
-    final response = await _open(client, loginUri, cookieJar);
-    final body = await utf8.decodeStream(response);
+    final loginPage = await _openFollowingRedirects(
+      client,
+      loginUri,
+      cookieJar,
+    );
+    if (_isNextcloudLoginFlowDone(loginPage.body)) {
+      return true;
+    }
+    final loginPageGrant = _tryParseNextcloudLoginFlowGrant(
+      loginPage.body,
+      loginPage.uri,
+    );
+    if (loginPageGrant != null) {
+      await _submitNextcloudGrant(
+        client,
+        loginPageGrant,
+        cookieJar,
+        referer: loginPage.uri,
+      );
+      return true;
+    }
     final oidcLogin =
-        _tryParseNextcloudOidcProviderLink(body, loginUri) ??
-        _tryParseNextcloudAlternativeLoginLink(body, loginUri);
+        _tryParseNextcloudOidcProviderLink(loginPage.body, loginPage.uri) ??
+        _tryParseNextcloudAlternativeLoginLink(loginPage.body, loginPage.uri);
     if (oidcLogin == null) {
-      final snippet = body.replaceAll(RegExp(r'\s+'), ' ');
       throw StateError(
         'Nextcloud login page did not expose an OIDC provider link. '
-        'Status=${response.statusCode} Body=${snippet.substring(0, snippet.length > 300 ? 300 : snippet.length)}',
+        '${_describeNextcloudPage(loginPage.body, loginPage.uri, loginPage.statusCode)}',
       );
     }
 
@@ -463,7 +494,24 @@ class LiveOidcTestDriver
         grantSubmitted = true;
       },
     );
-    return grantSubmitted;
+    if (grantSubmitted) {
+      return true;
+    }
+
+    final page = await _openFollowingRedirects(client, grantUri, cookieJar);
+    final grant = _tryParseNextcloudLoginFlowGrant(page.body, page.uri);
+    if (grant != null) {
+      await _submitNextcloudGrant(client, grant, cookieJar, referer: page.uri);
+      return true;
+    }
+    if (_isNextcloudLoginFlowDone(page.body)) {
+      return true;
+    }
+    _logNextcloudFlow(
+      'NEXTCLOUD_LOGIN_FLOW_POST_SIGN_IN '
+      '${_describeNextcloudPage(page.body, page.uri, page.statusCode)}',
+    );
+    return false;
   }
 
   Future<void> _submitNextcloudGrant(
@@ -483,17 +531,27 @@ class LiveOidcTestDriver
     final body = await utf8.decodeStream(response);
     if (_isRedirect(response.statusCode) && location != null) {
       final redirected = grant.action.resolve(location);
-      final followUp = await _open(client, redirected, cookieJar);
-      await utf8.decodeStream(followUp);
+      final followUp = await _openFollowingRedirects(
+        client,
+        redirected,
+        cookieJar,
+      );
+      _logNextcloudFlow(
+        'NEXTCLOUD_LOGIN_FLOW_GRANT_SUBMITTED '
+        '${_describeNextcloudPage(followUp.body, followUp.uri, followUp.statusCode)}',
+      );
       return;
     }
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      final snippet = body.replaceAll(RegExp(r'\s+'), ' ');
       throw StateError(
         'Nextcloud rejected the login-flow grant. '
-        'Status=${response.statusCode} Body=${snippet.substring(0, snippet.length > 300 ? 300 : snippet.length)}',
+        '${_describeNextcloudPage(body, grant.action, response.statusCode)}',
       );
     }
+    _logNextcloudFlow(
+      'NEXTCLOUD_LOGIN_FLOW_GRANT_SUBMITTED '
+      '${_describeNextcloudPage(body, grant.action, response.statusCode)}',
+    );
   }
 
   Future<Map<String, dynamic>> _readDiscovery(Uri issuer) async {
@@ -548,6 +606,37 @@ class LiveOidcTestDriver
     final response = await request.close();
     _storeCookies(response, uri, cookieJar);
     return response;
+  }
+
+  Future<_FetchedPage> _openFollowingRedirects(
+    HttpClient client,
+    Uri uri,
+    List<_StoredCookie> cookieJar, {
+    int maxRedirects = 6,
+  }) async {
+    var currentUri = uri;
+    for (
+      var redirectCount = 0;
+      redirectCount <= maxRedirects;
+      redirectCount++
+    ) {
+      final response = await _open(client, currentUri, cookieJar);
+      final location = response.headers.value(HttpHeaders.locationHeader);
+      final body = await utf8.decodeStream(response);
+      if (_isRedirect(response.statusCode) && location != null) {
+        currentUri = currentUri.resolve(location);
+        continue;
+      }
+      return _FetchedPage(
+        uri: currentUri,
+        statusCode: response.statusCode,
+        body: body,
+      );
+    }
+    throw StateError(
+      'Nextcloud login flow exceeded redirect limit at '
+      '${_safeUriForDiagnostics(currentUri)}.',
+    );
   }
 
   Future<HttpClientResponse> _postForm(
@@ -687,6 +776,86 @@ class LiveOidcTestDriver
         html.contains('Login - Nextcloud') ||
         html.contains('id="body-login"') ||
         html.contains("id='body-login'");
+  }
+
+  bool _isNextcloudLoginFlowDone(String html) {
+    return _tryParseInitialState(html, 'initial-state-core-loginFlowState') ==
+        'done';
+  }
+
+  String _describeNextcloudPage(String html, Uri uri, int statusCode) {
+    final initialStateIds = _initialStateIds(html).take(12).join(',');
+    final formSummaries = _formSummaries(html, uri).take(4).join(';');
+    final flowState = _tryParseInitialState(
+      html,
+      'initial-state-core-loginFlowState',
+    );
+    return 'status=$statusCode '
+        'uri=${_safeUriForDiagnostics(uri)} '
+        'flowState=${flowState is String ? flowState : 'none'} '
+        'hasAuth=${_tryParseNextcloudLoginFlowAuth(html, uri) != null} '
+        'hasGrant=${_tryParseNextcloudLoginFlowGrant(html, uri) != null} '
+        'hasRequestToken=${_tryParseRequestToken(html) != null} '
+        'hasOidcLink=${_tryParseNextcloudOidcProviderLink(html, uri) != null} '
+        'hasAlternativeLogin=${_tryParseNextcloudAlternativeLoginLink(html, uri) != null} '
+        'hasLoginForm=${_tryParseLoginForm(html, uri) != null} '
+        'initialStateIds=[$initialStateIds] '
+        'forms=[$formSummaries]';
+  }
+
+  Iterable<String> _initialStateIds(String html) sync* {
+    final inputMatches = RegExp(
+      r'<input([^>]*)>',
+      caseSensitive: false,
+    ).allMatches(html);
+    for (final match in inputMatches) {
+      final id = _extractHtmlAttribute(match.group(1) ?? '', 'id');
+      if (id != null && id.startsWith('initial-state-')) {
+        yield id;
+      }
+    }
+  }
+
+  Iterable<String> _formSummaries(String html, Uri baseUri) sync* {
+    final formMatches = RegExp(
+      r'<form([^>]*)>([\s\S]*?)</form>',
+      caseSensitive: false,
+    ).allMatches(html);
+    for (final match in formMatches) {
+      final attributes = match.group(1) ?? '';
+      final formHtml = match.group(0)!;
+      final action = _safeUriForDiagnostics(
+        _resolveFormAction(attributes, baseUri),
+      );
+      final fieldNames = _parseFormFields(formHtml).keys.take(8).join('|');
+      yield '$action fields=$fieldNames';
+    }
+  }
+
+  String _safeUriForDiagnostics(Uri uri) {
+    var safePath = uri.path.replaceAll(
+      RegExp(r'/login/v2/(flow|poll)/[^/?#]+'),
+      r'/login/v2/$1/<redacted>',
+    );
+    if (safePath.length > 120) {
+      safePath = '${safePath.substring(0, 117)}...';
+    }
+    final query = uri.queryParametersAll.keys
+        .take(12)
+        .map((key) {
+          return '${Uri.encodeQueryComponent(key)}=<redacted>';
+        })
+        .join('&');
+    return uri
+        .replace(path: safePath, query: query.isEmpty ? null : query)
+        .toString();
+  }
+
+  void _logNextcloudFlow(String message) {
+    // Integration-test diagnostics are intentionally printed because GitHub
+    // Actions preserves stdout with the failed Flutter test output.
+    // ignore: avoid_print
+    print(message);
   }
 
   Uri _nextcloudLoginUriForGrant(Uri grantUri) {
@@ -1055,6 +1224,18 @@ class _NextcloudLoginFlowGrant {
 class _SimpleHttpResponse {
   const _SimpleHttpResponse(this.statusCode, this.body);
 
+  final int statusCode;
+  final String body;
+}
+
+class _FetchedPage {
+  const _FetchedPage({
+    required this.uri,
+    required this.statusCode,
+    required this.body,
+  });
+
+  final Uri uri;
   final int statusCode;
   final String body;
 }

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -401,10 +401,11 @@ class LiveOidcTestDriver
       }
 
       if (grantResponse.statusCode == 401 ||
-          _hasNextcloudLoginAction(grantBody, grantUri)) {
+          _hasNextcloudLoginAction(grantBody, grantUri) ||
+          _isNextcloudLoginPage(grantBody, grantUri)) {
         final grantSubmitted = await _signIntoNextcloud(
           client,
-          auth.loginRedirectUrl,
+          grantUri,
           cookieJar,
         );
         if (grantSubmitted) {
@@ -439,7 +440,7 @@ class LiveOidcTestDriver
     Uri grantUri,
     List<_StoredCookie> cookieJar,
   ) async {
-    final loginUri = grantUri.replace(path: '/login', queryParameters: null);
+    final loginUri = _nextcloudLoginUriForGrant(grantUri);
     final response = await _open(client, loginUri, cookieJar);
     final body = await utf8.decodeStream(response);
     final oidcLogin =
@@ -676,6 +677,31 @@ class LiveOidcTestDriver
     return _tryParseNextcloudOidcProviderLink(html, baseUri) != null ||
         _tryParseNextcloudAlternativeLoginLink(html, baseUri) != null ||
         _tryParseLoginForm(html, baseUri) != null;
+  }
+
+  bool _isNextcloudLoginPage(String html, Uri uri) {
+    if (uri.path == '/login' || uri.path.endsWith('/login')) {
+      return true;
+    }
+    return html.contains('Login – Nextcloud') ||
+        html.contains('Login - Nextcloud') ||
+        html.contains('id="body-login"') ||
+        html.contains("id='body-login'");
+  }
+
+  Uri _nextcloudLoginUriForGrant(Uri grantUri) {
+    if (grantUri.path == '/login' || grantUri.path.endsWith('/login')) {
+      return grantUri;
+    }
+
+    final relativeGrant = Uri(
+      path: grantUri.path,
+      query: grantUri.query.isEmpty ? null : grantUri.query,
+    ).toString();
+    return grantUri.replace(
+      path: '/login',
+      queryParameters: <String, String>{'redirect_url': relativeGrant},
+    );
   }
 
   _NextcloudLoginFlowAuth? _tryParseNextcloudLoginFlowAuth(

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -588,7 +588,8 @@ class LiveOidcTestDriver
           host == '127.0.0.1' ||
           host.endsWith('.localhost') ||
           host.endsWith('.weave.local') ||
-          host.endsWith('.sslip.io');
+          host == '127.0.0.1.sslip.io' ||
+          host.endsWith('.127.0.0.1.sslip.io');
   }
 
   bool _isRedirect(int statusCode) =>

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -683,11 +683,16 @@ class LiveOidcTestDriver
     List<_StoredCookie> cookieJar,
   ) {
     for (final cookie in response.cookies) {
+      final stored = _StoredCookie.fromCookie(cookie, uri);
       cookieJar.removeWhere(
         (existing) =>
-            existing.name == cookie.name && existing.domain == cookie.domain,
+            existing.name == stored.name &&
+            existing.domain == stored.domain &&
+            existing.path == stored.path,
       );
-      cookieJar.add(_StoredCookie.fromCookie(cookie, uri));
+      if (stored.value.isNotEmpty) {
+        cookieJar.add(stored);
+      }
     }
   }
 

--- a/integration_test/helpers/live_oidc_test_driver.dart
+++ b/integration_test/helpers/live_oidc_test_driver.dart
@@ -170,10 +170,13 @@ class LiveOidcTestDriver
   Future<Uri?> _driveBrowserLikeFlow({
     required Uri startUri,
     Uri? redirectUri,
+    HttpClient? clientOverride,
+    List<_StoredCookie>? cookieJarOverride,
   }) async {
-    final client = _newHttpClient();
+    final client = clientOverride ?? _newHttpClient();
+    final ownsClient = clientOverride == null;
     try {
-      final cookieJar = <_StoredCookie>[];
+      final cookieJar = cookieJarOverride ?? <_StoredCookie>[];
       Uri? previousUri;
       var madeProgress = false;
       var nextUri = startUri;
@@ -203,6 +206,45 @@ class LiveOidcTestDriver
           previousUri = nextUri;
           nextUri = nextcloudOidcLink;
           continue;
+        }
+
+        final nextcloudAlternativeLogin =
+            _tryParseNextcloudAlternativeLoginLink(body, nextUri);
+        if (nextcloudAlternativeLogin != null &&
+            nextcloudAlternativeLogin != nextUri) {
+          madeProgress = true;
+          previousUri = nextUri;
+          nextUri = nextcloudAlternativeLogin;
+          continue;
+        }
+
+        final nextcloudLoginFlowAuth = _tryParseNextcloudLoginFlowAuth(
+          body,
+          nextUri,
+        );
+        if (nextcloudLoginFlowAuth != null && redirectUri == null) {
+          madeProgress = true;
+          await _completeNextcloudLoginFlow(
+            client,
+            nextcloudLoginFlowAuth,
+            cookieJar,
+          );
+          return null;
+        }
+
+        final nextcloudLoginFlowGrant = _tryParseNextcloudLoginFlowGrant(
+          body,
+          nextUri,
+        );
+        if (nextcloudLoginFlowGrant != null && redirectUri == null) {
+          madeProgress = true;
+          await _submitNextcloudGrant(
+            client,
+            nextcloudLoginFlowGrant,
+            cookieJar,
+            referer: previousUri ?? nextUri,
+          );
+          return null;
         }
 
         final loginForm = _tryParseLoginForm(body, nextUri);
@@ -328,7 +370,108 @@ class LiveOidcTestDriver
         );
       }
     } finally {
-      client.close(force: true);
+      if (ownsClient) {
+        client.close(force: true);
+      }
+    }
+  }
+
+  Future<void> _completeNextcloudLoginFlow(
+    HttpClient client,
+    _NextcloudLoginFlowAuth auth,
+    List<_StoredCookie> cookieJar,
+  ) async {
+    var grantResponse = await _open(client, auth.loginRedirectUrl, cookieJar);
+    var grantBody = await utf8.decodeStream(grantResponse);
+
+    if (grantResponse.statusCode == 401) {
+      await _signIntoNextcloud(client, auth.loginRedirectUrl, cookieJar);
+      grantResponse = await _open(client, auth.loginRedirectUrl, cookieJar);
+      grantBody = await utf8.decodeStream(grantResponse);
+    }
+
+    final grantLocation = grantResponse.headers.value(
+      HttpHeaders.locationHeader,
+    );
+    if (_isRedirect(grantResponse.statusCode) && grantLocation != null) {
+      final redirected = auth.loginRedirectUrl.resolve(grantLocation);
+      grantResponse = await _open(client, redirected, cookieJar);
+      grantBody = await utf8.decodeStream(grantResponse);
+    }
+
+    final grant = _tryParseNextcloudLoginFlowGrant(
+      grantBody,
+      auth.loginRedirectUrl,
+    );
+    if (grant == null) {
+      final snippet = grantBody.replaceAll(RegExp(r'\s+'), ' ');
+      throw StateError(
+        'Nextcloud login flow did not expose a grant form after sign-in. '
+        'Status=${grantResponse.statusCode} Body=${snippet.substring(0, snippet.length > 300 ? 300 : snippet.length)}',
+      );
+    }
+
+    await _submitNextcloudGrant(
+      client,
+      grant,
+      cookieJar,
+      referer: auth.loginRedirectUrl,
+    );
+  }
+
+  Future<void> _signIntoNextcloud(
+    HttpClient client,
+    Uri grantUri,
+    List<_StoredCookie> cookieJar,
+  ) async {
+    final loginUri = grantUri.replace(path: '/login', queryParameters: null);
+    final response = await _open(client, loginUri, cookieJar);
+    final body = await utf8.decodeStream(response);
+    final oidcLogin =
+        _tryParseNextcloudOidcProviderLink(body, loginUri) ??
+        _tryParseNextcloudAlternativeLoginLink(body, loginUri);
+    if (oidcLogin == null) {
+      final snippet = body.replaceAll(RegExp(r'\s+'), ' ');
+      throw StateError(
+        'Nextcloud login page did not expose an OIDC provider link. '
+        'Status=${response.statusCode} Body=${snippet.substring(0, snippet.length > 300 ? 300 : snippet.length)}',
+      );
+    }
+
+    await _driveBrowserLikeFlow(
+      startUri: oidcLogin,
+      clientOverride: client,
+      cookieJarOverride: cookieJar,
+    );
+  }
+
+  Future<void> _submitNextcloudGrant(
+    HttpClient client,
+    _NextcloudLoginFlowGrant grant,
+    List<_StoredCookie> cookieJar, {
+    Uri? referer,
+  }) async {
+    final response = await _postForm(
+      client,
+      grant.action,
+      grant.fields,
+      cookieJar,
+      referer: referer,
+    );
+    final location = response.headers.value(HttpHeaders.locationHeader);
+    final body = await utf8.decodeStream(response);
+    if (_isRedirect(response.statusCode) && location != null) {
+      final redirected = grant.action.resolve(location);
+      final followUp = await _open(client, redirected, cookieJar);
+      await utf8.decodeStream(followUp);
+      return;
+    }
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final snippet = body.replaceAll(RegExp(r'\s+'), ' ');
+      throw StateError(
+        'Nextcloud rejected the login-flow grant. '
+        'Status=${response.statusCode} Body=${snippet.substring(0, snippet.length > 300 ? 300 : snippet.length)}',
+      );
     }
   }
 
@@ -507,6 +650,138 @@ class LiveOidcTestDriver
     return oidcDefaultScopes;
   }
 
+  _NextcloudLoginFlowAuth? _tryParseNextcloudLoginFlowAuth(
+    String html,
+    Uri baseUri,
+  ) {
+    final payload = _tryParseInitialStateObject(
+      html,
+      'initial-state-core-loginFlowAuth',
+    );
+    final loginRedirectUrl = payload?['loginRedirectUrl'];
+    final appTokenUrl = payload?['appTokenUrl'];
+    final stateToken = payload?['stateToken'];
+    if (loginRedirectUrl is! String ||
+        loginRedirectUrl.trim().isEmpty ||
+        appTokenUrl is! String ||
+        appTokenUrl.trim().isEmpty ||
+        stateToken is! String ||
+        stateToken.trim().isEmpty) {
+      return null;
+    }
+    return _NextcloudLoginFlowAuth(
+      loginRedirectUrl: baseUri.resolve(_htmlDecode(loginRedirectUrl)),
+      appTokenUrl: baseUri.resolve(_htmlDecode(appTokenUrl)),
+      stateToken: stateToken,
+    );
+  }
+
+  _NextcloudLoginFlowGrant? _tryParseNextcloudLoginFlowGrant(
+    String html,
+    Uri baseUri,
+  ) {
+    final payload = _tryParseInitialStateObject(
+      html,
+      'initial-state-core-loginFlowGrant',
+    );
+    final actionUrl = payload?['actionUrl'];
+    final stateToken = payload?['stateToken'];
+    final requestToken = _tryParseRequestToken(html);
+    if (actionUrl is! String ||
+        actionUrl.trim().isEmpty ||
+        stateToken is! String ||
+        stateToken.trim().isEmpty ||
+        requestToken == null ||
+        requestToken.trim().isEmpty) {
+      return null;
+    }
+
+    String? optionalString(String key) {
+      final value = payload?[key];
+      if (value is String && value.trim().isNotEmpty) {
+        return value;
+      }
+      return null;
+    }
+
+    return _NextcloudLoginFlowGrant(
+      action: baseUri.resolve(_htmlDecode(actionUrl)),
+      requestToken: requestToken,
+      stateToken: stateToken,
+      direct: payload?['direct'] == true,
+      clientIdentifier: optionalString('clientIdentifier'),
+      oauthState: optionalString('oauthState'),
+      providedRedirectUri: optionalString('providedRedirectUri'),
+    );
+  }
+
+  Uri? _tryParseNextcloudAlternativeLoginLink(String html, Uri baseUri) {
+    final decoded = _tryParseInitialState(
+      html,
+      'initial-state-core-alternativeLogins',
+    );
+    if (decoded is! List) {
+      return null;
+    }
+    for (final entry in decoded) {
+      if (entry is! Map) {
+        continue;
+      }
+      final href = entry['href'];
+      if (href is! String || href.trim().isEmpty) {
+        continue;
+      }
+      final resolved = baseUri.resolve(_htmlDecode(href));
+      if (resolved.path.contains('/apps/user_oidc/login/')) {
+        return resolved;
+      }
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _tryParseInitialStateObject(String html, String id) {
+    final decoded = _tryParseInitialState(html, id);
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    return null;
+  }
+
+  Object? _tryParseInitialState(String html, String id) {
+    final inputMatches = RegExp(
+      r'<input([^>]*)>',
+      caseSensitive: false,
+    ).allMatches(html);
+    for (final match in inputMatches) {
+      final attributes = match.group(1) ?? '';
+      if (_extractHtmlAttribute(attributes, 'id') != id) {
+        continue;
+      }
+      final value = _extractHtmlAttribute(attributes, 'value');
+      if (value == null || value.trim().isEmpty) {
+        return null;
+      }
+      try {
+        return jsonDecode(utf8.decode(base64Decode(value)));
+      } catch (_) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  String? _tryParseRequestToken(String html) {
+    final headMatch = RegExp(
+      r'<head([^>]*)>',
+      caseSensitive: false,
+    ).firstMatch(html);
+    final attributes = headMatch?.group(1);
+    if (attributes == null) {
+      return null;
+    }
+    return _extractHtmlAttribute(attributes, 'data-requesttoken');
+  }
+
   Uri? _tryParseNextcloudOidcProviderLink(String html, Uri baseUri) {
     final anchorMatches = RegExp(
       r'<a([^>]*)>',
@@ -591,11 +866,9 @@ class LiveOidcTestDriver
   }
 
   Uri _resolveFormAction(String formAttributes, Uri baseUri) {
-    final actionMatch = RegExp(
-      r'action="([^"]*)"',
-      caseSensitive: false,
-    ).firstMatch(formAttributes);
-    final rawAction = _htmlDecode(actionMatch?.group(1) ?? '').trim();
+    final rawAction = _htmlDecode(
+      _extractHtmlAttribute(formAttributes, 'action') ?? '',
+    ).trim();
     if (rawAction.isEmpty) {
       return baseUri;
     }
@@ -630,10 +903,10 @@ class LiveOidcTestDriver
 
   String? _extractHtmlAttribute(String html, String name) {
     final match = RegExp(
-      '$name="([^"]*)"',
+      "\\b${RegExp.escape(name)}\\s*=\\s*([\"'])((?:.|\\n)*?)\\1",
       caseSensitive: false,
     ).firstMatch(html);
-    final value = match?.group(1);
+    final value = match?.group(2);
     if (value == null) {
       return null;
     }
@@ -654,6 +927,7 @@ class LiveOidcTestDriver
         .replaceAll('&amp;', '&')
         .replaceAll('&#x2F;', '/')
         .replaceAll('&quot;', '"')
+        .replaceAll('&#039;', "'")
         .replaceAll('&#39;', "'");
   }
 
@@ -678,6 +952,50 @@ class _ParsedLoginForm {
 
   final Uri action;
   final Map<String, String> fields;
+}
+
+class _NextcloudLoginFlowAuth {
+  const _NextcloudLoginFlowAuth({
+    required this.loginRedirectUrl,
+    required this.appTokenUrl,
+    required this.stateToken,
+  });
+
+  final Uri loginRedirectUrl;
+  final Uri appTokenUrl;
+  final String stateToken;
+}
+
+class _NextcloudLoginFlowGrant {
+  const _NextcloudLoginFlowGrant({
+    required this.action,
+    required this.requestToken,
+    required this.stateToken,
+    required this.direct,
+    this.clientIdentifier,
+    this.oauthState,
+    this.providedRedirectUri,
+  });
+
+  final Uri action;
+  final String requestToken;
+  final String stateToken;
+  final bool direct;
+  final String? clientIdentifier;
+  final String? oauthState;
+  final String? providedRedirectUri;
+
+  Map<String, String> get fields {
+    return <String, String>{
+      'requesttoken': requestToken,
+      'stateToken': stateToken,
+      if (direct) 'direct': '1',
+      if (clientIdentifier != null) 'clientIdentifier': clientIdentifier!,
+      if (oauthState != null) 'oauthState': oauthState!,
+      if (providedRedirectUri != null)
+        'providedRedirectUri': providedRedirectUri!,
+    };
+  }
 }
 
 class _SimpleHttpResponse {

--- a/integration_test/helpers/test_config.dart
+++ b/integration_test/helpers/test_config.dart
@@ -34,8 +34,8 @@ class TestConfig {
       password: const String.fromEnvironment('WEAVE_TEST_PASSWORD').trim(),
       issuerUrl: issuerUrl,
       clientId: clientId,
-      matrixHomeserverUrl: _serviceUri(baseUrl, host: 'matrix.$workspaceHost'),
-      nextcloudBaseUrl: _serviceUri(baseUrl, host: 'files.$workspaceHost'),
+      matrixHomeserverUrl: _matrixHomeserverUrl(baseUrl, workspaceHost),
+      nextcloudBaseUrl: _nextcloudBaseUrl(baseUrl, workspaceHost),
       backendApiBaseUrl: baseUrl,
     );
   }
@@ -145,6 +145,34 @@ class TestConfig {
       host: 'auth.$workspaceHost',
       pathSegments: const <String>['realms', 'weave'],
     );
+  }
+
+  static Uri _matrixHomeserverUrl(Uri baseUrl, String workspaceHost) {
+    const override = String.fromEnvironment('WEAVE_MATRIX_HOMESERVER_URL');
+    if (override.trim().isNotEmpty) {
+      return _parseUrl(override, variableName: 'WEAVE_MATRIX_HOMESERVER_URL');
+    }
+
+    const legacyOverride = String.fromEnvironment('WEAVE_MATRIX_URL');
+    if (legacyOverride.trim().isNotEmpty) {
+      return _parseUrl(legacyOverride, variableName: 'WEAVE_MATRIX_URL');
+    }
+
+    return _serviceUri(baseUrl, host: 'matrix.$workspaceHost');
+  }
+
+  static Uri _nextcloudBaseUrl(Uri baseUrl, String workspaceHost) {
+    const override = String.fromEnvironment('WEAVE_NEXTCLOUD_BASE_URL');
+    if (override.trim().isNotEmpty) {
+      return _parseUrl(override, variableName: 'WEAVE_NEXTCLOUD_BASE_URL');
+    }
+
+    const legacyOverride = String.fromEnvironment('WEAVE_NEXTCLOUD_URL');
+    if (legacyOverride.trim().isNotEmpty) {
+      return _parseUrl(legacyOverride, variableName: 'WEAVE_NEXTCLOUD_URL');
+    }
+
+    return _serviceUri(baseUrl, host: 'files.$workspaceHost');
   }
 
   static List<String> _dropDuplicateApiSegment(

--- a/integration_test/helpers/test_config.dart
+++ b/integration_test/helpers/test_config.dart
@@ -17,7 +17,7 @@ class TestConfig {
     final baseUrl = _parseUrl(
       const String.fromEnvironment(
         'WEAVE_BASE_URL',
-        defaultValue: 'https://api.weave.local',
+        defaultValue: 'https://weave.local/api',
       ),
       variableName: 'WEAVE_BASE_URL',
     );
@@ -35,7 +35,7 @@ class TestConfig {
       issuerUrl: issuerUrl,
       clientId: clientId,
       matrixHomeserverUrl: _serviceUri(baseUrl, host: 'matrix.$workspaceHost'),
-      nextcloudBaseUrl: _serviceUri(baseUrl, host: 'nextcloud.$workspaceHost'),
+      nextcloudBaseUrl: _serviceUri(baseUrl, host: 'files.$workspaceHost'),
       backendApiBaseUrl: baseUrl,
     );
   }
@@ -76,15 +76,14 @@ class TestConfig {
         .split('/')
         .where((segment) => segment.isNotEmpty)
         .toList(growable: false);
-
-    return backendApiBaseUrl.replace(
-      pathSegments: [
-        ...backendApiBaseUrl.pathSegments.where(
-          (segment) => segment.isNotEmpty,
-        ),
-        ...pathSegments,
-      ],
+    final normalizedPathSegments = _dropDuplicateApiSegment(
+      backendApiBaseUrl.pathSegments
+          .where((segment) => segment.isNotEmpty)
+          .toList(growable: false),
+      pathSegments,
     );
+
+    return backendApiBaseUrl.replace(pathSegments: normalizedPathSegments);
   }
 
   Uri unreachableBackendApiBaseUrl() {
@@ -143,9 +142,23 @@ class TestConfig {
 
     return _serviceUri(
       baseUrl,
-      host: 'keycloak.$workspaceHost',
+      host: 'auth.$workspaceHost',
       pathSegments: const <String>['realms', 'weave'],
     );
+  }
+
+  static List<String> _dropDuplicateApiSegment(
+    List<String> baseSegments,
+    List<String> pathSegments,
+  ) {
+    if (baseSegments.isNotEmpty &&
+        pathSegments.isNotEmpty &&
+        baseSegments.last == 'api' &&
+        pathSegments.first == 'api') {
+      return [...baseSegments, ...pathSegments.skip(1)];
+    }
+
+    return [...baseSegments, ...pathSegments];
   }
 
   static String _workspaceHost(String host) {

--- a/integration_test/helpers/test_http_overrides.dart
+++ b/integration_test/helpers/test_http_overrides.dart
@@ -10,6 +10,7 @@ class TestHttpOverrides extends HttpOverrides {
     final normalized = host.toLowerCase();
     return normalized == '127.0.0.1' ||
         normalized == 'localhost' ||
+        normalized.endsWith('.localhost') ||
         normalized.endsWith('.weave.local');
   }
 

--- a/integration_test/helpers/test_http_overrides.dart
+++ b/integration_test/helpers/test_http_overrides.dart
@@ -11,7 +11,9 @@ class TestHttpOverrides extends HttpOverrides {
     return normalized == '127.0.0.1' ||
         normalized == 'localhost' ||
         normalized.endsWith('.localhost') ||
-        normalized.endsWith('.weave.local');
+        normalized.endsWith('.weave.local') ||
+        normalized == '127.0.0.1.sslip.io' ||
+        normalized.endsWith('.127.0.0.1.sslip.io');
   }
 
   @override

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -61,249 +61,252 @@ void main() {
     }
   });
 
-  testWidgets('real live-stack sign-in, Matrix connect, and Nextcloud browse', (
-    tester,
-  ) async {
-    final serverConfig = ServerConfiguration(
-      providerType: OidcProviderType.keycloak,
-      oidcIssuerUrl: config.issuerUrl,
-      oidcClientRegistration: OidcClientRegistration.manual(
-        clientId: config.clientId,
-      ),
-      serviceEndpoints: ServiceEndpoints(
-        matrixHomeserverUrl: config.matrixHomeserverUrl,
-        nextcloudBaseUrl: config.nextcloudBaseUrl,
-        backendApiBaseUrl: config.backendApiBaseUrl,
-      ),
-    );
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          secureStoreProvider.overrideWithValue(_MemorySecureStore()),
-          serverConfigurationRepositoryProvider.overrideWithValue(
-            _MemoryServerConfigurationRepository(serverConfig),
-          ),
-          oidcClientProvider.overrideWithValue(liveOidcDriver),
-          matrixAuthBrowserProvider.overrideWithValue(liveOidcDriver),
-          matrixClientFactoryProvider.overrideWithValue(
-            liveMatrixClientFactory,
-          ),
-          nextcloudHttpClientProvider.overrideWithValue(nextcloudHttpClient),
-          nextcloudLoginLauncherProvider.overrideWithValue(liveOidcDriver),
-        ],
-        child: const WeaveApp(),
-      ),
-    );
-
-    await _pumpUntilSettled(tester);
-
-    final container = ProviderScope.containerOf(
-      tester.element(find.byType(WeaveApp)),
-    );
-
-    await _waitFor(
-      tester,
-      () => find.text('Anmelden').evaluate().isNotEmpty,
-      reason: 'App should reach the sign-in screen with the live config.',
-      diagnostics: () {
-        final bootstrap = container.read(appBootstrapProvider);
-        final texts = find
-            .byType(Text)
-            .evaluate()
-            .map((element) => (element.widget as Text).data)
-            .whereType<String>()
-            .join(' | ');
-        return 'bootstrap=$bootstrap\ntexts=$texts';
-      },
-    );
-
-    await tester.tap(find.widgetWithText(AccessibleButton, 'Anmelden').first);
-    await tester.pump();
-
-    container.read(chatProvider.notifier).connect();
-    await tester.pump();
-
-    await _waitFor(
-      tester,
-      () {
-        final state = container.read(chatProvider);
-        return state.phase == ChatViewPhase.empty ||
-            state.phase == ChatViewPhase.content ||
-            state.phase == ChatViewPhase.error ||
-            state.phase == ChatViewPhase.unsupported;
-      },
-      reason: 'Matrix chat should connect against the live homeserver.',
-      timeout: const Duration(minutes: 2),
-      diagnostics: () {
-        final state = container.read(chatProvider);
-        return 'chatPhase=${state.phase} '
-            'failure=${state.failure?.message} '
-            'cause=${state.failure?.cause} '
-            'conversations=${state.conversations.length}';
-      },
-    );
-
-    final chatState = container.read(chatProvider);
-    final matrixConnected =
-        chatState.phase == ChatViewPhase.empty ||
-        chatState.phase == ChatViewPhase.content;
-
-    final chatRepository = container.read(chatRepositoryProvider);
-    final matrixClientFactory = container.read(matrixClientFactoryProvider);
-    final matrixClient = await matrixClientFactory.getClientForHomeserver(
-      config.matrixHomeserverUrl,
-    );
-    final roomName = 'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}';
-    final roomId = await matrixClient.createGroupChat(
-      groupName: roomName,
-      enableEncryption: false,
-      waitForSync: true,
-      federated: false,
-    );
-    final sentMessage =
-        'live-e2e message ${DateTime.now().toUtc().toIso8601String()}';
-    await chatRepository.sendMessage(roomId: roomId, message: sentMessage);
-    final timeline = await chatRepository.loadRoomTimeline(roomId);
-    final deliveredMessage = timeline.messages
-        .where((message) => message.text == sentMessage)
-        .toList(growable: false);
-    // ignore: avoid_print
-    print(
-      'CHAT_RESULT roomId=$roomId roomName=$roomName '
-      'timelineMessages=${timeline.messages.length} '
-      'matchedMessages=${deliveredMessage.length}',
-    );
-
-    // Keep the Matrix outcome visible while still validating the Nextcloud path.
-    // ignore: avoid_print
-    print(
-      'MATRIX_RESULT phase=${chatState.phase} '
-      'failure=${chatState.failure} '
-      'cause=${chatState.failure?.cause}',
-    );
-
-    await container.read(filesProvider.notifier).connect();
-    await tester.pump();
-
-    await _waitFor(
-      tester,
-      () {
-        final asyncState = container.read(filesProvider);
-        if (asyncState.hasError) {
-          return true;
-        }
-        if (!asyncState.hasValue) {
-          return false;
-        }
-        final state = asyncState.requireValue;
-        return state.connectionState.isConnected &&
-            state.directoryListing != null;
-      },
-      reason: 'Nextcloud should connect and return a real directory listing.',
-      timeout: const Duration(minutes: 1),
-      diagnostics: () {
-        final asyncState = container.read(filesProvider);
-        if (asyncState.hasError) {
-          return 'filesError=${asyncState.error}';
-        }
-        if (!asyncState.hasValue) {
-          return 'filesState=loading';
-        }
-        final state = asyncState.requireValue;
-        return 'filesConnected=${state.connectionState.isConnected} '
-            'filesStatus=${state.connectionState.status} '
-            'filesMessage=${state.connectionState.message} '
-            'directoryFailure=${state.directoryFailure?.message} '
-            'directoryFailureCause=${state.directoryFailure?.cause} '
-            'configuredNextcloudBaseUrl=${config.nextcloudBaseUrl} '
-            'hasListing=${state.directoryListing != null}';
-      },
-    );
-
-    final filesState = container.read(filesProvider).requireValue;
-    final nextcloudConnected =
-        filesState.connectionState.isConnected &&
-        filesState.directoryListing != null;
-
-    final nextcloudSession = await container
-        .read(nextcloudConnectionServiceProvider)
-        .requireLiveSession();
-    final seededFileName =
-        'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}.txt';
-    final seededFileUri = nextcloudSession.baseUrl.resolve(
-      'remote.php/dav/files/${Uri.encodeComponent(nextcloudSession.userId)}/$seededFileName',
-    );
-    final putResponse = await nextcloudHttpClient.put(
-      seededFileUri,
-      headers: <String, String>{
-        ...buildNextcloudAuthHeaders(nextcloudSession),
-        HttpHeaders.contentTypeHeader: 'text/plain; charset=utf-8',
-      },
-      body: 'weave live e2e ${DateTime.now().toUtc().toIso8601String()}',
-    );
-    expect(
-      putResponse.statusCode,
-      anyOf(201, 204),
-      reason: 'Nextcloud WebDAV upload should succeed for the live session.',
-    );
-
-    await container.read(filesProvider.notifier).refresh();
-    await _waitFor(
-      tester,
-      () {
-        final state = container.read(filesProvider);
-        if (!state.hasValue) {
-          return false;
-        }
-        final listing = state.requireValue.directoryListing;
-        return listing != null &&
-            listing.entries.any((entry) => entry.name == seededFileName);
-      },
-      reason:
-          'Files view should show the file uploaded to the live Nextcloud WebDAV path.',
-      timeout: const Duration(minutes: 1),
-    );
-
-    final refreshedFilesState = container.read(filesProvider).requireValue;
-    final matchedFiles = refreshedFilesState.directoryListing!.entries
-        .where((entry) => entry.name == seededFileName)
-        .toList(growable: false);
-    // ignore: avoid_print
-    print(
-      'FILES_RESULT path=${refreshedFilesState.directoryListing!.path} '
-      'entries=${refreshedFilesState.directoryListing!.entries.length} '
-      'matchedFiles=${matchedFiles.length} '
-      'fileName=$seededFileName',
-    );
-
-    if (!matrixConnected ||
-        !nextcloudConnected ||
-        deliveredMessage.isEmpty ||
-        matchedFiles.isEmpty) {
-      fail(
-        'live_e2e_result '
-        'authSignedIn=true '
-        'matrixConnected=$matrixConnected '
-        'matrixPhase=${chatState.phase} '
-        'matrixFailure=${chatState.failure} '
-        'matrixCause=${chatState.failure?.cause} '
-        'chatRoomId=$roomId '
-        'chatMatchedMessages=${deliveredMessage.length} '
-        'nextcloudConnected=$nextcloudConnected '
-        'nextcloudStatus=${filesState.connectionState.status} '
-        'nextcloudMessage=${filesState.connectionState.message} '
-        'nextcloudEntries=${refreshedFilesState.directoryListing?.entries.length} '
-        'nextcloudMatchedFiles=${matchedFiles.length} '
-        'seededFileName=$seededFileName',
+  testWidgets(
+    'real live-stack sign-in, Matrix connect, and Nextcloud browse',
+    (tester) async {
+      final serverConfig = ServerConfiguration(
+        providerType: OidcProviderType.keycloak,
+        oidcIssuerUrl: config.issuerUrl,
+        oidcClientRegistration: OidcClientRegistration.manual(
+          clientId: config.clientId,
+        ),
+        serviceEndpoints: ServiceEndpoints(
+          matrixHomeserverUrl: config.matrixHomeserverUrl,
+          nextcloudBaseUrl: config.nextcloudBaseUrl,
+          backendApiBaseUrl: config.backendApiBaseUrl,
+        ),
       );
-    }
 
-    expect(matrixConnected, isTrue);
-    expect(deliveredMessage, isNotEmpty);
-    expect(nextcloudConnected, isTrue);
-    expect(matchedFiles, isNotEmpty);
-  });
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            secureStoreProvider.overrideWithValue(_MemorySecureStore()),
+            serverConfigurationRepositoryProvider.overrideWithValue(
+              _MemoryServerConfigurationRepository(serverConfig),
+            ),
+            oidcClientProvider.overrideWithValue(liveOidcDriver),
+            matrixAuthBrowserProvider.overrideWithValue(liveOidcDriver),
+            matrixClientFactoryProvider.overrideWithValue(
+              liveMatrixClientFactory,
+            ),
+            nextcloudHttpClientProvider.overrideWithValue(nextcloudHttpClient),
+            nextcloudLoginLauncherProvider.overrideWithValue(liveOidcDriver),
+          ],
+          child: const WeaveApp(),
+        ),
+      );
+
+      await _pumpUntilSettled(tester);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(WeaveApp)),
+      );
+
+      await _waitFor(
+        tester,
+        () => find.text('Anmelden').evaluate().isNotEmpty,
+        reason: 'App should reach the sign-in screen with the live config.',
+        diagnostics: () {
+          final bootstrap = container.read(appBootstrapProvider);
+          final texts = find
+              .byType(Text)
+              .evaluate()
+              .map((element) => (element.widget as Text).data)
+              .whereType<String>()
+              .join(' | ');
+          return 'bootstrap=$bootstrap\ntexts=$texts';
+        },
+      );
+
+      await tester.tap(find.widgetWithText(AccessibleButton, 'Anmelden').first);
+      await tester.pump();
+
+      container.read(chatProvider.notifier).connect();
+      await tester.pump();
+
+      await _waitFor(
+        tester,
+        () {
+          final state = container.read(chatProvider);
+          return state.phase == ChatViewPhase.empty ||
+              state.phase == ChatViewPhase.content ||
+              state.phase == ChatViewPhase.error ||
+              state.phase == ChatViewPhase.unsupported;
+        },
+        reason: 'Matrix chat should connect against the live homeserver.',
+        timeout: const Duration(minutes: 2),
+        diagnostics: () {
+          final state = container.read(chatProvider);
+          return 'chatPhase=${state.phase} '
+              'failure=${state.failure?.message} '
+              'cause=${state.failure?.cause} '
+              'conversations=${state.conversations.length}';
+        },
+      );
+
+      final chatState = container.read(chatProvider);
+      final matrixConnected =
+          chatState.phase == ChatViewPhase.empty ||
+          chatState.phase == ChatViewPhase.content;
+
+      final chatRepository = container.read(chatRepositoryProvider);
+      final matrixClientFactory = container.read(matrixClientFactoryProvider);
+      final matrixClient = await matrixClientFactory.getClientForHomeserver(
+        config.matrixHomeserverUrl,
+      );
+      final roomName =
+          'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}';
+      final roomId = await matrixClient.createGroupChat(
+        groupName: roomName,
+        enableEncryption: false,
+        waitForSync: true,
+        federated: false,
+      );
+      final sentMessage =
+          'live-e2e message ${DateTime.now().toUtc().toIso8601String()}';
+      await chatRepository.sendMessage(roomId: roomId, message: sentMessage);
+      final timeline = await chatRepository.loadRoomTimeline(roomId);
+      final deliveredMessage = timeline.messages
+          .where((message) => message.text == sentMessage)
+          .toList(growable: false);
+      // ignore: avoid_print
+      print(
+        'CHAT_RESULT roomId=$roomId roomName=$roomName '
+        'timelineMessages=${timeline.messages.length} '
+        'matchedMessages=${deliveredMessage.length}',
+      );
+
+      // Keep the Matrix outcome visible while still validating the Nextcloud path.
+      // ignore: avoid_print
+      print(
+        'MATRIX_RESULT phase=${chatState.phase} '
+        'failure=${chatState.failure} '
+        'cause=${chatState.failure?.cause}',
+      );
+
+      await container.read(filesProvider.notifier).connect();
+      await tester.pump();
+
+      await _waitFor(
+        tester,
+        () {
+          final asyncState = container.read(filesProvider);
+          if (asyncState.hasError) {
+            return true;
+          }
+          if (!asyncState.hasValue) {
+            return false;
+          }
+          final state = asyncState.requireValue;
+          return state.connectionState.isConnected &&
+              state.directoryListing != null;
+        },
+        reason: 'Nextcloud should connect and return a real directory listing.',
+        timeout: const Duration(minutes: 1),
+        diagnostics: () {
+          final asyncState = container.read(filesProvider);
+          if (asyncState.hasError) {
+            return 'filesError=${asyncState.error}';
+          }
+          if (!asyncState.hasValue) {
+            return 'filesState=loading';
+          }
+          final state = asyncState.requireValue;
+          return 'filesConnected=${state.connectionState.isConnected} '
+              'filesStatus=${state.connectionState.status} '
+              'filesMessage=${state.connectionState.message} '
+              'directoryFailure=${state.directoryFailure?.message} '
+              'directoryFailureCause=${state.directoryFailure?.cause} '
+              'configuredNextcloudBaseUrl=${config.nextcloudBaseUrl} '
+              'hasListing=${state.directoryListing != null}';
+        },
+      );
+
+      final filesState = container.read(filesProvider).requireValue;
+      final nextcloudConnected =
+          filesState.connectionState.isConnected &&
+          filesState.directoryListing != null;
+
+      final nextcloudSession = await container
+          .read(nextcloudConnectionServiceProvider)
+          .requireLiveSession();
+      final seededFileName =
+          'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}.txt';
+      final seededFileUri = nextcloudSession.baseUrl.resolve(
+        'remote.php/dav/files/${Uri.encodeComponent(nextcloudSession.userId)}/$seededFileName',
+      );
+      final putResponse = await nextcloudHttpClient.put(
+        seededFileUri,
+        headers: <String, String>{
+          ...buildNextcloudAuthHeaders(nextcloudSession),
+          HttpHeaders.contentTypeHeader: 'text/plain; charset=utf-8',
+        },
+        body: 'weave live e2e ${DateTime.now().toUtc().toIso8601String()}',
+      );
+      expect(
+        putResponse.statusCode,
+        anyOf(201, 204),
+        reason: 'Nextcloud WebDAV upload should succeed for the live session.',
+      );
+
+      await container.read(filesProvider.notifier).refresh();
+      await _waitFor(
+        tester,
+        () {
+          final state = container.read(filesProvider);
+          if (!state.hasValue) {
+            return false;
+          }
+          final listing = state.requireValue.directoryListing;
+          return listing != null &&
+              listing.entries.any((entry) => entry.name == seededFileName);
+        },
+        reason:
+            'Files view should show the file uploaded to the live Nextcloud WebDAV path.',
+        timeout: const Duration(minutes: 1),
+      );
+
+      final refreshedFilesState = container.read(filesProvider).requireValue;
+      final matchedFiles = refreshedFilesState.directoryListing!.entries
+          .where((entry) => entry.name == seededFileName)
+          .toList(growable: false);
+      // ignore: avoid_print
+      print(
+        'FILES_RESULT path=${refreshedFilesState.directoryListing!.path} '
+        'entries=${refreshedFilesState.directoryListing!.entries.length} '
+        'matchedFiles=${matchedFiles.length} '
+        'fileName=$seededFileName',
+      );
+
+      if (!matrixConnected ||
+          !nextcloudConnected ||
+          deliveredMessage.isEmpty ||
+          matchedFiles.isEmpty) {
+        fail(
+          'live_e2e_result '
+          'authSignedIn=true '
+          'matrixConnected=$matrixConnected '
+          'matrixPhase=${chatState.phase} '
+          'matrixFailure=${chatState.failure} '
+          'matrixCause=${chatState.failure?.cause} '
+          'chatRoomId=$roomId '
+          'chatMatchedMessages=${deliveredMessage.length} '
+          'nextcloudConnected=$nextcloudConnected '
+          'nextcloudStatus=${filesState.connectionState.status} '
+          'nextcloudMessage=${filesState.connectionState.message} '
+          'nextcloudEntries=${refreshedFilesState.directoryListing?.entries.length} '
+          'nextcloudMatchedFiles=${matchedFiles.length} '
+          'seededFileName=$seededFileName',
+        );
+      }
+
+      expect(matrixConnected, isTrue);
+      expect(deliveredMessage, isNotEmpty);
+      expect(nextcloudConnected, isTrue);
+      expect(matchedFiles, isNotEmpty);
+    },
+    semanticsEnabled: false,
+  );
 }
 
 Future<void> _pumpUntilSettled(WidgetTester tester) async {

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -214,6 +214,9 @@ void main() {
         return 'filesConnected=${state.connectionState.isConnected} '
             'filesStatus=${state.connectionState.status} '
             'filesMessage=${state.connectionState.message} '
+            'directoryFailure=${state.directoryFailure?.message} '
+            'directoryFailureCause=${state.directoryFailure?.cause} '
+            'configuredNextcloudBaseUrl=${config.nextcloudBaseUrl} '
             'hasListing=${state.directoryListing != null}';
       },
     );

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -31,7 +31,11 @@ import 'helpers/test_config.dart';
 import 'helpers/test_http_overrides.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  // The self-hosted macOS runner can expose host accessibility state to the
+  // launched Flutter app. Keep the live E2E deterministic and prevent a
+  // platform-requested semantics handle from leaking past test teardown.
+  binding.platformDispatcher.semanticsEnabledTestValue = false;
   HttpOverrides.global = TestHttpOverrides();
 
   late TestConfig config;

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -12,6 +12,7 @@ import 'package:weave/core/persistence/secure_store.dart';
 import 'package:weave/features/auth/data/services/flutter_appauth_oidc_client.dart';
 import 'package:weave/features/chat/data/services/matrix_auth_browser.dart';
 import 'package:weave/features/chat/data/services/matrix_client_factory.dart';
+import 'package:weave/features/chat/data/services/matrix_client_factory_io.dart';
 import 'package:weave/features/chat/presentation/providers/chat_provider.dart';
 import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
 import 'package:weave/features/files/presentation/providers/files_provider.dart';
@@ -36,16 +37,28 @@ void main() {
   late TestConfig config;
   late LiveOidcTestDriver liveOidcDriver;
   late http.Client nextcloudHttpClient;
+  late Directory matrixSupportDirectory;
+  late SdkMatrixClientFactory liveMatrixClientFactory;
 
-  setUp(() {
+  setUp(() async {
     config = TestConfig.fromEnvironment();
     config.requireCredentials();
     liveOidcDriver = LiveOidcTestDriver(config: config);
     nextcloudHttpClient = createTrustedTestHttpClient();
+    matrixSupportDirectory = await Directory.systemTemp.createTemp(
+      'weave-live-e2e-matrix-',
+    );
+    liveMatrixClientFactory = SdkMatrixClientFactory(
+      appSupportDirectoryProvider: () async => matrixSupportDirectory,
+    );
   });
 
-  tearDown(() {
+  tearDown(() async {
     nextcloudHttpClient.close();
+    await liveMatrixClientFactory.dispose();
+    if (await matrixSupportDirectory.exists()) {
+      await matrixSupportDirectory.delete(recursive: true);
+    }
   });
 
   testWidgets('real live-stack sign-in, Matrix connect, and Nextcloud browse', (
@@ -73,6 +86,9 @@ void main() {
           ),
           oidcClientProvider.overrideWithValue(liveOidcDriver),
           matrixAuthBrowserProvider.overrideWithValue(liveOidcDriver),
+          matrixClientFactoryProvider.overrideWithValue(
+            liveMatrixClientFactory,
+          ),
           nextcloudHttpClientProvider.overrideWithValue(nextcloudHttpClient),
         ],
         child: const WeaveApp(),

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -90,6 +90,7 @@ void main() {
             liveMatrixClientFactory,
           ),
           nextcloudHttpClientProvider.overrideWithValue(nextcloudHttpClient),
+          nextcloudLoginLauncherProvider.overrideWithValue(liveOidcDriver),
         ],
         child: const WeaveApp(),
       ),

--- a/lib/features/server_config/data/services/service_endpoint_deriver.dart
+++ b/lib/features/server_config/data/services/service_endpoint_deriver.dart
@@ -65,8 +65,8 @@ class ServiceEndpointDeriver {
 
     return ServiceEndpoints(
       matrixHomeserverUrl: Uri.parse('$scheme://matrix.$baseHost'),
-      nextcloudBaseUrl: Uri.parse('$scheme://nextcloud.$baseHost'),
-      backendApiBaseUrl: Uri.parse('$scheme://api.$baseHost'),
+      nextcloudBaseUrl: Uri.parse('$scheme://files.$baseHost'),
+      backendApiBaseUrl: Uri.parse('$scheme://$baseHost/api'),
     );
   }
 

--- a/lib/features/server_config/presentation/widgets/server_configuration_form.dart
+++ b/lib/features/server_config/presentation/widgets/server_configuration_form.dart
@@ -241,7 +241,7 @@ class _ServerConfigurationFormState
           textInputAction: TextInputAction.next,
           decoration: InputDecoration(
             labelText: l10n.serverConfigurationNextcloudLabel,
-            hintText: 'https://nextcloud.home.internal',
+            hintText: 'https://files.home.internal',
             helperText: formState.derivedNextcloudBaseUrl.isEmpty
                 ? null
                 : l10n.serverConfigurationDerivedHint(
@@ -260,7 +260,7 @@ class _ServerConfigurationFormState
           textInputAction: TextInputAction.done,
           decoration: InputDecoration(
             labelText: l10n.serverConfigurationBackendApiLabel,
-            hintText: 'https://api.home.internal',
+            hintText: 'https://home.internal/api',
             helperText: formState.derivedBackendApiBaseUrl.isEmpty
                 ? null
                 : l10n.serverConfigurationDerivedHint(

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -78,13 +78,26 @@ class HttpWeaveApiClient implements WeaveApiClient {
 
   Uri _workspaceCapabilitiesUri(Uri baseUrl) {
     return baseUrl.replace(
-      pathSegments: [
-        ...baseUrl.pathSegments.where((segment) => segment.isNotEmpty),
+      pathSegments: _apiPath(baseUrl, const [
         'api',
         'v1',
         'workspace',
         'capabilities',
-      ],
+      ]),
     );
+  }
+
+  List<String> _apiPath(Uri baseUrl, List<String> pathSegments) {
+    final baseSegments = baseUrl.pathSegments
+        .where((segment) => segment.isNotEmpty)
+        .toList(growable: false);
+    if (baseSegments.isNotEmpty &&
+        pathSegments.isNotEmpty &&
+        baseSegments.last == 'api' &&
+        pathSegments.first == 'api') {
+      return [...baseSegments, ...pathSegments.skip(1)];
+    }
+
+    return [...baseSegments, ...pathSegments];
   }
 }

--- a/test/features/app/presentation/providers/workspace_connection_provider_test.dart
+++ b/test/features/app/presentation/providers/workspace_connection_provider_test.dart
@@ -129,7 +129,7 @@ void main() {
           filesRepositoryProvider.overrideWithValue(
             _FakeFilesRepository(
               connectionState: FilesConnectionState.invalid(
-                baseUrl: Uri.parse('https://nextcloud.home.internal'),
+                baseUrl: Uri.parse('https://files.home.internal'),
               ),
             ),
           ),
@@ -244,7 +244,7 @@ void main() {
             filesRepositoryProvider.overrideWithValue(
               _FakeFilesRepository(
                 connectionState: FilesConnectionState.connected(
-                  baseUrl: Uri.parse('https://nextcloud.home.internal'),
+                  baseUrl: Uri.parse('https://files.home.internal'),
                   accountLabel: 'alice',
                 ),
               ),
@@ -318,7 +318,7 @@ void main() {
             filesRepositoryProvider.overrideWithValue(
               _FakeFilesRepository(
                 connectionState: FilesConnectionState.connected(
-                  baseUrl: Uri.parse('https://nextcloud.home.internal'),
+                  baseUrl: Uri.parse('https://files.home.internal'),
                   accountLabel: 'alice',
                 ),
               ),

--- a/test/features/app/release_golden_paths_test.dart
+++ b/test/features/app/release_golden_paths_test.dart
@@ -94,7 +94,7 @@ class _MutableFilesRepository implements FilesRepository {
        _connectedState =
            connectedState ??
            FilesConnectionState.connected(
-             baseUrl: Uri.parse('https://nextcloud.home.internal'),
+             baseUrl: Uri.parse('https://files.home.internal'),
              accountLabel: 'alice',
            );
 
@@ -306,7 +306,7 @@ void main() {
         });
         final filesRepository = _MutableFilesRepository(
           initialConnectionState: FilesConnectionState.disconnected(
-            baseUrl: Uri.parse('https://nextcloud.home.internal'),
+            baseUrl: Uri.parse('https://files.home.internal'),
           ),
           listings: <String, DirectoryListing>{
             '/': const DirectoryListing(
@@ -440,7 +440,7 @@ void main() {
       });
       final filesRepository = _MutableFilesRepository(
         initialConnectionState: FilesConnectionState.connected(
-          baseUrl: Uri.parse('https://nextcloud.home.internal'),
+          baseUrl: Uri.parse('https://files.home.internal'),
           accountLabel: 'alice',
         ),
         listings: const <String, DirectoryListing>{
@@ -525,7 +525,7 @@ void main() {
         );
         final filesRepository = _MutableFilesRepository(
           initialConnectionState: FilesConnectionState.connected(
-            baseUrl: Uri.parse('https://nextcloud.home.internal'),
+            baseUrl: Uri.parse('https://files.home.internal'),
             accountLabel: 'alice',
           ),
           listings: const <String, DirectoryListing>{

--- a/test/features/app/weave_app_backend_capability_flow_test.dart
+++ b/test/features/app/weave_app_backend_capability_flow_test.dart
@@ -176,7 +176,7 @@ void main() {
             filesRepositoryProvider.overrideWithValue(
               _FakeFilesRepository(
                 connectionState: FilesConnectionState.connected(
-                  baseUrl: Uri.parse('https://nextcloud.home.internal'),
+                  baseUrl: Uri.parse('https://files.home.internal'),
                   accountLabel: 'alice',
                 ),
               ),
@@ -196,7 +196,7 @@ void main() {
       expect(weaveApiClient.callCount, 1);
       expect(
         weaveApiClient.lastBaseUrl,
-        Uri.parse('https://api.home.internal'),
+        Uri.parse('https://home.internal/api'),
       );
       expect(weaveApiClient.lastAccessToken, 'backend-boundary-token');
 

--- a/test/features/onboarding/setup_flow_test.dart
+++ b/test/features/onboarding/setup_flow_test.dart
@@ -126,8 +126,8 @@ void main() {
 
       expect(find.text('Review Service Endpoints'), findsOneWidget);
       expect(find.text('https://matrix.home.internal'), findsWidgets);
-      expect(find.text('https://nextcloud.home.internal'), findsWidgets);
-      expect(find.text('https://api.home.internal'), findsWidgets);
+      expect(find.text('https://files.home.internal'), findsWidgets);
+      expect(find.text('https://home.internal/api'), findsWidgets);
       expect(find.text('Finish'), findsOneWidget);
     });
 
@@ -146,7 +146,7 @@ void main() {
 
       await tester.enterText(
         _textFieldWithLabel('Nextcloud Base URL'),
-        'https://nextcloud.home.internal',
+        'https://files.home.internal',
       );
       await tester.tap(find.text('Finish'));
       await tester.pumpAndSettle();
@@ -156,7 +156,7 @@ void main() {
       final raw = preferencesStore.rawString(serverConfigurationStorageKey);
       final json = jsonDecode(raw!) as Map<String, dynamic>;
       expect(json['oidcClientId'], 'weave-app');
-      expect(json['backendApiBaseUrl'], 'https://api.home.internal');
+      expect(json['backendApiBaseUrl'], 'https://home.internal/api');
     });
 
     testWidgets('goes back to provider step from services step', (

--- a/test/features/server_config/data/repositories/shared_preferences_server_configuration_repository_test.dart
+++ b/test/features/server_config/data/repositories/shared_preferences_server_configuration_repository_test.dart
@@ -92,7 +92,7 @@ void main() {
 
         expect(
           loaded?.serviceEndpoints.backendApiBaseUrl.toString(),
-          'https://api.home.internal',
+          'https://home.internal/api',
         );
       },
     );
@@ -118,7 +118,7 @@ void main() {
         'oidcIssuerUrl': 'https://auth.home.internal',
         'oidcClientRegistrationMode': 'manual',
         'matrixHomeserverUrl': 'https://matrix.home.internal',
-        'nextcloudBaseUrl': 'https://nextcloud.home.internal',
+        'nextcloudBaseUrl': 'https://files.home.internal',
       });
       final store = InMemoryPreferencesStore({
         serverConfigurationStorageKey: raw,

--- a/test/features/server_config/data/services/service_endpoint_deriver_test.dart
+++ b/test/features/server_config/data/services/service_endpoint_deriver_test.dart
@@ -16,11 +16,11 @@ void main() {
       );
       expect(
         endpoints.nextcloudBaseUrl.toString(),
-        'https://nextcloud.home.internal',
+        'https://files.home.internal',
       );
       expect(
         endpoints.backendApiBaseUrl.toString(),
-        'https://api.home.internal',
+        'https://home.internal/api',
       );
     });
 
@@ -34,9 +34,9 @@ void main() {
       );
       expect(
         endpoints.nextcloudBaseUrl.toString(),
-        'https://nextcloud.example.com',
+        'https://files.example.com',
       );
-      expect(endpoints.backendApiBaseUrl.toString(), 'https://api.example.com');
+      expect(endpoints.backendApiBaseUrl.toString(), 'https://example.com/api');
     });
 
     test(
@@ -53,11 +53,11 @@ void main() {
         );
         expect(
           endpoints.nextcloudBaseUrl.toString(),
-          'https://nextcloud.workspace.example.com',
+          'https://files.workspace.example.com',
         );
         expect(
           endpoints.backendApiBaseUrl.toString(),
-          'https://api.workspace.example.com',
+          'https://workspace.example.com/api',
         );
       },
     );
@@ -72,11 +72,11 @@ void main() {
       );
       expect(
         endpoints.nextcloudBaseUrl.toString(),
-        'http://nextcloud.home.internal',
+        'http://files.home.internal',
       );
       expect(
         endpoints.backendApiBaseUrl.toString(),
-        'http://api.home.internal',
+        'http://home.internal/api',
       );
     });
 

--- a/test/features/server_config/presentation/providers/server_configuration_form_controller_test.dart
+++ b/test/features/server_config/presentation/providers/server_configuration_form_controller_test.dart
@@ -16,7 +16,7 @@ void main() {
 
         controller.state = controller.state.copyWith(
           matrixHomeserverUrl: 'https://matrix.custom.example',
-          nextcloudBaseUrl: 'https://nextcloud.custom.example',
+          nextcloudBaseUrl: 'https://files.custom.example',
           matrixError: 'matrix validation failed',
           nextcloudError: 'nextcloud validation failed',
         );
@@ -26,9 +26,9 @@ void main() {
         final state = container.read(serverConfigurationFormControllerProvider);
 
         expect(state.derivedMatrixHomeserverUrl, 'https://matrix.example.com');
-        expect(state.derivedNextcloudBaseUrl, 'https://nextcloud.example.com');
+        expect(state.derivedNextcloudBaseUrl, 'https://files.example.com');
         expect(state.matrixHomeserverUrl, 'https://matrix.example.com');
-        expect(state.nextcloudBaseUrl, 'https://nextcloud.example.com');
+        expect(state.nextcloudBaseUrl, 'https://files.example.com');
         expect(state.matrixError, isNull);
         expect(state.nextcloudError, isNull);
       },

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -165,20 +165,20 @@ void main() {
       expect(find.text('Server Configuration'), findsOneWidget);
       expect(find.text('https://auth.home.internal'), findsWidgets);
       expect(find.text('weave-app'), findsWidgets);
-      expect(find.text('https://api.home.internal'), findsWidgets);
+      expect(find.text('https://home.internal/api'), findsWidgets);
 
       await tester.enterText(
         _textFieldWithLabel('Nextcloud Base URL'),
-        'https://nextcloud-alt.home.internal',
+        'https://files-alt.home.internal',
       );
       await tester.pump();
-      expect(find.text('https://nextcloud-alt.home.internal'), findsWidgets);
+      expect(find.text('https://files-alt.home.internal'), findsWidgets);
 
       expect(
         container
             .read(serverConfigurationFormControllerProvider)
             .nextcloudBaseUrl,
-        'https://nextcloud-alt.home.internal',
+        'https://files-alt.home.internal',
       );
 
       await container
@@ -189,8 +189,8 @@ void main() {
       final raw = store.rawString(serverConfigurationStorageKey);
       final json = jsonDecode(raw!) as Map<String, dynamic>;
 
-      expect(json['nextcloudBaseUrl'], 'https://nextcloud-alt.home.internal');
-      expect(json['backendApiBaseUrl'], 'https://api.home.internal');
+      expect(json['nextcloudBaseUrl'], 'https://files-alt.home.internal');
+      expect(json['backendApiBaseUrl'], 'https://home.internal/api');
     });
 
     testWidgets('preserves overridden service URLs when the issuer changes', (

--- a/test/helpers/server_config_test_data.dart
+++ b/test/helpers/server_config_test_data.dart
@@ -11,8 +11,8 @@ ServerConfiguration buildTestConfiguration({
   String issuerUrl = 'https://auth.home.internal',
   String clientId = 'weave-app',
   String matrixHomeserverUrl = 'https://matrix.home.internal',
-  String nextcloudBaseUrl = 'https://nextcloud.home.internal',
-  String backendApiBaseUrl = 'https://api.home.internal',
+  String nextcloudBaseUrl = 'https://files.home.internal',
+  String backendApiBaseUrl = 'https://home.internal/api',
 }) {
   return ServerConfiguration(
     providerType: providerType,
@@ -31,8 +31,8 @@ String encodeTestConfiguration({
   String issuerUrl = 'https://auth.home.internal',
   String clientId = 'weave-app',
   String matrixHomeserverUrl = 'https://matrix.home.internal',
-  String nextcloudBaseUrl = 'https://nextcloud.home.internal',
-  String? backendApiBaseUrl = 'https://api.home.internal',
+  String nextcloudBaseUrl = 'https://files.home.internal',
+  String? backendApiBaseUrl = 'https://home.internal/api',
 }) {
   final json = <String, Object?>{
     'providerType': providerType.name,
@@ -53,8 +53,8 @@ Map<String, Object> buildStoredConfiguration({
   String issuerUrl = 'https://auth.home.internal',
   String clientId = 'weave-app',
   String matrixHomeserverUrl = 'https://matrix.home.internal',
-  String nextcloudBaseUrl = 'https://nextcloud.home.internal',
-  String? backendApiBaseUrl = 'https://api.home.internal',
+  String nextcloudBaseUrl = 'https://files.home.internal',
+  String? backendApiBaseUrl = 'https://home.internal/api',
 }) {
   return {
     serverConfigurationStorageKey: encodeTestConfiguration(

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -47,13 +47,13 @@ void main() {
       );
 
       final snapshot = await client.fetchWorkspaceCapabilities(
-        baseUrl: Uri.parse('https://api.home.internal'),
+        baseUrl: Uri.parse('https://home.internal/api'),
         accessToken: 'token-123',
       );
 
       expect(
         capturedRequest.url.toString(),
-        'https://api.home.internal/api/v1/workspace/capabilities',
+        'https://home.internal/api/v1/workspace/capabilities',
       );
       expect(capturedRequest.headers['Accept'], 'application/json');
       expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
@@ -68,31 +68,63 @@ void main() {
       );
     });
 
-    test('preserves a base path when building the workspace endpoint', () async {
-      late http.BaseRequest capturedRequest;
-      final client = HttpWeaveApiClient(
-        httpClient: _RecordingHttpClient((request) async {
-          capturedRequest = request;
-          return _jsonResponse({
-            'shellAccess': {'enabled': true, 'readiness': 'ready'},
-            'chat': {'enabled': true, 'readiness': 'ready'},
-            'files': {'enabled': true, 'readiness': 'ready'},
-            'calendar': {'enabled': true, 'readiness': 'ready'},
-            'boards': {'enabled': true, 'readiness': 'ready'},
-          });
-        }),
-      );
+    test(
+      'preserves a base path when building the workspace endpoint',
+      () async {
+        late http.BaseRequest capturedRequest;
+        final client = HttpWeaveApiClient(
+          httpClient: _RecordingHttpClient((request) async {
+            capturedRequest = request;
+            return _jsonResponse({
+              'shellAccess': {'enabled': true, 'readiness': 'ready'},
+              'chat': {'enabled': true, 'readiness': 'ready'},
+              'files': {'enabled': true, 'readiness': 'ready'},
+              'calendar': {'enabled': true, 'readiness': 'ready'},
+              'boards': {'enabled': true, 'readiness': 'ready'},
+            });
+          }),
+        );
 
-      await client.fetchWorkspaceCapabilities(
-        baseUrl: Uri.parse('https://api.home.internal/service/root'),
-        accessToken: 'token-123',
-      );
+        await client.fetchWorkspaceCapabilities(
+          baseUrl: Uri.parse('https://home.internal/service/root'),
+          accessToken: 'token-123',
+        );
 
-      expect(
-        capturedRequest.url.toString(),
-        'https://api.home.internal/service/root/api/v1/workspace/capabilities',
-      );
-    });
+        expect(
+          capturedRequest.url.toString(),
+          'https://home.internal/service/root/api/v1/workspace/capabilities',
+        );
+      },
+    );
+
+    test(
+      'does not duplicate the api segment for canonical API bases',
+      () async {
+        late http.BaseRequest capturedRequest;
+        final client = HttpWeaveApiClient(
+          httpClient: _RecordingHttpClient((request) async {
+            capturedRequest = request;
+            return _jsonResponse({
+              'shellAccess': {'enabled': true, 'readiness': 'ready'},
+              'chat': {'enabled': true, 'readiness': 'ready'},
+              'files': {'enabled': true, 'readiness': 'ready'},
+              'calendar': {'enabled': true, 'readiness': 'ready'},
+              'boards': {'enabled': true, 'readiness': 'ready'},
+            });
+          }),
+        );
+
+        await client.fetchWorkspaceCapabilities(
+          baseUrl: Uri.parse('https://weave.local/api'),
+          accessToken: 'token-123',
+        );
+
+        expect(
+          capturedRequest.url.toString(),
+          'https://weave.local/api/v1/workspace/capabilities',
+        );
+      },
+    );
 
     test(
       'rejects unauthorized backend sessions with a dedicated failure',
@@ -108,7 +140,7 @@ void main() {
 
           await expectLater(
             () => client.fetchWorkspaceCapabilities(
-              baseUrl: Uri.parse('https://api.home.internal'),
+              baseUrl: Uri.parse('https://home.internal/api'),
               accessToken: 'token-123',
             ),
             throwsA(
@@ -132,7 +164,7 @@ void main() {
 
       await expectLater(
         () => client.fetchWorkspaceCapabilities(
-          baseUrl: Uri.parse('https://api.home.internal'),
+          baseUrl: Uri.parse('https://home.internal/api'),
           accessToken: 'token-123',
         ),
         throwsA(isA<AppFailure>()),

--- a/test/release_1/release_golden_paths_test.dart
+++ b/test/release_1/release_golden_paths_test.dart
@@ -111,8 +111,8 @@ void main() {
 
         expect(find.text('Review Service Endpoints'), findsOneWidget);
         expect(find.text('https://matrix.weave.local'), findsWidgets);
-        expect(find.text('https://nextcloud.weave.local'), findsWidgets);
-        expect(find.text('https://api.weave.local'), findsWidgets);
+        expect(find.text('https://files.weave.local'), findsWidgets);
+        expect(find.text('https://weave.local/api'), findsWidgets);
 
         await tester.tap(find.text('Finish'));
         await tester.pumpAndSettle();
@@ -347,7 +347,7 @@ class _ScenarioFilesRepository implements FilesRepository {
           .configuration
           ?.serviceEndpoints
           .nextcloudBaseUrl ??
-      Uri.parse('https://nextcloud.weave.local');
+      Uri.parse('https://files.weave.local');
 
   @override
   Future<FilesConnectionState> connect() async {


### PR DESCRIPTION
## Summary
- Align Flutter local defaults with the final weave.local product gateway contract.
- Derive Matrix at matrix.<base-domain>, raw files at files.<base-domain>, and backend API at <base-domain>/api.
- Avoid duplicate /api paths when the configured backend base URL already includes /api, and update live identity checks to call /api/me.
- Clarify that pull-request CI uses a loopback sslip.io tenant for runner safety while standalone Live Stack E2E covers canonical *.weave.local hostnames.
- Document the current Nextcloud HTML login-flow E2E as a compatibility smoke, not the long-term product contract.

## Why
This is the client slice of the cross-repo platform-contract baseline from the final Weave specs. It keeps Matrix and raw Nextcloud client flows client-owned while pointing product API traffic at the product gateway. It also records that deterministic backend/API contracts should replace brittle Flutter-side Nextcloud HTML scraping where product files flows move backend-owned after MVP.

## Validation
- CI `build` ✅ on head `5995e839cff9aafb288b4a1dda5adb060da18840`
- CI `Live Stack Integration Test` ✅ on head `5995e839cff9aafb288b4a1dda5adb060da18840`
- Run: https://github.com/masssi164/weave/actions/runs/24940595513
