### PR TITLE
chore: add backend facade seams for files and calendar

### DIFF
--- a/lib/features/calendar/data/repositories/stub_calendar_repository.dart
+++ b/lib/features/calendar/data/repositories/stub_calendar_repository.dart
@@ -1,12 +1,12 @@
-import 'package:weave/features/calendar/data/services/caldav_client.dart';
+import 'package:weave/features/calendar/data/services/calendar_facade_client.dart';
 import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
 import 'package:weave/features/calendar/domain/repositories/calendar_repository.dart';
 
 class StubCalendarRepository implements CalendarRepository {
-  const StubCalendarRepository({required CalDavClient client})
+  const StubCalendarRepository({required CalendarFacadeClient client})
     : _client = client;
 
-  final CalDavClient _client;
+  final CalendarFacadeClient _client;
 
   @override
   Future<List<CalendarEvent>> loadEvents() async {

--- a/lib/features/calendar/data/services/caldav_client.dart
+++ b/lib/features/calendar/data/services/caldav_client.dart
@@ -1,4 +1,0 @@
-/// Placeholder CalDAV client boundary for future calendar integration.
-class CalDavClient {
-  const CalDavClient();
-}

--- a/lib/features/calendar/data/services/calendar_facade_client.dart
+++ b/lib/features/calendar/data/services/calendar_facade_client.dart
@@ -1,0 +1,9 @@
+/// Placeholder client boundary for future calendar backend-facade integration.
+///
+/// The MVP contract is for Flutter calendar product flows to use
+/// `weave-backend`, while the backend owns direct CalDAV access to Nextcloud.
+/// Keep this as a facade seam until concrete backend calendar endpoints are
+/// implemented.
+class CalendarFacadeClient {
+  const CalendarFacadeClient();
+}

--- a/lib/features/calendar/presentation/providers/calendar_provider.dart
+++ b/lib/features/calendar/presentation/providers/calendar_provider.dart
@@ -1,17 +1,19 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:weave/features/calendar/data/repositories/stub_calendar_repository.dart';
-import 'package:weave/features/calendar/data/services/caldav_client.dart';
+import 'package:weave/features/calendar/data/services/calendar_facade_client.dart';
 import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
 import 'package:weave/features/calendar/domain/repositories/calendar_repository.dart';
 
 part 'calendar_provider.g.dart';
 
 @Riverpod(keepAlive: true)
-CalDavClient calDavClient(Ref ref) => const CalDavClient();
+CalendarFacadeClient calendarFacadeClient(Ref ref) {
+  return const CalendarFacadeClient();
+}
 
 @Riverpod(keepAlive: true)
 CalendarRepository calendarRepository(Ref ref) {
-  final client = ref.watch(calDavClientProvider);
+  final client = ref.watch(calendarFacadeClientProvider);
   return StubCalendarRepository(client: client);
 }
 

--- a/lib/features/calendar/presentation/providers/calendar_provider.g.dart
+++ b/lib/features/calendar/presentation/providers/calendar_provider.g.dart
@@ -9,46 +9,53 @@ part of 'calendar_provider.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
-@ProviderFor(calDavClient)
-final calDavClientProvider = CalDavClientProvider._();
+@ProviderFor(calendarFacadeClient)
+final calendarFacadeClientProvider = CalendarFacadeClientProvider._();
 
-final class CalDavClientProvider
-    extends $FunctionalProvider<CalDavClient, CalDavClient, CalDavClient>
-    with $Provider<CalDavClient> {
-  CalDavClientProvider._()
+final class CalendarFacadeClientProvider
+    extends
+        $FunctionalProvider<
+          CalendarFacadeClient,
+          CalendarFacadeClient,
+          CalendarFacadeClient
+        >
+    with $Provider<CalendarFacadeClient> {
+  CalendarFacadeClientProvider._()
     : super(
         from: null,
         argument: null,
         retry: null,
-        name: r'calDavClientProvider',
+        name: r'calendarFacadeClientProvider',
         isAutoDispose: false,
         dependencies: null,
         $allTransitiveDependencies: null,
       );
 
   @override
-  String debugGetCreateSourceHash() => _$calDavClientHash();
+  String debugGetCreateSourceHash() => _$calendarFacadeClientHash();
 
   @$internal
   @override
-  $ProviderElement<CalDavClient> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $ProviderElement<CalendarFacadeClient> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
 
   @override
-  CalDavClient create(Ref ref) {
-    return calDavClient(ref);
+  CalendarFacadeClient create(Ref ref) {
+    return calendarFacadeClient(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(CalDavClient value) {
+  Override overrideWithValue(CalendarFacadeClient value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<CalDavClient>(value),
+      providerOverride: $SyncValueProvider<CalendarFacadeClient>(value),
     );
   }
 }
 
-String _$calDavClientHash() => r'962ad8cc88b0a849e1d18cd1917c814dec6dfe6f';
+String _$calendarFacadeClientHash() =>
+    r'f1f923661276ce71b02dc5223e9557d09219d95b';
 
 @ProviderFor(calendarRepository)
 final calendarRepositoryProvider = CalendarRepositoryProvider._();
@@ -96,7 +103,7 @@ final class CalendarRepositoryProvider
 }
 
 String _$calendarRepositoryHash() =>
-    r'59521acab9f18ab5b82d10a1c4ab1768dac972cb';
+    r'94d351d7eded9adf8096a8ba3f544767731c5871';
 
 @ProviderFor(CalendarNotifier)
 final calendarProvider = CalendarNotifierProvider._();

--- a/lib/features/files/data/repositories/backend_files_repository.dart
+++ b/lib/features/files/data/repositories/backend_files_repository.dart
@@ -1,0 +1,50 @@
+import 'package:weave/features/files/domain/entities/directory_listing.dart';
+import 'package:weave/features/files/domain/entities/file_upload_request.dart';
+import 'package:weave/features/files/domain/entities/files_connection_state.dart';
+import 'package:weave/features/files/domain/entities/files_failure.dart';
+import 'package:weave/features/files/domain/repositories/files_repository.dart';
+
+/// Backend-facade repository seam for MVP files product flows.
+///
+/// The MVP contract is for Flutter to use `weave-backend` files APIs while the
+/// backend owns the Nextcloud WebDAV/OCS integration. The concrete HTTP facade
+/// endpoints are still blocked on masssi164/weave-backend#24/#26/#27, so this
+/// implementation deliberately reports the facade as unavailable instead of
+/// adding new direct Flutter-to-Nextcloud product calls.
+class BackendFilesRepository implements FilesRepository {
+  const BackendFilesRepository();
+
+  static const unavailableMessage =
+      'Files are waiting for the Weave backend files facade.';
+
+  @override
+  Future<FilesConnectionState> restoreConnection() async {
+    return const FilesConnectionState.misconfigured(
+      message: unavailableMessage,
+    );
+  }
+
+  @override
+  Future<FilesConnectionState> connect() async {
+    throw const FilesFailure.configuration(unavailableMessage);
+  }
+
+  @override
+  Future<void> disconnect() async {
+    // No local Nextcloud session is owned by the backend-facade path.
+  }
+
+  @override
+  Future<DirectoryListing> listDirectory(String path) async {
+    throw const FilesFailure.configuration(unavailableMessage);
+  }
+
+  @override
+  Future<void> uploadFile(
+    String directoryPath,
+    FileUploadRequest request, {
+    FileUploadProgressCallback? onProgress,
+  }) async {
+    throw const FilesFailure.configuration(unavailableMessage);
+  }
+}

--- a/lib/features/files/presentation/providers/files_repository_provider.dart
+++ b/lib/features/files/presentation/providers/files_repository_provider.dart
@@ -1,12 +1,23 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:weave/features/files/data/repositories/nextcloud_files_repository.dart';
-import 'package:weave/features/files/data/services/nextcloud_dav_client.dart';
+import 'package:weave/features/files/data/repositories/backend_files_repository.dart';
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
-import 'package:weave/integrations/nextcloud/presentation/providers/nextcloud_provider.dart';
+import 'package:weave/features/files/presentation/providers/legacy_direct_nextcloud_files_repository_provider.dart';
+
+/// Enables the backend files facade path once the backend endpoints exist.
+///
+/// Keep this disabled by default so current merged live-stack auth/chat/files
+/// read tests continue to exercise the compatibility adapter. Set
+/// `--dart-define=WEAVE_USE_BACKEND_FILES_FACADE=true` or override this provider
+/// in tests to verify the facade path without introducing new direct
+/// Flutter-to-Nextcloud product calls.
+final useBackendFilesFacadeProvider = Provider<bool>((ref) {
+  return const bool.fromEnvironment('WEAVE_USE_BACKEND_FILES_FACADE');
+});
 
 final filesRepositoryProvider = Provider<FilesRepository>((ref) {
-  return NextcloudFilesRepository(
-    connectionService: ref.watch(nextcloudConnectionServiceProvider),
-    client: ref.watch(nextcloudDavClientProvider),
-  );
+  if (ref.watch(useBackendFilesFacadeProvider)) {
+    return const BackendFilesRepository();
+  }
+
+  return ref.watch(legacyDirectNextcloudFilesRepositoryProvider);
 });

--- a/lib/features/files/presentation/providers/legacy_direct_nextcloud_files_repository_provider.dart
+++ b/lib/features/files/presentation/providers/legacy_direct_nextcloud_files_repository_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weave/features/files/data/repositories/nextcloud_files_repository.dart';
+import 'package:weave/features/files/data/services/nextcloud_dav_client.dart';
+import 'package:weave/features/files/domain/repositories/files_repository.dart';
+import 'package:weave/integrations/nextcloud/presentation/providers/nextcloud_provider.dart';
+
+/// Compatibility adapter for the pre-facade live stack.
+///
+/// Product files flows should move to the backend facade (issue #85). This
+/// provider keeps today's merged live-stack files-read tests working until the
+/// backend files facade is implemented in masssi164/weave-backend#24/#26/#27.
+final legacyDirectNextcloudFilesRepositoryProvider = Provider<FilesRepository>((
+  ref,
+) {
+  return NextcloudFilesRepository(
+    connectionService: ref.watch(nextcloudConnectionServiceProvider),
+    client: ref.watch(nextcloudDavClientProvider),
+  );
+});

--- a/test/architecture/backend_facade_contract_test.dart
+++ b/test/architecture/backend_facade_contract_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'primary files provider is wired through the backend-facade seam',
+    () async {
+      final source = await File(
+        'lib/features/files/presentation/providers/files_repository_provider.dart',
+      ).readAsString();
+
+      expect(source, contains('BackendFilesRepository'));
+      expect(source, contains('legacyDirectNextcloudFilesRepositoryProvider'));
+      expect(source, isNot(contains('integrations/nextcloud')));
+      expect(
+        source,
+        isNot(contains('data/repositories/nextcloud_files_repository.dart')),
+      );
+      expect(source, isNot(contains('nextcloudDavClientProvider')));
+    },
+  );
+
+  test('calendar provider exposes a backend-facade seam, not CalDAV', () async {
+    final source = await File(
+      'lib/features/calendar/presentation/providers/calendar_provider.dart',
+    ).readAsString();
+
+    expect(source, contains('CalendarFacadeClient'));
+    expect(source, isNot(contains('CalDavClient')));
+    expect(source, isNot(contains('caldav_client.dart')));
+  });
+}

--- a/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
+++ b/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/files/data/repositories/backend_files_repository.dart';
+import 'package:weave/features/files/domain/entities/file_upload_request.dart';
+import 'package:weave/features/files/domain/entities/files_connection_state.dart';
+import 'package:weave/features/files/domain/entities/files_failure.dart';
+import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
+
+void main() {
+  group('filesRepositoryProvider backend-facade seam', () {
+    test('keeps backend facade disabled as the compatibility default', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(useBackendFilesFacadeProvider), isFalse);
+    });
+
+    test(
+      'can be switched to the backend files facade without Nextcloud deps',
+      () {
+        final container = ProviderContainer(
+          overrides: [useBackendFilesFacadeProvider.overrideWithValue(true)],
+        );
+        addTearDown(container.dispose);
+
+        expect(
+          container.read(filesRepositoryProvider),
+          isA<BackendFilesRepository>(),
+        );
+      },
+    );
+  });
+
+  group('BackendFilesRepository', () {
+    const repository = BackendFilesRepository();
+
+    test(
+      'reports the backend files facade as unavailable until implemented',
+      () async {
+        final state = await repository.restoreConnection();
+
+        expect(state.status, FilesConnectionStatus.misconfigured);
+        expect(state.message, BackendFilesRepository.unavailableMessage);
+      },
+    );
+
+    test(
+      'blocks product file operations instead of using direct Nextcloud',
+      () async {
+        await expectLater(
+          repository.connect(),
+          throwsA(
+            isA<FilesFailure>()
+                .having(
+                  (failure) => failure.type,
+                  'type',
+                  FilesFailureType.configuration,
+                )
+                .having(
+                  (failure) => failure.message,
+                  'message',
+                  BackendFilesRepository.unavailableMessage,
+                ),
+          ),
+        );
+
+        await expectLater(
+          repository.listDirectory('/'),
+          throwsA(isA<FilesFailure>()),
+        );
+
+        await expectLater(
+          repository.uploadFile(
+            '/',
+            const FileUploadRequest(
+              fileName: 'notes.txt',
+              sizeInBytes: 0,
+              byteStream: Stream<List<int>>.empty(),
+            ),
+          ),
+          throwsA(isA<FilesFailure>()),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a backend-facade files repository seam and `WEAVE_USE_BACKEND_FILES_FACADE` provider switch without depending on unimplemented backend endpoints.
- Moves the old direct Nextcloud files repository wiring behind an explicit legacy compatibility provider so current live-stack files-read coverage can continue.
- Renames the calendar placeholder from CalDAV to a backend-facade client seam and adds architecture/provider tests to prevent direct-protocol drift.

## Contract context
- Refs #85.
- Backend blockers remain:
  - masssi164/weave-backend#24 for upload facade
  - masssi164/weave-backend#26 for files browse/download facade
  - masssi164/weave-backend#27 for calendar facade

## Validation
- `dart run build_runner build --delete-conflicting-outputs`
- `dart format --output=none --set-exit-if-changed ...changed files...`
- `flutter analyze --fatal-infos`
- `flutter test test/features/files/presentation/providers/files_backend_facade_provider_test.dart test/architecture/backend_facade_contract_test.dart test/features/calendar/calendar_screen_test.dart test/features/files/presentation/providers/files_provider_test.dart`
- `flutter test test/features/app/release_golden_paths_test.dart test/release_1/release_golden_paths_test.dart`

## Not fully run
- `flutter test integration_test/app_test.dart -d macos` built the macOS app, then failed because `WEAVE_TEST_USERNAME` and `WEAVE_TEST_PASSWORD` dart-defines were not available in this worktree/session.
