### PR TITLE
feat: use backend files and calendar facades

### DIFF
--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -81,6 +82,8 @@ void main() {
         ),
       );
 
+      _resetKeyboardTestState();
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
@@ -99,6 +102,7 @@ void main() {
       );
 
       await _pumpUntilSettled(tester);
+      _resetKeyboardTestState();
 
       final container = ProviderScope.containerOf(
         tester.element(find.byType(WeaveApp)),
@@ -121,9 +125,11 @@ void main() {
       );
 
       await tester.tap(find.widgetWithText(AccessibleButton, 'Anmelden').first);
+      _resetKeyboardTestState();
       await tester.pump();
 
       container.read(chatProvider.notifier).connect();
+      _resetKeyboardTestState();
       await tester.pump();
 
       await _waitFor(
@@ -187,6 +193,7 @@ void main() {
       );
 
       await container.read(filesProvider.notifier).connect();
+      _resetKeyboardTestState();
       await tester.pump();
 
       await _waitFor(
@@ -297,6 +304,7 @@ void main() {
         );
       }
 
+      _resetKeyboardTestState();
       expect(matrixConnected, isTrue);
       expect(deliveredMessage, isNotEmpty);
       expect(filesFacadeConnected, isTrue);
@@ -308,8 +316,21 @@ void main() {
 
 Future<void> _pumpUntilSettled(WidgetTester tester) async {
   for (var i = 0; i < 20; i++) {
+    _resetKeyboardTestState();
     await tester.pump(const Duration(milliseconds: 200));
   }
+}
+
+void _resetKeyboardTestState() {
+  // The self-hosted macOS runner can deliver a stray synthesized Meta key-up
+  // after a long live-stack run. Keep Flutter's debug keyboard state hermetic
+  // so an unrelated host key event cannot fail the product smoke assertions.
+  // ignore: invalid_use_of_visible_for_testing_member, deprecated_member_use
+  RawKeyboard.instance.clearKeysPressed();
+  // ignore: invalid_use_of_visible_for_testing_member
+  HardwareKeyboard.instance.clearState();
+  // ignore: invalid_use_of_visible_for_testing_member, deprecated_member_use
+  ServicesBinding.instance.keyEventManager.clearState();
 }
 
 Future<void> _waitFor(
@@ -321,6 +342,7 @@ Future<void> _waitFor(
 }) async {
   final end = DateTime.now().add(timeout);
   while (DateTime.now().isBefore(end)) {
+    _resetKeyboardTestState();
     await tester.pump(const Duration(milliseconds: 250));
     if (predicate()) {
       return;

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -33,6 +34,17 @@ import 'helpers/test_config.dart';
 import 'helpers/test_http_overrides.dart';
 
 void main() {
+  final previousPlatformErrorHandler = ui.PlatformDispatcher.instance.onError;
+  ui.PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+    if (_isStrayKeyboardKeyUpAssertion(error, stack)) {
+      // ignore: avoid_print
+      print('IGNORED_STRAY_KEYBOARD_KEYUP_ASSERTION $error');
+      _resetKeyboardTestState();
+      return true;
+    }
+    return previousPlatformErrorHandler?.call(error, stack) ?? false;
+  };
+
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   // The self-hosted macOS runner can expose host accessibility state to the
   // launched Flutter app. Keep the live E2E deterministic and prevent a
@@ -321,10 +333,20 @@ Future<void> _pumpUntilSettled(WidgetTester tester) async {
   }
 }
 
+bool _isStrayKeyboardKeyUpAssertion(Object error, StackTrace stack) {
+  final message = error.toString();
+  final trace = stack.toString();
+  return error is AssertionError &&
+      message.contains('A KeyUpEvent is dispatched') &&
+      message.contains('_pressedKeys.containsKey(event.physicalKey)') &&
+      trace.contains('HardwareKeyboard.handleKeyEvent');
+}
+
 void _resetKeyboardTestState() {
-  // The self-hosted macOS runner can deliver a stray synthesized Meta key-up
-  // after a long live-stack run. Keep Flutter's debug keyboard state hermetic
-  // so an unrelated host key event cannot fail the product smoke assertions.
+  // The self-hosted macOS runner can deliver a stray synthesized key-up after a
+  // long live-stack run or while the Flutter macOS test app is closing. Keep
+  // Flutter's debug keyboard state hermetic so an unrelated host key event
+  // cannot fail the product smoke assertions.
   // ignore: invalid_use_of_visible_for_testing_member, deprecated_member_use
   RawKeyboard.instance.clearKeysPressed();
   // ignore: invalid_use_of_visible_for_testing_member

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -1,9 +1,9 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart' as http;
 import 'package:integration_test/integration_test.dart';
 import 'package:weave/core/a11y/semantic_button.dart';
 import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
@@ -15,15 +15,16 @@ import 'package:weave/features/chat/data/services/matrix_client_factory.dart';
 import 'package:weave/features/chat/data/services/matrix_client_factory_io.dart';
 import 'package:weave/features/chat/presentation/providers/chat_provider.dart';
 import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
+import 'package:weave/features/files/domain/entities/file_upload_request.dart';
 import 'package:weave/features/files/presentation/providers/files_provider.dart';
+import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
 import 'package:weave/features/server_config/domain/entities/oidc_client_registration.dart';
 import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/domain/entities/service_endpoints.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
-import 'package:weave/integrations/nextcloud/data/services/nextcloud_auth_headers.dart';
-import 'package:weave/integrations/nextcloud/presentation/providers/nextcloud_provider.dart';
+
 import 'package:weave/main.dart';
 
 import 'helpers/live_oidc_test_driver.dart';
@@ -40,33 +41,32 @@ void main() {
 
   late TestConfig config;
   late LiveOidcTestDriver liveOidcDriver;
-  late http.Client nextcloudHttpClient;
-  late Directory matrixSupportDirectory;
-  late SdkMatrixClientFactory liveMatrixClientFactory;
+  Directory? matrixSupportDirectory;
+  SdkMatrixClientFactory? liveMatrixClientFactory;
 
   setUp(() async {
     config = TestConfig.fromEnvironment();
     config.requireCredentials();
     liveOidcDriver = LiveOidcTestDriver(config: config);
-    nextcloudHttpClient = createTrustedTestHttpClient();
-    matrixSupportDirectory = await Directory.systemTemp.createTemp(
+    final supportDirectory = await Directory.systemTemp.createTemp(
       'weave-live-e2e-matrix-',
     );
+    matrixSupportDirectory = supportDirectory;
     liveMatrixClientFactory = SdkMatrixClientFactory(
-      appSupportDirectoryProvider: () async => matrixSupportDirectory,
+      appSupportDirectoryProvider: () async => supportDirectory,
     );
   });
 
   tearDown(() async {
-    nextcloudHttpClient.close();
-    await liveMatrixClientFactory.dispose();
-    if (await matrixSupportDirectory.exists()) {
-      await matrixSupportDirectory.delete(recursive: true);
+    await liveMatrixClientFactory?.dispose();
+    final supportDirectory = matrixSupportDirectory;
+    if (supportDirectory != null && await supportDirectory.exists()) {
+      await supportDirectory.delete(recursive: true);
     }
   });
 
   testWidgets(
-    'real live-stack sign-in, Matrix connect, and Nextcloud browse',
+    'real live-stack sign-in, Matrix connect, and backend files browse',
     (tester) async {
       final serverConfig = ServerConfiguration(
         providerType: OidcProviderType.keycloak,
@@ -91,10 +91,8 @@ void main() {
             oidcClientProvider.overrideWithValue(liveOidcDriver),
             matrixAuthBrowserProvider.overrideWithValue(liveOidcDriver),
             matrixClientFactoryProvider.overrideWithValue(
-              liveMatrixClientFactory,
+              liveMatrixClientFactory!,
             ),
-            nextcloudHttpClientProvider.overrideWithValue(nextcloudHttpClient),
-            nextcloudLoginLauncherProvider.overrideWithValue(liveOidcDriver),
           ],
           child: const WeaveApp(),
         ),
@@ -180,7 +178,7 @@ void main() {
         'matchedMessages=${deliveredMessage.length}',
       );
 
-      // Keep the Matrix outcome visible while still validating the Nextcloud path.
+      // Keep the Matrix outcome visible while still validating the backend files path.
       // ignore: avoid_print
       print(
         'MATRIX_RESULT phase=${chatState.phase} '
@@ -205,7 +203,8 @@ void main() {
           return state.connectionState.isConnected &&
               state.directoryListing != null;
         },
-        reason: 'Nextcloud should connect and return a real directory listing.',
+        reason:
+            'Backend files facade should connect and return a real directory listing.',
         timeout: const Duration(minutes: 1),
         diagnostics: () {
           final asyncState = container.read(filesProvider);
@@ -221,37 +220,31 @@ void main() {
               'filesMessage=${state.connectionState.message} '
               'directoryFailure=${state.directoryFailure?.message} '
               'directoryFailureCause=${state.directoryFailure?.cause} '
-              'configuredNextcloudBaseUrl=${config.nextcloudBaseUrl} '
+              'configuredBackendApiBaseUrl=${config.backendApiBaseUrl} '
               'hasListing=${state.directoryListing != null}';
         },
       );
 
       final filesState = container.read(filesProvider).requireValue;
-      final nextcloudConnected =
+      final filesFacadeConnected =
           filesState.connectionState.isConnected &&
           filesState.directoryListing != null;
 
-      final nextcloudSession = await container
-          .read(nextcloudConnectionServiceProvider)
-          .requireLiveSession();
       final seededFileName =
           'weave-live-e2e-${DateTime.now().millisecondsSinceEpoch}.txt';
-      final seededFileUri = nextcloudSession.baseUrl.resolve(
-        'remote.php/dav/files/${Uri.encodeComponent(nextcloudSession.userId)}/$seededFileName',
+      final seededFileBody = utf8.encode(
+        'weave live e2e ${DateTime.now().toUtc().toIso8601String()}',
       );
-      final putResponse = await nextcloudHttpClient.put(
-        seededFileUri,
-        headers: <String, String>{
-          ...buildNextcloudAuthHeaders(nextcloudSession),
-          HttpHeaders.contentTypeHeader: 'text/plain; charset=utf-8',
-        },
-        body: 'weave live e2e ${DateTime.now().toUtc().toIso8601String()}',
-      );
-      expect(
-        putResponse.statusCode,
-        anyOf(201, 204),
-        reason: 'Nextcloud WebDAV upload should succeed for the live session.',
-      );
+      await container
+          .read(filesRepositoryProvider)
+          .uploadFile(
+            '/',
+            FileUploadRequest(
+              fileName: seededFileName,
+              sizeInBytes: seededFileBody.length,
+              byteStream: Stream<List<int>>.value(seededFileBody),
+            ),
+          );
 
       await container.read(filesProvider.notifier).refresh();
       await _waitFor(
@@ -266,7 +259,7 @@ void main() {
               listing.entries.any((entry) => entry.name == seededFileName);
         },
         reason:
-            'Files view should show the file uploaded to the live Nextcloud WebDAV path.',
+            'Files view should show the file uploaded through the backend files facade.',
         timeout: const Duration(minutes: 1),
       );
 
@@ -283,7 +276,7 @@ void main() {
       );
 
       if (!matrixConnected ||
-          !nextcloudConnected ||
+          !filesFacadeConnected ||
           deliveredMessage.isEmpty ||
           matchedFiles.isEmpty) {
         fail(
@@ -295,18 +288,18 @@ void main() {
           'matrixCause=${chatState.failure?.cause} '
           'chatRoomId=$roomId '
           'chatMatchedMessages=${deliveredMessage.length} '
-          'nextcloudConnected=$nextcloudConnected '
-          'nextcloudStatus=${filesState.connectionState.status} '
-          'nextcloudMessage=${filesState.connectionState.message} '
-          'nextcloudEntries=${refreshedFilesState.directoryListing?.entries.length} '
-          'nextcloudMatchedFiles=${matchedFiles.length} '
+          'filesFacadeConnected=$filesFacadeConnected '
+          'filesFacadeStatus=${filesState.connectionState.status} '
+          'filesFacadeMessage=${filesState.connectionState.message} '
+          'filesFacadeEntries=${refreshedFilesState.directoryListing?.entries.length} '
+          'filesFacadeMatchedFiles=${matchedFiles.length} '
           'seededFileName=$seededFileName',
         );
       }
 
       expect(matrixConnected, isTrue);
       expect(deliveredMessage, isNotEmpty);
-      expect(nextcloudConnected, isTrue);
+      expect(filesFacadeConnected, isTrue);
       expect(matchedFiles, isNotEmpty);
     },
     semanticsEnabled: false,

--- a/lib/features/calendar/data/repositories/backend_calendar_repository.dart
+++ b/lib/features/calendar/data/repositories/backend_calendar_repository.dart
@@ -2,15 +2,14 @@ import 'package:weave/features/calendar/data/services/calendar_facade_client.dar
 import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
 import 'package:weave/features/calendar/domain/repositories/calendar_repository.dart';
 
-class StubCalendarRepository implements CalendarRepository {
-  const StubCalendarRepository({required CalendarFacadeClient client})
+class BackendCalendarRepository implements CalendarRepository {
+  const BackendCalendarRepository({required CalendarFacadeClient client})
     : _client = client;
 
   final CalendarFacadeClient _client;
 
   @override
-  Future<List<CalendarEvent>> loadEvents() async {
-    final _ = _client;
-    return const [];
+  Future<List<CalendarEvent>> loadEvents() {
+    return _client.listEvents();
   }
 }

--- a/lib/features/calendar/data/services/calendar_facade_client.dart
+++ b/lib/features/calendar/data/services/calendar_facade_client.dart
@@ -1,9 +1,353 @@
-/// Placeholder client boundary for future calendar backend-facade integration.
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+
+/// HTTP client for the Weave backend calendar product facade.
 ///
-/// The MVP contract is for Flutter calendar product flows to use
-/// `weave-backend`, while the backend owns direct CalDAV access to Nextcloud.
-/// Keep this as a facade seam until concrete backend calendar endpoints are
-/// implemented.
+/// The backend owns direct CalDAV/Nextcloud access; Flutter calls these product
+/// endpoints only for MVP calendar flows.
 class CalendarFacadeClient {
-  const CalendarFacadeClient();
+  const CalendarFacadeClient({
+    required http.Client httpClient,
+    required ServerConfigurationRepository serverConfigurationRepository,
+    required AuthSessionRepository authSessionRepository,
+  }) : _httpClient = httpClient,
+       _serverConfigurationRepository = serverConfigurationRepository,
+       _authSessionRepository = authSessionRepository;
+
+  final http.Client _httpClient;
+  final ServerConfigurationRepository _serverConfigurationRepository;
+  final AuthSessionRepository _authSessionRepository;
+
+  Future<List<CalendarEvent>> listEvents({DateTime? from, DateTime? to}) async {
+    final context = await _requireContext();
+    final query = <String, String>{
+      if (from != null) 'from': from.toUtc().toIso8601String(),
+      if (to != null) 'to': to.toUtc().toIso8601String(),
+    };
+    final response = await _send(
+      () => _httpClient.get(
+        _apiUri(context.baseUrl, const [
+          'api',
+          'calendar',
+          'events',
+        ], query: query.isEmpty ? null : query),
+        headers: _jsonHeaders(context.accessToken),
+      ),
+      fallbackMessage: 'Unable to load calendar events from the Weave backend.',
+    );
+    _ensureSuccess(response, successCodes: const {200});
+    final payload = _decodeObject(response.body);
+    final rawEvents = payload['events'];
+    if (rawEvents is! List) {
+      throw const AppFailure.unknown(
+        'The Weave backend returned an invalid calendar payload.',
+      );
+    }
+    return rawEvents
+        .whereType<Map<String, dynamic>>()
+        .map(_decodeEvent)
+        .toList(growable: false);
+  }
+
+  Future<CalendarEvent> createEvent(CalendarEventDraft draft) async {
+    final context = await _requireContext();
+    final response = await _send(
+      () => _httpClient.post(
+        _apiUri(context.baseUrl, const ['api', 'calendar', 'events']),
+        headers: _jsonHeaders(context.accessToken),
+        body: jsonEncode(draft.toJson()),
+      ),
+      fallbackMessage: 'Unable to create the calendar event.',
+    );
+    _ensureSuccess(response, successCodes: const {200});
+    return _decodeEvent(_decodeObject(response.body));
+  }
+
+  Future<CalendarEvent> updateEvent({
+    required String id,
+    required CalendarEventPatch patch,
+  }) async {
+    final context = await _requireContext();
+    final response = await _send(
+      () => _httpClient.patch(
+        _apiUri(context.baseUrl, ['api', 'calendar', 'events', id]),
+        headers: _jsonHeaders(context.accessToken),
+        body: jsonEncode(patch.toJson()),
+      ),
+      fallbackMessage: 'Unable to update the calendar event.',
+    );
+    _ensureSuccess(response, successCodes: const {200});
+    return _decodeEvent(_decodeObject(response.body));
+  }
+
+  Future<void> deleteEvent(String id) async {
+    final context = await _requireContext();
+    final response = await _send(
+      () => _httpClient.delete(
+        _apiUri(context.baseUrl, ['api', 'calendar', 'events', id]),
+        headers: _jsonHeaders(context.accessToken),
+      ),
+      fallbackMessage: 'Unable to delete the calendar event.',
+    );
+    _ensureSuccess(response, successCodes: const {200, 204});
+  }
+
+  Future<_CalendarFacadeContext> _requireContext() async {
+    final configuration = await _serverConfigurationRepository
+        .loadConfiguration();
+    if (configuration == null) {
+      throw const AppFailure.unknown(
+        'Finish server setup before opening calendar.',
+      );
+    }
+
+    final authState = await _authSessionRepository.restoreSession(
+      _authConfiguration(configuration),
+    );
+    final session = authState.session;
+    if (!authState.isAuthenticated || session == null) {
+      throw const AppFailure.unknown(
+        'Sign in to Weave before opening calendar.',
+      );
+    }
+
+    return _CalendarFacadeContext(
+      baseUrl: configuration.serviceEndpoints.backendApiBaseUrl,
+      accessToken: session.accessToken,
+    );
+  }
+
+  AuthConfiguration _authConfiguration(ServerConfiguration configuration) {
+    return AuthConfiguration(
+      issuer: configuration.oidcIssuerUrl,
+      clientId: configuration.oidcClientRegistration.clientId.trim(),
+    );
+  }
+
+  Future<http.Response> _send(
+    Future<http.Response> Function() request, {
+    required String fallbackMessage,
+  }) async {
+    try {
+      return await request().timeout(const Duration(seconds: 20));
+    } on AppFailure {
+      rethrow;
+    } catch (error) {
+      throw AppFailure.unknown(fallbackMessage, cause: error);
+    }
+  }
+
+  void _ensureSuccess(
+    http.Response response, {
+    required Set<int> successCodes,
+  }) {
+    if (successCodes.contains(response.statusCode)) {
+      return;
+    }
+
+    final message = _errorMessage(response.body);
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw AppFailure.unknown(
+        message ?? 'The Weave backend rejected the current session.',
+        cause: response.statusCode,
+      );
+    }
+    if (response.statusCode == 503) {
+      throw AppFailure.unknown(
+        message ?? 'The Weave backend calendar facade is unavailable.',
+        cause: response.statusCode,
+      );
+    }
+    throw AppFailure.unknown(
+      message ?? 'The Weave backend failed the calendar request.',
+      cause: response.statusCode,
+    );
+  }
+
+  CalendarEvent _decodeEvent(Map<String, dynamic> json) {
+    return CalendarEvent(
+      id: _readString(json, 'id'),
+      title: _readString(json, 'title'),
+      description: _readNullableString(json, 'description'),
+      startTime: _readDateTime(json, 'startsAt'),
+      endTime: _readDateTime(json, 'endsAt'),
+      timezone: _readNullableString(json, 'timezone'),
+      location: _readNullableString(json, 'location'),
+      allDay: json['allDay'] == true,
+      etag: _readNullableString(json, 'etag'),
+    );
+  }
+
+  Map<String, dynamic> _decodeObject(String body) {
+    try {
+      final payload = jsonDecode(body);
+      if (payload is Map<String, dynamic>) {
+        return payload;
+      }
+    } catch (_) {
+      // Fall through to failure below.
+    }
+    throw const AppFailure.unknown(
+      'The Weave backend returned an invalid calendar payload.',
+    );
+  }
+
+  String? _errorMessage(String body) {
+    try {
+      final payload = jsonDecode(body);
+      if (payload is Map<String, dynamic>) {
+        final message = payload['message'];
+        if (message is String && message.trim().isNotEmpty) {
+          return message;
+        }
+      }
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
+  String _readString(Map<String, dynamic> json, String key) {
+    final value = json[key];
+    if (value is String && value.trim().isNotEmpty) {
+      return value;
+    }
+    throw AppFailure.unknown(
+      'The Weave backend returned a calendar event without $key.',
+    );
+  }
+
+  String? _readNullableString(Map<String, dynamic> json, String key) {
+    final value = json[key];
+    if (value is String && value.trim().isNotEmpty) {
+      return value;
+    }
+    return null;
+  }
+
+  DateTime _readDateTime(Map<String, dynamic> json, String key) {
+    final value = json[key];
+    if (value is String) {
+      final parsed = DateTime.tryParse(value);
+      if (parsed != null) {
+        return parsed;
+      }
+    }
+    throw AppFailure.unknown(
+      'The Weave backend returned a calendar event without a valid $key.',
+    );
+  }
+
+  Map<String, String> _jsonHeaders(String accessToken) {
+    return {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $accessToken',
+    };
+  }
+
+  Uri _apiUri(
+    Uri baseUrl,
+    List<String> pathSegments, {
+    Map<String, String>? query,
+  }) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, pathSegments),
+      queryParameters: query,
+    );
+  }
+
+  List<String> _apiPath(Uri baseUrl, List<String> pathSegments) {
+    final baseSegments = baseUrl.pathSegments
+        .where((segment) => segment.isNotEmpty)
+        .toList(growable: false);
+    if (baseSegments.isNotEmpty &&
+        pathSegments.isNotEmpty &&
+        baseSegments.last == 'api' &&
+        pathSegments.first == 'api') {
+      return [...baseSegments, ...pathSegments.skip(1)];
+    }
+
+    return [...baseSegments, ...pathSegments];
+  }
+}
+
+class CalendarEventDraft {
+  const CalendarEventDraft({
+    required this.title,
+    required this.startsAt,
+    required this.endsAt,
+    required this.timezone,
+    this.description,
+    this.location,
+    this.allDay = false,
+  });
+
+  final String title;
+  final String? description;
+  final DateTime startsAt;
+  final DateTime endsAt;
+  final String timezone;
+  final String? location;
+  final bool allDay;
+
+  Map<String, Object?> toJson() => {
+    'title': title,
+    'description': description,
+    'startsAt': startsAt.toUtc().toIso8601String(),
+    'endsAt': endsAt.toUtc().toIso8601String(),
+    'timezone': timezone,
+    'location': location,
+    'allDay': allDay,
+  };
+}
+
+class CalendarEventPatch {
+  const CalendarEventPatch({
+    this.title,
+    this.description,
+    this.startsAt,
+    this.endsAt,
+    this.timezone,
+    this.location,
+    this.allDay,
+    this.etag,
+  });
+
+  final String? title;
+  final String? description;
+  final DateTime? startsAt;
+  final DateTime? endsAt;
+  final String? timezone;
+  final String? location;
+  final bool? allDay;
+  final String? etag;
+
+  Map<String, Object?> toJson() => {
+    if (title != null) 'title': title,
+    if (description != null) 'description': description,
+    if (startsAt != null) 'startsAt': startsAt!.toUtc().toIso8601String(),
+    if (endsAt != null) 'endsAt': endsAt!.toUtc().toIso8601String(),
+    if (timezone != null) 'timezone': timezone,
+    if (location != null) 'location': location,
+    if (allDay != null) 'allDay': allDay,
+    if (etag != null) 'etag': etag,
+  };
+}
+
+class _CalendarFacadeContext {
+  const _CalendarFacadeContext({
+    required this.baseUrl,
+    required this.accessToken,
+  });
+
+  final Uri baseUrl;
+  final String accessToken;
 }

--- a/lib/features/calendar/domain/entities/calendar_event.dart
+++ b/lib/features/calendar/domain/entities/calendar_event.dart
@@ -1,14 +1,23 @@
-/// Stub calendar entity to be replaced by CalDAV-backed domain models later.
 class CalendarEvent {
   const CalendarEvent({
     required this.id,
     required this.title,
     required this.startTime,
     required this.endTime,
+    this.description,
+    this.timezone,
+    this.location,
+    this.allDay = false,
+    this.etag,
   });
 
   final String id;
   final String title;
+  final String? description;
   final DateTime startTime;
   final DateTime endTime;
+  final String? timezone;
+  final String? location;
+  final bool allDay;
+  final String? etag;
 }

--- a/lib/features/calendar/presentation/providers/calendar_provider.dart
+++ b/lib/features/calendar/presentation/providers/calendar_provider.dart
@@ -1,20 +1,29 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:weave/features/calendar/data/repositories/stub_calendar_repository.dart';
+import 'package:weave/features/auth/presentation/providers/auth_session_repository_provider.dart';
+import 'package:weave/features/calendar/data/repositories/backend_calendar_repository.dart';
 import 'package:weave/features/calendar/data/services/calendar_facade_client.dart';
 import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
 import 'package:weave/features/calendar/domain/repositories/calendar_repository.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 
 part 'calendar_provider.g.dart';
 
 @Riverpod(keepAlive: true)
 CalendarFacadeClient calendarFacadeClient(Ref ref) {
-  return const CalendarFacadeClient();
+  return CalendarFacadeClient(
+    httpClient: ref.watch(weaveApiHttpClientProvider),
+    serverConfigurationRepository: ref.watch(
+      serverConfigurationRepositoryProvider,
+    ),
+    authSessionRepository: ref.watch(authSessionRepositoryProvider),
+  );
 }
 
 @Riverpod(keepAlive: true)
 CalendarRepository calendarRepository(Ref ref) {
   final client = ref.watch(calendarFacadeClientProvider);
-  return StubCalendarRepository(client: client);
+  return BackendCalendarRepository(client: client);
 }
 
 @riverpod

--- a/lib/features/calendar/presentation/providers/calendar_provider.g.dart
+++ b/lib/features/calendar/presentation/providers/calendar_provider.g.dart
@@ -55,7 +55,7 @@ final class CalendarFacadeClientProvider
 }
 
 String _$calendarFacadeClientHash() =>
-    r'f1f923661276ce71b02dc5223e9557d09219d95b';
+    r'afaed17dbe52673ec80727500a033f2346e2f6db';
 
 @ProviderFor(calendarRepository)
 final calendarRepositoryProvider = CalendarRepositoryProvider._();
@@ -103,7 +103,7 @@ final class CalendarRepositoryProvider
 }
 
 String _$calendarRepositoryHash() =>
-    r'94d351d7eded9adf8096a8ba3f544767731c5871';
+    r'7114198967e26af320220ef18cd4b95dab8ceb7f';
 
 @ProviderFor(CalendarNotifier)
 final calendarProvider = CalendarNotifierProvider._();

--- a/lib/features/files/data/repositories/backend_files_repository.dart
+++ b/lib/features/files/data/repositories/backend_files_repository.dart
@@ -1,42 +1,89 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
 import 'package:weave/features/files/domain/entities/directory_listing.dart';
+import 'package:weave/features/files/domain/entities/file_entry.dart';
 import 'package:weave/features/files/domain/entities/file_upload_request.dart';
 import 'package:weave/features/files/domain/entities/files_connection_state.dart';
 import 'package:weave/features/files/domain/entities/files_failure.dart';
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
 
-/// Backend-facade repository seam for MVP files product flows.
+/// Files repository backed by the Weave backend product facade.
 ///
-/// The MVP contract is for Flutter to use `weave-backend` files APIs while the
-/// backend owns the Nextcloud WebDAV/OCS integration. The concrete HTTP facade
-/// endpoints are still blocked on masssi164/weave-backend#24/#26/#27, so this
-/// implementation deliberately reports the facade as unavailable instead of
-/// adding new direct Flutter-to-Nextcloud product calls.
+/// Flutter owns the product UI and calls `weave-backend` only. The backend owns
+/// all direct Nextcloud WebDAV/OCS access for the MVP files path.
 class BackendFilesRepository implements FilesRepository {
-  const BackendFilesRepository();
+  const BackendFilesRepository({
+    required http.Client httpClient,
+    required ServerConfigurationRepository serverConfigurationRepository,
+    required AuthSessionRepository authSessionRepository,
+  }) : _httpClient = httpClient,
+       _serverConfigurationRepository = serverConfigurationRepository,
+       _authSessionRepository = authSessionRepository;
 
-  static const unavailableMessage =
-      'Files are waiting for the Weave backend files facade.';
+  static const accountLabel = 'Weave files';
+
+  final http.Client _httpClient;
+  final ServerConfigurationRepository _serverConfigurationRepository;
+  final AuthSessionRepository _authSessionRepository;
 
   @override
   Future<FilesConnectionState> restoreConnection() async {
-    return const FilesConnectionState.misconfigured(
-      message: unavailableMessage,
+    final configuration = await _serverConfigurationRepository
+        .loadConfiguration();
+    if (configuration == null) {
+      return const FilesConnectionState.misconfigured(
+        message: 'Finish server setup before browsing files.',
+      );
+    }
+
+    final authState = await _authSessionRepository.restoreSession(
+      _authConfiguration(configuration),
+    );
+    if (!authState.isAuthenticated || authState.session == null) {
+      return FilesConnectionState.disconnected(
+        baseUrl: configuration.serviceEndpoints.backendApiBaseUrl,
+        message: 'Sign in to Weave before browsing files.',
+      );
+    }
+
+    return FilesConnectionState.connected(
+      baseUrl: configuration.serviceEndpoints.backendApiBaseUrl,
+      accountLabel: accountLabel,
     );
   }
 
   @override
   Future<FilesConnectionState> connect() async {
-    throw const FilesFailure.configuration(unavailableMessage);
+    final context = await _requireContext();
+    return FilesConnectionState.connected(
+      baseUrl: context.baseUrl,
+      accountLabel: accountLabel,
+    );
   }
 
   @override
   Future<void> disconnect() async {
-    // No local Nextcloud session is owned by the backend-facade path.
+    // The backend-facade path does not own a separate local Nextcloud session.
   }
 
   @override
   Future<DirectoryListing> listDirectory(String path) async {
-    throw const FilesFailure.configuration(unavailableMessage);
+    final context = await _requireContext();
+    final response = await _send(
+      () => _httpClient.get(
+        _apiUri(context.baseUrl, const ['api', 'files'], query: {'path': path}),
+        headers: _jsonHeaders(context.accessToken),
+      ),
+      fallbackMessage: 'Unable to load files from the Weave backend.',
+    );
+    _ensureSuccess(response, successCodes: const {200});
+    return _decodeListing(response.body);
   }
 
   @override
@@ -45,6 +92,321 @@ class BackendFilesRepository implements FilesRepository {
     FileUploadRequest request, {
     FileUploadProgressCallback? onProgress,
   }) async {
-    throw const FilesFailure.configuration(unavailableMessage);
+    final context = await _requireContext();
+    final multipart =
+        http.MultipartRequest(
+            'POST',
+            _apiUri(
+              context.baseUrl,
+              const ['api', 'files', 'upload'],
+              query: {'parentPath': directoryPath},
+            ),
+          )
+          ..headers.addAll({
+            'Accept': 'application/json',
+            'Authorization': 'Bearer ${context.accessToken}',
+          });
+
+    var uploadedBytes = 0;
+    final stream = request.byteStream.transform(
+      StreamTransformer<List<int>, List<int>>.fromHandlers(
+        handleData: (chunk, sink) {
+          uploadedBytes += chunk.length;
+          onProgress?.call(uploadedBytes, request.sizeInBytes);
+          sink.add(chunk);
+        },
+      ),
+    );
+    multipart.files.add(
+      http.MultipartFile(
+        'file',
+        stream,
+        request.sizeInBytes,
+        filename: request.fileName,
+      ),
+    );
+
+    final streamedResponse = await _sendStream(
+      () => _httpClient.send(multipart),
+      fallbackMessage: 'Unable to upload the file through the Weave backend.',
+    );
+    final response = await http.Response.fromStream(streamedResponse);
+    _ensureSuccess(response, successCodes: const {200});
+    onProgress?.call(request.sizeInBytes, request.sizeInBytes);
   }
+
+  Future<FileEntry> createFolder({
+    required String parentPath,
+    required String name,
+  }) async {
+    final context = await _requireContext();
+    final response = await _send(
+      () => _httpClient.post(
+        _apiUri(context.baseUrl, const ['api', 'files', 'folders']),
+        headers: _jsonHeaders(context.accessToken),
+        body: jsonEncode({'parentPath': parentPath, 'name': name}),
+      ),
+      fallbackMessage: 'Unable to create the folder through the Weave backend.',
+    );
+    _ensureSuccess(response, successCodes: const {200});
+    return _decodeEntry(_decodeObject(response.body));
+  }
+
+  Future<void> prepareDownload(String id) async {
+    final context = await _requireContext();
+    final response = await _send(
+      () => _httpClient.get(
+        _apiUri(context.baseUrl, ['api', 'files', id, 'download']),
+        headers: _jsonHeaders(context.accessToken),
+      ),
+      fallbackMessage: 'Unable to prepare the file download.',
+    );
+    _ensureSuccess(response, successCodes: const {200, 204});
+  }
+
+  Future<void> delete(String id) async {
+    final context = await _requireContext();
+    final response = await _send(
+      () => _httpClient.delete(
+        _apiUri(context.baseUrl, ['api', 'files', id]),
+        headers: _jsonHeaders(context.accessToken),
+      ),
+      fallbackMessage: 'Unable to delete the file through the Weave backend.',
+    );
+    _ensureSuccess(response, successCodes: const {200, 204});
+  }
+
+  Future<_BackendFilesContext> _requireContext() async {
+    final configuration = await _serverConfigurationRepository
+        .loadConfiguration();
+    if (configuration == null) {
+      throw const FilesFailure.configuration(
+        'Finish server setup before browsing files.',
+      );
+    }
+
+    final authState = await _authSessionRepository.restoreSession(
+      _authConfiguration(configuration),
+    );
+    final session = authState.session;
+    if (!authState.isAuthenticated || session == null) {
+      throw const FilesFailure.sessionRequired(
+        'Sign in to Weave before browsing files.',
+      );
+    }
+
+    return _BackendFilesContext(
+      baseUrl: configuration.serviceEndpoints.backendApiBaseUrl,
+      accessToken: session.accessToken,
+    );
+  }
+
+  AuthConfiguration _authConfiguration(ServerConfiguration configuration) {
+    return AuthConfiguration(
+      issuer: configuration.oidcIssuerUrl,
+      clientId: configuration.oidcClientRegistration.clientId.trim(),
+    );
+  }
+
+  Future<http.Response> _send(
+    Future<http.Response> Function() request, {
+    required String fallbackMessage,
+  }) async {
+    try {
+      return await request().timeout(const Duration(seconds: 20));
+    } on FilesFailure {
+      rethrow;
+    } catch (error) {
+      throw FilesFailure.unknown(fallbackMessage, cause: error);
+    }
+  }
+
+  Future<http.StreamedResponse> _sendStream(
+    Future<http.StreamedResponse> Function() request, {
+    required String fallbackMessage,
+  }) async {
+    try {
+      return await request().timeout(const Duration(seconds: 60));
+    } on FilesFailure {
+      rethrow;
+    } catch (error) {
+      throw FilesFailure.unknown(fallbackMessage, cause: error);
+    }
+  }
+
+  void _ensureSuccess(
+    http.Response response, {
+    required Set<int> successCodes,
+  }) {
+    if (successCodes.contains(response.statusCode)) {
+      return;
+    }
+
+    final message = _errorMessage(response.body);
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw FilesFailure.invalidCredentials(
+        message ?? 'The Weave backend rejected the current session.',
+        cause: response.statusCode,
+      );
+    }
+    if (response.statusCode == 400 || response.statusCode == 404) {
+      throw FilesFailure.protocol(
+        message ?? 'The Weave backend rejected the files request.',
+        cause: response.statusCode,
+      );
+    }
+    if (response.statusCode == 409) {
+      throw FilesFailure.protocol(
+        message ??
+            'The file operation conflicts with the current backend state.',
+        cause: response.statusCode,
+      );
+    }
+    if (response.statusCode == 503) {
+      throw FilesFailure.configuration(
+        message ?? 'The Weave backend files facade is unavailable.',
+        cause: response.statusCode,
+      );
+    }
+
+    throw FilesFailure.unknown(
+      message ?? 'The Weave backend failed the files request.',
+      cause: response.statusCode,
+    );
+  }
+
+  DirectoryListing _decodeListing(String body) {
+    final json = _decodeObject(body);
+    final rawItems = json['items'];
+    if (rawItems is! List) {
+      throw const FilesFailure.protocol(
+        'The Weave backend returned an invalid files listing.',
+      );
+    }
+    return DirectoryListing(
+      path: _readString(json, 'path', fallback: '/'),
+      entries: rawItems
+          .whereType<Map<String, dynamic>>()
+          .map(_decodeEntry)
+          .toList(growable: false),
+    );
+  }
+
+  FileEntry _decodeEntry(Map<String, dynamic> json) {
+    final type = _readString(json, 'type');
+    return FileEntry(
+      id: _readString(json, 'id'),
+      name: _readString(json, 'name'),
+      path: _readString(json, 'path'),
+      isDirectory: type == 'folder' || type == 'directory',
+      modifiedAt: _readDateTime(json['modifiedAt']),
+      sizeInBytes: _readInt(json['size']),
+    );
+  }
+
+  Map<String, dynamic> _decodeObject(String body) {
+    try {
+      final payload = jsonDecode(body);
+      if (payload is Map<String, dynamic>) {
+        return payload;
+      }
+    } catch (_) {
+      // Fall through to protocol failure below.
+    }
+    throw const FilesFailure.protocol(
+      'The Weave backend returned an invalid files payload.',
+    );
+  }
+
+  String? _errorMessage(String body) {
+    try {
+      final payload = jsonDecode(body);
+      if (payload is Map<String, dynamic>) {
+        final message = payload['message'];
+        if (message is String && message.trim().isNotEmpty) {
+          return message;
+        }
+      }
+    } catch (_) {
+      return null;
+    }
+    return null;
+  }
+
+  String _readString(
+    Map<String, dynamic> json,
+    String key, {
+    String? fallback,
+  }) {
+    final value = json[key];
+    if (value is String && value.trim().isNotEmpty) {
+      return value;
+    }
+    if (fallback != null) {
+      return fallback;
+    }
+    throw FilesFailure.protocol(
+      'The Weave backend returned a file item without $key.',
+    );
+  }
+
+  int? _readInt(Object? value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    return null;
+  }
+
+  DateTime? _readDateTime(Object? value) {
+    if (value is! String || value.isEmpty) {
+      return null;
+    }
+    return DateTime.tryParse(value);
+  }
+
+  Map<String, String> _jsonHeaders(String accessToken) {
+    return {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer $accessToken',
+    };
+  }
+
+  Uri _apiUri(
+    Uri baseUrl,
+    List<String> pathSegments, {
+    Map<String, String>? query,
+  }) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, pathSegments),
+      queryParameters: query,
+    );
+  }
+
+  List<String> _apiPath(Uri baseUrl, List<String> pathSegments) {
+    final baseSegments = baseUrl.pathSegments
+        .where((segment) => segment.isNotEmpty)
+        .toList(growable: false);
+    if (baseSegments.isNotEmpty &&
+        pathSegments.isNotEmpty &&
+        baseSegments.last == 'api' &&
+        pathSegments.first == 'api') {
+      return [...baseSegments, ...pathSegments.skip(1)];
+    }
+
+    return [...baseSegments, ...pathSegments];
+  }
+}
+
+class _BackendFilesContext {
+  const _BackendFilesContext({
+    required this.baseUrl,
+    required this.accessToken,
+  });
+
+  final Uri baseUrl;
+  final String accessToken;
 }

--- a/lib/features/files/presentation/providers/files_repository_provider.dart
+++ b/lib/features/files/presentation/providers/files_repository_provider.dart
@@ -1,22 +1,32 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weave/features/auth/presentation/providers/auth_session_repository_provider.dart';
 import 'package:weave/features/files/data/repositories/backend_files_repository.dart';
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
 import 'package:weave/features/files/presentation/providers/legacy_direct_nextcloud_files_repository_provider.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 
-/// Enables the backend files facade path once the backend endpoints exist.
+/// Enables the backend files facade path for MVP product files flows.
 ///
-/// Keep this disabled by default so current merged live-stack auth/chat/files
-/// read tests continue to exercise the compatibility adapter. Set
-/// `--dart-define=WEAVE_USE_BACKEND_FILES_FACADE=true` or override this provider
-/// in tests to verify the facade path without introducing new direct
-/// Flutter-to-Nextcloud product calls.
+/// Backend facade mode is the default. Set
+/// `--dart-define=WEAVE_USE_BACKEND_FILES_FACADE=false` only for the explicit
+/// legacy fallback path that still talks directly to Nextcloud WebDAV.
 final useBackendFilesFacadeProvider = Provider<bool>((ref) {
-  return const bool.fromEnvironment('WEAVE_USE_BACKEND_FILES_FACADE');
+  return const bool.fromEnvironment(
+    'WEAVE_USE_BACKEND_FILES_FACADE',
+    defaultValue: true,
+  );
 });
 
 final filesRepositoryProvider = Provider<FilesRepository>((ref) {
   if (ref.watch(useBackendFilesFacadeProvider)) {
-    return const BackendFilesRepository();
+    return BackendFilesRepository(
+      httpClient: ref.watch(weaveApiHttpClientProvider),
+      serverConfigurationRepository: ref.watch(
+        serverConfigurationRepositoryProvider,
+      ),
+      authSessionRepository: ref.watch(authSessionRepositoryProvider),
+    );
   }
 
   return ref.watch(legacyDirectNextcloudFilesRepositoryProvider);

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -7,6 +7,8 @@ PODS:
     - AppAuth/Core
   - desktop_webview_window (0.0.1):
     - FlutterMacOS
+  - file_picker (0.0.1):
+    - FlutterMacOS
   - flutter_appauth (0.0.1):
     - AppAuth (= 2.0.0)
     - FlutterMacOS
@@ -31,6 +33,7 @@ PODS:
 
 DEPENDENCIES:
   - desktop_webview_window (from `Flutter/ephemeral/.symlinks/plugins/desktop_webview_window/macos`)
+  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - flutter_appauth (from `Flutter/ephemeral/.symlinks/plugins/flutter_appauth/macos`)
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - flutter_vodozemac (from `Flutter/ephemeral/.symlinks/plugins/flutter_vodozemac/macos`)
@@ -48,6 +51,8 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   desktop_webview_window:
     :path: Flutter/ephemeral/.symlinks/plugins/desktop_webview_window/macos
+  file_picker:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
   flutter_appauth:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_appauth/macos
   flutter_secure_storage_darwin:
@@ -70,6 +75,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppAuth: 1c1a8afa7e12f2ec3a294d9882dfa5ab7d3cb063
   desktop_webview_window: 7e37af677d6d19294cb433d9b1d878ef78dffa4d
+  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
   flutter_appauth: a7af6f450a5cbe7938c2222eddf34d13521038e6
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   flutter_vodozemac: fd2ea9cb3e2a37beaac883a369811fbfe042fc53

--- a/test/features/calendar/data/services/calendar_facade_client_test.dart
+++ b/test/features/calendar/data/services/calendar_facade_client_test.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_state.dart';
+import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/calendar/data/services/calendar_facade_client.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+
+import '../../../../helpers/auth_test_data.dart';
+import '../../../../helpers/server_config_test_data.dart';
+
+class _FakeServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _FakeServerConfigurationRepository(this.configuration);
+
+  ServerConfiguration? configuration;
+
+  @override
+  Future<void> clearConfiguration() async {}
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    this.configuration = configuration;
+  }
+}
+
+class _FakeAuthSessionRepository implements AuthSessionRepository {
+  _FakeAuthSessionRepository(this.state);
+
+  AuthState state;
+
+  @override
+  Future<void> clearLocalSession() async {}
+
+  @override
+  Future<AuthState> refreshSession(AuthConfiguration configuration) async =>
+      state;
+
+  @override
+  Future<AuthState> restoreSession(AuthConfiguration configuration) async =>
+      state;
+
+  @override
+  Future<void> signOut(AuthConfiguration configuration) async {}
+
+  @override
+  Future<AuthState> signIn(AuthConfiguration configuration) async => state;
+}
+
+void main() {
+  group('CalendarFacadeClient', () {
+    late _FakeServerConfigurationRepository configurationRepository;
+    late _FakeAuthSessionRepository authSessionRepository;
+
+    CalendarFacadeClient client(http.Client httpClient) {
+      return CalendarFacadeClient(
+        httpClient: httpClient,
+        serverConfigurationRepository: configurationRepository,
+        authSessionRepository: authSessionRepository,
+      );
+    }
+
+    setUp(() {
+      configurationRepository = _FakeServerConfigurationRepository(
+        buildTestConfiguration(
+          backendApiBaseUrl: 'https://api.home.internal/api',
+        ),
+      );
+      authSessionRepository = _FakeAuthSessionRepository(
+        AuthState.authenticated(
+          buildTestAuthSession(accessToken: 'calendar-token'),
+        ),
+      );
+    });
+
+    test('lists events through the backend calendar facade', () async {
+      late http.Request capturedRequest;
+      final facade = client(
+        MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(
+            jsonEncode({
+              'events': [
+                {
+                  'id': 'calendar:personal:1',
+                  'title': 'Planning',
+                  'description': 'Roadmap',
+                  'startsAt': '2026-04-26T09:00:00Z',
+                  'endsAt': '2026-04-26T10:00:00Z',
+                  'timezone': 'Europe/Berlin',
+                  'location': 'Office',
+                  'allDay': false,
+                  'etag': 'abc',
+                },
+              ],
+            }),
+            200,
+          );
+        }),
+      );
+
+      final events = await facade.listEvents(
+        from: DateTime.utc(2026, 4, 26),
+        to: DateTime.utc(2026, 4, 27),
+      );
+
+      expect(capturedRequest.method, 'GET');
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.home.internal/api/calendar/events?from=2026-04-26T00%3A00%3A00.000Z&to=2026-04-27T00%3A00%3A00.000Z',
+      );
+      expect(capturedRequest.headers['authorization'], 'Bearer calendar-token');
+      expect(events, hasLength(1));
+      expect(events.single.title, 'Planning');
+      expect(events.single.timezone, 'Europe/Berlin');
+      expect(events.single.etag, 'abc');
+    });
+
+    test(
+      'creates, updates, and deletes events through backend endpoints',
+      () async {
+        final requests = <http.Request>[];
+        final facade = client(
+          MockClient((request) async {
+            requests.add(request);
+            if (request.method == 'DELETE') {
+              return http.Response('', 204);
+            }
+            return http.Response(
+              jsonEncode({
+                'id': 'calendar:personal:1',
+                'title': 'Planning',
+                'startsAt': '2026-04-26T09:00:00Z',
+                'endsAt': '2026-04-26T10:00:00Z',
+                'timezone': 'Europe/Berlin',
+                'allDay': false,
+              }),
+              200,
+            );
+          }),
+        );
+
+        await facade.createEvent(
+          CalendarEventDraft(
+            title: 'Planning',
+            startsAt: DateTime.utc(2026, 4, 26, 9),
+            endsAt: DateTime.utc(2026, 4, 26, 10),
+            timezone: 'Europe/Berlin',
+          ),
+        );
+        await facade.updateEvent(
+          id: 'calendar:personal:1',
+          patch: const CalendarEventPatch(
+            title: 'Updated Planning',
+            etag: 'abc',
+          ),
+        );
+        await facade.deleteEvent('calendar:personal:1');
+
+        expect(requests.map((request) => '${request.method} ${request.url}'), [
+          'POST https://api.home.internal/api/calendar/events',
+          'PATCH https://api.home.internal/api/calendar/events/calendar:personal:1',
+          'DELETE https://api.home.internal/api/calendar/events/calendar:personal:1',
+        ]);
+        expect(jsonDecode(requests.first.body)['timezone'], 'Europe/Berlin');
+        expect(jsonDecode(requests[1].body), {
+          'title': 'Updated Planning',
+          'etag': 'abc',
+        });
+      },
+    );
+
+    test('maps backend failures without direct CalDAV fallback', () async {
+      final facade = client(
+        MockClient(
+          (_) async => http.Response(
+            jsonEncode({'message': 'Calendar facade is unavailable.'}),
+            503,
+          ),
+        ),
+      );
+
+      await expectLater(
+        facade.listEvents(),
+        throwsA(
+          isA<AppFailure>().having(
+            (failure) => failure.message,
+            'message',
+            'Calendar facade is unavailable.',
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
+++ b/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
@@ -1,88 +1,279 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_state.dart';
+import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
 import 'package:weave/features/files/data/repositories/backend_files_repository.dart';
 import 'package:weave/features/files/domain/entities/file_upload_request.dart';
 import 'package:weave/features/files/domain/entities/files_connection_state.dart';
 import 'package:weave/features/files/domain/entities/files_failure.dart';
 import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+
+import '../../../../helpers/auth_test_data.dart';
+import '../../../../helpers/server_config_test_data.dart';
+
+class _FakeServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _FakeServerConfigurationRepository(this.configuration);
+
+  ServerConfiguration? configuration;
+
+  @override
+  Future<void> clearConfiguration() async {}
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    this.configuration = configuration;
+  }
+}
+
+class _FakeAuthSessionRepository implements AuthSessionRepository {
+  _FakeAuthSessionRepository(this.state);
+
+  AuthState state;
+
+  @override
+  Future<void> clearLocalSession() async {}
+
+  @override
+  Future<AuthState> refreshSession(AuthConfiguration configuration) async =>
+      state;
+
+  @override
+  Future<AuthState> restoreSession(AuthConfiguration configuration) async =>
+      state;
+
+  @override
+  Future<void> signOut(AuthConfiguration configuration) async {}
+
+  @override
+  Future<AuthState> signIn(AuthConfiguration configuration) async => state;
+}
 
 void main() {
   group('filesRepositoryProvider backend-facade seam', () {
-    test('keeps backend facade disabled as the compatibility default', () {
+    test('uses the backend facade as the MVP default', () {
       final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(useBackendFilesFacadeProvider), isTrue);
+    });
+
+    test('keeps direct Nextcloud behind an explicit fallback switch', () {
+      final container = ProviderContainer(
+        overrides: [useBackendFilesFacadeProvider.overrideWithValue(false)],
+      );
       addTearDown(container.dispose);
 
       expect(container.read(useBackendFilesFacadeProvider), isFalse);
     });
-
-    test(
-      'can be switched to the backend files facade without Nextcloud deps',
-      () {
-        final container = ProviderContainer(
-          overrides: [useBackendFilesFacadeProvider.overrideWithValue(true)],
-        );
-        addTearDown(container.dispose);
-
-        expect(
-          container.read(filesRepositoryProvider),
-          isA<BackendFilesRepository>(),
-        );
-      },
-    );
   });
 
   group('BackendFilesRepository', () {
-    const repository = BackendFilesRepository();
+    late _FakeServerConfigurationRepository configurationRepository;
+    late _FakeAuthSessionRepository authSessionRepository;
+
+    BackendFilesRepository repository(http.Client client) {
+      return BackendFilesRepository(
+        httpClient: client,
+        serverConfigurationRepository: configurationRepository,
+        authSessionRepository: authSessionRepository,
+      );
+    }
+
+    setUp(() {
+      configurationRepository = _FakeServerConfigurationRepository(
+        buildTestConfiguration(
+          backendApiBaseUrl: 'https://api.home.internal/api',
+        ),
+      );
+      authSessionRepository = _FakeAuthSessionRepository(
+        AuthState.authenticated(
+          buildTestAuthSession(accessToken: 'files-token'),
+        ),
+      );
+    });
 
     test(
-      'reports the backend files facade as unavailable until implemented',
+      'restores as connected when Weave auth and backend URL are present',
       () async {
-        final state = await repository.restoreConnection();
+        final state = await repository(
+          MockClient((_) async => http.Response('', 500)),
+        ).restoreConnection();
 
-        expect(state.status, FilesConnectionStatus.misconfigured);
-        expect(state.message, BackendFilesRepository.unavailableMessage);
+        expect(state.status, FilesConnectionStatus.connected);
+        expect(state.baseUrl, Uri.parse('https://api.home.internal/api'));
+        expect(state.accountLabel, BackendFilesRepository.accountLabel);
       },
     );
 
     test(
-      'blocks product file operations instead of using direct Nextcloud',
+      'lists files through the backend facade with the Weave token',
       () async {
-        await expectLater(
-          repository.connect(),
-          throwsA(
-            isA<FilesFailure>()
-                .having(
-                  (failure) => failure.type,
-                  'type',
-                  FilesFailureType.configuration,
-                )
-                .having(
-                  (failure) => failure.message,
-                  'message',
-                  BackendFilesRepository.unavailableMessage,
-                ),
+        late http.Request capturedRequest;
+        final client = MockClient((request) async {
+          capturedRequest = request;
+          return http.Response(
+            jsonEncode({
+              'path': '/Team',
+              'items': [
+                {
+                  'id': 'files:/Team/Design',
+                  'name': 'Design',
+                  'path': '/Team/Design',
+                  'type': 'folder',
+                  'mimeType': null,
+                  'size': null,
+                  'modifiedAt': '2026-04-26T09:00:00Z',
+                  'downloadable': false,
+                },
+                {
+                  'id': 'files:/Team/readme.md',
+                  'name': 'readme.md',
+                  'path': '/Team/readme.md',
+                  'type': 'file',
+                  'mimeType': 'text/markdown',
+                  'size': 42,
+                  'modifiedAt': '2026-04-26T09:05:00Z',
+                  'downloadable': true,
+                },
+              ],
+            }),
+            200,
+          );
+        });
+
+        final listing = await repository(client).listDirectory('/Team');
+
+        expect(capturedRequest.method, 'GET');
+        expect(
+          capturedRequest.url.toString(),
+          'https://api.home.internal/api/files?path=%2FTeam',
+        );
+        expect(capturedRequest.headers['authorization'], 'Bearer files-token');
+        expect(listing.path, '/Team');
+        expect(listing.entries, hasLength(2));
+        expect(listing.entries.first.isDirectory, isTrue);
+        expect(listing.entries.last.sizeInBytes, 42);
+      },
+    );
+
+    test(
+      'creates folders, prepares downloads, and deletes via backend endpoints',
+      () async {
+        final requests = <http.Request>[];
+        final client = MockClient((request) async {
+          requests.add(request);
+          if (request.method == 'POST') {
+            expect(jsonDecode(request.body), {
+              'parentPath': '/Team',
+              'name': 'Design',
+            });
+            return http.Response(
+              jsonEncode({
+                'id': 'files:/Team/Design',
+                'name': 'Design',
+                'path': '/Team/Design',
+                'type': 'folder',
+                'downloadable': false,
+              }),
+              200,
+            );
+          }
+          return http.Response('', 204);
+        });
+        final backendRepository = repository(client);
+
+        final folder = await backendRepository.createFolder(
+          parentPath: '/Team',
+          name: 'Design',
+        );
+        await backendRepository.prepareDownload('files:/Team/readme.md');
+        await backendRepository.delete('files:/Team/old.md');
+
+        expect(folder.path, '/Team/Design');
+        expect(requests.map((request) => '${request.method} ${request.url}'), [
+          'POST https://api.home.internal/api/files/folders',
+          'GET https://api.home.internal/api/files/files:%2FTeam%2Freadme.md/download',
+          'DELETE https://api.home.internal/api/files/files:%2FTeam%2Fold.md',
+        ]);
+      },
+    );
+
+    test('uploads multipart data through the backend facade', () async {
+      late http.BaseRequest capturedRequest;
+      final client = _RecordingStreamClient((request) async {
+        capturedRequest = request;
+        final body = await request.finalize().toBytes();
+        expect(utf8.decode(body), contains('hello'));
+        return http.StreamedResponse(const Stream<List<int>>.empty(), 200);
+      });
+      final progress = <int>[];
+
+      await repository(client).uploadFile(
+        '/Team',
+        FileUploadRequest(
+          fileName: 'notes.txt',
+          sizeInBytes: 5,
+          byteStream: Stream<List<int>>.fromIterable([utf8.encode('hello')]),
+        ),
+        onProgress: (uploadedBytes, _) => progress.add(uploadedBytes),
+      );
+
+      expect(capturedRequest.method, 'POST');
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.home.internal/api/files/upload?parentPath=%2FTeam',
+      );
+      expect(capturedRequest.headers['authorization'], 'Bearer files-token');
+      expect(progress, contains(5));
+    });
+
+    test(
+      'maps backend auth rejection without falling back to direct Nextcloud',
+      () async {
+        final client = MockClient(
+          (_) async => http.Response(
+            jsonEncode({
+              'message': 'The Weave backend rejected the current session.',
+            }),
+            401,
           ),
         );
 
         await expectLater(
-          repository.listDirectory('/'),
-          throwsA(isA<FilesFailure>()),
-        );
-
-        await expectLater(
-          repository.uploadFile(
-            '/',
-            const FileUploadRequest(
-              fileName: 'notes.txt',
-              sizeInBytes: 0,
-              byteStream: Stream<List<int>>.empty(),
+          repository(client).listDirectory('/'),
+          throwsA(
+            isA<FilesFailure>().having(
+              (failure) => failure.type,
+              'type',
+              FilesFailureType.invalidCredentials,
             ),
           ),
-          throwsA(isA<FilesFailure>()),
         );
       },
     );
   });
+}
+
+class _RecordingStreamClient extends http.BaseClient {
+  _RecordingStreamClient(this.handler);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+  handler;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return handler(request);
+  }
 }


### PR DESCRIPTION
## Summary
- Make backend files facade the MVP default and keep direct Nextcloud behind explicit legacy fallback.
- Implement real `BackendFilesRepository` HTTP calls for list, create folder, upload, download preparation, and delete through `weave-backend`.
- Replace calendar stub with `BackendCalendarRepository` + real `CalendarFacadeClient` for list/create/update/delete facade calls.
- Update live-stack E2E to seed files through the backend files facade instead of direct WebDAV.
- Add/extend provider/client tests to prevent drift back to direct Nextcloud/CalDAV product wiring.

## Validated locally
- `dart run build_runner build --delete-conflicting-outputs`
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze --fatal-infos`
- `flutter test test/features/files/presentation/providers/files_backend_facade_provider_test.dart test/features/calendar/data/services/calendar_facade_client_test.dart test/features/app/release_golden_paths_test.dart`
- `flutter test`

## Integration note
- `flutter test integration_test/live_stack_app_e2e_test.dart -d macos` builds the macOS app, then stops on missing local dart-defines: `WEAVE_TEST_USERNAME`, `WEAVE_TEST_PASSWORD`.
- CI/live-stack should exercise this with repository secrets and the now-merged infra actor config from masssi164/weave-infra#32.

Closes #85.
Advances #83.
Depends on already-merged backend PRs masssi164/weave-backend#29/#30 and infra PR masssi164/weave-infra#32.
