### PR TITLE
test: keep dummy live-stack contracts offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,12 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed .
       - run: flutter analyze --fatal-infos
       - run: flutter test
+      - name: Run dummy live-stack contract checks offline
+        run: WEAVE_TEST_USERNAME=dummy WEAVE_TEST_PASSWORD=dummy make integration-test
 
   integration-test:
     name: Live Stack Integration Test
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     concurrency:
       group: weave-live-stack-self-hosted
       cancel-in-progress: false

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ integration-test:
 	caller_WEAVE_TEST_PASSWORD_set="$${WEAVE_TEST_PASSWORD+x}"; \
 	caller_WEAVE_TEST_PASSWORD="$${WEAVE_TEST_PASSWORD-}"; \
 	test_device="$${WEAVE_INTEGRATION_TEST_DEVICE:-$${FLUTTER_TEST_DEVICE:-macos}}"; \
+	run_app_e2e="$${WEAVE_RUN_APP_E2E:-true}"; \
 	if [ -f "$$bootstrap_env" ]; then \
 	  . "$$bootstrap_env"; \
 	fi; \
@@ -46,6 +47,15 @@ integration-test:
 	  '  "WEAVE_TEST_USERNAME": "'"$${WEAVE_TEST_USERNAME}"'",' \
 	  '  "WEAVE_TEST_PASSWORD": "'"$${WEAVE_TEST_PASSWORD}"'"' \
 	  '}' > "$$dart_defines_file"; \
+	flutter test test/live_stack_contract_test.dart \
+	  --dart-define-from-file="$$dart_defines_file" || exit $$?; \
+	if [ "$$run_app_e2e" = "false" ]; then \
+	  exit 0; \
+	fi; \
+	if [ "$${WEAVE_TEST_USERNAME}" = dummy ] || [ "$${WEAVE_TEST_PASSWORD}" = dummy ]; then \
+	  echo "Dummy credentials: offline live-stack contract checks completed; skipping real live E2E."; \
+	  exit 0; \
+	fi; \
 	for test_file in integration_test/app_test.dart integration_test/live_stack_app_e2e_test.dart; do \
 	  flutter test "$$test_file" -d "$$test_device" \
 	    --dart-define-from-file="$$dart_defines_file" || exit $$?; \

--- a/integration_test/helpers/test_config.dart
+++ b/integration_test/helpers/test_config.dart
@@ -92,11 +92,23 @@ class TestConfig {
     );
   }
 
+  bool get hasCredentials =>
+      username.trim().isNotEmpty && password.trim().isNotEmpty;
+
+  bool get usesDummyCredentials =>
+      _isDummyValue(username) || _isDummyValue(password);
+
+  bool get hasLiveCredentials => hasCredentials && !usesDummyCredentials;
+
   void requireCredentials() {
     final missing = <String>[
       if (username.trim().isEmpty) 'WEAVE_TEST_USERNAME',
       if (password.trim().isEmpty) 'WEAVE_TEST_PASSWORD',
     ];
+
+    if (usesDummyCredentials) {
+      missing.add('real non-dummy WEAVE_TEST_USERNAME/WEAVE_TEST_PASSWORD');
+    }
 
     if (missing.isNotEmpty) {
       throw StateError(
@@ -104,6 +116,10 @@ class TestConfig {
         '${missing.join(', ')}.',
       );
     }
+  }
+
+  static bool _isDummyValue(String value) {
+    return value.trim().toLowerCase() == 'dummy';
   }
 
   static Uri _parseUrl(String value, {required String variableName}) {

--- a/test/live_stack_contract_test.dart
+++ b/test/live_stack_contract_test.dart
@@ -1,0 +1,482 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
+import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
+import 'package:weave/features/app/presentation/providers/app_application_providers.dart';
+import 'package:weave/features/app/presentation/providers/workspace_invalidation_provider.dart';
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_session.dart';
+import 'package:weave/features/auth/domain/entities/auth_state.dart';
+import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/auth/presentation/providers/auth_session_repository_provider.dart';
+import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
+import 'package:weave/features/chat/domain/entities/chat_room_timeline.dart';
+import 'package:weave/features/chat/domain/entities/chat_security_state.dart';
+import 'package:weave/features/chat/domain/repositories/chat_repository.dart';
+import 'package:weave/features/chat/domain/repositories/chat_security_repository.dart';
+import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
+import 'package:weave/features/chat/presentation/providers/chat_security_repository_provider.dart';
+import 'package:weave/features/files/domain/entities/directory_listing.dart';
+import 'package:weave/features/files/domain/entities/file_upload_request.dart';
+import 'package:weave/features/files/domain/entities/files_connection_state.dart';
+import 'package:weave/features/files/domain/repositories/files_repository.dart';
+import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
+import 'package:weave/features/server_config/domain/entities/oidc_client_registration.dart';
+import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration_save_result.dart';
+import 'package:weave/features/server_config/domain/entities/service_endpoints.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
+
+import '../integration_test/helpers/auth_helper.dart';
+import '../integration_test/helpers/test_config.dart';
+import '../integration_test/helpers/test_http_overrides.dart';
+
+void main() {
+  HttpOverrides.global = TestHttpOverrides();
+
+  final liveConfig = TestConfig.fromEnvironment();
+  final liveSkipReason = liveConfig.hasLiveCredentials
+      ? false
+      : liveConfig.usesDummyCredentials
+      ? 'Dummy credentials run the offline contract checks only.'
+      : 'Requires real WEAVE_TEST_USERNAME and WEAVE_TEST_PASSWORD dart-defines.';
+
+  late TestConfig config;
+  late http.Client httpClient;
+  late AuthHelper authHelper;
+
+  setUp(() {
+    config = liveConfig;
+    httpClient = createTrustedTestHttpClient();
+    authHelper = AuthHelper();
+  });
+
+  tearDown(() {
+    httpClient.close();
+  });
+
+  group('offline contract checks', () {
+    test(
+      'dummy credentials are accepted only for offline contract mode',
+      () {
+        expect(liveConfig.hasCredentials, isTrue);
+        expect(liveConfig.usesDummyCredentials, isTrue);
+        expect(liveConfig.hasLiveCredentials, isFalse);
+        expect(liveConfig.requireCredentials, throwsStateError);
+      },
+      skip: liveConfig.usesDummyCredentials
+          ? false
+          : 'Requires dummy credentials.',
+    );
+
+    test('canonical backend API paths do not duplicate the /api prefix', () {
+      expect(
+        liveConfig
+            .copyWith(
+              backendApiBaseUrl: Uri.parse('https://api.weave.local/api'),
+            )
+            .apiUri('/api/me')
+            .toString(),
+        'https://api.weave.local/api/me',
+      );
+    });
+
+    test(
+      'shell readiness contract can be exercised without live auth',
+      () async {
+        final session = AuthSession(
+          issuer: liveConfig.issuerUrl,
+          clientId: liveConfig.clientId,
+          accessToken: 'offline-contract-token',
+          refreshToken: 'offline-refresh-token',
+          idToken: 'offline-id-token',
+          expiresAt: DateTime.now().add(const Duration(hours: 1)),
+          tokenType: 'Bearer',
+          scopes: const ['openid', 'profile', 'email', 'weave:workspace'],
+        );
+        final container = _createAppContainer(
+          config: liveConfig,
+          session: session,
+        );
+        addTearDown(container.dispose);
+
+        final bootstrap = await container.read(appBootstrapProvider.future);
+
+        expect(bootstrap.phase, BootstrapPhase.ready);
+      },
+    );
+  });
+
+  test('setup -> sign-in -> shell ready', () async {
+    final session = await authHelper.signInForAppSession(config);
+    final container = _createAppContainer(config: config, session: session);
+    addTearDown(container.dispose);
+
+    final bootstrap = await container.read(appBootstrapProvider.future);
+
+    expect(session.accessToken, isNotEmpty);
+    expect(bootstrap.phase, BootstrapPhase.ready);
+  }, skip: liveSkipReason);
+
+  test('settings/config change -> targeted invalidation fires', () async {
+    final session = await authHelper.signInForAppSession(config);
+    final container = _createAppContainer(config: config, session: session);
+    addTearDown(container.dispose);
+
+    final updatedBackendUrl = config.backendApiBaseUrl.replace(
+      pathSegments: [
+        ...config.backendApiBaseUrl.pathSegments.where(
+          (segment) => segment.isNotEmpty,
+        ),
+        'e2e-settings-change',
+      ],
+    );
+
+    await container
+        .read(applyServerConfigurationChangesProvider)
+        .call(
+          ServerConfigurationSaveResult(
+            configuration: _serverConfiguration(
+              config.copyWith(backendApiBaseUrl: updatedBackendUrl),
+            ),
+            authConfigurationChanged: false,
+            matrixHomeserverChanged: false,
+            nextcloudBaseUrlChanged: false,
+            backendApiBaseUrlChanged: true,
+          ),
+        );
+    await container
+        .read(serverConfigurationRepositoryProvider)
+        .saveConfiguration(
+          _serverConfiguration(
+            config.copyWith(backendApiBaseUrl: updatedBackendUrl),
+          ),
+        );
+
+    final backendInvalidation = container.read(
+      integrationInvalidationProvider(WorkspaceIntegration.weaveBackend),
+    );
+    expect(backendInvalidation?.sequence, 1);
+    expect(
+      backendInvalidation?.reason,
+      IntegrationInvalidationReason.backendApiBaseUrlChanged,
+    );
+    expect(
+      container.read(
+        integrationInvalidationProvider(WorkspaceIntegration.matrix),
+      ),
+      isNull,
+    );
+    expect(
+      container.read(
+        integrationInvalidationProvider(WorkspaceIntegration.nextcloud),
+      ),
+      isNull,
+    );
+  }, skip: liveSkipReason);
+
+  test('authenticated GET /api/me returns expected claims', () async {
+    final accessToken = await authHelper.signIn(config);
+
+    final response = await httpClient.get(
+      config.apiUri('/api/me'),
+      headers: <String, String>{
+        'Accept': 'application/json',
+        'Authorization': 'Bearer $accessToken',
+      },
+    );
+
+    expect(response.statusCode, 200, reason: response.body);
+    final payload = _decodeObject(response.body);
+    expect(payload['sub'], isA<String>());
+    expect((payload['sub'] as String).trim(), isNotEmpty);
+    expect(payload['email'], isA<String>());
+    expect((payload['email'] as String).trim(), isNotEmpty);
+  }, skip: liveSkipReason);
+
+  test('authenticated GET /api/workspace/capabilities returns expected '
+      'structure', () async {
+    final accessToken = await authHelper.signIn(config);
+
+    final response = await httpClient.get(
+      config.apiUri('/api/workspace/capabilities'),
+      headers: <String, String>{
+        'Accept': 'application/json',
+        'Authorization': 'Bearer $accessToken',
+      },
+    );
+
+    expect(response.statusCode, 200, reason: response.body);
+    final payload = _decodeObject(response.body);
+
+    final features = payload['features'];
+    if (features != null) {
+      expect(features, isA<Map>());
+    } else {
+      for (final key in <String>[
+        'shellAccess',
+        'chat',
+        'files',
+        'calendar',
+        'boards',
+      ]) {
+        expect(payload[key], isA<Map>(), reason: 'Missing "$key".');
+      }
+    }
+  }, skip: liveSkipReason);
+
+  test(
+    'backend unavailable -> backend client surfaces unreachable failure',
+    () async {
+      final accessToken = await authHelper.signIn(config);
+      final unreachableConfig = config.copyWith(
+        backendApiBaseUrl: config.unreachableBackendApiBaseUrl(),
+      );
+      final client = HttpWeaveApiClient(httpClient: httpClient);
+
+      Object? error;
+      try {
+        await client.fetchWorkspaceCapabilities(
+          baseUrl: unreachableConfig.backendApiBaseUrl,
+          accessToken: accessToken,
+        );
+      } catch (thrown) {
+        error = thrown;
+      }
+
+      expect(error, isA<AppFailure>());
+      expect(
+        (error as AppFailure).message,
+        contains('Unable to reach the Weave backend right now.'),
+      );
+    },
+    skip: liveSkipReason,
+  );
+}
+
+ProviderContainer _createAppContainer({
+  required TestConfig config,
+  required AuthSession session,
+}) {
+  return ProviderContainer.test(
+    overrides: [
+      serverConfigurationRepositoryProvider.overrideWithValue(
+        _MemoryServerConfigurationRepository(_serverConfiguration(config)),
+      ),
+      authSessionRepositoryProvider.overrideWithValue(
+        _SessionAuthRepository(session),
+      ),
+      chatRepositoryProvider.overrideWithValue(_EmptyChatRepository()),
+      chatSecurityRepositoryProvider.overrideWithValue(
+        _SignedOutChatSecurityRepository(),
+      ),
+      filesRepositoryProvider.overrideWithValue(_DisconnectedFilesRepository()),
+    ],
+  );
+}
+
+ServerConfiguration _serverConfiguration(TestConfig config) {
+  return ServerConfiguration(
+    providerType: OidcProviderType.keycloak,
+    oidcIssuerUrl: config.issuerUrl,
+    oidcClientRegistration: OidcClientRegistration.manual(
+      clientId: config.clientId,
+    ),
+    serviceEndpoints: ServiceEndpoints(
+      matrixHomeserverUrl: config.matrixHomeserverUrl,
+      nextcloudBaseUrl: config.nextcloudBaseUrl,
+      backendApiBaseUrl: config.backendApiBaseUrl,
+    ),
+  );
+}
+
+Map<String, dynamic> _decodeObject(String body) {
+  final decoded = jsonDecode(body);
+  if (decoded is! Map<String, dynamic>) {
+    throw StateError('Expected a JSON object response.');
+  }
+
+  return decoded;
+}
+
+class _MemoryServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _MemoryServerConfigurationRepository(this.configuration);
+
+  ServerConfiguration? configuration;
+
+  @override
+  Future<void> clearConfiguration() async {
+    configuration = null;
+  }
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    this.configuration = configuration;
+  }
+}
+
+class _SessionAuthRepository implements AuthSessionRepository {
+  _SessionAuthRepository(this._session);
+
+  AuthSession? _session;
+
+  @override
+  Future<void> clearLocalSession() async {
+    _session = null;
+  }
+
+  @override
+  Future<AuthState> restoreSession(AuthConfiguration configuration) async {
+    final session = _session;
+    if (session == null || !session.matches(configuration)) {
+      return const AuthState.signedOut();
+    }
+
+    return AuthState.authenticated(session);
+  }
+
+  @override
+  Future<AuthState> signIn(AuthConfiguration configuration) async {
+    final session = _session;
+    if (session == null || !session.matches(configuration)) {
+      return const AuthState.signedOut();
+    }
+
+    return AuthState.authenticated(session);
+  }
+
+  @override
+  Future<AuthState> refreshSession(AuthConfiguration configuration) async {
+    final session = _session;
+    if (session == null || !session.matches(configuration)) {
+      return const AuthState.signedOut();
+    }
+
+    return AuthState.authenticated(session);
+  }
+
+  @override
+  Future<void> signOut(AuthConfiguration configuration) async {
+    _session = null;
+  }
+}
+
+class _EmptyChatRepository implements ChatRepository {
+  @override
+  Future<void> clearSession() async {}
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<List<ChatConversation>> loadConversations() async =>
+      const <ChatConversation>[];
+
+  @override
+  Future<ChatRoomTimeline> loadRoomTimeline(String roomId) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> markRoomRead(String roomId) async {}
+
+  @override
+  Future<void> sendMessage({
+    required String roomId,
+    required String message,
+  }) async {}
+
+  @override
+  Future<void> signOut() async {}
+}
+
+class _SignedOutChatSecurityRepository implements ChatSecurityRepository {
+  @override
+  Future<void> acceptVerification() async {}
+
+  @override
+  Future<String> bootstrapSecurity({String? passphrase}) async =>
+      'unused-recovery-key';
+
+  @override
+  Future<void> cancelVerification() async {}
+
+  @override
+  Future<void> confirmSas({required bool matches}) async {}
+
+  @override
+  Future<void> dismissVerificationResult() async {}
+
+  @override
+  Future<ChatSecurityState> loadSecurityState({bool refresh = false}) async {
+    return const ChatSecurityState(
+      isMatrixSignedIn: false,
+      bootstrapState: ChatSecurityBootstrapState.signedOut,
+      accountVerificationState: ChatAccountVerificationState.unavailable,
+      deviceVerificationState: ChatDeviceVerificationState.unavailable,
+      keyBackupState: ChatKeyBackupState.unavailable,
+      roomEncryptionReadiness: ChatRoomEncryptionReadiness.unavailable,
+      secretStorageReady: false,
+      crossSigningReady: false,
+      hasEncryptedConversations: false,
+      verificationSession: ChatVerificationSession.none(),
+    );
+  }
+
+  @override
+  Future<void> restoreSecurity({
+    required String recoveryKeyOrPassphrase,
+  }) async {}
+
+  @override
+  Future<void> startSasVerification() async {}
+
+  @override
+  Future<void> startVerification() async {}
+
+  @override
+  Future<void> unlockVerification({
+    required String recoveryKeyOrPassphrase,
+  }) async {}
+
+  @override
+  Stream<ChatVerificationSession> watchVerificationUpdates() =>
+      const Stream<ChatVerificationSession>.empty();
+}
+
+class _DisconnectedFilesRepository implements FilesRepository {
+  @override
+  Future<FilesConnectionState> connect() async =>
+      const FilesConnectionState.disconnected();
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<DirectoryListing> listDirectory(String path) async =>
+      DirectoryListing(path: path, entries: const []);
+
+  @override
+  Future<FilesConnectionState> restoreConnection() async =>
+      const FilesConnectionState.disconnected();
+
+  @override
+  Future<void> uploadFile(
+    String directoryPath,
+    FileUploadRequest request, {
+    FileUploadProgressCallback? onProgress,
+  }) async {}
+}

--- a/test/live_stack_contract_test.dart
+++ b/test/live_stack_contract_test.dart
@@ -197,8 +197,8 @@ void main() {
 
     expect(response.statusCode, 200, reason: response.body);
     final payload = _decodeObject(response.body);
-    expect(payload['sub'], isA<String>());
-    expect((payload['sub'] as String).trim(), isNotEmpty);
+    expect(payload['userId'], isA<String>());
+    expect((payload['userId'] as String).trim(), isNotEmpty);
     expect(payload['email'], isA<String>());
     expect((payload['email'] as String).trim(), isNotEmpty);
   }, skip: liveSkipReason);


### PR DESCRIPTION
## Summary
- split dummy/offline live-stack contract checks from real live-stack auth/E2E
- make `dummy/dummy` credentials exercise offline contract checks without attempting network sign-in
- make `make integration-test` stop after offline contract checks when dummy credentials are used
- align live contract endpoints with backend facade routes (`/api/me`, `/api/workspace/capabilities`)

## Why
Dummy values are useful for PR-level contract safety, but they must not produce fake live-stack green or fail by trying real auth against local DNS. Real credentials remain required for real Auth/Matrix/Files/Calendar live-stack validation.

## Validation
- `flutter test test/live_stack_contract_test.dart --dart-define=WEAVE_TEST_USERNAME=dummy --dart-define=WEAVE_TEST_PASSWORD=dummy`
- `WEAVE_TEST_USERNAME=dummy WEAVE_TEST_PASSWORD=dummy make integration-test`
- `flutter analyze --fatal-infos test/live_stack_contract_test.dart integration_test/helpers/test_config.dart lib/integrations/weave_api/data/services/weave_api_uri_builder.dart`
