### PR TITLE
ci: support OrbStack Docker socket for live E2E

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -117,6 +117,10 @@ jobs:
           GHCR_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          if [ -z "${DOCKER_HOST:-}" ] && [ -S "$HOME/.orbstack/run/docker.sock" ]; then
+            echo "DOCKER_HOST=unix://$HOME/.orbstack/run/docker.sock" >> "$GITHUB_ENV"
+            export DOCKER_HOST="unix://$HOME/.orbstack/run/docker.sock"
+          fi
           export DOCKER_CONFIG="$RUNNER_TEMP/docker-config"
           mkdir -p "$DOCKER_CONFIG"
           chmod 700 "$DOCKER_CONFIG"


### PR DESCRIPTION
## Summary
- Detect the self-hosted macOS runner's OrbStack Docker socket when `DOCKER_HOST` is unset.
- Persist that socket through `GITHUB_ENV` so later Docker/Buildx/Terraform steps use the same engine.

## Why
The manual Live Stack E2E run on `main` failed before stack bootstrap because the runner defaulted to `unix:///var/run/docker.sock`, while this Mac mini uses OrbStack at `$HOME/.orbstack/run/docker.sock`.

## Validation
- YAML parses successfully with Python `yaml.safe_load`.
- Failure evidence: Live Stack E2E run `25792899540` failed at `docker --config "$DOCKER_CONFIG" info` with missing `/var/run/docker.sock`.
