### PR TITLE
ci: align live e2e reset confirmation

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -85,7 +85,7 @@ jobs:
       TF_VAR_backend_host_port: '48084'
       WEAVE_RUNNER_HYGIENE: 'true'
       WEAVE_REMOVE_VOLUMES: 'true'
-      WEAVE_CONFIRM_REMOVE_VOLUMES: weave-delete-local-data
+      WEAVE_CONFIRM_DESTRUCTIVE_RESET: weave
       WEAVE_INTEGRATION_TEST_DEVICE: macos
 
     defaults:


### PR DESCRIPTION
## Summary
- update the manual Live Stack E2E workflow to use the new destructive reset confirmation introduced by weave-infra#40
- avoid the old rejected WEAVE_CONFIRM_REMOVE_VOLUMES token so post-merge live E2E can clean volumes intentionally

## Validation
- `git diff --check`

## Context
weave-infra main now requires `WEAVE_CONFIRM_DESTRUCTIVE_RESET=weave` for local volume deletion. Without this, the next Live Stack E2E against main/main/main would fail during teardown before proving the release gate.