### PR TITLE
fix(ci): avoid interactive CA trust in live E2E

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -204,8 +204,21 @@ jobs:
 
       - name: Trust local Weave CA for this runner user
         run: |
+          set -euo pipefail
           CA_FILE="$GITHUB_WORKSPACE/weave-infra/weave-workspace/01-infrastructure/.generated/caddy/certs/weave-local-ca.pem"
-          security add-trusted-cert -d -r trustRoot -k "$HOME/Library/Keychains/login.keychain-db" "$CA_FILE" || true
+          if [ ! -s "$CA_FILE" ]; then
+            echo "::error::Weave local CA certificate not found at $CA_FILE"
+            exit 1
+          fi
+          # The login keychain can prompt/hang on the self-hosted macOS runner. Use
+          # passwordless sudo and the system keychain only; never wait for UI input.
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            if ! sudo -n security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CA_FILE"; then
+              echo "::warning::Could not add Weave local CA to the system keychain; integration tests may fail TLS validation."
+            fi
+          else
+            echo "::warning::Passwordless sudo is unavailable; skipping non-interactive Weave local CA trust."
+          fi
 
       - name: Install Flutter dependencies
         working-directory: weave


### PR DESCRIPTION
## Summary
- avoid login keychain prompts in Live Stack E2E CA trust setup
- use non-interactive passwordless sudo with the macOS system keychain
- fail early if the generated Weave local CA certificate is missing

## Verification
- python workflow sanity check: confirms system keychain path and no login.keychain-db usage
- git diff --check