### PR TITLE
test(files): harden backend upload flow

### DIFF
--- a/lib/features/files/data/repositories/backend_files_repository.dart
+++ b/lib/features/files/data/repositories/backend_files_repository.dart
@@ -267,6 +267,13 @@ class BackendFilesRepository
         cause: response.statusCode,
       );
     }
+    if (response.statusCode == 413 || response.statusCode == 507) {
+      throw FilesFailure.storage(
+        message ??
+            'There is not enough storage available to complete this file operation.',
+        cause: response.statusCode,
+      );
+    }
     if (response.statusCode == 503) {
       throw FilesFailure.configuration(
         message ?? 'The Weave backend files facade is unavailable.',

--- a/test/features/files/files_screen_test.dart
+++ b/test/features/files/files_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/file_entry.dart';
 import 'package:weave/features/files/domain/entities/file_upload_request.dart';
 import 'package:weave/features/files/domain/entities/files_connection_state.dart';
+import 'package:weave/features/files/domain/entities/files_failure.dart';
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
 import 'package:weave/features/files/domain/services/files_import_picker.dart';
 import 'package:weave/features/files/presentation/files_screen.dart';
@@ -393,6 +394,118 @@ void main() {
         find.bySemanticsLabel('Uploaded brief.txt.'),
         findsAtLeastNWidgets(1),
       );
+    });
+
+    testWidgets('cancelled file picker leaves no upload status behind', (
+      tester,
+    ) async {
+      final repository = _FakeFilesRepository(
+        connectionState: FilesConnectionState.connected(
+          baseUrl: Uri.parse('https://files.home.internal'),
+          accountLabel: 'alice',
+        ),
+        listings: const {
+          '/': DirectoryListing(
+            path: '/',
+            entries: [
+              FileEntry(
+                id: 'file-1',
+                name: 'existing.txt',
+                path: '/existing.txt',
+                isDirectory: false,
+                sizeInBytes: 8,
+              ),
+            ],
+          ),
+        },
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          const FilesScreen(),
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            filesImportPickerProvider.overrideWithValue(
+              _FakeFilesImportPicker(null),
+            ),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Upload'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('existing.txt'), findsOneWidget);
+      expect(find.text('Upload failed.'), findsNothing);
+      expect(find.text('Choose a file to upload…'), findsNothing);
+      expect(repository.requestedPaths, ['/']);
+    });
+
+    testWidgets('shows a friendly accessible upload failure', (tester) async {
+      final repository = _FakeFilesRepository(
+        connectionState: FilesConnectionState.connected(
+          baseUrl: Uri.parse('https://files.home.internal'),
+          accountLabel: 'alice',
+        ),
+        listings: const {
+          '/': DirectoryListing(
+            path: '/',
+            entries: [
+              FileEntry(
+                id: 'file-1',
+                name: 'existing.txt',
+                path: '/existing.txt',
+                isDirectory: false,
+                sizeInBytes: 8,
+              ),
+            ],
+          ),
+        },
+        uploadFileHandler: (_, _, _) async {
+          throw const FilesFailure.storage(
+            'There is not enough storage available to upload this file.',
+          );
+        },
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          const FilesScreen(),
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            filesImportPickerProvider.overrideWithValue(
+              _FakeFilesImportPicker(
+                FileUploadRequest(
+                  fileName: 'brief.txt',
+                  sizeInBytes: 4,
+                  byteStream: Stream<List<int>>.fromIterable(const [
+                    [1, 2, 3, 4],
+                  ]),
+                ),
+              ),
+            ),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Upload'));
+      await tester.pumpAndSettle();
+
+      const message =
+          'There is not enough storage available to upload this file.';
+      expect(find.text(message), findsOneWidget);
+      expect(find.bySemanticsLabel(message), findsAtLeastNWidgets(1));
+      expect(repository.requestedPaths, ['/']);
     });
 
     testWidgets('creates a folder and refreshes the current directory', (

--- a/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
+++ b/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
@@ -240,6 +240,52 @@ void main() {
     });
 
     test(
+      'maps backend quota/storage upload failures to friendly files errors',
+      () async {
+        final client = _RecordingStreamClient((request) async {
+          await request.finalize().drain<void>();
+          return http.StreamedResponse(
+            Stream<List<int>>.value(
+              utf8.encode(
+                jsonEncode({
+                  'message':
+                      'There is not enough storage available to upload this file.',
+                }),
+              ),
+            ),
+            507,
+          );
+        });
+
+        await expectLater(
+          repository(client).uploadFile(
+            '/',
+            FileUploadRequest(
+              fileName: 'brief.txt',
+              sizeInBytes: 4,
+              byteStream: Stream<List<int>>.fromIterable(const [
+                [1, 2, 3, 4],
+              ]),
+            ),
+          ),
+          throwsA(
+            isA<FilesFailure>()
+                .having(
+                  (failure) => failure.type,
+                  'type',
+                  FilesFailureType.storage,
+                )
+                .having(
+                  (failure) => failure.message,
+                  'message',
+                  'There is not enough storage available to upload this file.',
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
       'maps backend auth rejection without falling back to direct Nextcloud',
       () async {
         final client = MockClient(

--- a/test/features/files/presentation/providers/files_provider_test.dart
+++ b/test/features/files/presentation/providers/files_provider_test.dart
@@ -339,6 +339,136 @@ void main() {
       },
     );
 
+    test(
+      'cancelled upload picker leaves the current directory unchanged',
+      () async {
+        var uploadAttempts = 0;
+        var listCalls = 0;
+        final repository = _FakeFilesRepository(
+          restoreConnectionHandler: () async => FilesConnectionState.connected(
+            baseUrl: Uri.parse('https://files.home.internal'),
+            accountLabel: 'alice',
+          ),
+          connectHandler: () async => throw UnimplementedError(),
+          disconnectHandler: () async {},
+          listDirectoryHandler: (path) async {
+            listCalls += 1;
+            return const DirectoryListing(
+              path: '/',
+              entries: [
+                FileEntry(
+                  id: 'existing-1',
+                  name: 'existing.txt',
+                  path: '/existing.txt',
+                  isDirectory: false,
+                  sizeInBytes: 8,
+                ),
+              ],
+            );
+          },
+          uploadFileHandler: (_, _, _) async {
+            uploadAttempts += 1;
+          },
+        );
+        final container = ProviderContainer(
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            filesImportPickerProvider.overrideWithValue(
+              _FakeFilesImportPicker(null),
+            ),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final initialState = await container.read(filesProvider.future);
+        await container.read(filesProvider.notifier).pickAndUpload();
+        final state = container.read(filesProvider).requireValue;
+
+        expect(uploadAttempts, 0);
+        expect(listCalls, 1);
+        expect(state.uploadStatus.phase, FilesUploadPhase.idle);
+        expect(state.directoryListing, same(initialState.directoryListing));
+        expect(state.directoryListing?.entries.single.name, 'existing.txt');
+        expect(state.directoryFailure, isNull);
+        expect(state.isBusy, isFalse);
+      },
+    );
+
+    test(
+      'failed upload keeps the directory and shows a friendly failure',
+      () async {
+        var listCalls = 0;
+        final repository = _FakeFilesRepository(
+          restoreConnectionHandler: () async => FilesConnectionState.connected(
+            baseUrl: Uri.parse('https://files.home.internal'),
+            accountLabel: 'alice',
+          ),
+          connectHandler: () async => throw UnimplementedError(),
+          disconnectHandler: () async {},
+          listDirectoryHandler: (path) async {
+            listCalls += 1;
+            return const DirectoryListing(
+              path: '/',
+              entries: [
+                FileEntry(
+                  id: 'existing-1',
+                  name: 'existing.txt',
+                  path: '/existing.txt',
+                  isDirectory: false,
+                  sizeInBytes: 8,
+                ),
+              ],
+            );
+          },
+          uploadFileHandler: (_, _, _) async {
+            throw const FilesFailure.storage(
+              'There is not enough storage available to upload this file.',
+            );
+          },
+        );
+        final container = ProviderContainer(
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            filesImportPickerProvider.overrideWithValue(
+              _FakeFilesImportPicker(
+                FileUploadRequest(
+                  fileName: 'brief.txt',
+                  sizeInBytes: 4,
+                  byteStream: Stream<List<int>>.fromIterable(const [
+                    [1, 2, 3, 4],
+                  ]),
+                ),
+              ),
+            ),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(filesProvider.future);
+        await container.read(filesProvider.notifier).pickAndUpload();
+        final state = container.read(filesProvider).requireValue;
+
+        expect(listCalls, 1);
+        expect(state.uploadStatus.phase, FilesUploadPhase.failed);
+        expect(state.uploadStatus.fileName, 'brief.txt');
+        expect(
+          state.uploadStatus.failure?.message,
+          'There is not enough storage available to upload this file.',
+        );
+        expect(state.directoryListing?.entries.single.name, 'existing.txt');
+        expect(state.directoryFailure, isNull);
+        expect(state.isBusy, isFalse);
+      },
+    );
+
     test('creates a folder and refreshes the current directory', () async {
       var createdParentPath = '';
       var createdName = '';


### PR DESCRIPTION
## Summary
- harden the backend files upload facade path by mapping backend quota/storage upload failures to friendly `FilesFailure.storage` errors
- add provider coverage for picker cancellation no-op, upload failure state, and preserving the current listing
- add widget coverage for accessible cancellation/failure feedback alongside the existing success/refresh upload tests

## Spec alignment
- `weave` remains on the backend product files API via app/server config; no direct Nextcloud/WebDAV credentials or HTML parsing are introduced.
- Aligns with `specs/06-api-routing-and-backend-contract.md`, `specs/07-nextcloud-files-calendar-contract.md`, and `specs/13-mvp-decisions-and-roadmap.md`.

## Validation
- `flutter pub get`
- `flutter test test/features/files/presentation/providers/files_provider_test.dart test/features/files/files_screen_test.dart test/features/files/presentation/providers/files_backend_facade_provider_test.dart`
- `flutter analyze --fatal-infos`

Live E2E intentionally not run per task constraints.

Closes #83
