### PR TITLE
fix(files): improve upload feedback semantics

### DIFF
--- a/lib/features/files/presentation/files_screen.dart
+++ b/lib/features/files/presentation/files_screen.dart
@@ -401,7 +401,8 @@ class _UploadStatusCard extends StatelessWidget {
       _ => Icons.cloud_upload_outlined,
     };
     final semanticLabel = switch (uploadStatus.phase) {
-      FilesUploadPhase.uploading when fileName != null =>
+      FilesUploadPhase.uploading
+          when fileName != null && progressFraction != null =>
         l10n.filesUploadProgressSemantic(fileName, percent),
       _ => message,
     };

--- a/test/features/files/files_screen_test.dart
+++ b/test/features/files/files_screen_test.dart
@@ -431,6 +431,135 @@ void main() {
       );
     });
 
+    testWidgets('shows accessible in-progress upload feedback', (tester) async {
+      final uploadCompleter = Completer<void>();
+      var uploadComplete = false;
+      final repository = _FakeFilesRepository(
+        connectionState: FilesConnectionState.connected(
+          baseUrl: Uri.parse('https://files.home.internal'),
+          accountLabel: 'alice',
+        ),
+        listDirectoryHandler: (path) async {
+          return DirectoryListing(
+            path: '/',
+            entries: uploadComplete
+                ? const [
+                    FileEntry(
+                      id: 'file-1',
+                      name: 'brief.txt',
+                      path: '/brief.txt',
+                      isDirectory: false,
+                      sizeInBytes: 4,
+                    ),
+                  ]
+                : const [],
+          );
+        },
+        uploadFileHandler: (_, request, onProgress) async {
+          onProgress?.call(2, request.sizeInBytes);
+          await uploadCompleter.future;
+          uploadComplete = true;
+        },
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          const FilesScreen(),
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            filesImportPickerProvider.overrideWithValue(
+              _FakeFilesImportPicker(
+                FileUploadRequest(
+                  fileName: 'brief.txt',
+                  sizeInBytes: 4,
+                  byteStream: Stream<List<int>>.fromIterable(const [
+                    [1, 2],
+                    [3, 4],
+                  ]),
+                ),
+              ),
+            ),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Upload'));
+      await tester.pump();
+
+      expect(find.text('Uploading brief.txt: 50%'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Upload progress for brief.txt: 50 percent'),
+        findsOneWidget,
+      );
+
+      uploadCompleter.complete();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Uploaded brief.txt.'), findsOneWidget);
+      expect(find.text('brief.txt'), findsOneWidget);
+    });
+
+    testWidgets(
+      'announces indeterminate upload progress without a misleading percent',
+      (tester) async {
+        final uploadCompleter = Completer<void>();
+        final repository = _FakeFilesRepository(
+          connectionState: FilesConnectionState.connected(
+            baseUrl: Uri.parse('https://files.home.internal'),
+            accountLabel: 'alice',
+          ),
+          uploadFileHandler: (_, _, _) async {
+            await uploadCompleter.future;
+          },
+        );
+
+        await tester.pumpWidget(
+          createTestApp(
+            const FilesScreen(),
+            overrides: [
+              filesRepositoryProvider.overrideWithValue(repository),
+              filesImportPickerProvider.overrideWithValue(
+                _FakeFilesImportPicker(
+                  const FileUploadRequest(
+                    fileName: 'brief.txt',
+                    sizeInBytes: 0,
+                    byteStream: Stream<List<int>>.empty(),
+                  ),
+                ),
+              ),
+              serverConfigurationRepositoryProvider.overrideWith(
+                (ref) => _FakeServerConfigurationRepository(
+                  buildTestConfiguration(),
+                ),
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Upload'));
+        await tester.pump();
+
+        expect(find.text('Uploading brief.txt…'), findsOneWidget);
+        expect(
+          find.bySemanticsLabel('Upload progress for brief.txt: 0 percent'),
+          findsNothing,
+        );
+        expect(
+          find.bySemanticsLabel('Uploading brief.txt…'),
+          findsAtLeastNWidgets(1),
+        );
+
+        uploadCompleter.complete();
+        await tester.pumpAndSettle();
+      },
+    );
+
     testWidgets('cancelled file picker leaves no upload status behind', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

Improves the Files upload feedback path for issue #58 by making in-progress upload feedback explicitly covered at the widget layer and by preventing indeterminate uploads from being announced as a misleading `0%` to screen reader users.

## Changes

- Keep determinate upload progress announced with a percentage when total size is known.
- Announce indeterminate uploads with the same clear in-progress message shown visually instead of a fake percentage.
- Add Files screen tests for visible/semantic in-progress upload feedback, completion feedback, and indeterminate upload semantics.

## Testing

- `flutter pub get`
- `dart format --output=none --set-exit-if-changed lib/features/files/presentation/files_screen.dart test/features/files/files_screen_test.dart`
- `flutter analyze --fatal-infos`
- `flutter test test/features/files/files_screen_test.dart test/features/files/presentation/providers/files_provider_test.dart test/features/files/presentation/providers/files_backend_facade_provider_test.dart`

Fixes masssi164/weave#58