### PR TITLE
feat(files): harden native file picker imports

### DIFF
--- a/lib/features/files/data/services/file_picker_files_import_picker.dart
+++ b/lib/features/files/data/services/file_picker_files_import_picker.dart
@@ -2,20 +2,58 @@ import 'dart:async';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
+import 'package:weave/features/files/data/services/file_upload_request_from_path_stub.dart'
+    if (dart.library.io) 'package:weave/features/files/data/services/file_upload_request_from_path_io.dart';
 import 'package:weave/features/files/domain/entities/file_upload_request.dart';
 import 'package:weave/features/files/domain/entities/files_failure.dart';
 import 'package:weave/features/files/domain/services/files_import_picker.dart';
 
+typedef FilePickerPickFiles =
+    Future<FilePickerResult?> Function({
+      String? dialogTitle,
+      bool allowMultiple,
+      bool withData,
+      bool withReadStream,
+    });
+
 class FilePickerFilesImportPicker implements FilesImportPicker {
-  const FilePickerFilesImportPicker();
+  FilePickerFilesImportPicker({FilePickerPickFiles? pickFiles})
+    : _pickFiles = pickFiles ?? _defaultPickFiles;
+
+  final FilePickerPickFiles _pickFiles;
+
+  static Future<FilePickerResult?> _defaultPickFiles({
+    String? dialogTitle,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+  }) {
+    return FilePicker.pickFiles(
+      dialogTitle: dialogTitle,
+      allowMultiple: allowMultiple,
+      withData: withData,
+      withReadStream: withReadStream,
+    );
+  }
 
   @override
   Future<FileUploadRequest?> pickFile() async {
-    final result = await FilePicker.pickFiles(
-      allowMultiple: false,
-      withData: false,
-      withReadStream: true,
-    );
+    final FilePickerResult? result;
+    try {
+      result = await _pickFiles(
+        dialogTitle: 'Choose a file to upload',
+        allowMultiple: false,
+        withData: false,
+        withReadStream: true,
+      );
+    } on PlatformException catch (error) {
+      if (_isPickerCancellation(error)) {
+        return null;
+      }
+      throw _mapPlatformException(error);
+    }
+
     final file = result?.files.singleOrNull;
     if (file == null) {
       return null;
@@ -39,12 +77,72 @@ class FilePickerFilesImportPicker implements FilesImportPicker {
       );
     }
 
-    throw const FilesFailure.unsupportedPlatform(
-      'This device did not provide a readable file for upload.',
+    final pathRequest = fileUploadRequestFromPath(
+      fileName: file.name,
+      sizeInBytes: file.size,
+      path: file.path,
+    );
+    if (pathRequest != null) {
+      return pathRequest;
+    }
+
+    throw FilesFailure.unsupportedPlatform(
+      'This device selected ${file.name}, but did not provide a readable file. '
+      'Try choosing a local file or checking platform file permissions.',
+    );
+  }
+
+  bool _isPickerCancellation(PlatformException error) {
+    final code = error.code.toLowerCase();
+    final message = error.message?.toLowerCase() ?? '';
+    return code.contains('cancel') ||
+        code.contains('abort') ||
+        message.contains('cancel') ||
+        message.contains('abort');
+  }
+
+  FilesFailure _mapPlatformException(PlatformException error) {
+    final code = error.code.toLowerCase();
+    final message = error.message?.toLowerCase() ?? '';
+    final details = '${error.code} ${error.message ?? ''}'.trim();
+
+    if (code.contains('permission') ||
+        code.contains('denied') ||
+        code.contains('security') ||
+        message.contains('permission') ||
+        message.contains('denied') ||
+        message.contains('security')) {
+      return FilesFailure.storage(
+        'Weave could not access the selected file. Check file or document picker permissions and try again.',
+        cause: error,
+      );
+    }
+
+    if (code.contains('entitlement') || message.contains('entitlement')) {
+      return FilesFailure.configuration(
+        'This app build is missing file access permissions for the native picker.',
+        cause: error,
+      );
+    }
+
+    if (code.contains('unsupported') ||
+        code.contains('unavailable') ||
+        code.contains('missing_plugin')) {
+      return FilesFailure.unsupportedPlatform(
+        'Native file picking is unavailable on this platform.',
+        cause: error,
+      );
+    }
+
+    return FilesFailure.unknown(
+      details.isEmpty
+          ? 'Unable to choose a file for upload. Try again or pick a local file you can access.'
+          : 'Unable to choose a file for upload ($details).',
+      cause: error,
     );
   }
 }
 
 final filesImportPickerProvider = Provider<FilesImportPicker>((ref) {
-  return const FilePickerFilesImportPicker();
+  return FilePickerFilesImportPicker();
 });

--- a/lib/features/files/data/services/file_upload_request_from_path_io.dart
+++ b/lib/features/files/data/services/file_upload_request_from_path_io.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+import 'package:weave/features/files/domain/entities/file_upload_request.dart';
+
+FileUploadRequest? fileUploadRequestFromPath({
+  required String fileName,
+  required int sizeInBytes,
+  required String? path,
+}) {
+  if (path == null || path.isEmpty) {
+    return null;
+  }
+
+  final file = File(path);
+  return FileUploadRequest(
+    fileName: fileName,
+    sizeInBytes: sizeInBytes,
+    byteStream: file.openRead(),
+  );
+}

--- a/lib/features/files/data/services/file_upload_request_from_path_stub.dart
+++ b/lib/features/files/data/services/file_upload_request_from_path_stub.dart
@@ -1,0 +1,9 @@
+import 'package:weave/features/files/domain/entities/file_upload_request.dart';
+
+FileUploadRequest? fileUploadRequestFromPath({
+  required String fileName,
+  required int sizeInBytes,
+  required String? path,
+}) {
+  return null;
+}

--- a/test/features/files/data/services/file_picker_files_import_picker_test.dart
+++ b/test/features/files/data/services/file_picker_files_import_picker_test.dart
@@ -1,0 +1,343 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/files/data/services/file_picker_files_import_picker.dart';
+import 'package:weave/features/files/domain/entities/files_failure.dart';
+
+void main() {
+  group('FilePickerFilesImportPicker', () {
+    test(
+      'opens a single native picker and treats cancellation as no-op',
+      () async {
+        final calls =
+            <
+              ({
+                String? dialogTitle,
+                bool allowMultiple,
+                bool withData,
+                bool withReadStream,
+              })
+            >[];
+        final picker = FilePickerFilesImportPicker(
+          pickFiles:
+              ({
+                String? dialogTitle,
+                bool allowMultiple = true,
+                bool withData = true,
+                bool withReadStream = false,
+              }) async {
+                calls.add((
+                  dialogTitle: dialogTitle,
+                  allowMultiple: allowMultiple,
+                  withData: withData,
+                  withReadStream: withReadStream,
+                ));
+                return null;
+              },
+        );
+
+        final request = await picker.pickFile();
+
+        expect(request, isNull);
+        expect(calls, hasLength(1));
+        expect(calls.single.dialogTitle, 'Choose a file to upload');
+        expect(calls.single.allowMultiple, isFalse);
+        expect(calls.single.withData, isFalse);
+        expect(calls.single.withReadStream, isTrue);
+      },
+    );
+
+    test('uses the picked file read stream for upload', () async {
+      final stream = Stream<List<int>>.fromIterable(const [
+        [1, 2],
+        [3, 4],
+      ]);
+      final picker = FilePickerFilesImportPicker(
+        pickFiles:
+            ({
+              String? dialogTitle,
+              bool allowMultiple = false,
+              bool withData = false,
+              bool withReadStream = false,
+            }) async => FilePickerResult([
+              PlatformFile(name: 'brief.txt', size: 4, readStream: stream),
+            ]),
+      );
+
+      final request = await picker.pickFile();
+
+      expect(request?.fileName, 'brief.txt');
+      expect(request?.sizeInBytes, 4);
+      expect(await request?.byteStream.expand((chunk) => chunk).toList(), [
+        1,
+        2,
+        3,
+        4,
+      ]);
+    });
+
+    test(
+      'falls back to picked file bytes when a stream is unavailable',
+      () async {
+        final picker = FilePickerFilesImportPicker(
+          pickFiles:
+              ({
+                String? dialogTitle,
+                bool allowMultiple = false,
+                bool withData = false,
+                bool withReadStream = false,
+              }) async => FilePickerResult([
+                PlatformFile(
+                  name: 'brief.txt',
+                  size: 4,
+                  bytes: Uint8List.fromList([1, 2, 3, 4]),
+                ),
+              ]),
+        );
+
+        final request = await picker.pickFile();
+
+        expect(request?.fileName, 'brief.txt');
+        expect(request?.sizeInBytes, 4);
+        expect(await request?.byteStream.expand((chunk) => chunk).toList(), [
+          1,
+          2,
+          3,
+          4,
+        ]);
+      },
+    );
+
+    test(
+      'falls back to a native path on desktop-style picker results',
+      () async {
+        final tempDirectory = await Directory.systemTemp.createTemp(
+          'weave-file-picker-test-',
+        );
+        addTearDown(() => tempDirectory.delete(recursive: true));
+        final file = File('${tempDirectory.path}/brief.txt');
+        await file.writeAsBytes([1, 2, 3, 4]);
+        final picker = FilePickerFilesImportPicker(
+          pickFiles:
+              ({
+                String? dialogTitle,
+                bool allowMultiple = false,
+                bool withData = false,
+                bool withReadStream = false,
+              }) async => FilePickerResult([
+                PlatformFile(name: 'brief.txt', size: 4, path: file.path),
+              ]),
+        );
+
+        final request = await picker.pickFile();
+
+        expect(request?.fileName, 'brief.txt');
+        expect(request?.sizeInBytes, 4);
+        expect(await request?.byteStream.expand((chunk) => chunk).toList(), [
+          1,
+          2,
+          3,
+          4,
+        ]);
+      },
+    );
+
+    test('treats platform cancellation exceptions as no-op', () async {
+      final picker = FilePickerFilesImportPicker(
+        pickFiles:
+            ({
+              String? dialogTitle,
+              bool allowMultiple = false,
+              bool withData = false,
+              bool withReadStream = false,
+            }) async {
+              throw PlatformException(code: 'CANCELLED');
+            },
+      );
+
+      await expectLater(picker.pickFile(), completion(isNull));
+    });
+
+    test(
+      'maps platform permission failures to a friendly files failure',
+      () async {
+        final picker = FilePickerFilesImportPicker(
+          pickFiles:
+              ({
+                String? dialogTitle,
+                bool allowMultiple = false,
+                bool withData = false,
+                bool withReadStream = false,
+              }) async {
+                throw PlatformException(
+                  code: 'permission_denied',
+                  message: 'Storage permission denied',
+                );
+              },
+        );
+
+        await expectLater(
+          picker.pickFile(),
+          throwsA(
+            isA<FilesFailure>()
+                .having(
+                  (failure) => failure.type,
+                  'type',
+                  FilesFailureType.storage,
+                )
+                .having(
+                  (failure) => failure.message,
+                  'message',
+                  'Weave could not access the selected file. Check file or document picker permissions and try again.',
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'maps native picker configuration failures to a friendly files failure',
+      () async {
+        final picker = FilePickerFilesImportPicker(
+          pickFiles:
+              ({
+                String? dialogTitle,
+                bool allowMultiple = false,
+                bool withData = false,
+                bool withReadStream = false,
+              }) async {
+                throw PlatformException(
+                  code: 'missing_entitlement',
+                  message: 'Document picker entitlement is missing',
+                );
+              },
+        );
+
+        await expectLater(
+          picker.pickFile(),
+          throwsA(
+            isA<FilesFailure>()
+                .having(
+                  (failure) => failure.type,
+                  'type',
+                  FilesFailureType.configuration,
+                )
+                .having(
+                  (failure) => failure.message,
+                  'message',
+                  'This app build is missing file access permissions for the native picker.',
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'maps unavailable native picker failures to a friendly files failure',
+      () async {
+        final picker = FilePickerFilesImportPicker(
+          pickFiles:
+              ({
+                String? dialogTitle,
+                bool allowMultiple = false,
+                bool withData = false,
+                bool withReadStream = false,
+              }) async {
+                throw PlatformException(code: 'missing_plugin');
+              },
+        );
+
+        await expectLater(
+          picker.pickFile(),
+          throwsA(
+            isA<FilesFailure>()
+                .having(
+                  (failure) => failure.type,
+                  'type',
+                  FilesFailureType.unsupportedPlatform,
+                )
+                .having(
+                  (failure) => failure.message,
+                  'message',
+                  'Native file picking is unavailable on this platform.',
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'maps unknown native picker failures to a retryable friendly files failure',
+      () async {
+        final picker = FilePickerFilesImportPicker(
+          pickFiles:
+              ({
+                String? dialogTitle,
+                bool allowMultiple = false,
+                bool withData = false,
+                bool withReadStream = false,
+              }) async {
+                throw PlatformException(
+                  code: 'picker_failed',
+                  message: 'Provider crashed',
+                );
+              },
+        );
+
+        await expectLater(
+          picker.pickFile(),
+          throwsA(
+            isA<FilesFailure>()
+                .having(
+                  (failure) => failure.type,
+                  'type',
+                  FilesFailureType.unknown,
+                )
+                .having(
+                  (failure) => failure.message,
+                  'message',
+                  'Unable to choose a file for upload (picker_failed Provider crashed).',
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'reports a friendly failure when the picked file is not readable',
+      () async {
+        final picker = FilePickerFilesImportPicker(
+          pickFiles:
+              ({
+                String? dialogTitle,
+                bool allowMultiple = false,
+                bool withData = false,
+                bool withReadStream = false,
+              }) async => FilePickerResult([
+                PlatformFile(name: 'remote-only.txt', size: 4),
+              ]),
+        );
+
+        await expectLater(
+          picker.pickFile(),
+          throwsA(
+            isA<FilesFailure>()
+                .having(
+                  (failure) => failure.type,
+                  'type',
+                  FilesFailureType.unsupportedPlatform,
+                )
+                .having(
+                  (failure) => failure.message,
+                  'message',
+                  contains('remote-only.txt'),
+                ),
+          ),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Hardens the native file/document picker import path so picked files enter the existing Weave Files upload flow with real bytes, filenames, cancellation handling, and friendly picker failure mapping.

## Changes

- Opens the platform picker as a single-file import with `withReadStream: true` and an accessible dialog title.
- Builds `FileUploadRequest` from picker read streams, in-memory bytes, or IO local paths for desktop-style picker results.
- Keeps a safe conditional stub for platforms where a local path cannot be read.
- Preserves the existing backend Files repository/facade upload flow; no direct Nextcloud/WebDAV/HTML scraping or separate credentials.
- Maps cancellation to no-op and permission/configuration/unsupported/unknown native picker failures to friendly `FilesFailure` messages.
- Adds service tests for cancellation, stream upload, bytes fallback, IO path fallback, unreadable picker results, and picker failure mapping.

## Validation

- `dart format --output=none --set-exit-if-changed lib/features/files/data/services/file_picker_files_import_picker.dart lib/features/files/data/services/file_upload_request_from_path_io.dart lib/features/files/data/services/file_upload_request_from_path_stub.dart test/features/files/data/services/file_picker_files_import_picker_test.dart`
- `flutter analyze --fatal-infos`
- `flutter test test/features/files/data/services/file_picker_files_import_picker_test.dart test/features/files/presentation/providers/files_provider_test.dart test/features/files/files_screen_test.dart test/features/files/presentation/providers/files_backend_facade_provider_test.dart`
- `git diff --check`

Live E2E was not run per assignment.

Fixes #59
