### PR TITLE
Align Release 1 shell with hidden calendar surface

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -5,7 +5,6 @@ import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
 import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
 import 'package:weave/core/router/app_routes.dart';
 import 'package:weave/features/auth/presentation/sign_in_screen.dart';
-import 'package:weave/features/calendar/presentation/calendar_screen.dart';
 import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 import 'package:weave/features/chat/presentation/chat_room_screen.dart';
 import 'package:weave/features/chat/presentation/chat_screen.dart';
@@ -37,7 +36,9 @@ GoRouter appRouter(Ref ref) {
           state.matchedLocation == AppRoutes.setup;
       final onSignIn = state.matchedLocation == AppRoutes.signIn;
       final onFirstRun = state.matchedLocation == AppRoutes.firstRun;
-      final onHiddenReleaseOneRoute = state.matchedLocation == AppRoutes.deck;
+      final onHiddenReleaseOneRoute =
+          state.matchedLocation == AppRoutes.calendar ||
+          state.matchedLocation == AppRoutes.deck;
 
       if (onHiddenReleaseOneRoute) {
         return AppRoutes.chat;
@@ -119,14 +120,6 @@ GoRouter appRouter(Ref ref) {
                 builder: (context, state) => FilesScreen(
                   initialPath: state.uri.queryParameters['path'] ?? '/',
                 ),
-              ),
-            ],
-          ),
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: AppRoutes.calendar,
-                builder: (context, state) => const CalendarScreen(),
               ),
             ],
           ),

--- a/lib/features/shell/presentation/app_shell.dart
+++ b/lib/features/shell/presentation/app_shell.dart
@@ -63,17 +63,6 @@ class AppShell extends ConsumerWidget {
           ),
           NavigationDestination(
             icon: Icon(
-              Icons.calendar_today_outlined,
-              semanticLabel: l10n.semanticCalendarIcon,
-            ),
-            selectedIcon: Icon(
-              Icons.calendar_today,
-              semanticLabel: l10n.semanticCalendarIcon,
-            ),
-            label: l10n.navCalendar,
-          ),
-          NavigationDestination(
-            icon: Icon(
               Icons.settings_outlined,
               semanticLabel: l10n.semanticSettingsIcon,
             ),

--- a/test/core/router/app_router_test.dart
+++ b/test/core/router/app_router_test.dart
@@ -12,10 +12,6 @@ import 'package:weave/features/chat/presentation/providers/chat_repository_provi
 import 'package:weave/features/auth/presentation/sign_in_screen.dart';
 import 'package:weave/features/files/domain/entities/files_connection_state.dart';
 import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
-import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
-import 'package:weave/features/calendar/domain/repositories/calendar_repository.dart';
-import 'package:weave/features/calendar/presentation/calendar_screen.dart';
-import 'package:weave/features/calendar/presentation/providers/calendar_provider.dart';
 import 'package:weave/features/onboarding/domain/entities/first_run_status.dart';
 import 'package:weave/features/onboarding/presentation/first_run_screen.dart';
 import 'package:weave/features/onboarding/presentation/providers/first_run_status_provider.dart';
@@ -71,24 +67,6 @@ class _FakeOidcClient implements OidcClient {
   }
 }
 
-class _EmptyCalendarRepository implements CalendarRepository {
-  @override
-  Future<CalendarEvent> createEvent(CalendarEventDraft draft) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<void> deleteEvent(String id) async {}
-
-  @override
-  Future<List<CalendarEvent>> loadEvents() async => const <CalendarEvent>[];
-
-  @override
-  Future<CalendarEvent> updateEvent(String id, CalendarEventDraft draft) {
-    throw UnimplementedError();
-  }
-}
-
 void main() {
   group('AppRouter', () {
     ProviderContainer createContainer({
@@ -117,9 +95,6 @@ void main() {
             (ref) async => firstRunStatus ?? buildTestFirstRunStatus(),
           ),
           userProfileProvider.overrideWith((ref) async => null),
-          calendarRepositoryProvider.overrideWithValue(
-            _EmptyCalendarRepository(),
-          ),
         ],
       );
       return container;
@@ -228,7 +203,9 @@ void main() {
       expect(find.text('Wait briefly, then refresh status.'), findsOneWidget);
     });
 
-    testWidgets('opens the calendar route when ready', (tester) async {
+    testWidgets('redirects the hidden calendar route back to chat when ready', (
+      tester,
+    ) async {
       final secureStore = InMemorySecureStore();
       await secureStore.write(
         authSessionStorageKey,
@@ -251,7 +228,15 @@ void main() {
       container.read(appRouterProvider).go(AppRoutes.calendar);
       await tester.pumpAndSettle();
 
-      expect(find.byType(CalendarScreen), findsOneWidget);
+      expect(
+        container
+            .read(appRouterProvider)
+            .routeInformationProvider
+            .value
+            .uri
+            .path,
+        AppRoutes.chat,
+      );
     });
 
     testWidgets('redirects shell routes back to welcome when setup is needed', (

--- a/test/features/shell/app_shell_test.dart
+++ b/test/features/shell/app_shell_test.dart
@@ -7,9 +7,6 @@ import 'package:weave/features/auth/data/dtos/auth_session_dto.dart';
 import 'package:weave/features/auth/data/repositories/oidc_auth_session_repository.dart';
 import 'package:weave/features/auth/data/services/flutter_appauth_oidc_client.dart';
 import 'package:weave/features/auth/data/services/oidc_client.dart';
-import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
-import 'package:weave/features/calendar/domain/repositories/calendar_repository.dart';
-import 'package:weave/features/calendar/presentation/providers/calendar_provider.dart';
 import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 import 'package:weave/features/chat/domain/entities/chat_message.dart';
 import 'package:weave/features/chat/domain/entities/chat_room_timeline.dart';
@@ -73,24 +70,6 @@ class _FakeOidcClient implements OidcClient {
   }
 }
 
-class _EmptyCalendarRepository implements CalendarRepository {
-  @override
-  Future<CalendarEvent> createEvent(CalendarEventDraft draft) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<void> deleteEvent(String id) async {}
-
-  @override
-  Future<List<CalendarEvent>> loadEvents() async => const <CalendarEvent>[];
-
-  @override
-  Future<CalendarEvent> updateEvent(String id, CalendarEventDraft draft) {
-    throw UnimplementedError();
-  }
-}
-
 void main() {
   group('AppShell', () {
     ProviderScope buildApp({
@@ -125,9 +104,6 @@ void main() {
           userProfileProvider.overrideWith((ref) async => null),
           firstRunStatusProvider.overrideWith(
             (ref) async => buildTestFirstRunStatus(),
-          ),
-          calendarRepositoryProvider.overrideWithValue(
-            _EmptyCalendarRepository(),
           ),
           filesRepositoryProvider.overrideWithValue(
             filesRepository ??
@@ -165,7 +141,7 @@ void main() {
       expect(find.byType(NavigationBar), findsOneWidget);
       expect(find.byIcon(Icons.chat_bubble), findsOneWidget);
       expect(find.byIcon(Icons.folder_outlined), findsOneWidget);
-      expect(find.byIcon(Icons.calendar_today_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.calendar_today_outlined), findsNothing);
       expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
       expect(find.byIcon(Icons.dashboard_outlined), findsNothing);
     });
@@ -186,17 +162,6 @@ void main() {
         expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
       },
     );
-
-    testWidgets('navigates to calendar from the bottom navigation bar', (
-      tester,
-    ) async {
-      await pumpReadyShell(tester);
-
-      await tester.tap(find.byIcon(Icons.calendar_today_outlined));
-      await tester.pumpAndSettle();
-
-      expect(find.text('No events yet'), findsOneWidget);
-    });
 
     testWidgets('navigates to settings from the bottom navigation bar', (
       tester,

--- a/test/release_1/release_golden_paths_test.dart
+++ b/test/release_1/release_golden_paths_test.dart
@@ -167,6 +167,27 @@ void main() {
         expect(find.widgetWithText(ListTile, 'Plans'), findsOneWidget);
         expect(find.widgetWithText(ListTile, 'spec.pdf'), findsOneWidget);
 
+        await tester.tap(find.text('New folder'));
+        await tester.pumpAndSettle();
+        await tester.enterText(_textFieldWithLabel('Folder name'), 'Archive');
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Create'));
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(ListTile, 'Archive'), findsOneWidget);
+        expect(find.text('Created folder Archive.'), findsOneWidget);
+        expect(filesRepository.createdFolders, contains('/Documents/Archive'));
+
+        await tester.tap(find.byTooltip('Delete spec.pdf'));
+        await tester.pumpAndSettle();
+        expect(find.text('Delete spec.pdf?'), findsOneWidget);
+        await tester.tap(find.text('Delete').last);
+        await tester.pumpAndSettle();
+
+        expect(find.widgetWithText(ListTile, 'spec.pdf'), findsNothing);
+        expect(find.text('Deleted spec.pdf.'), findsOneWidget);
+        expect(filesRepository.deletedEntries, contains('spec'));
+
         await tester.tap(find.text('Up'));
         await tester.pumpAndSettle();
 
@@ -408,13 +429,20 @@ class _ScenarioAuthSessionRepository implements AuthSessionRepository {
   }
 }
 
-class _ScenarioFilesRepository implements FilesRepository {
+class _ScenarioFilesRepository
+    implements FilesRepository, FilesEntryMutationRepository {
   _ScenarioFilesRepository(this._serverConfigurationRepository);
 
   final _MemoryServerConfigurationRepository _serverConfigurationRepository;
+  final Map<String, List<FileEntry>> _entriesByPath = <String, List<FileEntry>>{
+    '/': List<FileEntry>.of(_rootEntries),
+    '/Documents': List<FileEntry>.of(_documentsEntries),
+  };
   bool _connected = false;
   int connectCalls = 0;
   int disconnectCalls = 0;
+  final List<String> createdFolders = <String>[];
+  final List<String> deletedEntries = <String>[];
 
   Uri get lastConfiguredBaseUrl =>
       _serverConfigurationRepository
@@ -444,14 +472,12 @@ class _ScenarioFilesRepository implements FilesRepository {
       );
     }
 
-    return switch (path) {
-      '/' => const DirectoryListing(path: '/', entries: _rootEntries),
-      '/Documents' => const DirectoryListing(
-        path: '/Documents',
-        entries: _documentsEntries,
+    return DirectoryListing(
+      path: path,
+      entries: List<FileEntry>.unmodifiable(
+        _entriesByPath[path] ?? const <FileEntry>[],
       ),
-      _ => const DirectoryListing(path: '/', entries: <FileEntry>[]),
-    };
+    );
   }
 
   @override
@@ -464,7 +490,46 @@ class _ScenarioFilesRepository implements FilesRepository {
   }
 
   @override
+  Future<FileEntry> createFolder({
+    required String parentPath,
+    required String name,
+  }) async {
+    final normalizedParent = parentPath == '/' ? '' : parentPath;
+    final path = '$normalizedParent/$name';
+    final entry = FileEntry(
+      id: path,
+      name: name,
+      path: path,
+      isDirectory: true,
+    );
+    createdFolders.add(path);
+    _entriesByPath.putIfAbsent(parentPath, () => <FileEntry>[]).add(entry);
+    _entriesByPath[path] = <FileEntry>[];
+    return entry;
+  }
+
+  @override
+  Future<void> deleteEntry(FileEntry entry) async {
+    deletedEntries.add(entry.id);
+    final parentPath = _parentPath(entry.path);
+    _entriesByPath[parentPath]?.removeWhere(
+      (candidate) => candidate.id == entry.id,
+    );
+    if (entry.isDirectory) {
+      _entriesByPath.remove(entry.path);
+    }
+  }
+
+  @override
   Future<FilesConnectionState> restoreConnection() async => _connectionState();
+
+  String _parentPath(String path) {
+    final lastSlash = path.lastIndexOf('/');
+    if (lastSlash <= 0) {
+      return '/';
+    }
+    return path.substring(0, lastSlash);
+  }
 
   FilesConnectionState _connectionState() {
     return _connected


### PR DESCRIPTION
## Summary
- remove Calendar from the Release 1 shell navigation and hidden-route access, matching the current README boundary that Calendar/Deck are future product areas
- update router/shell tests to assert `/calendar` is hidden like `/deck`
- extend the Release 1 golden path with files create-folder and delete-entry coverage through the app UI

## Validation
- `dart format --output=none --set-exit-if-changed lib/core/router/app_router.dart lib/features/shell/presentation/app_shell.dart test/core/router/app_router_test.dart test/features/shell/app_shell_test.dart test/release_1/release_golden_paths_test.dart`
- `flutter test test/release_1/release_golden_paths_test.dart test/core/router/app_router_test.dart test/features/shell/app_shell_test.dart`
- `flutter analyze --fatal-infos`

## Follow-up backlog found while scouting
- Profile edit: app-side repository still defaults `profileEditingSupported = false` and surfaces “Profile editing is waiting for backend PATCH /api/profile support.” Once backend PATCH is contract-stable, wire the provider flag/client save path and add a settings/profile edit widget test.
- Files download: `BackendFilesRepository.prepareDownload()` has endpoint-level coverage, but there is no Release 1 user-visible download action in `FilesScreen`; add UI/launcher/download handling plus golden-path coverage once the intended app download UX is decided.
- Live integration: keep `integration_test/live_stack_app_e2e_test.dart` as the backend/infra proof point, but add Release 1 assertions for files create/delete/download and hidden calendar navigation once those backend endpoints are enabled in the stack.
