### PR TITLE
docs: record boards and tasks provider strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Release 1 is intentionally narrow and honest. The current user-facing app shell 
 - **Files** — a Weave files experience backed by the product backend and Nextcloud/WebDAV/OCS contracts.
 - **Settings and OIDC sign-in** — setup, authentication, stored server configuration, and account/session controls.
 
-Calendar, Deck, Slack/Teams interop, migration tooling, connector SDKs, and Weaver PA are future product areas unless a feature is explicitly marked as enabled. Calendar and Deck code may exist in the repository while those surfaces are under construction, but they are not Release 1 promises.
+Calendar, tasks/boards, Slack/Teams interop, migration tooling, connector SDKs, and Weaver PA are future product areas unless a feature is explicitly marked as enabled. Calendar and exploratory Deck/boards code may exist in the repository while those surfaces are under construction, but they are not Release 1 promises. The future tasks/boards direction is a Weave-owned accessible model with provider adapters, not a product dependency on Nextcloud Deck.
 
 ## Product architecture
 
@@ -50,7 +50,7 @@ The Weave product should feel like one collaboration platform even though sovere
 - **Nextcloud** provides files and future calendar data foundations.
 - **Caddy** exposes the local/dev HTTPS gateway.
 
-For the detailed Flutter architecture, see [docs/architecture.md](docs/architecture.md). For the post-Release-1 interop direction, see [docs/interop-gateway-and-external-collaboration.md](docs/interop-gateway-and-external-collaboration.md).
+For the detailed Flutter architecture, see [docs/architecture.md](docs/architecture.md). For the post-Release-1 interop direction, see [docs/interop-gateway-and-external-collaboration.md](docs/interop-gateway-and-external-collaboration.md). For future boards/tasks provider research, see [docs/research/boards-task-module-provider-strategy.md](docs/research/boards-task-module-provider-strategy.md).
 
 ## Current client foundation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,7 +42,7 @@ Shell destinations:
 - Chat
 - Files
 - Calendar (future, not part of Release 1 navigation)
-- Deck (future, not part of Release 1 navigation)
+- Tasks/Boards (future, not part of Release 1 navigation; provider-neutral Weave model, not a Nextcloud Deck product dependency)
 - Settings
 
 ## Shared server configuration
@@ -94,6 +94,10 @@ Current failure types:
 
 Slack, Teams, guest collaboration, migration tooling, and future connectors must attach through backend-owned Interop Gateway boundaries rather than provider-specific Flutter transport logic. See [Interop Gateway and External Collaboration](interop-gateway-and-external-collaboration.md). This direction is post-Release-1 and must remain feature-flagged/off by default until explicitly promoted.
 
+## Future tasks and boards
+
+Tasks/boards are post-Release-1. The planning recommendation is to build a Weave-owned, accessibility-first board/task model with provider adapters rather than exposing Nextcloud Deck or any other upstream tool as the product model. See [Boards and Tasks Provider Strategy](research/boards-task-module-provider-strategy.md).
+
 ## Feature and integration layering
 Each feature follows the same three layers:
 
@@ -110,7 +114,7 @@ Current repository-first stub boundaries:
 - `integrations/nextcloud` -> `NextcloudConnectionService` + `NextcloudAuthClient` + `NextcloudSessionRepository` + shared providers
 - `files` -> `FilesRepository` + `NextcloudDavClient`
 - `calendar` -> `CalendarRepository` + `CalDavClient`
-- `deck` -> `DeckRepository` + `DeckClient`
+- `deck` / future `tasks_boards` -> exploratory board repository/client boundaries; future work should use a provider-neutral Weave model with adapters
 
 Presentation depends on repository contracts and Riverpod providers only. It does not own storage or protocol logic.
 
@@ -155,7 +159,7 @@ Nextcloud is now split into:
 - `integrations/nextcloud/` for shared auth, session, account validation, login-flow handling, revoke policy, provider wiring, and connection lifecycle orchestration
 - `features/files/` for DAV directory browsing, file-entry mapping, and file-facing presentation/state
 
-This keeps the current Files UX intact while making the same Nextcloud platform layer reusable for future Calendar or Deck work without importing `features/files/`.
+This keeps the current Files UX intact while making the same Nextcloud platform layer reusable for future Calendar or provider-adapter board work without importing `features/files/`.
 
 ## Onboarding and settings
 Onboarding setup and Settings share:

--- a/docs/research/boards-task-module-provider-strategy.md
+++ b/docs/research/boards-task-module-provider-strategy.md
@@ -1,0 +1,64 @@
+# Boards and Tasks Provider Strategy
+
+Status: planning recommendation for post-Release-1 work  
+Date: 2026-05-14  
+Scope: future Weave tasks/boards module, provider research, accessibility baseline
+
+## Decision
+
+Weave should define its own accessibility-first Tasks/Boards product model and UI, then connect external engines through provider adapters. The product surface must not be named or shaped around a single upstream tool such as Nextcloud Deck.
+
+This module is **not Release 1 scope**. Release 1 stays focused on the app shell, sign-in/setup, chat, files, settings, and the explicitly enabled module contracts. Existing Deck/boards code is exploratory scaffolding unless a later issue/PR promotes it behind a reviewed feature flag.
+
+## Rationale
+
+A board/task system is a high-interaction workflow: keyboard navigation, screen-reader structure, drag alternatives, focus management, labels, status, due dates, comments, and notifications must be designed together. Directly exposing an upstream board UI or coupling Flutter to one provider's transport would make accessibility, future migration, and data sovereignty harder.
+
+A Weave-owned model lets the app present one consistent experience while adapters handle provider-specific APIs, auth, sync, and event quirks behind repository/backend boundaries.
+
+## Recommended model boundary
+
+Use provider-neutral domain concepts first:
+
+- workspace/project
+- board
+- column/list/status
+- task/card
+- assignee and watcher references
+- due/start dates
+- labels/tags/priority
+- checklist/subtasks where available
+- comments/activity
+- attachments/links
+- provider sync metadata kept out of presentation models
+
+The accessible UI must provide non-drag controls for moving cards, deterministic reading/focus order, visible focus, text scaling tolerance, status not communicated by color alone, and screen-reader-readable updates for creates, moves, errors, and sync conflicts.
+
+## Provider research outcome
+
+### First implementation spikes
+
+1. **Vikunja adapter spike** — first strategic spike for a lightweight, self-hostable OSS task engine with an API-oriented surface.
+2. **OpenProject accessibility benchmark** — use OpenProject as the accessibility and mature-workflow comparison point, not necessarily the first embedded provider.
+3. **Nextcloud Deck bridge spike** — evaluate as a low-friction bridge because Nextcloud is already in the Weave stack, but keep it behind the provider-adapter boundary and do not let Deck define the product model.
+
+### Defer or avoid as strategic base
+
+- **Focalboard / Mattermost Boards** — defer; not a strong strategic base for Weave's standalone accessibility-first module direction.
+- **Kanboard** — defer; useful reference for simplicity, but not the preferred base.
+- **Planka** — defer; attractive UI, weaker fit for Weave's adapter/accessibility/data-sovereignty direction.
+- **Taiga** — likely defer as a strategic base unless later research finds a compelling current-maintenance/API/accessibility fit.
+
+## Event normalizer
+
+Future provider work should include a provider-neutral event normalizer before broad UI investment. It should map provider-specific changes into Weave events such as task created, task moved, assignment changed, comment added, due date changed, task completed, and sync/conflict detected. This keeps notifications, recent activity, audit/support diagnostics, and future agent workflows independent from one provider.
+
+## Open follow-up issues
+
+Create or keep issues for:
+
+- [`provider-vikunja-spike`](https://github.com/masssi164/weave/issues/119)
+- [`openproject-a11y-benchmark`](https://github.com/masssi164/weave/issues/120)
+- [`deck-spike`](https://github.com/masssi164/weave/issues/121)
+- [`accessible-board-ui`](https://github.com/masssi164/weave/issues/122)
+- [`event-normalizer`](https://github.com/masssi164/weave/issues/123)


### PR DESCRIPTION
## Summary
- Records the post-Release-1 boards/tasks research recommendation: Weave-owned accessible model + provider adapters.
- Clarifies that exploratory Deck/boards code is not a Release 1 promise and should not define the product model.
- Links the follow-up spikes/issues for Vikunja, OpenProject accessibility benchmarking, Nextcloud Deck bridge, accessible board UI, and provider-neutral events.

## Follow-up issues
- #119
- #120
- #121
- #122
- #123

## Validation
- `git diff --check`
- docs link/path sanity check

## Contract impact
- Documentation/planning only.
- Keeps Release 1 scope honest; no runtime behavior change.
