### PR TITLE
docs: add reproducible marketing screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,15 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      capture_marketing_screenshots:
+        description: "Regenerate deterministic README/marketing screenshots and upload them as a workflow artifact"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
 
 permissions:
   contents: read
@@ -23,4 +32,15 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed .
       - run: flutter analyze --fatal-infos
       - run: flutter test
+      - name: Verify generated marketing screenshots
+        run: |
+          make marketing-screenshots
+          git diff --exit-code -- docs/assets/marketing
+      - name: Upload marketing screenshots
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.capture_marketing_screenshots == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: weave-marketing-screenshots
+          path: docs/assets/marketing
+          if-no-files-found: error
       - run: make offline-contract-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: offline-contract-test integration-contract-test integration-app-e2e integration-test
+.PHONY: offline-contract-test integration-contract-test integration-app-e2e integration-test marketing-screenshots
 
 offline-contract-test:
 	@WEAVE_OFFLINE_CONTRACT_ONLY=true \
@@ -99,3 +99,6 @@ integration-app-e2e:
 	  --dart-define-from-file="$$dart_defines_file"
 
 integration-test: integration-app-e2e
+
+marketing-screenshots:
+	@python3 tool/generate_marketing_screenshots.py

--- a/README.md
+++ b/README.md
@@ -35,13 +35,25 @@ Calendar, Deck, Slack/Teams interop, migration tooling, connector SDKs, and Weav
 
 The images below are deterministic Release 1 marketing screenshots generated from `tool/generate_marketing_screenshots.py`. They are checked into `docs/assets/marketing/` so the README is useful without downloading CI artifacts, and each image has descriptive alt text rather than relying on image-only documentation.
 
-| Setup | Chat | Files |
-| --- | --- | --- |
-| <img src="docs/assets/marketing/01-setup-start.svg" alt="Weave setup start screen showing a guided workspace setup path and canonical local service URLs." width="280"> | <img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room screenshot showing the Release Room, message history, and a send message action." width="280"> | <img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files screenshot showing the Documents folder with folders, files, and accessible file actions." width="280"> |
+### Setup
 
-| Endpoint review | Settings |
-| --- | --- |
-| <img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave setup endpoint review screenshot listing Matrix, files, and backend service URLs before finishing setup." width="280"> | <img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screenshot showing OIDC issuer, client ID, Nextcloud URL, and account session controls." width="280"> |
+<img src="docs/assets/marketing/01-setup-start.svg" alt="Weave setup start screen showing a guided workspace setup path and canonical local service URLs." width="560">
+
+### Endpoint review
+
+<img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave setup endpoint review screenshot listing Matrix, files, and backend service URLs before finishing setup." width="560">
+
+### Chat
+
+<img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room screenshot showing the Release Room, message history, and a send message action." width="560">
+
+### Files
+
+<img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files screenshot showing the Documents folder with folders, files, and accessible file actions." width="560">
+
+### Settings
+
+<img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screenshot showing OIDC issuer, client ID, Nextcloud URL, and account session controls." width="560">
 
 ## Product architecture
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ Release 1 is intentionally narrow and honest. The current user-facing app shell 
 
 Calendar, Deck, Slack/Teams interop, migration tooling, connector SDKs, and Weaver PA are future product areas unless a feature is explicitly marked as enabled. Calendar and Deck code may exist in the repository while those surfaces are under construction, but they are not Release 1 promises.
 
+## Product screenshots
+
+The images below are deterministic Release 1 marketing screenshots generated from `tool/generate_marketing_screenshots.py`. They are checked into `docs/assets/marketing/` so the README is useful without downloading CI artifacts, and each image has descriptive alt text rather than relying on image-only documentation.
+
+| Setup | Chat | Files |
+| --- | --- | --- |
+| <img src="docs/assets/marketing/01-setup-start.svg" alt="Weave setup start screen showing a guided workspace setup path and canonical local service URLs." width="280"> | <img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room screenshot showing the Release Room, message history, and a send message action." width="280"> | <img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files screenshot showing the Documents folder with folders, files, and accessible file actions." width="280"> |
+
+| Endpoint review | Settings |
+| --- | --- |
+| <img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave setup endpoint review screenshot listing Matrix, files, and backend service URLs before finishing setup." width="280"> | <img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screenshot showing OIDC issuer, client ID, Nextcloud URL, and account session controls." width="280"> |
+
 ## Product architecture
 
 Weave is the Flutter client in a three-repository product system:
@@ -154,6 +166,18 @@ flutter analyze --fatal-infos
 flutter test
 make offline-contract-test
 ```
+
+### Marketing screenshots
+
+Marketing/README screenshots are deterministic SVG assets generated from a small checked-in script, not pixel-perfect goldens. This keeps normal PR validation focused on behavior while still making docs imagery reproducible and reviewable.
+
+```sh
+make marketing-screenshots
+```
+
+The command regenerates the setup, endpoint review, chat, files, and settings images in `docs/assets/marketing/`. CI runs the generator and fails if the checked-in assets drift. In GitHub Actions, run the `CI` workflow manually with `capture_marketing_screenshots=true` to also download the `weave-marketing-screenshots` artifact.
+
+When adding selected images to the README or docs, keep nearby prose and descriptive `alt` text so the documentation is not image-only.
 
 ## Live stack and integration tests
 

--- a/docs/assets/marketing/01-setup-start.svg
+++ b/docs/assets/marketing/01-setup-start.svg
@@ -37,8 +37,6 @@
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Set up your Weave workspace</text>
   <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Connect identity, chat, files, and backend services through one</text>
 <text x="144" y="350" font-size="26" font-weight="400" fill="#475569">guided Release 1 setup path.</text>
-  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
-  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">API</text>

--- a/docs/assets/marketing/01-setup-start.svg
+++ b/docs/assets/marketing/01-setup-start.svg
@@ -1,0 +1,89 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Weave setup start screen</title>
+  <desc id="desc">A Weave welcome screen invites an admin to configure the self-hosted workspace.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eff6ff"/>
+      <stop offset="0.52" stop-color="#ecfeff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bg)"/>
+  <rect x="56" y="54" width="1328" height="792" rx="46" fill="#f8fafc" stroke="#bae6fd" stroke-width="3" filter="url(#shadow)"/>
+  <circle cx="111" cy="96" r="13" fill="#38bdf8"/>
+  <circle cx="149" cy="96" r="13" fill="#22d3ee"/>
+  <circle cx="187" cy="96" r="13" fill="#14b8a6"/>
+  <text x="234" y="105" font-size="34" font-weight="900" fill="#075985">Weave</text>
+
+    <rect x="86" y="116" width="180" height="56" rx="18" fill="#e0f2fe" stroke="#0891b2" stroke-width="2"/>
+    <text x="110" y="153" font-size="22" font-weight="700" fill="#075985">Setup</text>
+
+
+    <rect x="284" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="308" y="153" font-size="22" font-weight="700" fill="#475569">Chat</text>
+
+
+    <rect x="482" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="506" y="153" font-size="22" font-weight="700" fill="#475569">Files</text>
+
+
+    <rect x="680" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="704" y="153" font-size="22" font-weight="700" fill="#475569">Settings</text>
+
+  <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+  <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Set up your Weave workspace</text>
+  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Connect identity, chat, files, and backend services through one</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">guided Release 1 setup path.</text>
+  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
+  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
+
+    <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">API</text>
+    <text x="132" y="480" font-size="20" font-weight="400" fill="#0f172a">https://api.weave.local/api</text>
+
+
+    <rect x="480" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="508" y="444" font-size="21" font-weight="700" fill="#0369a1">Auth</text>
+    <text x="508" y="480" font-size="20" font-weight="400" fill="#0f172a">https://auth.weave.local</text>
+
+
+    <rect x="856" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="884" y="444" font-size="21" font-weight="700" fill="#0369a1">Client</text>
+    <text x="884" y="480" font-size="20" font-weight="400" fill="#0f172a">Flutter desktop + mobile</text>
+
+
+    <rect x="104" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="158" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="146" y="634" font-size="26" font-weight="800" fill="#0e7490">1</text>
+    <text x="200" y="631" font-size="24" font-weight="800" fill="#0f172a">OIDC sign-in</text>
+    <text x="136" y="678" font-size="22" font-weight="400" fill="#475569">Use Keycloak-backed</text>
+<text x="136" y="708" font-size="22" font-weight="400" fill="#475569">single sign-on with the</text>
+<text x="136" y="738" font-size="22" font-weight="400" fill="#475569">infra-managed weave-app</text>
+<text x="136" y="768" font-size="22" font-weight="400" fill="#475569">client.</text>
+
+
+    <rect x="480" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="534" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="522" y="634" font-size="26" font-weight="800" fill="#0e7490">2</text>
+    <text x="576" y="631" font-size="24" font-weight="800" fill="#0f172a">Service endpoints</text>
+    <text x="512" y="678" font-size="22" font-weight="400" fill="#475569">Review Matrix, files,</text>
+<text x="512" y="708" font-size="22" font-weight="400" fill="#475569">and backend URLs before</text>
+<text x="512" y="738" font-size="22" font-weight="400" fill="#475569">saving the local</text>
+<text x="512" y="768" font-size="22" font-weight="400" fill="#475569">workspace.</text>
+
+
+    <rect x="856" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="910" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="898" y="634" font-size="26" font-weight="800" fill="#0e7490">3</text>
+    <text x="952" y="631" font-size="24" font-weight="800" fill="#0f172a">Ready shell</text>
+    <text x="888" y="678" font-size="22" font-weight="400" fill="#475569">Open chat, files, and</text>
+<text x="888" y="708" font-size="22" font-weight="400" fill="#475569">settings from one</text>
+<text x="888" y="738" font-size="22" font-weight="400" fill="#475569">accessible navigation</text>
+<text x="888" y="768" font-size="22" font-weight="400" fill="#475569">model.</text>
+
+  <rect x="1012" y="96" width="300" height="54" rx="20" fill="#0f172a"/>
+  <text x="1042" y="132" font-size="22" font-weight="800" fill="#ffffff">Get Started</text>
+</svg>

--- a/docs/assets/marketing/02-review-service-endpoints.svg
+++ b/docs/assets/marketing/02-review-service-endpoints.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Weave service endpoint review screen</title>
+  <desc id="desc">The setup review lists canonical local service endpoints before finishing configuration.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eff6ff"/>
+      <stop offset="0.52" stop-color="#ecfeff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bg)"/>
+  <rect x="56" y="54" width="1328" height="792" rx="46" fill="#f8fafc" stroke="#bae6fd" stroke-width="3" filter="url(#shadow)"/>
+  <circle cx="111" cy="96" r="13" fill="#38bdf8"/>
+  <circle cx="149" cy="96" r="13" fill="#22d3ee"/>
+  <circle cx="187" cy="96" r="13" fill="#14b8a6"/>
+  <text x="234" y="105" font-size="34" font-weight="900" fill="#075985">Weave</text>
+
+    <rect x="86" y="116" width="180" height="56" rx="18" fill="#e0f2fe" stroke="#0891b2" stroke-width="2"/>
+    <text x="110" y="153" font-size="22" font-weight="700" fill="#075985">Setup</text>
+
+
+    <rect x="284" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="308" y="153" font-size="22" font-weight="700" fill="#475569">Chat</text>
+
+
+    <rect x="482" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="506" y="153" font-size="22" font-weight="700" fill="#475569">Files</text>
+
+
+    <rect x="680" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="704" y="153" font-size="22" font-weight="700" fill="#475569">Settings</text>
+
+  <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+  <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Review Service Endpoints</text>
+  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Release 1 keeps raw services behind clear product boundaries and</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">explicit local URLs.</text>
+  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
+  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
+
+    <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Matrix</text>
+    <text x="132" y="480" font-size="20" font-weight="400" fill="#0f172a">https://matrix.weave.local</text>
+
+
+    <rect x="480" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="508" y="444" font-size="21" font-weight="700" fill="#0369a1">Files</text>
+    <text x="508" y="480" font-size="20" font-weight="400" fill="#0f172a">https://files.weave.local</text>
+
+
+    <rect x="856" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="884" y="444" font-size="21" font-weight="700" fill="#0369a1">Backend</text>
+    <text x="884" y="480" font-size="20" font-weight="400" fill="#0f172a">https://api.weave.local/api</text>
+
+
+    <rect x="104" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="158" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="146" y="634" font-size="26" font-weight="800" fill="#0e7490">✓</text>
+    <text x="200" y="631" font-size="24" font-weight="800" fill="#0f172a">Identity authority</text>
+    <text x="136" y="678" font-size="22" font-weight="400" fill="#475569">Keycloak owns login,</text>
+<text x="136" y="708" font-size="22" font-weight="400" fill="#475569">sessions, and user</text>
+<text x="136" y="738" font-size="22" font-weight="400" fill="#475569">identity claims.</text>
+
+
+    <rect x="480" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="534" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="522" y="634" font-size="26" font-weight="800" fill="#0e7490">✓</text>
+    <text x="576" y="631" font-size="24" font-weight="800" fill="#0f172a">Backend facade</text>
+    <text x="512" y="678" font-size="22" font-weight="400" fill="#475569">Weave backend is the</text>
+<text x="512" y="708" font-size="22" font-weight="400" fill="#475569">product API after sign-</text>
+<text x="512" y="738" font-size="22" font-weight="400" fill="#475569">in.</text>
+
+
+    <rect x="856" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="910" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="898" y="634" font-size="26" font-weight="800" fill="#0e7490">✓</text>
+    <text x="952" y="631" font-size="24" font-weight="800" fill="#0f172a">Sovereign modules</text>
+    <text x="888" y="678" font-size="22" font-weight="400" fill="#475569">Matrix and Nextcloud</text>
+<text x="888" y="708" font-size="22" font-weight="400" fill="#475569">provide protocol/data</text>
+<text x="888" y="738" font-size="22" font-weight="400" fill="#475569">foundations behind Weave</text>
+<text x="888" y="768" font-size="22" font-weight="400" fill="#475569">UX.</text>
+
+  <rect x="1012" y="96" width="300" height="54" rx="20" fill="#0f172a"/>
+  <text x="1042" y="132" font-size="22" font-weight="800" fill="#ffffff">Finish setup</text>
+</svg>

--- a/docs/assets/marketing/02-review-service-endpoints.svg
+++ b/docs/assets/marketing/02-review-service-endpoints.svg
@@ -37,8 +37,6 @@
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Review Service Endpoints</text>
   <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Release 1 keeps raw services behind clear product boundaries and</text>
 <text x="144" y="350" font-size="26" font-weight="400" fill="#475569">explicit local URLs.</text>
-  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
-  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Matrix</text>

--- a/docs/assets/marketing/03-chat-room.svg
+++ b/docs/assets/marketing/03-chat-room.svg
@@ -37,8 +37,6 @@
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Release Room</text>
   <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Custom Matrix chat surface with room list, readable message</text>
 <text x="144" y="350" font-size="26" font-weight="400" fill="#475569">history, and a clear composer.</text>
-  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
-  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Room</text>

--- a/docs/assets/marketing/03-chat-room.svg
+++ b/docs/assets/marketing/03-chat-room.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Weave chat room screen</title>
+  <desc id="desc">The custom Weave chat room shows a Release Room conversation and accessible message composer.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eff6ff"/>
+      <stop offset="0.52" stop-color="#ecfeff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bg)"/>
+  <rect x="56" y="54" width="1328" height="792" rx="46" fill="#f8fafc" stroke="#bae6fd" stroke-width="3" filter="url(#shadow)"/>
+  <circle cx="111" cy="96" r="13" fill="#38bdf8"/>
+  <circle cx="149" cy="96" r="13" fill="#22d3ee"/>
+  <circle cx="187" cy="96" r="13" fill="#14b8a6"/>
+  <text x="234" y="105" font-size="34" font-weight="900" fill="#075985">Weave</text>
+
+    <rect x="86" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="110" y="153" font-size="22" font-weight="700" fill="#475569">Setup</text>
+
+
+    <rect x="284" y="116" width="180" height="56" rx="18" fill="#e0f2fe" stroke="#0891b2" stroke-width="2"/>
+    <text x="308" y="153" font-size="22" font-weight="700" fill="#075985">Chat</text>
+
+
+    <rect x="482" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="506" y="153" font-size="22" font-weight="700" fill="#475569">Files</text>
+
+
+    <rect x="680" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="704" y="153" font-size="22" font-weight="700" fill="#475569">Settings</text>
+
+  <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+  <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Release Room</text>
+  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Custom Matrix chat surface with room list, readable message</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">history, and a clear composer.</text>
+  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
+  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
+
+    <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Room</text>
+    <text x="132" y="480" font-size="20" font-weight="400" fill="#0f172a">#release-room</text>
+
+
+    <rect x="480" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="508" y="444" font-size="21" font-weight="700" fill="#0369a1">Encryption</text>
+    <text x="508" y="480" font-size="20" font-weight="400" fill="#0f172a">MVP non-E2EE, clearly labeled</text>
+
+
+    <rect x="856" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="884" y="444" font-size="21" font-weight="700" fill="#0369a1">State</text>
+    <text x="884" y="480" font-size="20" font-weight="400" fill="#0f172a">Connected</text>
+
+
+    <rect x="104" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="158" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="146" y="634" font-size="26" font-weight="800" fill="#0e7490">A</text>
+    <text x="200" y="631" font-size="24" font-weight="800" fill="#0f172a">Alice</text>
+    <text x="136" y="678" font-size="22" font-weight="400" fill="#475569">Golden path ready</text>
+
+
+    <rect x="480" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="534" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="522" y="634" font-size="26" font-weight="800" fill="#0e7490">W</text>
+    <text x="576" y="631" font-size="24" font-weight="800" fill="#0f172a">Weave</text>
+    <text x="512" y="678" font-size="22" font-weight="400" fill="#475569">Looks shippable</text>
+
+
+    <rect x="856" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="910" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="898" y="634" font-size="26" font-weight="800" fill="#0e7490">?</text>
+    <text x="952" y="631" font-size="24" font-weight="800" fill="#0f172a">Help</text>
+    <text x="888" y="678" font-size="22" font-weight="400" fill="#475569">Workspace rooms are</text>
+<text x="888" y="708" font-size="22" font-weight="400" fill="#475569">provisioned behind the</text>
+<text x="888" y="738" font-size="22" font-weight="400" fill="#475569">scenes.</text>
+
+  <rect x="1012" y="96" width="300" height="54" rx="20" fill="#0f172a"/>
+  <text x="1042" y="132" font-size="22" font-weight="800" fill="#ffffff">Send message</text>
+</svg>

--- a/docs/assets/marketing/04-files-documents.svg
+++ b/docs/assets/marketing/04-files-documents.svg
@@ -37,8 +37,6 @@
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">/Documents</text>
   <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">A basic Weave-owned files UI backed by the product backend and</text>
 <text x="144" y="350" font-size="26" font-weight="400" fill="#475569">Nextcloud protocols.</text>
-  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
-  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Connection</text>

--- a/docs/assets/marketing/04-files-documents.svg
+++ b/docs/assets/marketing/04-files-documents.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Weave files documents screen</title>
+  <desc id="desc">The Weave files screen lists folders and files through the backend files facade.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eff6ff"/>
+      <stop offset="0.52" stop-color="#ecfeff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bg)"/>
+  <rect x="56" y="54" width="1328" height="792" rx="46" fill="#f8fafc" stroke="#bae6fd" stroke-width="3" filter="url(#shadow)"/>
+  <circle cx="111" cy="96" r="13" fill="#38bdf8"/>
+  <circle cx="149" cy="96" r="13" fill="#22d3ee"/>
+  <circle cx="187" cy="96" r="13" fill="#14b8a6"/>
+  <text x="234" y="105" font-size="34" font-weight="900" fill="#075985">Weave</text>
+
+    <rect x="86" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="110" y="153" font-size="22" font-weight="700" fill="#475569">Setup</text>
+
+
+    <rect x="284" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="308" y="153" font-size="22" font-weight="700" fill="#475569">Chat</text>
+
+
+    <rect x="482" y="116" width="180" height="56" rx="18" fill="#e0f2fe" stroke="#0891b2" stroke-width="2"/>
+    <text x="506" y="153" font-size="22" font-weight="700" fill="#075985">Files</text>
+
+
+    <rect x="680" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="704" y="153" font-size="22" font-weight="700" fill="#475569">Settings</text>
+
+  <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+  <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">/Documents</text>
+  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">A basic Weave-owned files UI backed by the product backend and</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">Nextcloud protocols.</text>
+  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
+  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
+
+    <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Connection</text>
+    <text x="132" y="480" font-size="20" font-weight="400" fill="#0f172a">Connected</text>
+
+
+    <rect x="480" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="508" y="444" font-size="21" font-weight="700" fill="#0369a1">Backend</text>
+    <text x="508" y="480" font-size="20" font-weight="400" fill="#0f172a">Files facade</text>
+
+
+    <rect x="856" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="884" y="444" font-size="21" font-weight="700" fill="#0369a1">Path</text>
+    <text x="884" y="480" font-size="20" font-weight="400" fill="#0f172a">/Documents</text>
+
+
+    <rect x="104" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="158" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="146" y="634" font-size="26" font-weight="800" fill="#0e7490">📁</text>
+    <text x="200" y="631" font-size="24" font-weight="800" fill="#0f172a">Plans</text>
+    <text x="136" y="678" font-size="22" font-weight="400" fill="#475569">Folder · updated today</text>
+
+
+    <rect x="480" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="534" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="522" y="634" font-size="26" font-weight="800" fill="#0e7490">📄</text>
+    <text x="576" y="631" font-size="24" font-weight="800" fill="#0f172a">spec.pdf</text>
+    <text x="512" y="678" font-size="22" font-weight="400" fill="#475569">PDF · Delete action has</text>
+<text x="512" y="708" font-size="22" font-weight="400" fill="#475569">a label</text>
+
+
+    <rect x="856" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="910" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="898" y="634" font-size="26" font-weight="800" fill="#0e7490">＋</text>
+    <text x="952" y="631" font-size="24" font-weight="800" fill="#0f172a">New folder</text>
+    <text x="888" y="678" font-size="22" font-weight="400" fill="#475569">Create folders without</text>
+<text x="888" y="708" font-size="22" font-weight="400" fill="#475569">visiting raw Nextcloud</text>
+<text x="888" y="738" font-size="22" font-weight="400" fill="#475569">UI.</text>
+
+  <rect x="1012" y="96" width="300" height="54" rx="20" fill="#0f172a"/>
+  <text x="1042" y="132" font-size="22" font-weight="800" fill="#ffffff">Upload / create folder</text>
+</svg>

--- a/docs/assets/marketing/05-settings.svg
+++ b/docs/assets/marketing/05-settings.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Weave settings screen</title>
+  <desc id="desc">The Weave settings screen shows saved local service configuration and sign-out controls.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eff6ff"/>
+      <stop offset="0.52" stop-color="#ecfeff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bg)"/>
+  <rect x="56" y="54" width="1328" height="792" rx="46" fill="#f8fafc" stroke="#bae6fd" stroke-width="3" filter="url(#shadow)"/>
+  <circle cx="111" cy="96" r="13" fill="#38bdf8"/>
+  <circle cx="149" cy="96" r="13" fill="#22d3ee"/>
+  <circle cx="187" cy="96" r="13" fill="#14b8a6"/>
+  <text x="234" y="105" font-size="34" font-weight="900" fill="#075985">Weave</text>
+
+    <rect x="86" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="110" y="153" font-size="22" font-weight="700" fill="#475569">Setup</text>
+
+
+    <rect x="284" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="308" y="153" font-size="22" font-weight="700" fill="#475569">Chat</text>
+
+
+    <rect x="482" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="506" y="153" font-size="22" font-weight="700" fill="#475569">Files</text>
+
+
+    <rect x="680" y="116" width="180" height="56" rx="18" fill="#e0f2fe" stroke="#0891b2" stroke-width="2"/>
+    <text x="704" y="153" font-size="22" font-weight="700" fill="#075985">Settings</text>
+
+  <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+  <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Workspace Settings</text>
+  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Review server configuration, update service URLs, and manage the</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">current session.</text>
+  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
+  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
+
+    <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">OIDC issuer</text>
+    <text x="132" y="480" font-size="20" font-weight="400" fill="#0f172a">https://auth.weave.local/realms</text>
+<text x="132" y="507" font-size="20" font-weight="400" fill="#0f172a">/weave</text>
+
+
+    <rect x="480" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="508" y="444" font-size="21" font-weight="700" fill="#0369a1">Client ID</text>
+    <text x="508" y="480" font-size="20" font-weight="400" fill="#0f172a">weave-app</text>
+
+
+    <rect x="856" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="884" y="444" font-size="21" font-weight="700" fill="#0369a1">Nextcloud</text>
+    <text x="884" y="480" font-size="20" font-weight="400" fill="#0f172a">https://files.weave.local</text>
+
+
+    <rect x="104" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="158" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="146" y="634" font-size="26" font-weight="800" fill="#0e7490">⚙</text>
+    <text x="200" y="631" font-size="24" font-weight="800" fill="#0f172a">Server configuration</text>
+    <text x="136" y="678" font-size="22" font-weight="400" fill="#475569">One persisted setup</text>
+<text x="136" y="708" font-size="22" font-weight="400" fill="#475569">model shared by</text>
+<text x="136" y="738" font-size="22" font-weight="400" fill="#475569">onboarding and settings.</text>
+
+
+    <rect x="480" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="534" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="522" y="634" font-size="26" font-weight="800" fill="#0e7490">🔐</text>
+    <text x="576" y="631" font-size="24" font-weight="800" fill="#0f172a">Account session</text>
+    <text x="512" y="678" font-size="22" font-weight="400" fill="#475569">Sign out clears chat and</text>
+<text x="512" y="708" font-size="22" font-weight="400" fill="#475569">files module sessions</text>
+<text x="512" y="738" font-size="22" font-weight="400" fill="#475569">safely.</text>
+
+
+    <rect x="856" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="910" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="898" y="634" font-size="26" font-weight="800" fill="#0e7490">♿</text>
+    <text x="952" y="631" font-size="24" font-weight="800" fill="#0f172a">Accessible controls</text>
+    <text x="888" y="678" font-size="22" font-weight="400" fill="#475569">Large touch targets,</text>
+<text x="888" y="708" font-size="22" font-weight="400" fill="#475569">labels, and plain-</text>
+<text x="888" y="738" font-size="22" font-weight="400" fill="#475569">language state.</text>
+
+  <rect x="1012" y="96" width="300" height="54" rx="20" fill="#0f172a"/>
+  <text x="1042" y="132" font-size="22" font-weight="800" fill="#ffffff">Save Changes</text>
+</svg>

--- a/docs/assets/marketing/05-settings.svg
+++ b/docs/assets/marketing/05-settings.svg
@@ -37,8 +37,6 @@
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Workspace Settings</text>
   <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Review server configuration, update service URLs, and manage the</text>
 <text x="144" y="350" font-size="26" font-weight="400" fill="#475569">current session.</text>
-  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
-  <text x="1257" y="286" font-size="25" font-weight="900" fill="#ffffff">AA</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">OIDC issuer</text>

--- a/tool/generate_marketing_screenshots.py
+++ b/tool/generate_marketing_screenshots.py
@@ -208,8 +208,6 @@ def render(screen: Screen) -> str:
   <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
   {line(screen.hero, 144, 270, size=42, weight=900, fill="#0f172a")}
   {multiline(screen.subhero, 144, 316, width=880, size=26, fill="#475569", line_height=34)}
-  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
-  {line("AA", 1257, 286, size=25, weight=900, fill="#ffffff")}
   {metrics}
   {cards}
   <rect x="1012" y="96" width="300" height="54" rx="20" fill="#0f172a"/>

--- a/tool/generate_marketing_screenshots.py
+++ b/tool/generate_marketing_screenshots.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Generate deterministic README/marketing screenshots for Weave.
+
+The assets intentionally use SVG so they are small, reviewable, and stable in CI.
+They mirror the Release 1 golden-path app states without relying on live-stack or
+pixel-golden Flutter rendering, which keeps core E2E validation isolated from
+marketing artifact generation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+from textwrap import wrap
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_DIR = ROOT / "docs" / "assets" / "marketing"
+WIDTH = 1440
+HEIGHT = 900
+
+
+@dataclass(frozen=True)
+class Metric:
+    label: str
+    value: str
+
+
+@dataclass(frozen=True)
+class Screen:
+    file_name: str
+    title: str
+    description: str
+    active_nav: str
+    hero: str
+    subhero: str
+    metrics: tuple[Metric, ...]
+    cards: tuple[tuple[str, str, str], ...]
+    status: str
+
+
+SCREENS: tuple[Screen, ...] = (
+    Screen(
+        file_name="01-setup-start.svg",
+        title="Weave setup start screen",
+        description="A Weave welcome screen invites an admin to configure the self-hosted workspace.",
+        active_nav="Setup",
+        hero="Set up your Weave workspace",
+        subhero="Connect identity, chat, files, and backend services through one guided Release 1 setup path.",
+        metrics=(
+            Metric("API", "https://api.weave.local/api"),
+            Metric("Auth", "https://auth.weave.local"),
+            Metric("Client", "Flutter desktop + mobile"),
+        ),
+        cards=(
+            ("1", "OIDC sign-in", "Use Keycloak-backed single sign-on with the infra-managed weave-app client."),
+            ("2", "Service endpoints", "Review Matrix, files, and backend URLs before saving the local workspace."),
+            ("3", "Ready shell", "Open chat, files, and settings from one accessible navigation model."),
+        ),
+        status="Get Started",
+    ),
+    Screen(
+        file_name="02-review-service-endpoints.svg",
+        title="Weave service endpoint review screen",
+        description="The setup review lists canonical local service endpoints before finishing configuration.",
+        active_nav="Setup",
+        hero="Review Service Endpoints",
+        subhero="Release 1 keeps raw services behind clear product boundaries and explicit local URLs.",
+        metrics=(
+            Metric("Matrix", "https://matrix.weave.local"),
+            Metric("Files", "https://files.weave.local"),
+            Metric("Backend", "https://api.weave.local/api"),
+        ),
+        cards=(
+            ("✓", "Identity authority", "Keycloak owns login, sessions, and user identity claims."),
+            ("✓", "Backend facade", "Weave backend is the product API after sign-in."),
+            ("✓", "Sovereign modules", "Matrix and Nextcloud provide protocol/data foundations behind Weave UX."),
+        ),
+        status="Finish setup",
+    ),
+    Screen(
+        file_name="03-chat-room.svg",
+        title="Weave chat room screen",
+        description="The custom Weave chat room shows a Release Room conversation and accessible message composer.",
+        active_nav="Chat",
+        hero="Release Room",
+        subhero="Custom Matrix chat surface with room list, readable message history, and a clear composer.",
+        metrics=(
+            Metric("Room", "#release-room"),
+            Metric("Encryption", "MVP non-E2EE, clearly labeled"),
+            Metric("State", "Connected"),
+        ),
+        cards=(
+            ("A", "Alice", "Golden path ready"),
+            ("W", "Weave", "Looks shippable"),
+            ("?", "Help", "Workspace rooms are provisioned behind the scenes."),
+        ),
+        status="Send message",
+    ),
+    Screen(
+        file_name="04-files-documents.svg",
+        title="Weave files documents screen",
+        description="The Weave files screen lists folders and files through the backend files facade.",
+        active_nav="Files",
+        hero="/Documents",
+        subhero="A basic Weave-owned files UI backed by the product backend and Nextcloud protocols.",
+        metrics=(
+            Metric("Connection", "Connected"),
+            Metric("Backend", "Files facade"),
+            Metric("Path", "/Documents"),
+        ),
+        cards=(
+            ("📁", "Plans", "Folder · updated today"),
+            ("📄", "spec.pdf", "PDF · Delete action has a label"),
+            ("＋", "New folder", "Create folders without visiting raw Nextcloud UI."),
+        ),
+        status="Upload / create folder",
+    ),
+    Screen(
+        file_name="05-settings.svg",
+        title="Weave settings screen",
+        description="The Weave settings screen shows saved local service configuration and sign-out controls.",
+        active_nav="Settings",
+        hero="Workspace Settings",
+        subhero="Review server configuration, update service URLs, and manage the current session.",
+        metrics=(
+            Metric("OIDC issuer", "https://auth.weave.local/realms/weave"),
+            Metric("Client ID", "weave-app"),
+            Metric("Nextcloud", "https://files.weave.local"),
+        ),
+        cards=(
+            ("⚙", "Server configuration", "One persisted setup model shared by onboarding and settings."),
+            ("🔐", "Account session", "Sign out clears chat and files module sessions safely."),
+            ("♿", "Accessible controls", "Large touch targets, labels, and plain-language state."),
+        ),
+        status="Save Changes",
+    ),
+)
+
+
+def line(text: str, x: int, y: int, size: int = 28, weight: int = 500, fill: str = "#0f172a") -> str:
+    return f'<text x="{x}" y="{y}" font-size="{size}" font-weight="{weight}" fill="{fill}">{escape(text)}</text>'
+
+
+def multiline(text: str, x: int, y: int, *, width: int, size: int = 28, fill: str = "#334155", line_height: int = 38) -> str:
+    chars = max(18, width // max(size // 2, 1))
+    parts = []
+    for index, segment in enumerate(wrap(text, chars)):
+        parts.append(line(segment, x, y + index * line_height, size=size, weight=400, fill=fill))
+    return "\n".join(parts)
+
+
+def nav_item(label: str, x: int, y: int, active: bool) -> str:
+    fill = "#e0f2fe" if active else "#ffffff"
+    stroke = "#0891b2" if active else "#dbeafe"
+    text_fill = "#075985" if active else "#475569"
+    return f'''
+    <rect x="{x}" y="{y}" width="180" height="56" rx="18" fill="{fill}" stroke="{stroke}" stroke-width="2"/>
+    {line(label, x + 24, y + 37, size=22, weight=700, fill=text_fill)}
+    '''
+
+
+def metric_card(metric: Metric, x: int, y: int) -> str:
+    return f'''
+    <rect x="{x}" y="{y}" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    {line(metric.label, x + 28, y + 42, size=21, weight=700, fill="#0369a1")}
+    {multiline(metric.value, x + 28, y + 78, width=310, size=20, fill="#0f172a", line_height=27)}
+    '''
+
+
+def content_card(icon: str, title: str, body: str, x: int, y: int) -> str:
+    return f'''
+    <rect x="{x}" y="{y}" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="{x + 54}" cy="{y + 58}" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    {line(icon, x + 42, y + 68, size=26, weight=800, fill="#0e7490")}
+    {line(title, x + 96, y + 65, size=24, weight=800, fill="#0f172a")}
+    {multiline(body, x + 32, y + 112, width=270, size=22, fill="#475569", line_height=30)}
+    '''
+
+
+def render(screen: Screen) -> str:
+    nav = "\n".join(
+        nav_item(label, 86 + index * 198, 116, screen.active_nav == label)
+        for index, label in enumerate(("Setup", "Chat", "Files", "Settings"))
+    )
+    metrics = "\n".join(metric_card(metric, 104 + index * 376, 402) for index, metric in enumerate(screen.metrics))
+    cards = "\n".join(content_card(*card, x=104 + index * 376, y=566) for index, card in enumerate(screen.cards))
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" height="{HEIGHT}" viewBox="0 0 {WIDTH} {HEIGHT}" role="img" aria-labelledby="title desc">
+  <title id="title">{escape(screen.title)}</title>
+  <desc id="desc">{escape(screen.description)}</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eff6ff"/>
+      <stop offset="0.52" stop-color="#ecfeff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="{WIDTH}" height="{HEIGHT}" fill="url(#bg)"/>
+  <rect x="56" y="54" width="1328" height="792" rx="46" fill="#f8fafc" stroke="#bae6fd" stroke-width="3" filter="url(#shadow)"/>
+  <circle cx="111" cy="96" r="13" fill="#38bdf8"/>
+  <circle cx="149" cy="96" r="13" fill="#22d3ee"/>
+  <circle cx="187" cy="96" r="13" fill="#14b8a6"/>
+  {line("Weave", 234, 105, size=34, weight=900, fill="#075985")}
+  {nav}
+  <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+  {line(screen.hero, 144, 270, size=42, weight=900, fill="#0f172a")}
+  {multiline(screen.subhero, 144, 316, width=880, size=26, fill="#475569", line_height=34)}
+  <rect x="1228" y="248" width="104" height="56" rx="20" fill="#0e7490"/>
+  {line("AA", 1257, 286, size=25, weight=900, fill="#ffffff")}
+  {metrics}
+  {cards}
+  <rect x="1012" y="96" width="300" height="54" rx="20" fill="#0f172a"/>
+  {line(screen.status, 1042, 132, size=22, weight=800, fill="#ffffff")}
+</svg>
+'''
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    for screen in SCREENS:
+        path = OUTPUT_DIR / screen.file_name
+        svg = "\n".join(line.rstrip() for line in render(screen).splitlines()) + "\n"
+        path.write_text(svg, encoding="utf-8")
+        print(path.relative_to(ROOT))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

The README had no actual product/marketing screenshots, and there was no reproducible path for keeping documentation imagery current without making live E2E or widget screenshot capture flaky.

## Target behavior

- Check in deterministic Release 1 marketing screenshots under `docs/assets/marketing/`.
- Embed screenshots in the README with descriptive `alt` text.
- Provide a stable generator path via `make marketing-screenshots` and `tool/generate_marketing_screenshots.py`.
- Keep the core release/live-stack E2E paths untouched.
- Add a lightweight CI drift check so generated assets stay reproducible.

## Files changed

- `README.md`
- `Makefile`
- `.github/workflows/ci.yml`
- `tool/generate_marketing_screenshots.py`
- `docs/assets/marketing/*.svg`

## Validation

- `make marketing-screenshots`
- `python3 -m py_compile tool/generate_marketing_screenshots.py`
- XML parse/title/desc check for all generated SVGs
- `flutter test test/release_1/release_golden_paths_test.dart`
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze --fatal-infos`
- `flutter test`
- `make offline-contract-test`
- `git diff --cached --check`

## Contract impact

Frontend documentation/CI only. No backend, infra, API, auth, topology, or live-stack E2E contract changes.
