### PR TITLE
docs: link README marketing screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,33 @@ Calendar, tasks/boards, Slack/Teams interop, migration tooling, connector SDKs, 
 
 The images below are deterministic Release 1 marketing screenshots generated from `tool/generate_marketing_screenshots.py`. They are checked into `docs/assets/marketing/` so the README is useful without downloading CI artifacts, and each image has descriptive alt text rather than relying on image-only documentation.
 
+Screenshot links:
+
+- [Setup screenshot](docs/assets/marketing/01-setup-start.svg)
+- [Endpoint review screenshot](docs/assets/marketing/02-review-service-endpoints.svg)
+- [Chat screenshot](docs/assets/marketing/03-chat-room.svg)
+- [Files screenshot](docs/assets/marketing/04-files-documents.svg)
+- [Settings screenshot](docs/assets/marketing/05-settings.svg)
+
 ### Setup
 
-<img src="docs/assets/marketing/01-setup-start.svg" alt="Weave setup start screen showing a guided workspace setup path and canonical local service URLs." width="560">
+[<img src="docs/assets/marketing/01-setup-start.svg" alt="Weave setup start screen showing a guided workspace setup path and canonical local service URLs." width="560">](docs/assets/marketing/01-setup-start.svg)
 
 ### Endpoint review
 
-<img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave setup endpoint review screenshot listing Matrix, files, and backend service URLs before finishing setup." width="560">
+[<img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave setup endpoint review screenshot listing Matrix, files, and backend service URLs before finishing setup." width="560">](docs/assets/marketing/02-review-service-endpoints.svg)
 
 ### Chat
 
-<img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room screenshot showing the Release Room, message history, and a send message action." width="560">
+[<img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room screenshot showing the Release Room, message history, and a send message action." width="560">](docs/assets/marketing/03-chat-room.svg)
 
 ### Files
 
-<img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files screenshot showing the Documents folder with folders, files, and accessible file actions." width="560">
+[<img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files screenshot showing the Documents folder with folders, files, and accessible file actions." width="560">](docs/assets/marketing/04-files-documents.svg)
 
 ### Settings
 
-<img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screenshot showing OIDC issuer, client ID, Nextcloud URL, and account session controls." width="560">
+[<img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screenshot showing OIDC issuer, client ID, Nextcloud URL, and account session controls." width="560">](docs/assets/marketing/05-settings.svg)
 
 ## Product architecture
 


### PR DESCRIPTION
## Summary
- Adds an explicit screenshot link list to the README so the marketing SVGs are directly discoverable.
- Wraps each embedded screenshot image in a link to its checked-in SVG asset.
- Keeps descriptive alt text and avoids image-only documentation.

## Validation
- `git diff --check`

## Contract impact
- Documentation only.