### PR TITLE
test(release): guard hidden future surfaces

### DIFF
--- a/test/architecture/release_scope_contract_test.dart
+++ b/test/architecture/release_scope_contract_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'Release 1 router keeps future calendar and boards surfaces hidden',
+    () async {
+      final routerSource = await File(
+        'lib/core/router/app_router.dart',
+      ).readAsString();
+      final shellSource = await File(
+        'lib/features/shell/presentation/app_shell.dart',
+      ).readAsString();
+
+      expect(routerSource, contains('onHiddenReleaseOneRoute'));
+      expect(
+        routerSource,
+        contains('state.matchedLocation == AppRoutes.calendar'),
+      );
+      expect(routerSource, contains('state.matchedLocation == AppRoutes.deck'));
+      expect(routerSource, contains('return AppRoutes.chat'));
+
+      expect(routerSource, isNot(contains('CalendarScreen')));
+      expect(routerSource, isNot(contains('DeckScreen')));
+      expect(routerSource, isNot(contains('path: AppRoutes.calendar')));
+      expect(routerSource, isNot(contains('path: AppRoutes.deck')));
+
+      expect(shellSource, contains('l10n.navChat'));
+      expect(shellSource, contains('l10n.navFiles'));
+      expect(shellSource, contains('l10n.navSettings'));
+      expect(shellSource, isNot(contains('navCalendar')));
+      expect(shellSource, isNot(contains('navDeck')));
+    },
+  );
+
+  test(
+    'README screenshots show only implemented Release 1 product surfaces',
+    () async {
+      final readme = await File('README.md').readAsString();
+      final screenshotSection = _section(readme, '## Product screenshots');
+
+      final imageMatches = RegExp(
+        r'<img src="([^"]+)" alt="([^"]+)" width="560">',
+      ).allMatches(screenshotSection).toList();
+
+      expect(imageMatches.map((match) => match.group(1)).toList(), <String>[
+        'docs/assets/marketing/01-setup-start.svg',
+        'docs/assets/marketing/02-review-service-endpoints.svg',
+        'docs/assets/marketing/03-chat-room.svg',
+        'docs/assets/marketing/04-files-documents.svg',
+        'docs/assets/marketing/05-settings.svg',
+      ]);
+
+      for (final match in imageMatches) {
+        final assetPath = match.group(1)!;
+        final altText = match.group(2)!;
+
+        expect(
+          File(assetPath).existsSync(),
+          isTrue,
+          reason: '$assetPath exists',
+        );
+        expect(altText.trim(), isNotEmpty, reason: '$assetPath has alt text');
+        expect(altText.toLowerCase(), isNot(contains('preview')));
+      }
+
+      final lowerSection = screenshotSection.toLowerCase();
+      expect(lowerSection, isNot(contains('calendar')));
+      expect(lowerSection, isNot(contains('deck')));
+      expect(lowerSection, isNot(contains('boards')));
+      expect(lowerSection, isNot(contains('tasks')));
+    },
+  );
+}
+
+String _section(String markdown, String heading) {
+  final start = markdown.indexOf(heading);
+  expect(start, isNonNegative, reason: '$heading section exists');
+
+  final nextHeading = RegExp(
+    r'\n## ',
+  ).firstMatch(markdown.substring(start + 1));
+  if (nextHeading == null) {
+    return markdown.substring(start);
+  }
+
+  return markdown.substring(start, start + 1 + nextHeading.start);
+}


### PR DESCRIPTION
## Problem

The current Release 1 contract says Calendar and boards/tasks are future/hidden surfaces, while README screenshots must only show implemented and visible product flows. We had feature tests for the current shell, but no small architecture guard that ties the router/nav and README screenshot promises together.

## Target behavior

- Keep Calendar and Deck/boards routes hidden from Release 1 navigation and redirect direct hidden-route hits back to Chat.
- Keep README product screenshots limited to the implemented setup, chat, files, and settings surfaces.
- Preserve the calendar backend-facade/no direct CalDAV direction and boards/provider-neutral direction already documented in main.

## Changes

- Added `test/architecture/release_scope_contract_test.dart`:
  - asserts the router continues to redirect hidden Calendar/Deck routes and does not wire `CalendarScreen`/`DeckScreen` into shell routes;
  - asserts the app shell nav remains Chat, Files, Settings only;
  - asserts the README screenshot section references exactly the deterministic implemented-surface SVGs, with alt text, and does not market preview Calendar/Deck/boards/tasks surfaces.

## Validation

Local:

- `dart format test/architecture/release_scope_contract_test.dart`
- `flutter test test/architecture/backend_facade_contract_test.dart test/architecture/release_scope_contract_test.dart`
- `make marketing-screenshots && git diff --exit-code -- docs/assets/marketing`
- `flutter test test/features/shell/app_shell_test.dart test/features/calendar/calendar_screen_test.dart test/architecture/release_scope_contract_test.dart`
- `flutter test` — all tests passed; live-stack credentialed tests skipped as designed without live credentials.

CI:

- Push CI `Offline Flutter Checks`: pass — https://github.com/masssi164/weave/actions/runs/25857175630/job/75977818379
- PR CI `Offline Flutter Checks`: pass — https://github.com/masssi164/weave/actions/runs/25857187209/job/75977857618

## Contract changes

No product contract change. This PR adds executable guards for the existing Release 1 scope/screenshots contract.
