### PR TITLE
docs: add workspace calendar preview screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ A first look at the Release 1 experience: guided setup, chat, files, and workspa
 
 [<img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screenshot showing OIDC issuer, client ID, Nextcloud URL, and account session controls." width="560">](docs/assets/marketing/05-settings.svg)
 
+### Hidden preview: workspace calendar
+
+Calendar is not a Release 1 navigation promise yet. The checked-in preview screenshot is included only to document the current in-progress shape: a Weave-owned workspace-calendar surface backed by the backend facade, with private per-user calendars still blocked on the documented access model.
+
+[<img src="docs/assets/marketing/06-calendar-workspace-preview.svg" alt="Weave calendar preview screenshot showing a workspace calendar scope label, backend facade contract, and private calendar blocker." width="560">](docs/assets/marketing/06-calendar-workspace-preview.svg)
+
+Regenerate screenshots with `make marketing-screenshots` and review the SVG diff before committing.
+
 ## Product architecture
 
 Weave is the Flutter client in a three-repository product system:

--- a/docs/assets/marketing/06-calendar-workspace-preview.svg
+++ b/docs/assets/marketing/06-calendar-workspace-preview.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Weave workspace calendar preview screen</title>
+  <desc id="desc">The hidden Calendar preview labels the first backend-provided scope as a shared workspace calendar, not a private user calendar.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#eff6ff"/>
+      <stop offset="0.52" stop-color="#ecfeff"/>
+      <stop offset="1" stop-color="#f8fafc"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#0f172a" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bg)"/>
+  <rect x="56" y="54" width="1328" height="792" rx="46" fill="#f8fafc" stroke="#bae6fd" stroke-width="3" filter="url(#shadow)"/>
+  <circle cx="111" cy="96" r="13" fill="#38bdf8"/>
+  <circle cx="149" cy="96" r="13" fill="#22d3ee"/>
+  <circle cx="187" cy="96" r="13" fill="#14b8a6"/>
+  <text x="234" y="105" font-size="34" font-weight="900" fill="#075985">Weave</text>
+
+    <rect x="86" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="110" y="153" font-size="22" font-weight="700" fill="#475569">Setup</text>
+
+
+    <rect x="284" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="308" y="153" font-size="22" font-weight="700" fill="#475569">Chat</text>
+
+
+    <rect x="482" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="506" y="153" font-size="22" font-weight="700" fill="#475569">Files</text>
+
+
+    <rect x="680" y="116" width="180" height="56" rx="18" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="704" y="153" font-size="22" font-weight="700" fill="#475569">Settings</text>
+
+  <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+  <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Workspace calendar preview</text>
+  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Calendar is hidden from Release 1 navigation while the first safe</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">slice uses the backend facade and clearly labels shared workspace</text>
+<text x="144" y="384" font-size="26" font-weight="400" fill="#475569">scope.</text>
+
+    <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Scope</text>
+    <text x="132" y="480" font-size="20" font-weight="400" fill="#0f172a">Workspace calendar</text>
+
+
+    <rect x="480" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="508" y="444" font-size="21" font-weight="700" fill="#0369a1">Facade</text>
+    <text x="508" y="480" font-size="20" font-weight="400" fill="#0f172a">/api/calendar/events</text>
+
+
+    <rect x="856" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
+    <text x="884" y="444" font-size="21" font-weight="700" fill="#0369a1">Release</text>
+    <text x="884" y="480" font-size="20" font-weight="400" fill="#0f172a">Hidden preview</text>
+
+
+    <rect x="104" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="158" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="146" y="634" font-size="26" font-weight="800" fill="#0e7490">👥</text>
+    <text x="200" y="631" font-size="24" font-weight="800" fill="#0f172a">Shared by the workspace</text>
+    <text x="136" y="678" font-size="22" font-weight="400" fill="#475569">Events belong to the</text>
+<text x="136" y="708" font-size="22" font-weight="400" fill="#475569">backend-provisioned</text>
+<text x="136" y="738" font-size="22" font-weight="400" fill="#475569">workspace calendar for</text>
+<text x="136" y="768" font-size="22" font-weight="400" fill="#475569">this first slice.</text>
+
+
+    <rect x="480" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="534" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="522" y="634" font-size="26" font-weight="800" fill="#0e7490">✓</text>
+    <text x="576" y="631" font-size="24" font-weight="800" fill="#0f172a">Create and edit events</text>
+    <text x="512" y="678" font-size="22" font-weight="400" fill="#475569">The Flutter surface</text>
+<text x="512" y="708" font-size="22" font-weight="400" fill="#475569">talks to Weave backend,</text>
+<text x="512" y="738" font-size="22" font-weight="400" fill="#475569">which owns CalDAV</text>
+<text x="512" y="768" font-size="22" font-weight="400" fill="#475569">credentials and errors.</text>
+
+
+    <rect x="856" y="566" width="336" height="210" rx="32" fill="#ffffff" stroke="#e2e8f0" stroke-width="2"/>
+    <circle cx="910" cy="624" r="28" fill="#ecfeff" stroke="#67e8f9" stroke-width="2"/>
+    <text x="898" y="634" font-size="26" font-weight="800" fill="#0e7490">🔒</text>
+    <text x="952" y="631" font-size="24" font-weight="800" fill="#0f172a">Private calendars blocked</text>
+    <text x="888" y="678" font-size="22" font-weight="400" fill="#475569">Per-user calendars stay</text>
+<text x="888" y="708" font-size="22" font-weight="400" fill="#475569">disabled until issue #52</text>
+<text x="888" y="738" font-size="22" font-weight="400" fill="#475569">defines sharing or</text>
+<text x="888" y="768" font-size="22" font-weight="400" fill="#475569">delegation.</text>
+
+  <rect x="1012" y="96" width="300" height="54" rx="20" fill="#0f172a"/>
+  <text x="1042" y="132" font-size="22" font-weight="800" fill="#ffffff">Preview only</text>
+</svg>

--- a/tool/generate_marketing_screenshots.py
+++ b/tool/generate_marketing_screenshots.py
@@ -135,6 +135,26 @@ SCREENS: tuple[Screen, ...] = (
         ),
         status="Save Changes",
     ),
+
+    Screen(
+        file_name="06-calendar-workspace-preview.svg",
+        title="Weave workspace calendar preview screen",
+        description="The hidden Calendar preview labels the first backend-provided scope as a shared workspace calendar, not a private user calendar.",
+        active_nav="Preview",
+        hero="Workspace calendar preview",
+        subhero="Calendar is hidden from Release 1 navigation while the first safe slice uses the backend facade and clearly labels shared workspace scope.",
+        metrics=(
+            Metric("Scope", "Workspace calendar"),
+            Metric("Facade", "/api/calendar/events"),
+            Metric("Release", "Hidden preview"),
+        ),
+        cards=(
+            ("👥", "Shared by the workspace", "Events belong to the backend-provisioned workspace calendar for this first slice."),
+            ("✓", "Create and edit events", "The Flutter surface talks to Weave backend, which owns CalDAV credentials and errors."),
+            ("🔒", "Private calendars blocked", "Per-user calendars stay disabled until issue #52 defines sharing or delegation."),
+        ),
+        status="Preview only",
+    ),
 )
 
 


### PR DESCRIPTION
## Summary
- add a generated README screenshot asset for the hidden workspace-calendar preview
- document that Calendar remains preview-only and not a Release 1 navigation promise
- keep the screenshot copy aligned with the backend-facade workspace scope and private-calendar blocker (#52)

## Validation
- `make marketing-screenshots`
- `flutter test test/features/calendar/calendar_screen_test.dart test/features/calendar/data/services/calendar_facade_client_test.dart`
- `flutter analyze`
- `git diff --check`
- backend contract sanity: `./gradlew test --tests 'com.massimotter.weave.backend.service.calendar.CalDavCalendarAdapterTest'` in `weave-backend` at `origin/main`

## Contract notes
- No new runtime route exposure; Calendar remains hidden from the Release 1 shell.
- No direct Flutter-to-CalDAV fallback; copy explicitly references the Weave backend facade.
- Private per-user calendars remain blocked on `weave-backend#52`.
