### PR TITLE
feat(boards): prototype connector event normalizer

### DIFF
--- a/docs/research/boards-task-domain-contract.md
+++ b/docs/research/boards-task-domain-contract.md
@@ -139,6 +139,10 @@ Event handling must document ordering, idempotency, redaction/privacy, replay be
 - Backend/API contracts include capability discovery, support-safe errors, pagination, sync metadata, and normalized events.
 - Accessibility test/audit strategy covers keyboard-only, screen reader, non-drag movement, visible focus, non-color status, and text scaling.
 
+## Evidence artifacts
+
+- [Boards connector spikes: Vikunja, OpenProject, Nextcloud Deck](provider-spikes/boards-connectors-spikes.md) captures source-backed findings and the tested adapter/event-normalizer prototype for issues #119, #120, #121, and #123.
+
 ## Related issues
 
 - [#119 provider-vikunja-spike](https://github.com/masssi164/weave/issues/119)

--- a/docs/research/boards-task-module-provider-strategy.md
+++ b/docs/research/boards-task-module-provider-strategy.md
@@ -55,6 +55,8 @@ See [Boards and Tasks Domain Contract](boards-task-domain-contract.md) for the n
 
 Future provider work should include a provider-neutral event normalizer before broad UI investment. It should map provider-specific changes into Weave events such as task created, task moved, assignment changed, comment added, due date changed, task completed, and sync/conflict detected. This keeps notifications, recent activity, audit/support diagnostics, and future agent workflows independent from one provider.
 
+The source-backed spike findings and tested adapter/event-normalizer prototype are documented in [Boards connector spikes: Vikunja, OpenProject, Nextcloud Deck](provider-spikes/boards-connectors-spikes.md).
+
 ## Open follow-up issues
 
 Create or keep issues for:

--- a/docs/research/provider-spikes/boards-connectors-spikes.md
+++ b/docs/research/provider-spikes/boards-connectors-spikes.md
@@ -1,0 +1,123 @@
+# Boards connector spikes: Vikunja, OpenProject, Nextcloud Deck
+
+Status: evidence artifact and adapter-shape proposal for post-Release-1 boards/tasks work  
+Date: 2026-05-14  
+Related issues: [#119](https://github.com/masssi164/weave/issues/119), [#120](https://github.com/masssi164/weave/issues/120), [#121](https://github.com/masssi164/weave/issues/121), [#123](https://github.com/masssi164/weave/issues/123)
+
+## Scope boundary
+
+Boards/tasks remain post-Release-1. This spike does not promote a live provider integration, does not add provider credentials, and does not bind the Weave UI to Vikunja, OpenProject, or Deck vocabulary.
+
+The testable code artifact is a provider-neutral adapter/event shape:
+
+- `lib/features/boards/domain/adapters/board_provider_adapter.dart`
+- `lib/features/boards/domain/entities/task_board_event.dart`
+- `lib/features/boards/data/normalizers/task_board_event_normalizer.dart`
+- `test/features/boards/domain/task_board_event_normalizer_test.dart`
+
+## Minimal adapter contract
+
+Provider adapters must expose Weave concepts only:
+
+- provider refs, not provider-native IDs in UI state;
+- explicit capabilities instead of pretending every provider supports comments, attachments, webhooks, or incremental sync;
+- support-safe errors: unauthorized, forbidden, not found, conflict, rate limited, offline, validation, provider unavailable, unknown;
+- paged list/sync responses with cursors, ETags, or timestamps;
+- normalized `TaskBoardEvent` output for automation, notifications, recent activity, audit, and support diagnostics.
+
+## Vikunja spike (#119)
+
+Recommendation: keep Vikunja as the first implementation candidate, but require reconciliation in addition to webhooks.
+
+Findings:
+
+- API/auth fit is strong: Vikunja documents instance-local Swagger/OpenAPI at `/api/v1/docs`, a public docs instance, `/api/v1/docs.json`, and API-token Bearer auth as the recommended mode. Source: <https://vikunja.io/docs/api-documentation/>
+- Coverage is broad for the first adapter: the OpenAPI paths include projects, project views/buckets, tasks, task position, assignees, comments, labels, attachments, relations, and project/user webhooks. Source: <https://try.vikunja.io/api/v1/docs.json>
+- Pagination/error fit needs adapter wrapping: API responses expose paginated collection endpoints plus provider-specific error bodies/codes, so Weave should surface typed adapter errors rather than raw Vikunja failures. Source: <https://try.vikunja.io/api/v1/docs.json>
+- Webhook payloads already use task-like event names such as `task.created`, include ISO timestamps, and include `task` plus `doer` objects; this maps cleanly into the Weave event envelope. Source: <https://vikunja.io/docs/webhooks/>
+- Risk: webhook delivery is documented as at-most-once with no retry on failed deliveries. Therefore `webhookEvents` is useful but not enough; adapters need periodic incremental reconciliation and idempotency keys.
+- Data portability is better than average: Vikunja documents full data export/import for backup and migration, and the OpenAPI includes `/user/export*` plus multiple migration endpoints. Sources: <https://vikunja.io/help/import-and-export/>, <https://try.vikunja.io/api/v1/docs.json>
+- Licensing/deployment note: Vikunja is self-hostable as a single binary or Docker container, and the upstream repository reports AGPL-3.0. Sources: <https://vikunja.io/docs/installing/>, <https://github.com/go-vikunja/vikunja>
+- Product-model note: Vikunja project/view/bucket/task terms should map to Weave workspace/project/board/column/task behind provider refs.
+
+## OpenProject accessibility benchmark (#120)
+
+Recommendation: use OpenProject as an accessibility and mature-workflow benchmark only for now; do not choose it as the first provider until a later auth/sync spike.
+
+Findings:
+
+- OpenProject's accessibility checklist targets WCAG 2.1 AA and explicitly calls out logical reading/navigation order, non-color-only information, doubled text size, full keyboard availability, no keyboard traps, visible focus, and informative labels. Source: <https://raw.githubusercontent.com/opf/openproject/dev/docs/development/accessibility-checklist/README.md>
+- OpenProject documents keyboard shortcuts/access keys for global search, work package navigation, new work package, edit/preview, more menu, and list item movement. Weave should prefer discoverable command menus and avoid shortcuts that conflict with screen readers. Source: <https://raw.githubusercontent.com/opf/openproject/dev/docs/user-guide/keyboard-shortcuts-access-keys/README.md>
+- OpenProject's design docs use ARIA live regions for dynamic announcements. Weave's future board UI should similarly announce create/move/complete/conflict outcomes without moving focus. Source: <https://raw.githubusercontent.com/opf/openproject/dev/lookbook/docs/patterns/accessibility/18-aria-live.md.erb>
+- OpenProject boards are mature workflow references: Basic boards can move cards without mutating work-package fields, while Action boards map lists to status/assignee/version/subproject fields and movement changes those fields. Source: <https://www.openproject.org/docs/user-guide/agile-boards/>
+- API fit is likely rich but complex: work packages expose attachments, comments/activities, status, assignee, priority, project, custom fields, watchers, relations, optimistic lock version, and update links. Source: <https://www.openproject.org/docs/api/endpoints/work-packages/>
+
+Pitfalls to avoid:
+
+- do not require drag-and-drop for movement;
+- do not hide state changes behind color-only chips;
+- do not move focus unexpectedly after card mutations;
+- do not rely on unannounced background refreshes for conflict or permission outcomes.
+
+Concrete Weave UI requirements from this benchmark:
+
+- keyboard-only creation, opening, moving, assigning, completing, and filtering;
+- visible focus and deterministic reading order across columns/cards;
+- non-drag alternatives for every move operation;
+- status, priority, due-date, conflict, and permission states as text, not color alone;
+- screen-reader announcements for create/update/move/delete/conflict;
+- text scaling tolerance so action menus remain reachable.
+
+## Nextcloud Deck bridge spike (#121)
+
+Recommendation: Deck is suitable as a bridge/import or low-friction fallback adapter because Nextcloud is already in Weave's stack, but it should not define the Weave product surface.
+
+Findings:
+
+- Deck's API is authenticated through the Nextcloud app route and requires `OCS-APIRequest: true`; it defines board/stack/card/label naming and exposes API versions. Source: <https://raw.githubusercontent.com/nextcloud/deck/main/docs/API.md>
+- API coverage is good for a bridge: boards, stacks, cards, labels, assignments, archives/unarchives, reorder, comments, attachments, config, and import endpoints are documented. Source: <https://raw.githubusercontent.com/nextcloud/deck/main/docs/API.md>
+- Incremental sync is plausible through `If-Modified-Since`, `If-None-Match`, ETags on board/stack/card/attachment endpoints, and parent ETag propagation when child elements change. Source: <https://raw.githubusercontent.com/nextcloud/deck/main/docs/API.md>
+- Event gap: no first-class Deck webhook source was found in the API notes. The prototype treats Deck events as polling/snapshot-derived events with ETag-backed idempotency.
+- Auth/session fit: Deck should reuse the existing Nextcloud session/facade direction instead of adding Flutter-side raw credentials.
+- Product risk: Deck-specific terms and limitations must stay in adapter docs/support diagnostics only; Weave UI remains provider-neutral.
+
+Gap categories:
+
+- API: good CRUD coverage for bridge use; comments/activity and attachments are available, but Deck's board/stack/card model needs translation.
+- Auth: likely reusable through the existing Nextcloud session/BFF direction; do not add raw Deck credentials in Flutter.
+- Sync/event: polling/ETag reconciliation is required unless a later server-side Deck event source is proven.
+- Accessibility: API docs do not prove accessible workflows; Weave must keep its own keyboard/screen-reader/non-drag requirements.
+- Product-model mismatch: Deck may be an import/bridge surface, not the normal Weave boards vocabulary or UX.
+
+## Event normalizer (#123)
+
+Recommendation: the first production event normalizer belongs in the backend-owned BFF/interop boundary, eventually aligning with the disabled-by-default interop gateway foundation in `weave-backend` [#38](https://github.com/masssi164/weave-backend/issues/38). A public connector SDK remains deferred until real connectors prove the internal framework, matching `weave-backend` [#43](https://github.com/masssi164/weave-backend/issues/43).
+
+This PR keeps a Flutter-side, testable domain prototype so presentation state can consume normalized events without provider-specific logic when the backend contract arrives.
+
+Required event envelope:
+
+- idempotency key;
+- event type;
+- actor ref;
+- occurred-at timestamp;
+- workspace/project/board/task identifiers;
+- provider ref with external ID, optional URL/version/ETag/raw type;
+- redaction level;
+- support-safe payload.
+
+Initial event types:
+
+- `task.created`, `task.updated`, `task.completed`, `task.archived`, `task.moved`;
+- `assignment.changed`, `label.changed`, `priority.changed`, `due_date.changed`;
+- `comment.added`, `attachment.changed`;
+- `sync.conflict_detected`.
+
+Operational requirements before production:
+
+- store idempotency keys and dedupe before notifications/recent activity;
+- preserve provider ordering metadata but tolerate out-of-order deliveries;
+- reconcile webhook gaps with periodic sync for at-most-once or polling-only providers;
+- redact user content from support bundles unless explicitly consented;
+- keep raw provider payloads out of Flutter state and support logs;
+- represent conflict events before overwriting local or provider state.

--- a/lib/core/router/app_router.g.dart
+++ b/lib/core/router/app_router.g.dart
@@ -55,4 +55,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'9c4dab3c0972fcdda1ca521a38114f38011b0173';
+String _$appRouterHash() => r'f459dab64d60ec0a480a6fd26076fd3af4e68aef';

--- a/lib/features/boards/data/normalizers/task_board_event_normalizer.dart
+++ b/lib/features/boards/data/normalizers/task_board_event_normalizer.dart
@@ -1,0 +1,198 @@
+import 'package:weave/features/boards/domain/entities/task_board_event.dart';
+
+class VikunjaWebhookNormalizer {
+  const VikunjaWebhookNormalizer();
+
+  TaskBoardEvent normalize({
+    required Map<String, Object?> payload,
+    required String workspaceId,
+    String? projectId,
+  }) {
+    final eventName = _string(payload['event_name']) ?? 'task.updated';
+    final data = _map(payload['data']);
+    final task = _map(data['task']);
+    final doer = _map(data['doer']);
+    final occurredAt = _date(payload['time']) ?? DateTime.now().toUtc();
+    final taskId = _id(task['id']);
+    final project = projectId ?? _id(task['project_id']);
+    final bucketId = _id(task['bucket_id']);
+
+    return TaskBoardEvent(
+      idempotencyKey: _idempotencyKey(
+        provider: BoardEventProvider.vikunja,
+        eventName: eventName,
+        occurredAt: occurredAt,
+        primaryId: taskId,
+      ),
+      type: _vikunjaType(eventName, task),
+      actorRef: _actor(doer, BoardEventProvider.vikunja),
+      occurredAt: occurredAt,
+      workspaceId: workspaceId,
+      projectId: project,
+      boardId: project,
+      taskId: taskId,
+      providerRef: BoardProviderRef(
+        provider: BoardEventProvider.vikunja,
+        externalId: taskId ?? 'unknown-task',
+        rawType: eventName,
+      ),
+      redactionLevel: BoardEventRedactionLevel.supportSafe,
+      payload: {
+        if (bucketId != null) 'target_column_id': bucketId,
+        if (_id(task['position']) != null) 'position': _id(task['position']),
+        if (_bool(task['done']) != null) 'completed': _bool(task['done']),
+        if (_string(task['priority']) != null)
+          'priority': _string(task['priority']),
+        if (_string(task['due_date']) != null)
+          'due_at': _string(task['due_date']),
+      },
+    );
+  }
+
+  static BoardEventType _vikunjaType(
+    String eventName,
+    Map<String, Object?> task,
+  ) {
+    if (eventName.contains('comment')) return BoardEventType.commentAdded;
+    if (eventName.contains('attachment')) {
+      return BoardEventType.attachmentChanged;
+    }
+    if (eventName.contains('assignee')) return BoardEventType.assignmentChanged;
+    if (eventName.contains('label')) return BoardEventType.labelChanged;
+    if (eventName == 'task.created') return BoardEventType.taskCreated;
+    if (_bool(task['done']) == true) return BoardEventType.taskCompleted;
+    if (eventName.contains('moved') || task.containsKey('bucket_id')) {
+      return BoardEventType.taskMoved;
+    }
+    return BoardEventType.taskUpdated;
+  }
+}
+
+class DeckPollingEventNormalizer {
+  const DeckPollingEventNormalizer();
+
+  TaskBoardEvent normalizeCardSnapshot({
+    required Map<String, Object?> card,
+    required String workspaceId,
+    required String boardId,
+    required String stackId,
+    required DeckSnapshotChange change,
+    DateTime? observedAt,
+  }) {
+    final cardId = _id(card['id']) ?? 'unknown-card';
+    final archived = _bool(card['archived']) ?? false;
+    final done = _bool(card['done']) ?? false;
+    final etag = _string(card['ETag']) ?? _string(card['etag']);
+    final changedAt =
+        _date(card['lastModified']) ?? observedAt ?? DateTime.now().toUtc();
+
+    return TaskBoardEvent(
+      idempotencyKey: _idempotencyKey(
+        provider: BoardEventProvider.nextcloudDeck,
+        eventName: change.name,
+        occurredAt: changedAt,
+        primaryId: '$boardId:$stackId:$cardId:${etag ?? 'no-etag'}',
+      ),
+      type: _deckType(change, archived: archived, done: done),
+      actorRef: const BoardActorRef.system(),
+      occurredAt: changedAt,
+      workspaceId: workspaceId,
+      boardId: boardId,
+      taskId: cardId,
+      providerRef: BoardProviderRef(
+        provider: BoardEventProvider.nextcloudDeck,
+        externalId: cardId,
+        etag: etag,
+        rawType: 'card',
+      ),
+      redactionLevel: BoardEventRedactionLevel.supportSafe,
+      payload: {
+        'target_column_id': stackId,
+        if (_id(card['order']) != null) 'position': _id(card['order']),
+        if (archived) 'archived': true,
+        if (done) 'completed': true,
+        if (_string(card['duedate']) != null)
+          'due_at': _string(card['duedate']),
+      },
+    );
+  }
+
+  static BoardEventType _deckType(
+    DeckSnapshotChange change, {
+    required bool archived,
+    required bool done,
+  }) {
+    if (archived) return BoardEventType.taskArchived;
+    if (done) return BoardEventType.taskCompleted;
+    return switch (change) {
+      DeckSnapshotChange.created => BoardEventType.taskCreated,
+      DeckSnapshotChange.updated => BoardEventType.taskUpdated,
+      DeckSnapshotChange.moved => BoardEventType.taskMoved,
+      DeckSnapshotChange.deleted => BoardEventType.taskArchived,
+      DeckSnapshotChange.conflict => BoardEventType.syncConflictDetected,
+    };
+  }
+}
+
+enum DeckSnapshotChange { created, updated, moved, deleted, conflict }
+
+String _idempotencyKey({
+  required BoardEventProvider provider,
+  required String eventName,
+  required DateTime occurredAt,
+  required String? primaryId,
+}) {
+  final instant = occurredAt.toUtc().toIso8601String();
+  return '${provider.name}:$eventName:${primaryId ?? 'unknown'}:$instant';
+}
+
+BoardActorRef _actor(Map<String, Object?> json, BoardEventProvider provider) {
+  final id = _id(json['id']) ?? _string(json['username']) ?? 'unknown-actor';
+  return BoardActorRef(
+    id: id,
+    displayName: _string(json['name']) ?? _string(json['username']),
+    providerRef: BoardProviderRef(
+      provider: provider,
+      externalId: id,
+      rawType: 'user',
+    ),
+  );
+}
+
+Map<String, Object?> _map(Object? value) {
+  if (value is Map<String, Object?>) return value;
+  if (value is Map) return Map<String, Object?>.from(value);
+  return const <String, Object?>{};
+}
+
+String? _string(Object? value) => value?.toString();
+
+String? _id(Object? value) {
+  final raw = _string(value);
+  if (raw == null || raw.isEmpty || raw == 'null') return null;
+  return raw;
+}
+
+bool? _bool(Object? value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    if (value.toLowerCase() == 'true') return true;
+    if (value.toLowerCase() == 'false') return false;
+  }
+  return null;
+}
+
+DateTime? _date(Object? value) {
+  if (value is DateTime) return value.toUtc();
+  if (value is int) {
+    final isSeconds = value < 100000000000;
+    return DateTime.fromMillisecondsSinceEpoch(
+      isSeconds ? value * 1000 : value,
+      isUtc: true,
+    );
+  }
+  final raw = _string(value);
+  if (raw == null || raw.isEmpty) return null;
+  return DateTime.tryParse(raw)?.toUtc();
+}

--- a/lib/features/boards/domain/adapters/board_provider_adapter.dart
+++ b/lib/features/boards/domain/adapters/board_provider_adapter.dart
@@ -1,0 +1,212 @@
+import 'package:weave/features/boards/domain/entities/task_board_event.dart';
+
+enum BoardAdapterCapability {
+  comments,
+  attachments,
+  assignments,
+  labels,
+  priorities,
+  dueDates,
+  nonDestructiveArchive,
+  webhookEvents,
+  incrementalSync,
+  checklists,
+  customFields,
+}
+
+enum BoardAdapterReadiness { spikeOnly, prototype, productionCandidate }
+
+enum BoardAdapterErrorType {
+  unauthorized,
+  forbidden,
+  notFound,
+  conflict,
+  rateLimited,
+  offline,
+  validation,
+  providerUnavailable,
+  unknown,
+}
+
+class BoardAdapterDescriptor {
+  const BoardAdapterDescriptor({
+    required this.provider,
+    required this.displayName,
+    required this.readiness,
+    required this.capabilities,
+    required this.limitations,
+  });
+
+  final BoardEventProvider provider;
+  final String displayName;
+  final BoardAdapterReadiness readiness;
+  final Set<BoardAdapterCapability> capabilities;
+  final List<String> limitations;
+
+  bool supports(BoardAdapterCapability capability) =>
+      capabilities.contains(capability);
+}
+
+class BoardAdapterPage<T> {
+  const BoardAdapterPage({
+    required this.items,
+    this.nextCursor,
+    this.etag,
+    this.syncedAt,
+  });
+
+  final List<T> items;
+  final String? nextCursor;
+  final String? etag;
+  final DateTime? syncedAt;
+}
+
+class BoardAdapterError implements Exception {
+  const BoardAdapterError({
+    required this.type,
+    required this.message,
+    this.retryAfter,
+    this.providerRef,
+  });
+
+  final BoardAdapterErrorType type;
+  final String message;
+  final Duration? retryAfter;
+  final BoardProviderRef? providerRef;
+
+  @override
+  String toString() => 'BoardAdapterError(type: $type, message: $message)';
+}
+
+class BoardAdapterSyncRequest {
+  const BoardAdapterSyncRequest({
+    required this.workspaceId,
+    this.projectId,
+    this.boardId,
+    this.cursor,
+    this.ifNoneMatch,
+    this.since,
+  });
+
+  final String workspaceId;
+  final String? projectId;
+  final String? boardId;
+  final String? cursor;
+  final String? ifNoneMatch;
+  final DateTime? since;
+}
+
+class BoardAdapterTaskPatch {
+  const BoardAdapterTaskPatch({
+    this.title,
+    this.description,
+    this.assigneeIds,
+    this.labelIds,
+    this.priority,
+    this.dueAt,
+    this.completed,
+    this.archived,
+  });
+
+  final String? title;
+  final String? description;
+  final List<String>? assigneeIds;
+  final List<String>? labelIds;
+  final String? priority;
+  final DateTime? dueAt;
+  final bool? completed;
+  final bool? archived;
+}
+
+abstract interface class BoardProviderAdapter {
+  BoardAdapterDescriptor get descriptor;
+
+  Future<BoardAdapterPage<BoardProviderRef>> listBoards(
+    BoardAdapterSyncRequest request,
+  );
+
+  Future<BoardAdapterPage<BoardProviderRef>> listTasks(
+    BoardAdapterSyncRequest request,
+  );
+
+  Future<BoardProviderRef> createTask({
+    required BoardAdapterSyncRequest request,
+    required String title,
+    String? description,
+  });
+
+  Future<BoardProviderRef> updateTask({
+    required BoardAdapterSyncRequest request,
+    required String taskId,
+    required BoardAdapterTaskPatch patch,
+  });
+
+  Future<BoardProviderRef> moveTask({
+    required BoardAdapterSyncRequest request,
+    required String taskId,
+    required String targetColumnId,
+    int? targetPosition,
+  });
+
+  Future<BoardAdapterPage<TaskBoardEvent>> syncEvents(
+    BoardAdapterSyncRequest request,
+  );
+}
+
+const vikunjaAdapterDescriptor = BoardAdapterDescriptor(
+  provider: BoardEventProvider.vikunja,
+  displayName: 'Vikunja',
+  readiness: BoardAdapterReadiness.prototype,
+  capabilities: {
+    BoardAdapterCapability.comments,
+    BoardAdapterCapability.attachments,
+    BoardAdapterCapability.assignments,
+    BoardAdapterCapability.labels,
+    BoardAdapterCapability.priorities,
+    BoardAdapterCapability.dueDates,
+    BoardAdapterCapability.nonDestructiveArchive,
+    BoardAdapterCapability.webhookEvents,
+    BoardAdapterCapability.incrementalSync,
+  },
+  limitations: [
+    'Webhook delivery is at-most-once, so adapters still need periodic reconciliation.',
+    'Vikunja project/view/bucket vocabulary must stay behind provider refs.',
+  ],
+);
+
+const openProjectBenchmarkDescriptor = BoardAdapterDescriptor(
+  provider: BoardEventProvider.openProject,
+  displayName: 'OpenProject benchmark',
+  readiness: BoardAdapterReadiness.spikeOnly,
+  capabilities: {
+    BoardAdapterCapability.comments,
+    BoardAdapterCapability.attachments,
+    BoardAdapterCapability.assignments,
+    BoardAdapterCapability.priorities,
+    BoardAdapterCapability.dueDates,
+    BoardAdapterCapability.customFields,
+  },
+  limitations: [
+    'Benchmark-only until a later provider spike validates auth and sync.',
+    'Action boards can mutate work package fields; basic boards do not.',
+  ],
+);
+
+const nextcloudDeckBridgeDescriptor = BoardAdapterDescriptor(
+  provider: BoardEventProvider.nextcloudDeck,
+  displayName: 'Nextcloud Deck bridge',
+  readiness: BoardAdapterReadiness.prototype,
+  capabilities: {
+    BoardAdapterCapability.comments,
+    BoardAdapterCapability.attachments,
+    BoardAdapterCapability.assignments,
+    BoardAdapterCapability.labels,
+    BoardAdapterCapability.dueDates,
+    BoardAdapterCapability.nonDestructiveArchive,
+    BoardAdapterCapability.incrementalSync,
+  },
+  limitations: [
+    'Bridge/import candidate only; Deck board/stack/card names must not define Weave UI labels.',
+    'No first-class webhook source found in the Deck API notes; use ETag/If-Modified-Since polling.',
+  ],
+);

--- a/lib/features/boards/domain/entities/task_board_event.dart
+++ b/lib/features/boards/domain/entities/task_board_event.dart
@@ -1,0 +1,152 @@
+/// Provider-neutral event model for future Weave boards/tasks adapters.
+///
+/// This is post-Release-1 planning code. It keeps provider payloads behind a
+/// support-safe event envelope so future notifications, recent activity,
+/// diagnostics, and agent workflows do not depend on Vikunja, OpenProject, or
+/// Nextcloud Deck shapes directly.
+enum BoardEventProvider { vikunja, openProject, nextcloudDeck, unknown }
+
+enum BoardEventType {
+  taskCreated,
+  taskUpdated,
+  taskCompleted,
+  taskArchived,
+  taskMoved,
+  assignmentChanged,
+  labelChanged,
+  priorityChanged,
+  dueDateChanged,
+  commentAdded,
+  attachmentChanged,
+  syncConflictDetected,
+}
+
+enum BoardEventRedactionLevel {
+  /// Event can be shown in support diagnostics without raw user text.
+  supportSafe,
+
+  /// Event metadata is safe, but payload intentionally includes user-authored
+  /// content such as task titles or comment excerpts.
+  containsUserContent,
+
+  /// Provider payload contained credentials or other secrets and must never be
+  /// persisted or shown outside secure connector internals.
+  containsSecret,
+}
+
+class BoardProviderRef {
+  const BoardProviderRef({
+    required this.provider,
+    required this.externalId,
+    this.externalUrl,
+    this.version,
+    this.etag,
+    this.rawType,
+  });
+
+  final BoardEventProvider provider;
+  final String externalId;
+  final Uri? externalUrl;
+  final String? version;
+  final String? etag;
+  final String? rawType;
+
+  Map<String, Object?> toJson() => {
+    'provider': provider.name,
+    'external_id': externalId,
+    if (externalUrl != null) 'external_url': externalUrl.toString(),
+    if (version != null) 'version': version,
+    if (etag != null) 'etag': etag,
+    if (rawType != null) 'raw_type': rawType,
+  };
+}
+
+class BoardActorRef {
+  const BoardActorRef({
+    required this.id,
+    this.displayName,
+    this.providerRef,
+    this.isSystem = false,
+  });
+
+  const BoardActorRef.system()
+    : id = 'system',
+      displayName = 'System',
+      providerRef = null,
+      isSystem = true;
+
+  final String id;
+  final String? displayName;
+  final BoardProviderRef? providerRef;
+  final bool isSystem;
+
+  Map<String, Object?> toJson() => {
+    'id': id,
+    if (displayName != null) 'display_name': displayName,
+    if (providerRef != null) 'provider_ref': providerRef!.toJson(),
+    'is_system': isSystem,
+  };
+}
+
+class TaskBoardEvent {
+  const TaskBoardEvent({
+    required this.idempotencyKey,
+    required this.type,
+    required this.actorRef,
+    required this.occurredAt,
+    required this.workspaceId,
+    this.projectId,
+    this.boardId,
+    this.taskId,
+    this.providerRef,
+    this.redactionLevel = BoardEventRedactionLevel.supportSafe,
+    this.payload = const <String, Object?>{},
+  });
+
+  final String idempotencyKey;
+  final BoardEventType type;
+  final BoardActorRef actorRef;
+  final DateTime occurredAt;
+  final String workspaceId;
+  final String? projectId;
+  final String? boardId;
+  final String? taskId;
+  final BoardProviderRef? providerRef;
+  final BoardEventRedactionLevel redactionLevel;
+
+  /// Provider-neutral, redacted details. Do not store raw provider responses,
+  /// credentials, full comments, or long task descriptions here.
+  final Map<String, Object?> payload;
+
+  bool get isSupportSafe =>
+      redactionLevel == BoardEventRedactionLevel.supportSafe;
+
+  Map<String, Object?> toJson() => {
+    'idempotency_key': idempotencyKey,
+    'type': eventTypeWireName(type),
+    'actor_ref': actorRef.toJson(),
+    'occurred_at': occurredAt.toUtc().toIso8601String(),
+    'workspace_id': workspaceId,
+    if (projectId != null) 'project_id': projectId,
+    if (boardId != null) 'board_id': boardId,
+    if (taskId != null) 'task_id': taskId,
+    if (providerRef != null) 'provider_ref': providerRef!.toJson(),
+    'redaction_level': redactionLevel.name,
+    if (payload.isNotEmpty) 'payload': payload,
+  };
+}
+
+String eventTypeWireName(BoardEventType type) => switch (type) {
+  BoardEventType.taskCreated => 'task.created',
+  BoardEventType.taskUpdated => 'task.updated',
+  BoardEventType.taskCompleted => 'task.completed',
+  BoardEventType.taskArchived => 'task.archived',
+  BoardEventType.taskMoved => 'task.moved',
+  BoardEventType.assignmentChanged => 'assignment.changed',
+  BoardEventType.labelChanged => 'label.changed',
+  BoardEventType.priorityChanged => 'priority.changed',
+  BoardEventType.dueDateChanged => 'due_date.changed',
+  BoardEventType.commentAdded => 'comment.added',
+  BoardEventType.attachmentChanged => 'attachment.changed',
+  BoardEventType.syncConflictDetected => 'sync.conflict_detected',
+};

--- a/test/features/boards/domain/task_board_event_normalizer_test.dart
+++ b/test/features/boards/domain/task_board_event_normalizer_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/boards/data/normalizers/task_board_event_normalizer.dart';
+import 'package:weave/features/boards/domain/adapters/board_provider_adapter.dart';
+import 'package:weave/features/boards/domain/entities/task_board_event.dart';
+
+void main() {
+  group('VikunjaWebhookNormalizer', () {
+    test('maps task.created into a provider-neutral support-safe event', () {
+      final event = const VikunjaWebhookNormalizer().normalize(
+        workspaceId: 'weave-home',
+        payload: {
+          'event_name': 'task.created',
+          'time': '2026-05-14T12:00:00+02:00',
+          'data': {
+            'task': {
+              'id': 42,
+              'project_id': 7,
+              'bucket_id': 3,
+              'position': 100,
+              'done': false,
+            },
+            'doer': {'id': 5, 'username': 'ada', 'name': 'Ada'},
+          },
+        },
+      );
+
+      expect(event.type, BoardEventType.taskCreated);
+      expect(event.workspaceId, 'weave-home');
+      expect(event.projectId, '7');
+      expect(event.boardId, '7');
+      expect(event.taskId, '42');
+      expect(event.actorRef.displayName, 'Ada');
+      expect(event.providerRef!.provider, BoardEventProvider.vikunja);
+      expect(event.payload['target_column_id'], '3');
+      expect(event.isSupportSafe, isTrue);
+      expect(event.toJson()['type'], 'task.created');
+    });
+
+    test('maps completed Vikunja updates without storing raw task text', () {
+      final event = const VikunjaWebhookNormalizer().normalize(
+        workspaceId: 'weave-home',
+        payload: {
+          'event_name': 'task.updated',
+          'time': '2026-05-14T10:30:00Z',
+          'data': {
+            'task': {
+              'id': 43,
+              'project_id': 7,
+              'title': 'Secret task title',
+              'description': 'Do not persist this body in event logs',
+              'done': true,
+            },
+            'doer': {'id': 5, 'username': 'ada'},
+          },
+        },
+      );
+
+      expect(event.type, BoardEventType.taskCompleted);
+      expect(event.payload.containsKey('title'), isFalse);
+      expect(event.payload.containsKey('description'), isFalse);
+      expect(event.payload['completed'], isTrue);
+    });
+  });
+
+  group('DeckPollingEventNormalizer', () {
+    test('maps card move snapshots with ETag-backed idempotency', () {
+      final event = const DeckPollingEventNormalizer().normalizeCardSnapshot(
+        workspaceId: 'weave-home',
+        boardId: 'board-10',
+        stackId: 'stack-2',
+        change: DeckSnapshotChange.moved,
+        card: {
+          'id': 81,
+          'ETag': 'bdb10fa2d2aeda092a2b6b469454dc90',
+          'order': 200,
+          'lastModified': 1778752800,
+        },
+      );
+
+      expect(event.type, BoardEventType.taskMoved);
+      expect(event.taskId, '81');
+      expect(event.payload['target_column_id'], 'stack-2');
+      expect(event.providerRef!.etag, 'bdb10fa2d2aeda092a2b6b469454dc90');
+      expect(
+        event.idempotencyKey,
+        contains('nextcloudDeck:moved:board-10:stack-2:81:'),
+      );
+    });
+
+    test('maps Deck done and archive states to semantic Weave events', () {
+      final completed = const DeckPollingEventNormalizer()
+          .normalizeCardSnapshot(
+            workspaceId: 'weave-home',
+            boardId: 'board-10',
+            stackId: 'stack-2',
+            change: DeckSnapshotChange.updated,
+            card: {'id': 82, 'done': true},
+          );
+      final archived = const DeckPollingEventNormalizer().normalizeCardSnapshot(
+        workspaceId: 'weave-home',
+        boardId: 'board-10',
+        stackId: 'stack-2',
+        change: DeckSnapshotChange.updated,
+        card: {'id': 83, 'archived': true},
+      );
+
+      expect(completed.type, BoardEventType.taskCompleted);
+      expect(archived.type, BoardEventType.taskArchived);
+    });
+  });
+
+  group('adapter descriptors', () {
+    test(
+      'declare explicit capabilities and limitations per provider spike',
+      () {
+        expect(
+          vikunjaAdapterDescriptor.supports(
+            BoardAdapterCapability.webhookEvents,
+          ),
+          isTrue,
+        );
+        expect(
+          nextcloudDeckBridgeDescriptor.supports(
+            BoardAdapterCapability.incrementalSync,
+          ),
+          isTrue,
+        );
+        expect(
+          nextcloudDeckBridgeDescriptor.supports(
+            BoardAdapterCapability.webhookEvents,
+          ),
+          isFalse,
+        );
+        expect(
+          openProjectBenchmarkDescriptor.readiness,
+          BoardAdapterReadiness.spikeOnly,
+        );
+        expect(
+          openProjectBenchmarkDescriptor.limitations.join(' '),
+          contains('Benchmark-only'),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- define provider-neutral boards/task adapter descriptors, capabilities, typed errors, sync request/page shapes, and task patch contract
- add provider-neutral `TaskBoardEvent` envelope with actor/provider refs, idempotency, redaction levels, and support-safe payloads
- prototype Vikunja webhook and Nextcloud Deck polling/snapshot normalizers with tests
- add source-backed spike findings for Vikunja, OpenProject accessibility benchmark, Nextcloud Deck bridge, and the event-normalizer ownership decision

## Issue mapping
- Closes #119: Vikunja remains the first implementation candidate; notes cover API/auth/event/sync/export/deployment and adapter boundaries
- Closes #120: OpenProject remains benchmark-only; notes capture keyboard/screen-reader/non-drag/non-color/accessibility-live requirements
- Closes #121: Deck is a bridge/import/fallback candidate; notes categorize API/auth/sync-event/accessibility/product-model gaps
- Closes #123: provider-neutral event schema, idempotency, ordering, conflict, redaction/privacy, and backend ownership are documented and tested

## Validation
- `flutter gen-l10n` -> passed
- `dart run build_runner build --delete-conflicting-outputs` -> passed, wrote 14 outputs
- `dart format --output=none --set-exit-if-changed .` -> passed, 0 changed
- `flutter analyze --fatal-infos` -> passed, no issues
- `flutter test` -> passed, 259 passed / 6 skipped
