### PR TITLE
feat(boards): add provider-neutral activity event normalizer

### DIFF
--- a/docs/research/boards-task-domain-contract.md
+++ b/docs/research/boards-task-domain-contract.md
@@ -123,6 +123,8 @@ Initial event types:
 
 Event handling must document ordering, idempotency, redaction/privacy, replay behavior, and conflict resolution before powering notifications or recent activity.
 
+Implementation seed: `lib/features/boards/domain/entities/board_activity_event.dart` and the board activity normalizers under `lib/features/boards/data/services/` define the app-layer provider-neutral envelope and sample mappers for static preview fixtures plus external-provider-shaped events. They are deliberately post-Release-1 scaffolding and do **not** claim a live Vikunja, OpenProject, Deck, or gateway integration.
+
 ## Spike sequencing
 
 1. Use the Vikunja spike to validate API/auth/sync fit against this contract.

--- a/lib/features/boards/data/services/external_board_activity_normalizer.dart
+++ b/lib/features/boards/data/services/external_board_activity_normalizer.dart
@@ -1,0 +1,225 @@
+import 'package:weave/features/boards/domain/entities/board_activity_event.dart';
+import 'package:weave/features/boards/domain/services/board_activity_event_normalizer.dart';
+
+/// Provider-shaped DTO used by future adapters or backend gateway responses.
+///
+/// It intentionally models only the stable seam that the app consumes. Raw
+/// provider webhook bodies remain outside the Flutter presentation contract.
+class ExternalBoardProviderRawEvent {
+  const ExternalBoardProviderRawEvent({
+    required this.provider,
+    required this.eventId,
+    required this.eventName,
+    required this.occurredAt,
+    required this.actorId,
+    this.actorDisplayName,
+    required this.workspaceId,
+    this.projectId,
+    this.boardId,
+    this.taskId,
+    this.externalId,
+    this.externalUrl,
+    this.providerSequence,
+    this.syncCursor,
+    this.version,
+    this.etag,
+    this.title,
+    this.description,
+    this.fromColumnId,
+    this.toColumnId,
+    this.fromPosition,
+    this.toPosition,
+    this.addedAssigneeIds = const [],
+    this.removedAssigneeIds = const [],
+    this.addedLabelIds = const [],
+    this.removedLabelIds = const [],
+    this.fromPriority,
+    this.toPriority,
+    this.fromDueAt,
+    this.toDueAt,
+    this.commentId,
+    this.commentBodyPreview,
+    this.attachmentId,
+    this.attachmentChange,
+    this.attachmentDisplayName,
+    this.conflictId,
+    this.conflictReason,
+    this.localVersion,
+    this.remoteVersion,
+  });
+
+  final String provider;
+  final String eventId;
+  final String eventName;
+  final DateTime occurredAt;
+  final String actorId;
+  final String? actorDisplayName;
+  final String workspaceId;
+  final String? projectId;
+  final String? boardId;
+  final String? taskId;
+  final String? externalId;
+  final Uri? externalUrl;
+  final int? providerSequence;
+  final String? syncCursor;
+  final String? version;
+  final String? etag;
+  final String? title;
+  final String? description;
+  final String? fromColumnId;
+  final String? toColumnId;
+  final int? fromPosition;
+  final int? toPosition;
+  final List<String> addedAssigneeIds;
+  final List<String> removedAssigneeIds;
+  final List<String> addedLabelIds;
+  final List<String> removedLabelIds;
+  final String? fromPriority;
+  final String? toPriority;
+  final DateTime? fromDueAt;
+  final DateTime? toDueAt;
+  final String? commentId;
+  final String? commentBodyPreview;
+  final String? attachmentId;
+  final String? attachmentChange;
+  final String? attachmentDisplayName;
+  final String? conflictId;
+  final String? conflictReason;
+  final String? localVersion;
+  final String? remoteVersion;
+}
+
+class ExternalBoardActivityNormalizer
+    implements BoardActivityEventNormalizer<ExternalBoardProviderRawEvent> {
+  const ExternalBoardActivityNormalizer();
+
+  @override
+  Iterable<BoardActivityEvent<BoardActivityPayload>> normalize(
+    ExternalBoardProviderRawEvent raw,
+  ) sync* {
+    final type = _typeFor(raw.eventName);
+    if (type == null) {
+      return;
+    }
+
+    yield BoardActivityEvent<BoardActivityPayload>(
+      idempotencyKey: _idempotencyKey(raw, type),
+      type: type,
+      actor: BoardActivityActorRef(
+        id: raw.actorId,
+        displayName: raw.actorDisplayName,
+        kind: BoardActivityActorKind.user,
+      ),
+      occurredAt: raw.occurredAt,
+      source: BoardActivitySourceRef(
+        workspaceId: raw.workspaceId,
+        projectId: raw.projectId,
+        boardId: raw.boardId,
+        taskId: raw.taskId,
+      ),
+      providerRef: BoardProviderRef(
+        provider: raw.provider,
+        externalId: raw.externalId ?? raw.eventId,
+        externalUrl: raw.externalUrl,
+        version: raw.version,
+        etag: raw.etag,
+        lastSyncedAt: raw.occurredAt,
+      ),
+      redactionLevel: _redactionFor(type),
+      ordering: BoardActivityOrdering(
+        providerSequence: raw.providerSequence,
+        syncCursor: raw.syncCursor,
+        receivedAt: raw.occurredAt,
+      ),
+      payload: _payloadFor(raw, type),
+    );
+  }
+
+  BoardActivityEventType? _typeFor(String eventName) => switch (eventName) {
+    'task.created' || 'card.created' => BoardActivityEventType.taskCreated,
+    'task.updated' || 'card.updated' => BoardActivityEventType.taskUpdated,
+    'task.completed' ||
+    'card.completed' => BoardActivityEventType.taskCompleted,
+    'task.moved' || 'card.moved' => BoardActivityEventType.taskMoved,
+    'assignment.changed' ||
+    'assignee.changed' => BoardActivityEventType.assignmentChanged,
+    'label.changed' || 'tag.changed' => BoardActivityEventType.labelChanged,
+    'priority.changed' => BoardActivityEventType.priorityChanged,
+    'due_date.changed' ||
+    'due.changed' => BoardActivityEventType.dueDateChanged,
+    'comment.added' => BoardActivityEventType.commentAdded,
+    'attachment.changed' => BoardActivityEventType.attachmentChanged,
+    'sync.conflict_detected' ||
+    'conflict.detected' => BoardActivityEventType.syncConflictDetected,
+    _ => null,
+  };
+
+  BoardActivityRedactionLevel _redactionFor(BoardActivityEventType type) {
+    return switch (type) {
+      BoardActivityEventType.syncConflictDetected =>
+        BoardActivityRedactionLevel.supportSafe,
+      BoardActivityEventType.commentAdded =>
+        BoardActivityRedactionLevel.internal,
+      _ => BoardActivityRedactionLevel.userVisible,
+    };
+  }
+
+  BoardActivityPayload _payloadFor(
+    ExternalBoardProviderRawEvent raw,
+    BoardActivityEventType type,
+  ) {
+    return switch (type) {
+      BoardActivityEventType.taskCreated ||
+      BoardActivityEventType.taskUpdated ||
+      BoardActivityEventType.taskCompleted => TaskSnapshotPayload(
+        title: raw.title ?? raw.taskId ?? raw.externalId ?? 'Untitled task',
+        description: raw.description,
+      ),
+      BoardActivityEventType.taskMoved => TaskMovedPayload(
+        fromColumnId: raw.fromColumnId,
+        toColumnId: raw.toColumnId ?? 'unknown',
+        fromPosition: raw.fromPosition,
+        toPosition: raw.toPosition,
+      ),
+      BoardActivityEventType.assignmentChanged => AssignmentChangedPayload(
+        addedAssigneeIds: raw.addedAssigneeIds,
+        removedAssigneeIds: raw.removedAssigneeIds,
+      ),
+      BoardActivityEventType.labelChanged => LabelChangedPayload(
+        addedLabelIds: raw.addedLabelIds,
+        removedLabelIds: raw.removedLabelIds,
+      ),
+      BoardActivityEventType.priorityChanged => PriorityChangedPayload(
+        fromPriority: raw.fromPriority,
+        toPriority: raw.toPriority,
+      ),
+      BoardActivityEventType.dueDateChanged => DueDateChangedPayload(
+        fromDueAt: raw.fromDueAt,
+        toDueAt: raw.toDueAt,
+      ),
+      BoardActivityEventType.commentAdded => CommentAddedPayload(
+        commentId: raw.commentId ?? raw.eventId,
+        bodyPreview: raw.commentBodyPreview,
+      ),
+      BoardActivityEventType.attachmentChanged => AttachmentChangedPayload(
+        attachmentId: raw.attachmentId ?? raw.eventId,
+        change: raw.attachmentChange ?? 'changed',
+        displayName: raw.attachmentDisplayName,
+      ),
+      BoardActivityEventType.syncConflictDetected =>
+        SyncConflictDetectedPayload(
+          conflictId: raw.conflictId ?? raw.eventId,
+          reason: raw.conflictReason ?? 'provider reported a sync conflict',
+          localVersion: raw.localVersion,
+          remoteVersion: raw.remoteVersion,
+        ),
+    };
+  }
+
+  String _idempotencyKey(
+    ExternalBoardProviderRawEvent raw,
+    BoardActivityEventType type,
+  ) {
+    return '${raw.provider}:${raw.workspaceId}:${raw.eventId}:${type.wireName}';
+  }
+}

--- a/lib/features/boards/data/services/static_boards_preview_activity_normalizer.dart
+++ b/lib/features/boards/data/services/static_boards_preview_activity_normalizer.dart
@@ -1,0 +1,114 @@
+import 'package:weave/features/boards/domain/entities/board_activity_event.dart';
+import 'package:weave/features/boards/domain/entities/board_preview.dart';
+import 'package:weave/features/boards/domain/services/board_activity_event_normalizer.dart';
+
+class StaticBoardsPreviewRawEvent {
+  const StaticBoardsPreviewRawEvent.taskFixtureCreated({
+    required this.occurredAt,
+    required this.workspaceId,
+    required this.projectId,
+    required this.board,
+    required this.column,
+    required this.task,
+  }) : type = StaticBoardsPreviewRawEventType.taskFixtureCreated,
+       fromColumnId = null,
+       toColumnId = null,
+       fromPosition = null,
+       toPosition = null;
+
+  const StaticBoardsPreviewRawEvent.taskFixtureMoved({
+    required this.occurredAt,
+    required this.workspaceId,
+    required this.projectId,
+    required this.board,
+    required this.task,
+    required this.fromColumnId,
+    required this.toColumnId,
+    this.fromPosition,
+    this.toPosition,
+  }) : type = StaticBoardsPreviewRawEventType.taskFixtureMoved,
+       column = null;
+
+  final StaticBoardsPreviewRawEventType type;
+  final DateTime occurredAt;
+  final String workspaceId;
+  final String projectId;
+  final BoardPreview board;
+  final BoardColumnPreview? column;
+  final BoardTaskPreview task;
+  final String? fromColumnId;
+  final String? toColumnId;
+  final int? fromPosition;
+  final int? toPosition;
+}
+
+enum StaticBoardsPreviewRawEventType { taskFixtureCreated, taskFixtureMoved }
+
+class StaticBoardsPreviewActivityNormalizer
+    implements BoardActivityEventNormalizer<StaticBoardsPreviewRawEvent> {
+  const StaticBoardsPreviewActivityNormalizer();
+
+  static const providerName = 'static-preview';
+  static const actor = BoardActivityActorRef(
+    id: 'boards-preview-fixture',
+    displayName: 'Boards preview fixture',
+    kind: BoardActivityActorKind.system,
+  );
+
+  @override
+  Iterable<BoardActivityEvent<BoardActivityPayload>> normalize(
+    StaticBoardsPreviewRawEvent raw,
+  ) sync* {
+    final source = BoardActivitySourceRef(
+      workspaceId: raw.workspaceId,
+      projectId: raw.projectId,
+      boardId: raw.board.id,
+      taskId: raw.task.id,
+    );
+    final providerRef = BoardProviderRef(
+      provider: providerName,
+      externalId: '${raw.board.id}:${raw.task.id}',
+    );
+
+    switch (raw.type) {
+      case StaticBoardsPreviewRawEventType.taskFixtureCreated:
+        yield BoardActivityEvent<TaskSnapshotPayload>(
+          idempotencyKey: _key(raw, 'task.created'),
+          type: BoardActivityEventType.taskCreated,
+          actor: actor,
+          occurredAt: raw.occurredAt,
+          source: source,
+          providerRef: providerRef,
+          redactionLevel: BoardActivityRedactionLevel.userVisible,
+          payload: TaskSnapshotPayload(
+            title: raw.task.title,
+            description: raw.task.description,
+            status: raw.task.status.name,
+            columnId: raw.column?.id,
+            priority: raw.task.priorityLabel,
+          ),
+        );
+      case StaticBoardsPreviewRawEventType.taskFixtureMoved:
+        yield BoardActivityEvent<TaskMovedPayload>(
+          idempotencyKey: _key(raw, 'task.moved'),
+          type: BoardActivityEventType.taskMoved,
+          actor: actor,
+          occurredAt: raw.occurredAt,
+          source: source,
+          providerRef: providerRef,
+          redactionLevel: BoardActivityRedactionLevel.userVisible,
+          payload: TaskMovedPayload(
+            fromColumnId: raw.fromColumnId,
+            toColumnId: raw.toColumnId ?? 'unknown',
+            fromPosition: raw.fromPosition,
+            toPosition: raw.toPosition,
+          ),
+        );
+    }
+  }
+
+  String _key(StaticBoardsPreviewRawEvent raw, String eventType) {
+    final timestamp = raw.occurredAt.toUtc().toIso8601String();
+    return '$providerName:${raw.workspaceId}:${raw.board.id}:${raw.task.id}:$eventType:$timestamp';
+  }
+}

--- a/lib/features/boards/domain/entities/board_activity_event.dart
+++ b/lib/features/boards/domain/entities/board_activity_event.dart
@@ -1,0 +1,234 @@
+/// Provider-neutral activity emitted by future boards/tasks adapters.
+///
+/// This is an app-layer contract only: it normalizes preview fixtures and
+/// external-provider-shaped samples without claiming that a live provider is
+/// connected in Release 1.
+enum BoardActivityEventType {
+  taskCreated,
+  taskUpdated,
+  taskCompleted,
+  taskMoved,
+  assignmentChanged,
+  labelChanged,
+  priorityChanged,
+  dueDateChanged,
+  commentAdded,
+  attachmentChanged,
+  syncConflictDetected,
+}
+
+extension BoardActivityEventTypeName on BoardActivityEventType {
+  String get wireName => switch (this) {
+    BoardActivityEventType.taskCreated => 'task.created',
+    BoardActivityEventType.taskUpdated => 'task.updated',
+    BoardActivityEventType.taskCompleted => 'task.completed',
+    BoardActivityEventType.taskMoved => 'task.moved',
+    BoardActivityEventType.assignmentChanged => 'assignment.changed',
+    BoardActivityEventType.labelChanged => 'label.changed',
+    BoardActivityEventType.priorityChanged => 'priority.changed',
+    BoardActivityEventType.dueDateChanged => 'due_date.changed',
+    BoardActivityEventType.commentAdded => 'comment.added',
+    BoardActivityEventType.attachmentChanged => 'attachment.changed',
+    BoardActivityEventType.syncConflictDetected => 'sync.conflict_detected',
+  };
+}
+
+enum BoardActivityActorKind { user, service, system, unknown }
+
+enum BoardActivityRedactionLevel {
+  /// Safe for screen-reader announcements and recent-activity summaries.
+  userVisible,
+
+  /// Safe for support/audit diagnostics, with provider payload details removed.
+  supportSafe,
+
+  /// Internal sync metadata; never display directly without review.
+  internal,
+}
+
+class BoardActivityActorRef {
+  const BoardActivityActorRef({
+    required this.id,
+    this.displayName,
+    this.kind = BoardActivityActorKind.unknown,
+  });
+
+  final String id;
+  final String? displayName;
+  final BoardActivityActorKind kind;
+}
+
+class BoardActivitySourceRef {
+  const BoardActivitySourceRef({
+    required this.workspaceId,
+    this.projectId,
+    this.boardId,
+    this.taskId,
+  });
+
+  final String workspaceId;
+  final String? projectId;
+  final String? boardId;
+  final String? taskId;
+}
+
+class BoardProviderRef {
+  const BoardProviderRef({
+    required this.provider,
+    required this.externalId,
+    this.externalUrl,
+    this.version,
+    this.etag,
+    this.lastSyncedAt,
+  });
+
+  final String provider;
+  final String externalId;
+  final Uri? externalUrl;
+  final String? version;
+  final String? etag;
+  final DateTime? lastSyncedAt;
+}
+
+class BoardActivityOrdering {
+  const BoardActivityOrdering({
+    this.providerSequence,
+    this.syncCursor,
+    this.receivedAt,
+  });
+
+  final int? providerSequence;
+  final String? syncCursor;
+  final DateTime? receivedAt;
+}
+
+class BoardActivityEvent<TPayload extends BoardActivityPayload> {
+  const BoardActivityEvent({
+    required this.idempotencyKey,
+    required this.type,
+    required this.actor,
+    required this.occurredAt,
+    required this.source,
+    required this.payload,
+    this.providerRef,
+    this.redactionLevel = BoardActivityRedactionLevel.supportSafe,
+    this.ordering = const BoardActivityOrdering(),
+  });
+
+  final String idempotencyKey;
+  final BoardActivityEventType type;
+  final BoardActivityActorRef actor;
+  final DateTime occurredAt;
+  final BoardActivitySourceRef source;
+  final BoardProviderRef? providerRef;
+  final BoardActivityRedactionLevel redactionLevel;
+  final BoardActivityOrdering ordering;
+  final TPayload payload;
+}
+
+sealed class BoardActivityPayload {
+  const BoardActivityPayload();
+}
+
+class TaskSnapshotPayload extends BoardActivityPayload {
+  const TaskSnapshotPayload({
+    required this.title,
+    this.description,
+    this.status,
+    this.columnId,
+    this.assigneeIds = const [],
+    this.labelIds = const [],
+    this.priority,
+    this.dueAt,
+  });
+
+  final String title;
+  final String? description;
+  final String? status;
+  final String? columnId;
+  final List<String> assigneeIds;
+  final List<String> labelIds;
+  final String? priority;
+  final DateTime? dueAt;
+}
+
+class TaskMovedPayload extends BoardActivityPayload {
+  const TaskMovedPayload({
+    this.fromColumnId,
+    required this.toColumnId,
+    this.fromPosition,
+    this.toPosition,
+  });
+
+  final String? fromColumnId;
+  final String toColumnId;
+  final int? fromPosition;
+  final int? toPosition;
+}
+
+class AssignmentChangedPayload extends BoardActivityPayload {
+  const AssignmentChangedPayload({
+    this.addedAssigneeIds = const [],
+    this.removedAssigneeIds = const [],
+  });
+
+  final List<String> addedAssigneeIds;
+  final List<String> removedAssigneeIds;
+}
+
+class LabelChangedPayload extends BoardActivityPayload {
+  const LabelChangedPayload({
+    this.addedLabelIds = const [],
+    this.removedLabelIds = const [],
+  });
+
+  final List<String> addedLabelIds;
+  final List<String> removedLabelIds;
+}
+
+class PriorityChangedPayload extends BoardActivityPayload {
+  const PriorityChangedPayload({this.fromPriority, this.toPriority});
+
+  final String? fromPriority;
+  final String? toPriority;
+}
+
+class DueDateChangedPayload extends BoardActivityPayload {
+  const DueDateChangedPayload({this.fromDueAt, this.toDueAt});
+
+  final DateTime? fromDueAt;
+  final DateTime? toDueAt;
+}
+
+class CommentAddedPayload extends BoardActivityPayload {
+  const CommentAddedPayload({required this.commentId, this.bodyPreview});
+
+  final String commentId;
+  final String? bodyPreview;
+}
+
+class AttachmentChangedPayload extends BoardActivityPayload {
+  const AttachmentChangedPayload({
+    required this.attachmentId,
+    required this.change,
+    this.displayName,
+  });
+
+  final String attachmentId;
+  final String change;
+  final String? displayName;
+}
+
+class SyncConflictDetectedPayload extends BoardActivityPayload {
+  const SyncConflictDetectedPayload({
+    required this.conflictId,
+    required this.reason,
+    this.localVersion,
+    this.remoteVersion,
+  });
+
+  final String conflictId;
+  final String reason;
+  final String? localVersion;
+  final String? remoteVersion;
+}

--- a/lib/features/boards/domain/services/board_activity_event_normalizer.dart
+++ b/lib/features/boards/domain/services/board_activity_event_normalizer.dart
@@ -1,0 +1,5 @@
+import 'package:weave/features/boards/domain/entities/board_activity_event.dart';
+
+abstract interface class BoardActivityEventNormalizer<TRawEvent> {
+  Iterable<BoardActivityEvent<BoardActivityPayload>> normalize(TRawEvent raw);
+}

--- a/test/features/boards/data/board_activity_normalizer_test.dart
+++ b/test/features/boards/data/board_activity_normalizer_test.dart
@@ -1,0 +1,207 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/boards/data/repositories/static_boards_preview_repository.dart';
+import 'package:weave/features/boards/data/services/external_board_activity_normalizer.dart';
+import 'package:weave/features/boards/data/services/static_boards_preview_activity_normalizer.dart';
+import 'package:weave/features/boards/domain/entities/board_activity_event.dart';
+
+void main() {
+  group('StaticBoardsPreviewActivityNormalizer', () {
+    test(
+      'maps preview fixture activity without claiming a live provider',
+      () async {
+        final preview = await const StaticBoardsPreviewRepository()
+            .loadPreview();
+        final task = preview.columns.first.tasks.first;
+        final raw = StaticBoardsPreviewRawEvent.taskFixtureMoved(
+          occurredAt: DateTime.utc(2026, 5, 14, 12),
+          workspaceId: 'preview-workspace',
+          projectId: 'preview-project',
+          board: preview,
+          task: task,
+          fromColumnId: 'todo',
+          toColumnId: 'doing',
+          fromPosition: 0,
+          toPosition: 1,
+        );
+
+        final events = const StaticBoardsPreviewActivityNormalizer()
+            .normalize(raw)
+            .toList();
+
+        expect(events, hasLength(1));
+        final event = events.single;
+        expect(event.type, BoardActivityEventType.taskMoved);
+        expect(event.providerRef?.provider, 'static-preview');
+        expect(event.actor.kind, BoardActivityActorKind.system);
+        expect(event.source.workspaceId, 'preview-workspace');
+        expect(event.idempotencyKey, contains('static-preview'));
+        expect(event.payload, isA<TaskMovedPayload>());
+        expect((event.payload as TaskMovedPayload).toColumnId, 'doing');
+      },
+    );
+  });
+
+  group('ExternalBoardActivityNormalizer', () {
+    test('maps an external-provider-shaped card move into task.moved', () {
+      final raw = ExternalBoardProviderRawEvent(
+        provider: 'vikunja-spike-sample',
+        eventId: 'evt-42',
+        eventName: 'card.moved',
+        occurredAt: DateTime.utc(2026, 5, 14, 13),
+        actorId: 'provider-user-7',
+        actorDisplayName: 'Provider User',
+        workspaceId: 'workspace-1',
+        projectId: 'project-1',
+        boardId: 'board-1',
+        taskId: 'task-1',
+        externalId: 'vikunja-task-99',
+        providerSequence: 42,
+        syncCursor: 'cursor-42',
+        fromColumnId: 'backlog',
+        toColumnId: 'doing',
+        fromPosition: 3,
+        toPosition: 1,
+      );
+
+      final event = const ExternalBoardActivityNormalizer()
+          .normalize(raw)
+          .single;
+
+      expect(
+        event.idempotencyKey,
+        'vikunja-spike-sample:workspace-1:evt-42:task.moved',
+      );
+      expect(event.type, BoardActivityEventType.taskMoved);
+      expect(event.actor.displayName, 'Provider User');
+      expect(event.providerRef?.externalId, 'vikunja-task-99');
+      expect(event.ordering.providerSequence, 42);
+      expect(event.ordering.syncCursor, 'cursor-42');
+      expect(event.payload, isA<TaskMovedPayload>());
+      expect((event.payload as TaskMovedPayload).fromColumnId, 'backlog');
+    });
+
+    test(
+      'maps assignment, label, priority, due-date, comment, attachment, and conflict samples',
+      () {
+        const normalizer = ExternalBoardActivityNormalizer();
+        final occurredAt = DateTime.utc(2026, 5, 14, 14);
+        final samples = <ExternalBoardProviderRawEvent>[
+          ExternalBoardProviderRawEvent(
+            provider: 'openproject-shaped-sample',
+            eventId: 'assignment-1',
+            eventName: 'assignment.changed',
+            occurredAt: occurredAt,
+            actorId: 'user-1',
+            workspaceId: 'workspace-1',
+            taskId: 'task-1',
+            addedAssigneeIds: const ['user-2'],
+          ),
+          ExternalBoardProviderRawEvent(
+            provider: 'openproject-shaped-sample',
+            eventId: 'label-1',
+            eventName: 'tag.changed',
+            occurredAt: occurredAt,
+            actorId: 'user-1',
+            workspaceId: 'workspace-1',
+            taskId: 'task-1',
+            addedLabelIds: const ['accessibility'],
+          ),
+          ExternalBoardProviderRawEvent(
+            provider: 'openproject-shaped-sample',
+            eventId: 'priority-1',
+            eventName: 'priority.changed',
+            occurredAt: occurredAt,
+            actorId: 'user-1',
+            workspaceId: 'workspace-1',
+            taskId: 'task-1',
+            fromPriority: 'medium',
+            toPriority: 'high',
+          ),
+          ExternalBoardProviderRawEvent(
+            provider: 'openproject-shaped-sample',
+            eventId: 'due-1',
+            eventName: 'due.changed',
+            occurredAt: occurredAt,
+            actorId: 'user-1',
+            workspaceId: 'workspace-1',
+            taskId: 'task-1',
+            toDueAt: DateTime.utc(2026, 6),
+          ),
+          ExternalBoardProviderRawEvent(
+            provider: 'openproject-shaped-sample',
+            eventId: 'completed-1',
+            eventName: 'task.completed',
+            occurredAt: occurredAt,
+            actorId: 'user-1',
+            workspaceId: 'workspace-1',
+            taskId: 'task-1',
+            title: 'Keyboard movement review',
+          ),
+          ExternalBoardProviderRawEvent(
+            provider: 'deck-shaped-sample',
+            eventId: 'comment-1',
+            eventName: 'comment.added',
+            occurredAt: occurredAt,
+            actorId: 'user-1',
+            workspaceId: 'workspace-1',
+            taskId: 'task-1',
+            commentId: 'comment-1',
+            commentBodyPreview: 'Sanitized preview only',
+          ),
+          ExternalBoardProviderRawEvent(
+            provider: 'deck-shaped-sample',
+            eventId: 'attachment-1',
+            eventName: 'attachment.changed',
+            occurredAt: occurredAt,
+            actorId: 'user-1',
+            workspaceId: 'workspace-1',
+            taskId: 'task-1',
+            attachmentId: 'file-1',
+            attachmentChange: 'added',
+          ),
+          ExternalBoardProviderRawEvent(
+            provider: 'sync-gateway-shaped-sample',
+            eventId: 'conflict-1',
+            eventName: 'conflict.detected',
+            occurredAt: occurredAt,
+            actorId: 'sync-service',
+            workspaceId: 'workspace-1',
+            taskId: 'task-1',
+            conflictReason: 'remote update won optimistic sync race',
+          ),
+        ];
+
+        final events = samples.expand(normalizer.normalize).toList();
+
+        expect(events.map((event) => event.type), <BoardActivityEventType>[
+          BoardActivityEventType.assignmentChanged,
+          BoardActivityEventType.labelChanged,
+          BoardActivityEventType.priorityChanged,
+          BoardActivityEventType.dueDateChanged,
+          BoardActivityEventType.taskCompleted,
+          BoardActivityEventType.commentAdded,
+          BoardActivityEventType.attachmentChanged,
+          BoardActivityEventType.syncConflictDetected,
+        ]);
+        expect(events[5].redactionLevel, BoardActivityRedactionLevel.internal);
+        expect(events.last.payload, isA<SyncConflictDetectedPayload>());
+      },
+    );
+
+    test(
+      'drops unknown provider-shaped events until a mapping is reviewed',
+      () {
+        final raw = ExternalBoardProviderRawEvent(
+          provider: 'unknown-provider-sample',
+          eventId: 'evt-unknown',
+          eventName: 'provider.private_event',
+          occurredAt: DateTime.utc(2026, 5, 14, 15),
+          actorId: 'user-1',
+          workspaceId: 'workspace-1',
+        );
+
+        expect(const ExternalBoardActivityNormalizer().normalize(raw), isEmpty);
+      },
+    );
+  });
+}

--- a/test/features/boards/domain/board_activity_event_test.dart
+++ b/test/features/boards/domain/board_activity_event_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/boards/domain/entities/board_activity_event.dart';
+
+void main() {
+  group('BoardActivityEventTypeName', () {
+    test('covers provider-neutral task and board activity event names', () {
+      expect(
+        BoardActivityEventType.values.map((type) => type.wireName),
+        containsAll(<String>[
+          'task.created',
+          'task.updated',
+          'task.completed',
+          'task.moved',
+          'assignment.changed',
+          'label.changed',
+          'priority.changed',
+          'due_date.changed',
+          'comment.added',
+          'attachment.changed',
+          'sync.conflict_detected',
+        ]),
+      );
+    });
+
+    test('keeps required envelope fields explicit', () {
+      final event = BoardActivityEvent<TaskMovedPayload>(
+        idempotencyKey: 'provider:workspace:event:task.moved',
+        type: BoardActivityEventType.taskMoved,
+        actor: const BoardActivityActorRef(id: 'user-1'),
+        occurredAt: DateTime.utc(2026, 5, 14, 16),
+        source: const BoardActivitySourceRef(
+          workspaceId: 'workspace-1',
+          projectId: 'project-1',
+          boardId: 'board-1',
+          taskId: 'task-1',
+        ),
+        providerRef: const BoardProviderRef(
+          provider: 'provider-sample',
+          externalId: 'external-task-1',
+        ),
+        payload: const TaskMovedPayload(
+          fromColumnId: 'todo',
+          toColumnId: 'doing',
+        ),
+      );
+
+      expect(event.idempotencyKey, isNotEmpty);
+      expect(event.actor.id, 'user-1');
+      expect(event.source.workspaceId, 'workspace-1');
+      expect(event.providerRef?.provider, 'provider-sample');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a provider-neutral boards/task activity event envelope with typed payloads for task, movement, assignment, label, priority, due-date, comment, attachment, and sync conflict events.
- Add static preview fixture and external-provider-shaped normalizers without claiming a live provider integration.
- Document the app-layer implementation seed as post-Release-1 scaffolding.

Closes #123

## Validation
- `flutter analyze lib/features/boards test/features/boards` -> no issues found
- `flutter test test/features/boards` -> all tests passed
