### PR TITLE
test(e2e): wait for backend live session

### DIFF
--- a/integration_test/helpers/auth_helper.dart
+++ b/integration_test/helpers/auth_helper.dart
@@ -6,7 +6,12 @@ import 'package:weave/features/auth/domain/entities/oidc_constants.dart';
 
 import 'test_config.dart';
 
-const _integrationTestScopes = oidcDefaultScopes;
+const _integrationTestScopes = <String>[
+  'openid',
+  'profile',
+  'email',
+  oidcWorkspaceScope,
+];
 
 class TestAuthTokens {
   const TestAuthTokens({

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -25,6 +25,7 @@ import 'package:weave/features/files/presentation/providers/files_provider.dart'
 import 'package:weave/features/files/presentation/providers/files_repository_provider.dart';
 import 'package:weave/features/profile/domain/entities/user_profile.dart';
 import 'package:weave/features/profile/presentation/providers/user_profile_provider.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_authenticated_session_provider.dart';
 import 'package:weave/features/server_config/domain/entities/oidc_client_registration.dart';
 import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
@@ -148,6 +149,23 @@ void main() {
       container.read(chatProvider.notifier).connect();
       _resetKeyboardTestState();
       await tester.pump();
+
+      await _waitFor(
+        tester,
+        () {
+          final session = container
+              .read(weaveAuthenticatedSessionProvider)
+              .asData
+              ?.value;
+          return session != null && session.accessToken.isNotEmpty;
+        },
+        reason: 'The backend session should be restorable after live sign-in.',
+        timeout: const Duration(seconds: 30),
+        diagnostics: () {
+          final session = container.read(weaveAuthenticatedSessionProvider);
+          return 'weaveAuthenticatedSession=$session';
+        },
+      );
 
       final profileRepository = container.read(userProfileRepositoryProvider);
       final originalProfile = await profileRepository.loadProfile();

--- a/lib/core/router/app_router.g.dart
+++ b/lib/core/router/app_router.g.dart
@@ -55,4 +55,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'9c4dab3c0972fcdda1ca521a38114f38011b0173';
+String _$appRouterHash() => r'f459dab64d60ec0a480a6fd26076fd3af4e68aef';


### PR DESCRIPTION
## Summary

Fixes the current `main` Live Stack E2E failure after the Release 1 journey expansion.

## Changes

- waits until `weaveAuthenticatedSessionProvider` has restored a backend session before asserting profile facade behavior;
- keeps live password-grant contract tests aligned with the runner Keycloak policy by not requesting `offline_access` for direct password grants;
- regenerates the router provider hash after build_runner.

## Evidence

Failed run being fixed: https://github.com/masssi164/weave/actions/runs/25874731369

Local validation:
- `flutter gen-l10n`
- `dart run build_runner build --delete-conflicting-outputs`
- `dart format --output=none --set-exit-if-changed integration_test/live_stack_app_e2e_test.dart integration_test/helpers/auth_helper.dart`
- `flutter analyze --fatal-infos integration_test/live_stack_app_e2e_test.dart integration_test/helpers/auth_helper.dart`
- `flutter test test/live_stack_contract_test.dart test/release_1/release_golden_paths_test.dart`
