### PR TITLE
test(e2e): avoid duplicate live sign-in

### DIFF
--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:weave/core/a11y/semantic_button.dart';
 import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
 import 'package:weave/core/persistence/flutter_secure_store.dart';
 import 'package:weave/core/persistence/secure_store.dart';
@@ -143,7 +142,6 @@ void main() {
         },
       );
 
-      await tester.tap(find.widgetWithText(AccessibleButton, 'Anmelden').first);
       final signInSucceeded = await container
           .read(authFlowControllerProvider.notifier)
           .signIn();


### PR DESCRIPTION
## Summary

Fixes the current full live-stack gate failure by preventing the integration test from starting two OIDC authorization-code exchanges for the same sign-in step.

## Evidence

Failed run being fixed: https://github.com/masssi164/weave/actions/runs/25876260750

Local validation:
- `dart format integration_test/live_stack_app_e2e_test.dart`
- `flutter analyze --fatal-infos integration_test/live_stack_app_e2e_test.dart integration_test/helpers/auth_helper.dart`
- `flutter test test/live_stack_contract_test.dart test/release_1/release_golden_paths_test.dart`
