### PR TITLE
feat(boards): consume backend preview facade

### DIFF
--- a/lib/features/boards/data/repositories/backend_boards_preview_repository.dart
+++ b/lib/features/boards/data/repositories/backend_boards_preview_repository.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/boards/domain/entities/board_preview.dart';
+import 'package:weave/features/boards/domain/repositories/boards_preview_repository.dart';
+
+class BackendBoardsPreviewRepository implements BoardsPreviewRepository {
+  BackendBoardsPreviewRepository({
+    required http.Client httpClient,
+    required Uri apiBaseUrl,
+    required String accessToken,
+  }) : _httpClient = httpClient,
+       _apiBaseUrl = apiBaseUrl,
+       _accessToken = accessToken;
+
+  final http.Client _httpClient;
+  final Uri _apiBaseUrl;
+  final String _accessToken;
+
+  @override
+  Future<BoardPreview> loadPreview() async {
+    late http.Response response;
+    try {
+      response = await _httpClient
+          .get(
+            _boardsPreviewUri(),
+            headers: {
+              'Accept': 'application/json',
+              'Authorization': 'Bearer $_accessToken',
+            },
+          )
+          .timeout(const Duration(seconds: 5));
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to reach the Weave backend Boards preview right now.',
+        cause: error,
+      );
+    }
+
+    if (response.statusCode != 200) {
+      throw AppFailure.unknown(
+        'The Weave backend Boards preview is not enabled right now.',
+        cause: response.statusCode,
+      );
+    }
+
+    try {
+      final payload = jsonDecode(response.body);
+      if (payload is! Map<String, dynamic>) {
+        throw const AppFailure.unknown(
+          'The Weave backend returned an invalid Boards preview payload.',
+        );
+      }
+      return _parsePreview(payload);
+    } on AppFailure {
+      rethrow;
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to decode Boards preview data from the Weave backend.',
+        cause: error,
+      );
+    }
+  }
+
+  BoardPreview _parsePreview(Map<String, dynamic> payload) {
+    final boards = _listOfMaps(payload['boards']);
+    final tasks = _listOfMaps(payload['tasks']);
+    if (boards.isEmpty) {
+      throw const AppFailure.unknown(
+        'The Weave backend returned no Boards preview board.',
+      );
+    }
+
+    final board = boards.first;
+    final columns = _listOfMaps(board['columns']);
+    return BoardPreview(
+      id: _string(board['id'], fallback: 'backend-board'),
+      name: _string(board['name'], fallback: 'Boards preview'),
+      description: _string(board['description']),
+      columns: [
+        for (final column in columns)
+          BoardColumnPreview(
+            id: _string(column['id'], fallback: 'backend-column'),
+            name: _string(column['name'], fallback: 'Column'),
+            semanticStatus: _columnStatus(_string(column['semanticStatus'])),
+            wipLimit: column['wipLimit'] is int
+                ? column['wipLimit'] as int
+                : null,
+            tasks: [
+              for (final task in tasks.where(
+                (task) => task['columnId'] == column['id'],
+              ))
+                BoardTaskPreview(
+                  id: _string(task['id'], fallback: 'backend-task'),
+                  title: _string(task['title'], fallback: 'Untitled task'),
+                  description: _string(task['description']),
+                  status: _taskStatus(
+                    _string(task['status']),
+                    _columnStatus(_string(column['semanticStatus'])),
+                  ),
+                  assigneeLabel: _labelList(
+                    task['assigneeRefs'],
+                    fallback: 'Unassigned',
+                  ),
+                  dueLabel: _string(task['dueAt'], fallback: 'No due date'),
+                  labels: _stringList(task['labelRefs']),
+                  priorityLabel: _string(task['priority'], fallback: 'normal'),
+                ),
+            ],
+          ),
+      ],
+    );
+  }
+
+  Uri _boardsPreviewUri() {
+    final baseSegments = _apiBaseUrl.pathSegments
+        .where((segment) => segment.isNotEmpty)
+        .toList(growable: false);
+    final apiSegments = baseSegments.isNotEmpty && baseSegments.last == 'api'
+        ? [...baseSegments, 'boards', 'preview']
+        : [...baseSegments, 'api', 'boards', 'preview'];
+    return _apiBaseUrl.replace(pathSegments: apiSegments);
+  }
+}
+
+List<Map<String, dynamic>> _listOfMaps(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value
+      .whereType<Map>()
+      .map((item) => item.cast<String, dynamic>())
+      .toList(growable: false);
+}
+
+String _string(Object? value, {String fallback = ''}) {
+  if (value is String && value.trim().isNotEmpty) {
+    return value.trim();
+  }
+  return fallback;
+}
+
+List<String> _stringList(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value
+      .whereType<String>()
+      .map((item) => item.trim())
+      .where((item) => item.isNotEmpty)
+      .toList(growable: false);
+}
+
+String _labelList(Object? value, {required String fallback}) {
+  final values = _stringList(value);
+  return values.isEmpty ? fallback : values.join(', ');
+}
+
+BoardTaskStatus _columnStatus(String value) {
+  return switch (value) {
+    'in_progress' => BoardTaskStatus.inProgress,
+    'blocked' => BoardTaskStatus.blocked,
+    'done' || 'completed' => BoardTaskStatus.done,
+    _ => BoardTaskStatus.notStarted,
+  };
+}
+
+BoardTaskStatus _taskStatus(String value, BoardTaskStatus columnFallback) {
+  return switch (value) {
+    'blocked' => BoardTaskStatus.blocked,
+    'completed' || 'done' => BoardTaskStatus.done,
+    'open' => columnFallback,
+    _ => columnFallback,
+  };
+}

--- a/lib/features/boards/presentation/providers/boards_preview_provider.dart
+++ b/lib/features/boards/presentation/providers/boards_preview_provider.dart
@@ -1,13 +1,37 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/boards/data/repositories/backend_boards_preview_repository.dart';
 import 'package:weave/features/boards/data/repositories/static_boards_preview_repository.dart';
 import 'package:weave/features/boards/domain/entities/board_preview.dart';
 import 'package:weave/features/boards/domain/repositories/boards_preview_repository.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_authenticated_session_provider.dart';
 
 final boardsPreviewRepositoryProvider = Provider<BoardsPreviewRepository>(
   (ref) => const StaticBoardsPreviewRepository(),
 );
 
 final boardsPreviewProvider = FutureProvider<BoardPreview>((ref) async {
-  final repository = ref.watch(boardsPreviewRepositoryProvider);
-  return repository.loadPreview();
+  final staticRepository = ref.watch(boardsPreviewRepositoryProvider);
+  final WeaveAuthenticatedSession? session;
+  try {
+    session = await ref.watch(weaveAuthenticatedSessionProvider.future);
+  } on AppFailure {
+    return staticRepository.loadPreview();
+  }
+  if (session == null) {
+    return staticRepository.loadPreview();
+  }
+
+  final backendRepository = BackendBoardsPreviewRepository(
+    httpClient: ref.watch(weaveApiHttpClientProvider),
+    apiBaseUrl: session.apiBaseUrl,
+    accessToken: session.accessToken,
+  );
+
+  try {
+    return await backendRepository.loadPreview();
+  } on AppFailure {
+    return staticRepository.loadPreview();
+  }
 });

--- a/test/features/boards/boards_preview_screen_test.dart
+++ b/test/features/boards/boards_preview_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/features/boards/presentation/boards_preview_screen.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_authenticated_session_provider.dart';
 
 import '../../helpers/test_app.dart';
 
@@ -10,7 +11,12 @@ void main() {
       tester,
     ) async {
       _setCompactPreviewSurface(tester);
-      await tester.pumpWidget(createTestApp(const BoardsPreviewScreen()));
+      await tester.pumpWidget(
+        createTestApp(
+          const BoardsPreviewScreen(),
+          overrides: _staticPreviewOverrides,
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Boards preview'), findsWidgets);
@@ -26,7 +32,12 @@ void main() {
       tester,
     ) async {
       _setCompactPreviewSurface(tester);
-      await tester.pumpWidget(createTestApp(const BoardsPreviewScreen()));
+      await tester.pumpWidget(
+        createTestApp(
+          const BoardsPreviewScreen(),
+          overrides: _staticPreviewOverrides,
+        ),
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byIcon(Icons.more_vert).first);
@@ -46,7 +57,12 @@ void main() {
       tester,
     ) async {
       _setCompactPreviewSurface(tester);
-      await tester.pumpWidget(createTestApp(const BoardsPreviewScreen()));
+      await tester.pumpWidget(
+        createTestApp(
+          const BoardsPreviewScreen(),
+          overrides: _staticPreviewOverrides,
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(
@@ -79,7 +95,12 @@ void main() {
 
     testWidgets('meets tap-target accessibility guidelines', (tester) async {
       _setCompactPreviewSurface(tester);
-      await tester.pumpWidget(createTestApp(const BoardsPreviewScreen()));
+      await tester.pumpWidget(
+        createTestApp(
+          const BoardsPreviewScreen(),
+          overrides: _staticPreviewOverrides,
+        ),
+      );
       await tester.pumpAndSettle();
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
@@ -96,7 +117,12 @@ void main() {
       addTearDown(tester.view.resetDevicePixelRatio);
       addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
 
-      await tester.pumpWidget(createTestApp(const BoardsPreviewScreen()));
+      await tester.pumpWidget(
+        createTestApp(
+          const BoardsPreviewScreen(),
+          overrides: _staticPreviewOverrides,
+        ),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Future boards/tasks preview'), findsOneWidget);
@@ -109,6 +135,10 @@ void main() {
     });
   });
 }
+
+final _staticPreviewOverrides = [
+  weaveAuthenticatedSessionProvider.overrideWith((ref) async => null),
+];
 
 void _setCompactPreviewSurface(WidgetTester tester) {
   tester.view.devicePixelRatio = 1;

--- a/test/features/boards/data/backend_boards_preview_repository_test.dart
+++ b/test/features/boards/data/backend_boards_preview_repository_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:weave/features/boards/data/repositories/backend_boards_preview_repository.dart';
+import 'package:weave/features/boards/domain/entities/board_preview.dart';
+
+void main() {
+  test('loads provider-neutral Boards preview from backend facade', () async {
+    final repository = BackendBoardsPreviewRepository(
+      httpClient: MockClient((request) async {
+        expect(
+          request.url.toString(),
+          'https://api.weave.local/api/boards/preview',
+        );
+        expect(request.headers['Authorization'], 'Bearer token');
+        return http.Response(
+          '''
+{
+  "preview": true,
+  "releaseStatus": "post-release-hidden-preview",
+  "source": "local-preview-backend-facade",
+  "boards": [
+    {
+      "id": "board-1",
+      "name": "Launch board",
+      "description": "Backend-fed hidden preview",
+      "columns": [
+        {"id": "todo", "name": "To do", "semanticStatus": "not_started"},
+        {"id": "doing", "name": "Doing", "semanticStatus": "in_progress", "wipLimit": 3},
+        {"id": "done", "name": "Done", "semanticStatus": "done"}
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "id": "task-1",
+      "boardId": "board-1",
+      "columnId": "doing",
+      "title": "Validate keyboard movement",
+      "description": "No drag-only interactions.",
+      "status": "open",
+      "assigneeRefs": ["workspace:member"],
+      "labelRefs": ["a11y"],
+      "priority": "normal"
+    },
+    {
+      "id": "task-2",
+      "boardId": "board-1",
+      "columnId": "done",
+      "title": "Normalize events",
+      "description": "Support-safe payloads.",
+      "status": "completed",
+      "assigneeRefs": [],
+      "labelRefs": [],
+      "priority": "high"
+    }
+  ]
+}
+''',
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }),
+      apiBaseUrl: Uri.parse('https://api.weave.local/api'),
+      accessToken: 'token',
+    );
+
+    final preview = await repository.loadPreview();
+
+    expect(preview.id, 'board-1');
+    expect(preview.name, 'Launch board');
+    expect(preview.columns, hasLength(3));
+    expect(preview.taskCount, 2);
+    expect(preview.columns[1].wipLimit, 3);
+    expect(preview.columns[1].tasks.single.title, 'Validate keyboard movement');
+    expect(preview.columns[1].tasks.single.status, BoardTaskStatus.inProgress);
+    expect(preview.columns[2].tasks.single.status, BoardTaskStatus.done);
+  });
+}

--- a/test/features/deck/deck_screen_test.dart
+++ b/test/features/deck/deck_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/features/deck/presentation/deck_screen.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_authenticated_session_provider.dart';
 
 import '../../helpers/test_app.dart';
 
@@ -8,7 +9,9 @@ void main() {
     testWidgets('renders the hidden provider-neutral boards preview', (
       tester,
     ) async {
-      await tester.pumpWidget(createTestApp(const DeckScreen()));
+      await tester.pumpWidget(
+        createTestApp(const DeckScreen(), overrides: _staticPreviewOverrides),
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Future boards/tasks preview'), findsOneWidget);
@@ -16,17 +19,25 @@ void main() {
     });
 
     testWidgets('meets androidTapTargetGuideline', (tester) async {
-      await tester.pumpWidget(createTestApp(const DeckScreen()));
+      await tester.pumpWidget(
+        createTestApp(const DeckScreen(), overrides: _staticPreviewOverrides),
+      );
       await tester.pumpAndSettle();
 
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
     });
 
     testWidgets('meets labeledTapTargetGuideline', (tester) async {
-      await tester.pumpWidget(createTestApp(const DeckScreen()));
+      await tester.pumpWidget(
+        createTestApp(const DeckScreen(), overrides: _staticPreviewOverrides),
+      );
       await tester.pumpAndSettle();
 
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
     });
   });
 }
+
+final _staticPreviewOverrides = [
+  weaveAuthenticatedSessionProvider.overrideWith((ref) async => null),
+];


### PR DESCRIPTION
## Summary
- Adds a backend-backed Boards preview repository for the hidden Flutter preview route.
- Uses the authenticated Weave API session when available, then falls back to the existing static preview on unauthenticated/disabled/unreachable backend states.
- Keeps Boards/Tasks hidden, post-Release, and provider-neutral; no Release 1 navigation or live provider claims.

## Issue/spec matrix
| Track | Source | Outcome |
| --- | --- | --- |
| Boards/Tasks hidden preview | `specs/14-boards-tasks-domain-and-provider-adapter-contract.md`; weave #119-#123 | Flutter hidden preview can consume the backend facade from the paired backend PR. |
| Calendar private/workspace model | weave-backend #52 | Deferred: no Flutter private-calendar UI changes in this wave. |
| Calendar external credentials/profile | weave-backend #56; weave-infra #54 | Deferred: no fake profile/download UI; existing client setup remains secret-free/truthful. |

## Acceptance evidence
- Preview still renders with static fallback when unauthenticated or when backend preview is unavailable.
- Backend DTO parsing maps provider-neutral columns/tasks into existing accessible preview entities.
- Existing non-drag task actions, screen-reader summaries, tap-target tests, and large-text reachability remain covered.

## Validation
- `flutter gen-l10n`
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze --fatal-infos`
- `flutter test test/features/boards/data/backend_boards_preview_repository_test.dart test/features/boards/boards_preview_screen_test.dart`
- `flutter test test/features/deck/deck_screen_test.dart`
- `flutter test --reporter compact` (267 passed, 6 skipped)
- `make offline-contract-test`
- `git diff --check`

## Dependency
- Pair with backend PR for `/api/boards/preview` hidden runtime facade. Without it, the app safely falls back to static preview.
