### PR TITLE
Add guarded guest and connector preview UI

### DIFF
--- a/lib/features/connectors/domain/entities/connector_preview.dart
+++ b/lib/features/connectors/domain/entities/connector_preview.dart
@@ -1,0 +1,23 @@
+enum ConnectorPreviewStatus {
+  disabled,
+  unavailable,
+  degraded,
+  actionRequired,
+  configured,
+}
+
+class ConnectorPreviewCapability {
+  const ConnectorPreviewCapability({
+    required this.name,
+    required this.status,
+    required this.summary,
+    required this.providerActionsEnabled,
+    required this.auditSummary,
+  });
+
+  final String name;
+  final ConnectorPreviewStatus status;
+  final String summary;
+  final bool providerActionsEnabled;
+  final String auditSummary;
+}

--- a/lib/features/connectors/presentation/providers/connector_preview_provider.dart
+++ b/lib/features/connectors/presentation/providers/connector_preview_provider.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weave/features/connectors/domain/entities/connector_preview.dart';
+
+final connectorPreviewProvider = Provider<List<ConnectorPreviewCapability>>((
+  ref,
+) {
+  return const <ConnectorPreviewCapability>[
+    ConnectorPreviewCapability(
+      name: 'Slack one-channel bridge',
+      status: ConnectorPreviewStatus.disabled,
+      summary:
+          'Disabled by default. No OAuth, webhook, access token, or refresh token is collected in the app.',
+      providerActionsEnabled: false,
+      auditSummary:
+          'Install, scope, mapping, disconnect, and failure events will be audited by the backend.',
+    ),
+    ConnectorPreviewCapability(
+      name: 'Teams bridge',
+      status: ConnectorPreviewStatus.unavailable,
+      summary:
+          'Unavailable until Slack hardening proves the connector boundary.',
+      providerActionsEnabled: false,
+      auditSummary:
+          'Future consent and throttling states will be reported without exposing provider secrets.',
+    ),
+    ConnectorPreviewCapability(
+      name: 'Migration dry run',
+      status: ConnectorPreviewStatus.degraded,
+      summary:
+          'Preview status can describe rate limits and unmapped content before any import starts.',
+      providerActionsEnabled: false,
+      auditSummary: 'Dry-run inventory remains review-only and replay-safe.',
+    ),
+    ConnectorPreviewCapability(
+      name: 'Connector manifest',
+      status: ConnectorPreviewStatus.actionRequired,
+      summary:
+          'Requires reviewed scoped capabilities and secret references before runtime enablement.',
+      providerActionsEnabled: false,
+      auditSummary:
+          'Manifest validation rejects provider secrets in client-visible metadata.',
+    ),
+    ConnectorPreviewCapability(
+      name: 'Configured reference example',
+      status: ConnectorPreviewStatus.configured,
+      summary:
+          'Configured-reference means the backend knows a safe reference; the Flutter client still never handles raw secrets.',
+      providerActionsEnabled: true,
+      auditSummary:
+          'Provider actions become available only when backend metadata marks the connector enabled and configured.',
+    ),
+  ];
+});

--- a/lib/features/connectors/presentation/widgets/connector_settings_preview_card.dart
+++ b/lib/features/connectors/presentation/widgets/connector_settings_preview_card.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:weave/features/connectors/domain/entities/connector_preview.dart';
+
+class ConnectorSettingsPreviewCard extends StatelessWidget {
+  const ConnectorSettingsPreviewCard({
+    super.key,
+    required this.connectors,
+    this.title = 'Governed connectors preview',
+    this.description =
+        'Connector status is safe metadata from backend contracts or fixtures. OAuth, webhook, access-token, and refresh-token secrets never belong in this client.',
+  });
+
+  final List<ConnectorPreviewCapability> connectors;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      container: true,
+      label:
+          '$title. Hidden by default for Release 1. Provider secrets are never entered, shown, stored, or logged by the Flutter client.',
+      child: Card(
+        elevation: 0,
+        color: theme.colorScheme.surfaceContainerLow,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(24),
+          side: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.sync_alt_outlined,
+                    color: theme.colorScheme.primary,
+                    semanticLabel: 'Connectors preview icon',
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(title, style: theme.textTheme.titleLarge),
+                        const SizedBox(height: 8),
+                        Text(
+                          description,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              for (final connector in connectors) ...[
+                _ConnectorPreviewTile(connector: connector),
+                if (connector != connectors.last) const Divider(height: 24),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ConnectorPreviewTile extends StatelessWidget {
+  const _ConnectorPreviewTile({required this.connector});
+
+  final ConnectorPreviewCapability connector;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final statusLabel = _statusLabel(connector.status);
+    final actionAllowed = connector.providerActionsEnabled;
+
+    return Semantics(
+      container: true,
+      label:
+          '${connector.name}. Status $statusLabel. ${connector.summary} ${connector.auditSummary} Provider actions ${actionAllowed ? 'are preview-only until backend runtime enables them' : 'are unavailable'}; no provider secret is handled by the app.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              Text(
+                connector.name,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Chip(
+                label: Text(statusLabel),
+                avatar: Icon(_statusIcon(connector.status), size: 18),
+                side: BorderSide(color: theme.colorScheme.outlineVariant),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(connector.summary),
+          const SizedBox(height: 8),
+          Text(
+            connector.auditSummary,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 10),
+          OutlinedButton.icon(
+            onPressed: null,
+            icon: const Icon(Icons.lock),
+            label: Text(
+              actionAllowed
+                  ? 'Backend-configured action preview only'
+                  : 'Provider action unavailable',
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _statusLabel(ConnectorPreviewStatus status) {
+    return switch (status) {
+      ConnectorPreviewStatus.disabled => 'Disabled',
+      ConnectorPreviewStatus.unavailable => 'Unavailable',
+      ConnectorPreviewStatus.degraded => 'Degraded',
+      ConnectorPreviewStatus.actionRequired => 'Action required',
+      ConnectorPreviewStatus.configured => 'Configured reference',
+    };
+  }
+
+  static IconData _statusIcon(ConnectorPreviewStatus status) {
+    return switch (status) {
+      ConnectorPreviewStatus.disabled => Icons.toggle_off_outlined,
+      ConnectorPreviewStatus.unavailable => Icons.cloud_off_outlined,
+      ConnectorPreviewStatus.degraded => Icons.warning_amber_outlined,
+      ConnectorPreviewStatus.actionRequired => Icons.assignment_late_outlined,
+      ConnectorPreviewStatus.configured => Icons.verified_outlined,
+    };
+  }
+}

--- a/lib/features/guests/domain/entities/guest_preview.dart
+++ b/lib/features/guests/domain/entities/guest_preview.dart
@@ -1,0 +1,22 @@
+enum GuestPreviewStatus { pending, active, disabled, expired }
+
+enum GuestAccessCapability { chat, files, calendar, memberDirectory, admin }
+
+class GuestPreviewProfile {
+  const GuestPreviewProfile({
+    required this.displayName,
+    required this.email,
+    required this.status,
+    required this.allowedCapabilities,
+    required this.missingAccessMessages,
+  });
+
+  final String displayName;
+  final String email;
+  final GuestPreviewStatus status;
+  final Set<GuestAccessCapability> allowedCapabilities;
+  final List<String> missingAccessMessages;
+
+  bool get canSeeMemberOnlyAffordances =>
+      allowedCapabilities.contains(GuestAccessCapability.admin);
+}

--- a/lib/features/guests/presentation/providers/guest_preview_provider.dart
+++ b/lib/features/guests/presentation/providers/guest_preview_provider.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weave/features/guests/domain/entities/guest_preview.dart';
+
+final guestPreviewProvider = Provider<List<GuestPreviewProfile>>((ref) {
+  return const <GuestPreviewProfile>[
+    GuestPreviewProfile(
+      displayName: 'Mina Partner',
+      email: 'mina.partner@example.test',
+      status: GuestPreviewStatus.pending,
+      allowedCapabilities: <GuestAccessCapability>{},
+      missingAccessMessages: <String>[
+        'Chat, files, and calendar stay hidden until the invite is accepted and a policy grants access.',
+      ],
+    ),
+    GuestPreviewProfile(
+      displayName: 'Sam Contractor',
+      email: 'sam.contractor@example.test',
+      status: GuestPreviewStatus.active,
+      allowedCapabilities: <GuestAccessCapability>{GuestAccessCapability.chat},
+      missingAccessMessages: <String>[
+        'Files access requires an explicit guest policy from a workspace admin.',
+        'Calendar access is not shared with this guest.',
+      ],
+    ),
+    GuestPreviewProfile(
+      displayName: 'Rae Alumni',
+      email: 'rae.alumni@example.test',
+      status: GuestPreviewStatus.disabled,
+      allowedCapabilities: <GuestAccessCapability>{},
+      missingAccessMessages: <String>[
+        'This guest is disabled and cannot open workspace modules.',
+      ],
+    ),
+    GuestPreviewProfile(
+      displayName: 'Noor Vendor',
+      email: 'noor.vendor@example.test',
+      status: GuestPreviewStatus.expired,
+      allowedCapabilities: <GuestAccessCapability>{},
+      missingAccessMessages: <String>[
+        'The invitation expired. Send a new invite before granting access.',
+      ],
+    ),
+  ];
+});

--- a/lib/features/guests/presentation/widgets/guest_access_preview_card.dart
+++ b/lib/features/guests/presentation/widgets/guest_access_preview_card.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:weave/features/guests/domain/entities/guest_preview.dart';
+
+class GuestAccessPreviewCard extends StatelessWidget {
+  const GuestAccessPreviewCard({
+    super.key,
+    required this.guests,
+    this.title = 'Guest access preview',
+    this.description =
+        'Invite and restricted-access states are preview-only. Guest identities stay visibly separate from full members, and missing access is explained without exposing internal policy details.',
+  });
+
+  final List<GuestPreviewProfile> guests;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      container: true,
+      label:
+          '$title. Hidden by default for Release 1. Guests are distinct from members and only see explicitly granted capabilities.',
+      child: Card(
+        elevation: 0,
+        color: theme.colorScheme.surfaceContainerLow,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(24),
+          side: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.badge_outlined,
+                    color: theme.colorScheme.primary,
+                    semanticLabel: 'Guest preview icon',
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(title, style: theme.textTheme.titleLarge),
+                        const SizedBox(height: 8),
+                        Text(
+                          description,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              for (final guest in guests) ...[
+                _GuestPreviewTile(guest: guest),
+                if (guest != guests.last) const Divider(height: 24),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GuestPreviewTile extends StatelessWidget {
+  const _GuestPreviewTile({required this.guest});
+
+  final GuestPreviewProfile guest;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final statusLabel = _statusLabel(guest.status);
+    final capabilityText = _capabilityText(guest.allowedCapabilities);
+
+    return Semantics(
+      container: true,
+      label:
+          'Guest identity ${guest.displayName}, $statusLabel. $capabilityText. ${guest.missingAccessMessages.join(' ')}',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              Text(
+                guest.displayName,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Chip(
+                label: Text(statusLabel),
+                avatar: Icon(_statusIcon(guest.status), size: 18),
+                side: BorderSide(color: theme.colorScheme.outlineVariant),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Guest identity · ${guest.email}',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Text(capabilityText, style: theme.textTheme.bodyMedium),
+          const SizedBox(height: 8),
+          for (final message in guest.missingAccessMessages)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const ExcludeSemantics(
+                    child: Icon(Icons.lock_outline, size: 18),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(child: Text(message)),
+                ],
+              ),
+            ),
+          if (guest.canSeeMemberOnlyAffordances)
+            const Text('Member/admin affordances allowed by policy.')
+          else
+            Text(
+              'Owner, admin, and member-only affordances are hidden for this guest.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  static String _statusLabel(GuestPreviewStatus status) {
+    return switch (status) {
+      GuestPreviewStatus.pending => 'Pending invitation',
+      GuestPreviewStatus.active => 'Active guest',
+      GuestPreviewStatus.disabled => 'Disabled guest',
+      GuestPreviewStatus.expired => 'Expired invitation',
+    };
+  }
+
+  static IconData _statusIcon(GuestPreviewStatus status) {
+    return switch (status) {
+      GuestPreviewStatus.pending => Icons.schedule_outlined,
+      GuestPreviewStatus.active => Icons.verified_user_outlined,
+      GuestPreviewStatus.disabled => Icons.block_outlined,
+      GuestPreviewStatus.expired => Icons.event_busy_outlined,
+    };
+  }
+
+  static String _capabilityText(Set<GuestAccessCapability> capabilities) {
+    if (capabilities.isEmpty) {
+      return 'Allowed access: none yet.';
+    }
+
+    final labels = capabilities
+        .map(
+          (capability) => switch (capability) {
+            GuestAccessCapability.chat => 'chat',
+            GuestAccessCapability.files => 'files',
+            GuestAccessCapability.calendar => 'calendar',
+            GuestAccessCapability.memberDirectory => 'member directory',
+            GuestAccessCapability.admin => 'admin controls',
+          },
+        )
+        .join(', ');
+    return 'Allowed access: $labels.';
+  }
+}

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -14,6 +14,10 @@ import 'package:weave/features/app/domain/entities/workspace_connection_state.da
 import 'package:weave/features/app/presentation/providers/workspace_connection_provider.dart';
 import 'package:weave/features/auth/presentation/providers/auth_flow_controller.dart';
 import 'package:weave/features/chat/presentation/widgets/chat_security_settings_section.dart';
+import 'package:weave/features/connectors/presentation/providers/connector_preview_provider.dart';
+import 'package:weave/features/connectors/presentation/widgets/connector_settings_preview_card.dart';
+import 'package:weave/features/guests/presentation/providers/guest_preview_provider.dart';
+import 'package:weave/features/guests/presentation/widgets/guest_access_preview_card.dart';
 import 'package:weave/features/profile/presentation/widgets/profile_summary_card.dart';
 import 'package:weave/features/server_config/presentation/providers/'
     'server_configuration_form_controller.dart';
@@ -273,13 +277,15 @@ class _ShellModulePreferenceTile extends ConsumerWidget {
   }
 }
 
-class _FeaturePreviewSurfacesSection extends StatelessWidget {
+class _FeaturePreviewSurfacesSection extends ConsumerWidget {
   const _FeaturePreviewSurfacesSection();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
+    final guestPreview = ref.watch(guestPreviewProvider);
+    final connectorPreview = ref.watch(connectorPreviewProvider);
     return Card(
       elevation: 0,
       color: theme.colorScheme.surfaceContainerLow,
@@ -304,18 +310,22 @@ class _FeaturePreviewSurfacesSection extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 12),
-            if (FeatureFlags.guestPortal)
-              _PreviewSurfaceTile(
-                icon: Icons.badge_outlined,
+            if (FeatureFlags.guestPortal) ...[
+              GuestAccessPreviewCard(
+                guests: guestPreview,
                 title: l10n.settingsGuestPortalPreviewTitle,
                 description: l10n.settingsGuestPortalPreviewDescription,
               ),
-            if (FeatureFlags.interopAdmin)
-              _PreviewSurfaceTile(
-                icon: Icons.sync_alt_outlined,
+              const SizedBox(height: 12),
+            ],
+            if (FeatureFlags.interopAdmin) ...[
+              ConnectorSettingsPreviewCard(
+                connectors: connectorPreview,
                 title: l10n.settingsInteropAdminPreviewTitle,
                 description: l10n.settingsInteropAdminPreviewDescription,
               ),
+              const SizedBox(height: 12),
+            ],
             if (FeatureFlags.migrationDryRun)
               _PreviewSurfaceTile(
                 icon: Icons.fact_check_outlined,

--- a/test/features/connectors/connector_preview_provider_test.dart
+++ b/test/features/connectors/connector_preview_provider_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/connectors/domain/entities/connector_preview.dart';
+import 'package:weave/features/connectors/presentation/providers/connector_preview_provider.dart';
+
+void main() {
+  test('connector preview provider covers governed connector states', () {
+    final container = ProviderContainer.test();
+    addTearDown(container.dispose);
+
+    final connectors = container.read(connectorPreviewProvider);
+    expect(
+      connectors.map((connector) => connector.status).toSet(),
+      containsAll(<ConnectorPreviewStatus>{
+        ConnectorPreviewStatus.disabled,
+        ConnectorPreviewStatus.unavailable,
+        ConnectorPreviewStatus.degraded,
+        ConnectorPreviewStatus.actionRequired,
+        ConnectorPreviewStatus.configured,
+      }),
+    );
+    expect(
+      connectors.where((connector) => !connector.providerActionsEnabled),
+      isNotEmpty,
+    );
+    expect(
+      connectors.any(
+        (connector) =>
+            connector.summary.toLowerCase().contains('token') &&
+            connector.providerActionsEnabled,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/features/connectors/connector_settings_preview_test.dart
+++ b/test/features/connectors/connector_settings_preview_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/connectors/domain/entities/connector_preview.dart';
+import 'package:weave/features/connectors/presentation/widgets/connector_settings_preview_card.dart';
+
+void main() {
+  testWidgets('renders governed connector states without secret entry fields', (
+    tester,
+  ) async {
+    const connectors = <ConnectorPreviewCapability>[
+      ConnectorPreviewCapability(
+        name: 'Slack',
+        status: ConnectorPreviewStatus.disabled,
+        summary:
+            'No OAuth, webhook, access token, or refresh token is collected.',
+        providerActionsEnabled: false,
+        auditSummary: 'Install and disconnect events will be audited.',
+      ),
+      ConnectorPreviewCapability(
+        name: 'Teams',
+        status: ConnectorPreviewStatus.unavailable,
+        summary: 'Unavailable until Slack hardening.',
+        providerActionsEnabled: false,
+        auditSummary: 'Consent changes will be visible.',
+      ),
+      ConnectorPreviewCapability(
+        name: 'Migration',
+        status: ConnectorPreviewStatus.degraded,
+        summary: 'Rate limits are visible before import.',
+        providerActionsEnabled: false,
+        auditSummary: 'Dry runs are replay-safe.',
+      ),
+      ConnectorPreviewCapability(
+        name: 'Manifest',
+        status: ConnectorPreviewStatus.actionRequired,
+        summary: 'Requires reviewed scoped capabilities.',
+        providerActionsEnabled: false,
+        auditSummary: 'Secret values are rejected.',
+      ),
+      ConnectorPreviewCapability(
+        name: 'Configured reference',
+        status: ConnectorPreviewStatus.configured,
+        summary: 'The backend exposes only a safe reference.',
+        providerActionsEnabled: true,
+        auditSummary:
+            'Provider actions require enabled and configured metadata.',
+      ),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: ConnectorSettingsPreviewCard(connectors: connectors),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Disabled'), findsOneWidget);
+    expect(find.text('Unavailable'), findsOneWidget);
+    expect(find.text('Degraded'), findsOneWidget);
+    expect(find.text('Action required'), findsOneWidget);
+    expect(find.text('Configured reference'), findsWidgets);
+    expect(find.byType(TextField), findsNothing);
+    expect(find.textContaining('access token'), findsOneWidget);
+    expect(find.text('Provider action unavailable'), findsNWidgets(4));
+    expect(find.text('Backend-configured action preview only'), findsOneWidget);
+  });
+
+  testWidgets('exposes non-color status in connector semantics', (
+    tester,
+  ) async {
+    const connector = ConnectorPreviewCapability(
+      name: 'Slack',
+      status: ConnectorPreviewStatus.degraded,
+      summary: 'Rate-limited by provider.',
+      providerActionsEnabled: false,
+      auditSummary: 'Failure events are audited.',
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: ConnectorSettingsPreviewCard(
+            connectors: <ConnectorPreviewCapability>[connector],
+          ),
+        ),
+      ),
+    );
+
+    final semantics = tester.getSemantics(find.text('Slack'));
+    expect(semantics.label, contains('Status Degraded'));
+    expect(semantics.label, contains('Provider actions are unavailable'));
+    expect(semantics.label, contains('no provider secret is handled'));
+  });
+}

--- a/test/features/guests/guest_access_preview_test.dart
+++ b/test/features/guests/guest_access_preview_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/guests/domain/entities/guest_preview.dart';
+import 'package:weave/features/guests/presentation/widgets/guest_access_preview_card.dart';
+
+void main() {
+  testWidgets('renders guest states with restricted-access explanations', (
+    tester,
+  ) async {
+    const guests = <GuestPreviewProfile>[
+      GuestPreviewProfile(
+        displayName: 'Pending Partner',
+        email: 'pending@example.test',
+        status: GuestPreviewStatus.pending,
+        allowedCapabilities: <GuestAccessCapability>{},
+        missingAccessMessages: <String>['Invite acceptance is required.'],
+      ),
+      GuestPreviewProfile(
+        displayName: 'Active Contractor',
+        email: 'active@example.test',
+        status: GuestPreviewStatus.active,
+        allowedCapabilities: <GuestAccessCapability>{
+          GuestAccessCapability.chat,
+        },
+        missingAccessMessages: <String>[
+          'Files access requires an explicit guest policy.',
+        ],
+      ),
+      GuestPreviewProfile(
+        displayName: 'Disabled Vendor',
+        email: 'disabled@example.test',
+        status: GuestPreviewStatus.disabled,
+        allowedCapabilities: <GuestAccessCapability>{},
+        missingAccessMessages: <String>['This guest is disabled.'],
+      ),
+      GuestPreviewProfile(
+        displayName: 'Expired Reviewer',
+        email: 'expired@example.test',
+        status: GuestPreviewStatus.expired,
+        allowedCapabilities: <GuestAccessCapability>{},
+        missingAccessMessages: <String>['The invitation expired.'],
+      ),
+    ];
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: GuestAccessPreviewCard(guests: guests),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Pending invitation'), findsOneWidget);
+    expect(find.text('Active guest'), findsOneWidget);
+    expect(find.text('Disabled guest'), findsOneWidget);
+    expect(find.text('Expired invitation'), findsOneWidget);
+    expect(find.text('Guest identity · active@example.test'), findsOneWidget);
+    expect(find.text('Allowed access: chat.'), findsOneWidget);
+    expect(
+      find.text(
+        'Owner, admin, and member-only affordances are hidden for this guest.',
+      ),
+      findsNWidgets(4),
+    );
+    expect(find.textContaining('internal policy'), findsOneWidget);
+  });
+
+  testWidgets('exposes a screen-reader summary for guest identity state', (
+    tester,
+  ) async {
+    const guest = GuestPreviewProfile(
+      displayName: 'Sam Contractor',
+      email: 'sam@example.test',
+      status: GuestPreviewStatus.active,
+      allowedCapabilities: <GuestAccessCapability>{GuestAccessCapability.chat},
+      missingAccessMessages: <String>['Calendar access is not shared.'],
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: GuestAccessPreviewCard(guests: <GuestPreviewProfile>[guest]),
+        ),
+      ),
+    );
+
+    final semantics = tester.getSemantics(find.text('Sam Contractor'));
+    expect(semantics.label, contains('Guest identity Sam Contractor'));
+    expect(semantics.label, contains('Active guest'));
+    expect(semantics.label, contains('Allowed access: chat.'));
+  });
+}

--- a/test/features/guests/guest_preview_provider_test.dart
+++ b/test/features/guests/guest_preview_provider_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/guests/domain/entities/guest_preview.dart';
+import 'package:weave/features/guests/presentation/providers/guest_preview_provider.dart';
+
+void main() {
+  test('guest preview provider covers all safe guest states', () {
+    final container = ProviderContainer.test();
+    addTearDown(container.dispose);
+
+    final guests = container.read(guestPreviewProvider);
+    expect(
+      guests.map((guest) => guest.status).toSet(),
+      containsAll(<GuestPreviewStatus>{
+        GuestPreviewStatus.pending,
+        GuestPreviewStatus.active,
+        GuestPreviewStatus.disabled,
+        GuestPreviewStatus.expired,
+      }),
+    );
+    expect(guests.any((guest) => guest.canSeeMemberOnlyAffordances), isFalse);
+  });
+}

--- a/test/features/settings/post_release_preview_guard_test.dart
+++ b/test/features/settings/post_release_preview_guard_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/core/config/feature_flags.dart';
+
+void main() {
+  test(
+    'guest and connector previews remain hidden by default for Release 1',
+    () {
+      expect(FeatureFlags.guestPortal, isFalse);
+      expect(FeatureFlags.interopAdmin, isFalse);
+      expect(FeatureFlags.migrationDryRun, isFalse);
+      expect(FeatureFlags.hasPostReleaseSurfaces, isFalse);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds feature-flagged guest access preview models, provider fixtures, and accessible settings card for Release 2 guest states.
- Adds feature-flagged governed connector preview models, provider fixtures, and accessible settings card for Release 2 interop/admin states.
- Keeps both surfaces hidden by default for Release 1 with a guard test; no provider secrets or unsafe runtime actions are collected/exposed by the Flutter client.

Closes #151.
Closes #152.

## Contract / spec alignment
- Follows the existing post-Release-1 feature flag contract: `WEAVE_GUEST_PORTAL` and `WEAVE_INTEROP_ADMIN` default off.
- Frontend-only preview fixtures; no new backend endpoints, auth claims, Matrix/Nextcloud behavior, or public routes.
- Uses localized existing settings headings/descriptions where mounted in Settings; preview state fixture details remain non-runtime examples.

## Validation
- `flutter test test/features/guests test/features/connectors test/features/settings/post_release_preview_guard_test.dart test/features/settings/settings_screen_test.dart`
- `flutter analyze`
- `flutter test` (all tests passed; live-stack credential tests skipped as designed)

## Notes
- This is intentionally a hidden preview slice, not runtime guest provisioning or provider connector enablement.
