### PR TITLE
Add accessible shared state panel

### DIFF
--- a/lib/core/widgets/empty_state.dart
+++ b/lib/core/widgets/empty_state.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:weave/core/widgets/state_panel.dart';
 
 /// A shared empty-state placeholder with calm, screen-reader-friendly chrome.
 ///
@@ -13,6 +14,7 @@ class EmptyState extends StatelessWidget {
     this.icon = Icons.inbox_outlined,
     this.actionLabel,
     this.onAction,
+    this.semanticLabel,
   });
 
   /// Localised empty-state title, e.g. `No conversations yet`.
@@ -31,88 +33,20 @@ class EmptyState extends StatelessWidget {
   /// Callback for the optional CTA.
   final VoidCallback? onAction;
 
+  /// Optional full screen-reader label for the live empty-state region.
+  final String? semanticLabel;
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final minHeight = constraints.maxHeight.isFinite
-            ? (constraints.maxHeight - 32)
-                  .clamp(0.0, double.infinity)
-                  .toDouble()
-            : 0.0;
-
-        return SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: minHeight),
-            child: Center(
-              child: Semantics(
-                container: true,
-                liveRegion: true,
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 360),
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          DecoratedBox(
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest,
-                              borderRadius: BorderRadius.circular(16),
-                            ),
-                            child: Padding(
-                              padding: const EdgeInsets.all(12),
-                              child: ExcludeSemantics(
-                                child: Icon(
-                                  icon,
-                                  size: 28,
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                ),
-                              ),
-                            ),
-                          ),
-                          const SizedBox(height: 20),
-                          Semantics(
-                            header: true,
-                            child: Text(
-                              message,
-                              style: theme.textTheme.titleMedium,
-                              textAlign: TextAlign.center,
-                            ),
-                          ),
-                          if (guidance != null) ...[
-                            const SizedBox(height: 8),
-                            Text(
-                              guidance!,
-                              style: theme.textTheme.bodyMedium?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                          ],
-                          if (actionLabel != null && onAction != null) ...[
-                            const SizedBox(height: 24),
-                            FilledButton.tonal(
-                              onPressed: onAction,
-                              style: FilledButton.styleFrom(
-                                minimumSize: const Size(48, 48),
-                              ),
-                              child: Text(actionLabel!),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        );
-      },
+    return StatePanel(
+      variant: StatePanelVariant.empty,
+      message: message,
+      guidance: guidance,
+      icon: icon,
+      actionLabel: actionLabel,
+      onAction: onAction,
+      semanticLabel: semanticLabel,
+      outlinedAction: true,
     );
   }
 }

--- a/lib/core/widgets/error_state.dart
+++ b/lib/core/widgets/error_state.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:weave/core/a11y/semantic_button.dart';
+import 'package:weave/core/widgets/state_panel.dart';
 
 /// A shared error-state placeholder with friendly guidance and recovery.
 ///
@@ -13,6 +13,7 @@ class ErrorState extends StatelessWidget {
     this.guidance,
     this.retryLabel,
     this.onRetry,
+    this.semanticLabel,
   });
 
   /// Localised user-facing error title.
@@ -27,86 +28,18 @@ class ErrorState extends StatelessWidget {
   /// Callback when the user taps the retry button.
   final VoidCallback? onRetry;
 
+  /// Optional full screen-reader label for the live error-state region.
+  final String? semanticLabel;
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final minHeight = constraints.maxHeight.isFinite
-            ? (constraints.maxHeight - 32)
-                  .clamp(0.0, double.infinity)
-                  .toDouble()
-            : 0.0;
-
-        return SingleChildScrollView(
-          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minHeight: minHeight),
-            child: Center(
-              child: Semantics(
-                container: true,
-                liveRegion: true,
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 360),
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          DecoratedBox(
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.errorContainer,
-                              borderRadius: BorderRadius.circular(16),
-                            ),
-                            child: Padding(
-                              padding: const EdgeInsets.all(12),
-                              child: ExcludeSemantics(
-                                child: Icon(
-                                  Icons.error_outline,
-                                  size: 28,
-                                  color: theme.colorScheme.onErrorContainer,
-                                ),
-                              ),
-                            ),
-                          ),
-                          const SizedBox(height: 20),
-                          Semantics(
-                            header: true,
-                            child: Text(
-                              message,
-                              style: theme.textTheme.titleMedium,
-                              textAlign: TextAlign.center,
-                            ),
-                          ),
-                          if (guidance != null) ...[
-                            const SizedBox(height: 8),
-                            Text(
-                              guidance!,
-                              style: theme.textTheme.bodyMedium?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                          ],
-                          if (onRetry != null && retryLabel != null) ...[
-                            const SizedBox(height: 24),
-                            AccessibleButton(
-                              onPressed: onRetry,
-                              semanticLabel: retryLabel!,
-                              child: Text(retryLabel!),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        );
-      },
+    return StatePanel(
+      variant: StatePanelVariant.error,
+      message: message,
+      guidance: guidance,
+      actionLabel: retryLabel,
+      onAction: onRetry,
+      semanticLabel: semanticLabel,
     );
   }
 }

--- a/lib/core/widgets/loading_state.dart
+++ b/lib/core/widgets/loading_state.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:weave/core/widgets/state_panel.dart';
 
 /// A shared loading-state placeholder with a calm, accessible presentation.
 class LoadingState extends StatelessWidget {
@@ -7,6 +8,7 @@ class LoadingState extends StatelessWidget {
     required this.message,
     this.hint,
     this.icon = Icons.hourglass_top_rounded,
+    this.semanticLabel,
   });
 
   /// Localised loading message, e.g. `AppLocalizations.of(context).loadingLabel`.
@@ -18,66 +20,17 @@ class LoadingState extends StatelessWidget {
   /// Decorative icon shown above the loading copy.
   final IconData icon;
 
+  /// Optional full screen-reader label for the live loading region.
+  final String? semanticLabel;
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final semanticsLabel = [message, if (hint != null) hint!].join('. ');
-
-    return SingleChildScrollView(
-      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-      child: Center(
-        child: Semantics(
-          liveRegion: true,
-          label: semanticsLabel,
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 360),
-            child: Card(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.secondaryContainer,
-                        borderRadius: BorderRadius.circular(16),
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(12),
-                        child: ExcludeSemantics(
-                          child: Icon(
-                            icon,
-                            size: 28,
-                            color: theme.colorScheme.onSecondaryContainer,
-                          ),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 20),
-                    const CircularProgressIndicator(),
-                    const SizedBox(height: 20),
-                    Text(
-                      message,
-                      style: theme.textTheme.titleMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                    if (hint != null) ...[
-                      const SizedBox(height: 8),
-                      Text(
-                        hint!,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
+    return StatePanel(
+      variant: StatePanelVariant.loading,
+      message: message,
+      guidance: hint,
+      icon: icon,
+      semanticLabel: semanticLabel,
     );
   }
 }

--- a/lib/core/widgets/state_panel.dart
+++ b/lib/core/widgets/state_panel.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:weave/core/a11y/semantic_button.dart';
+
+/// Visual and semantic variants for shared feature state panels.
+enum StatePanelVariant { loading, empty, error, success }
+
+/// A reusable, accessible state panel for loading, empty, error, success, and
+/// recovery states.
+///
+/// The panel intentionally exposes one predictable live-region label composed
+/// from [message], [guidance], and the optional action label. Decorative chrome
+/// is excluded from semantics so screen-reader users hear the state and the
+/// available recovery path, not duplicate icon names.
+class StatePanel extends StatelessWidget {
+  const StatePanel({
+    super.key,
+    required this.variant,
+    required this.message,
+    this.guidance,
+    this.icon,
+    this.actionLabel,
+    this.onAction,
+    this.semanticLabel,
+    this.outlinedAction = false,
+  });
+
+  /// State category. This controls default icon and container color.
+  final StatePanelVariant variant;
+
+  /// Short localized state title.
+  final String message;
+
+  /// Optional localized explanation or next step.
+  final String? guidance;
+
+  /// Optional decorative icon. Defaults from [variant] when omitted.
+  final IconData? icon;
+
+  /// Optional localized recovery/action label.
+  final String? actionLabel;
+
+  /// Optional recovery/action callback.
+  final VoidCallback? onAction;
+
+  /// Optional full screen-reader label. When omitted, a label is composed from
+  /// [message], [guidance], and [actionLabel].
+  final String? semanticLabel;
+
+  /// Renders the optional action as an outlined button when true.
+  final bool outlinedAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final tokens = _StatePanelTokens.from(theme, variant);
+    final effectiveIcon = icon ?? tokens.icon;
+    final effectiveSemanticLabel = semanticLabel ?? _composeSemanticLabel();
+    final hasAction = actionLabel != null && onAction != null;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+      child: Center(
+        child: Semantics(
+          container: true,
+          explicitChildNodes: true,
+          liveRegion: true,
+          label: effectiveSemanticLabel,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 360),
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    ExcludeSemantics(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: tokens.containerColor,
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                            child: Padding(
+                              padding: const EdgeInsets.all(12),
+                              child: Icon(
+                                effectiveIcon,
+                                size: 28,
+                                color: tokens.onContainerColor,
+                              ),
+                            ),
+                          ),
+                          if (variant == StatePanelVariant.loading) ...[
+                            const SizedBox(height: 20),
+                            const CircularProgressIndicator(),
+                          ],
+                          const SizedBox(height: 20),
+                          Text(
+                            message,
+                            style: theme.textTheme.titleMedium,
+                            textAlign: TextAlign.center,
+                          ),
+                          if (guidance != null) ...[
+                            const SizedBox(height: 8),
+                            Text(
+                              guidance!,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                              textAlign: TextAlign.center,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    if (hasAction) ...[
+                      const SizedBox(height: 24),
+                      AccessibleButton(
+                        onPressed: onAction,
+                        semanticLabel: actionLabel!,
+                        outlined: outlinedAction,
+                        child: Text(actionLabel!),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _composeSemanticLabel() {
+    final parts = <String>[
+      message,
+      if (guidance != null && guidance!.trim().isNotEmpty) guidance!,
+      if (actionLabel != null && actionLabel!.trim().isNotEmpty)
+        'Action: $actionLabel',
+    ];
+
+    return [
+      for (var i = 0; i < parts.length; i++)
+        if (i == parts.length - 1)
+          parts[i].trim()
+        else
+          _withoutTerminalPunctuation(parts[i]),
+    ].join('. ');
+  }
+
+  String _withoutTerminalPunctuation(String value) {
+    return value.trim().replaceFirst(RegExp(r'[.!?…]+$'), '');
+  }
+}
+
+class _StatePanelTokens {
+  const _StatePanelTokens({
+    required this.icon,
+    required this.containerColor,
+    required this.onContainerColor,
+  });
+
+  final IconData icon;
+  final Color containerColor;
+  final Color onContainerColor;
+
+  factory _StatePanelTokens.from(ThemeData theme, StatePanelVariant variant) {
+    final colors = theme.colorScheme;
+    return switch (variant) {
+      StatePanelVariant.loading => _StatePanelTokens(
+        icon: Icons.hourglass_top_rounded,
+        containerColor: colors.secondaryContainer,
+        onContainerColor: colors.onSecondaryContainer,
+      ),
+      StatePanelVariant.empty => _StatePanelTokens(
+        icon: Icons.inbox_outlined,
+        containerColor: colors.surfaceContainerHighest,
+        onContainerColor: colors.onSurfaceVariant,
+      ),
+      StatePanelVariant.error => _StatePanelTokens(
+        icon: Icons.error_outline,
+        containerColor: colors.errorContainer,
+        onContainerColor: colors.onErrorContainer,
+      ),
+      StatePanelVariant.success => _StatePanelTokens(
+        icon: Icons.check_circle_outline,
+        containerColor: colors.tertiaryContainer,
+        onContainerColor: colors.onTertiaryContainer,
+      ),
+    };
+  }
+}

--- a/test/core/widgets/core_widgets_test.dart
+++ b/test/core/widgets/core_widgets_test.dart
@@ -1,10 +1,43 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/core/widgets/empty_state.dart';
 import 'package:weave/core/widgets/error_state.dart';
+import 'package:weave/core/widgets/loading_state.dart';
+import 'package:weave/core/widgets/state_panel.dart';
 
 void main() {
+  group('StatePanel', () {
+    testWidgets('supports success recovery states through the shared path', (
+      tester,
+    ) async {
+      var acknowledged = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: StatePanel(
+              variant: StatePanelVariant.success,
+              message: 'Upload complete',
+              guidance: 'The file is ready for your team.',
+              actionLabel: 'Done',
+              onAction: () => acknowledged = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(
+          'Upload complete. The file is ready for your team. Action: Done',
+        ),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.text('Done'));
+      expect(acknowledged, isTrue);
+    });
+  });
+
   group('LoadingState', () {
     testWidgets('displays shared loading chrome and supporting hint', (
       tester,
@@ -26,6 +59,29 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.byType(Card), findsOneWidget);
       expect(find.byIcon(Icons.folder_outlined), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Loading. Checking for changes.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('accepts an explicit screen-reader label', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingState(
+              message: 'Loading…',
+              hint: 'Checking for changes.',
+              semanticLabel: 'Files are loading. You can keep waiting.',
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.bySemanticsLabel('Files are loading. You can keep waiting.'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('meets labeledTapTargetGuideline', (tester) async {
@@ -57,6 +113,12 @@ void main() {
       expect(find.text('Add something when you are ready.'), findsOneWidget);
       expect(find.byType(Card), findsOneWidget);
       expect(find.byIcon(Icons.inbox_outlined), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(
+          'Nothing here. Add something when you are ready.',
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('renders CTA when actionLabel and onAction are provided', (
@@ -76,6 +138,8 @@ void main() {
       );
 
       expect(find.text('Add'), findsOneWidget);
+      expect(find.bySemanticsLabel('Empty. Action: Add'), findsOneWidget);
+      expect(find.bySemanticsLabel('Add'), findsOneWidget);
       await tester.tap(find.text('Add'));
       expect(tapped, isTrue);
     });
@@ -108,6 +172,10 @@ void main() {
       expect(find.text('Try again in a moment.'), findsOneWidget);
       expect(find.byType(Card), findsOneWidget);
       expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Something went wrong. Try again in a moment.'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('renders retry button when onRetry is provided', (
@@ -127,6 +195,8 @@ void main() {
       );
 
       expect(find.text('Retry'), findsOneWidget);
+      expect(find.bySemanticsLabel('Error. Action: Retry'), findsOneWidget);
+      expect(find.bySemanticsLabel('Retry'), findsOneWidget);
       await tester.tap(find.text('Retry'));
       expect(retried, isTrue);
     });


### PR DESCRIPTION
## Summary\n- Add a reusable StatePanel for loading, empty, error, success, and recovery states.\n- Refactor LoadingState, EmptyState, and ErrorState to share one accessible live-region pattern.\n- Add widget coverage for screen-reader labels, retry/CTA actions, and tap target guidelines.\n\nCloses #157\nProgresses #51\n\n## Validation\n- dart format --output=none --set-exit-if-changed lib/core/widgets test/core/widgets\n- flutter analyze --fatal-infos\n- flutter test test/core/widgets/core_widgets_test.dart\n- flutter test test/features/files/files_screen_test.dart test/features/calendar/calendar_screen_test.dart\n- flutter test\n\n## Contract impact\nFrontend-only shared UI/accessibility implementation. No backend, auth, routing, or infrastructure contract change.