### PR TITLE
Improve Files row accessibility metadata

### DIFF
--- a/lib/features/files/presentation/files_screen.dart
+++ b/lib/features/files/presentation/files_screen.dart
@@ -815,10 +815,9 @@ class _FileEntryTile extends ConsumerWidget {
     final l10n = AppLocalizations.of(context);
     return Semantics(
       container: true,
+      explicitChildNodes: true,
       button: entry.isDirectory,
-      label: entry.isDirectory
-          ? l10n.filesFolderSemantic(entry.name)
-          : l10n.filesFileSemantic(entry.name),
+      label: _semanticLabel(l10n, entry, subtitle),
       child: ListTile(
         contentPadding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
         leading: ExcludeSemantics(
@@ -870,6 +869,20 @@ class _FileEntryTile extends ConsumerWidget {
               },
       ),
     );
+  }
+
+  String _semanticLabel(
+    AppLocalizations l10n,
+    FileEntry entry,
+    String? subtitle,
+  ) {
+    final baseLabel = entry.isDirectory
+        ? l10n.filesFolderSemantic(entry.name)
+        : l10n.filesFileSemantic(entry.name);
+    if (subtitle == null || subtitle.trim().isEmpty) {
+      return baseLabel;
+    }
+    return '$baseLabel. $subtitle';
   }
 
   String? _subtitle(BuildContext context, FileEntry entry) {

--- a/test/features/files/files_screen_test.dart
+++ b/test/features/files/files_screen_test.dart
@@ -361,6 +361,50 @@ void main() {
       expect(find.text('Documents'), findsAtLeastNWidgets(1));
     });
 
+    testWidgets('includes file metadata in row semantics', (tester) async {
+      final repository = _FakeFilesRepository(
+        connectionState: FilesConnectionState.connected(
+          baseUrl: Uri.parse('https://files.home.internal'),
+          accountLabel: 'alice',
+        ),
+        listings: const {
+          '/': DirectoryListing(
+            path: '/',
+            entries: [
+              FileEntry(
+                id: 'file-1',
+                name: 'Roadmap.pdf',
+                path: '/Roadmap.pdf',
+                isDirectory: false,
+                sizeInBytes: 2048,
+              ),
+            ],
+          ),
+        },
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          const FilesScreen(),
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Roadmap.pdf'), findsOneWidget);
+      expect(find.text('2.0 KB'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel('Roadmap.pdf, file. 2.0 KB'),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('uploads a picked file with completion feedback', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary
- Include visible file/folder metadata in Files row semantics labels.
- Keep child controls available with explicit child semantics so export/delete actions remain reachable.
- Add focused widget coverage for the metadata semantics label.

## Spec alignment
- Supports `specs/04-accessibility-and-inclusive-ux.md` file-list accessibility expectations.
- Supports `specs/07-nextcloud-files-calendar-contract.md` Files MVP product UX without changing backend or infra contracts.

## Validation
- `dart format lib/features/files/presentation/files_screen.dart test/features/files/files_screen_test.dart`
- `flutter test test/features/files/files_screen_test.dart`
- `flutter analyze --fatal-infos`

Closes #159
Part of #49
