### PR TITLE
Announce Files row metadata accessibly

### DIFF
--- a/lib/features/files/presentation/files_screen.dart
+++ b/lib/features/files/presentation/files_screen.dart
@@ -804,8 +804,6 @@ class _DeleteEntryDialog extends StatelessWidget {
 class _FileEntryTile extends ConsumerWidget {
   const _FileEntryTile({required this.entry, required this.isBusy});
 
-  static final DateFormat _modifiedDateTimeFormat = DateFormat.yMMMd().add_Hm();
-
   final FileEntry entry;
   final bool isBusy;
 
@@ -816,9 +814,7 @@ class _FileEntryTile extends ConsumerWidget {
     return Semantics(
       container: true,
       button: entry.isDirectory,
-      label: entry.isDirectory
-          ? l10n.filesFolderSemantic(entry.name)
-          : l10n.filesFileSemantic(entry.name),
+      label: _semanticLabel(l10n, entry, subtitle),
       child: ListTile(
         contentPadding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
         leading: ExcludeSemantics(
@@ -879,12 +875,31 @@ class _FileEntryTile extends ConsumerWidget {
 
     final parts = <String>[];
     if (entry.modifiedAt != null) {
-      parts.add(_modifiedDateTimeFormat.format(entry.modifiedAt!.toLocal()));
+      final localeName = Localizations.localeOf(context).toString();
+      parts.add(
+        DateFormat.yMMMd(
+          localeName,
+        ).add_Hm().format(entry.modifiedAt!.toLocal()),
+      );
     }
     if (entry.sizeInBytes != null) {
       parts.add(_formatSize(entry.sizeInBytes!));
     }
     return parts.join(' • ');
+  }
+
+  String _semanticLabel(
+    AppLocalizations l10n,
+    FileEntry entry,
+    String? subtitle,
+  ) {
+    final baseLabel = entry.isDirectory
+        ? l10n.filesFolderSemantic(entry.name)
+        : l10n.filesFileSemantic(entry.name);
+    if (subtitle == null || subtitle.trim().isEmpty) {
+      return baseLabel;
+    }
+    return '$baseLabel. $subtitle';
   }
 
   String _formatSize(int sizeInBytes) {

--- a/test/features/files/files_screen_test.dart
+++ b/test/features/files/files_screen_test.dart
@@ -189,6 +189,64 @@ void main() {
       expect(find.text('Refresh'), findsAtLeastNWidgets(1));
     });
 
+    testWidgets('announces file row metadata and keeps row actions labeled', (
+      tester,
+    ) async {
+      final repository = _FakeFilesRepository(
+        connectionState: FilesConnectionState.connected(
+          baseUrl: Uri.parse('https://files.home.internal'),
+          accountLabel: 'alice',
+        ),
+        listings: {
+          '/': DirectoryListing(
+            path: '/',
+            entries: [
+              FileEntry(
+                id: 'file-1',
+                name: 'Roadmap.pdf',
+                path: '/Roadmap.pdf',
+                isDirectory: false,
+                modifiedAt: DateTime(2026, 5, 14, 10, 30),
+                sizeInBytes: 2048,
+              ),
+            ],
+          ),
+        },
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          const FilesScreen(),
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Roadmap.pdf'), findsOneWidget);
+      expect(find.textContaining('May 14, 2026'), findsOneWidget);
+      expect(find.textContaining('2.0 KB'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              (widget.properties.label ?? '').contains('Roadmap.pdf, file') &&
+              (widget.properties.label ?? '').contains('2.0 KB'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byTooltip('Export Roadmap.pdf to native files'),
+        findsOneWidget,
+      );
+      expect(find.byTooltip('Delete Roadmap.pdf'), findsOneWidget);
+    });
+
     testWidgets('renders directory contents and allows folder navigation', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary\n- Include file/folder row metadata in the row semantic label so screen-reader users hear the same modified-time and size context shown visually.\n- Format modified timestamps with the active Flutter locale instead of a process-default formatter.\n- Add Files widget coverage for metadata semantics plus export/delete action labels.\n\nCloses #160\nProgresses #49\n\n## Validation\n- dart format --output=none --set-exit-if-changed lib/features/files/presentation/files_screen.dart test/features/files/files_screen_test.dart\n- flutter analyze --fatal-infos\n- flutter test test/features/files/files_screen_test.dart\n- flutter test\n\n## Contract impact\nFrontend-only Files UX/accessibility improvement. No backend, auth, Nextcloud, routing, or infra contract change.