### PR TITLE
Announce chat send failures accessibly

### DIFF
--- a/lib/features/chat/presentation/chat_room_screen.dart
+++ b/lib/features/chat/presentation/chat_room_screen.dart
@@ -383,7 +383,11 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
             ),
           if (displayPendingMessage?.failure case final failure?)
             MaterialBanner(
-              content: Text(failure.message),
+              content: Semantics(
+                container: true,
+                liveRegion: true,
+                child: Text(failure.message),
+              ),
               actions: [
                 TextButton(
                   onPressed: _sending

--- a/test/features/chat/chat_room_screen_test.dart
+++ b/test/features/chat/chat_room_screen_test.dart
@@ -207,6 +207,19 @@ void main() {
       ),
       findsOneWidget,
     );
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Semantics &&
+            widget.properties.liveRegion == true &&
+            widget.child is Text &&
+            ((widget.child! as Text).data?.contains(
+                  'Message could not be sent',
+                ) ??
+                false),
+      ),
+      findsOneWidget,
+    );
     expect(find.text('Retry send'), findsOneWidget);
 
     await tester.tap(find.text('Retry send').first);


### PR DESCRIPTION
## Summary
- Expose failed outgoing chat send recovery text as a live semantic region.
- Preserve the visible failed pending message and `Retry send` recovery action.
- Extend chat room widget coverage for the live/retryable failure state.

## Spec alignment
- Supports `specs/08-matrix-chat-contract.md` dependable custom Matrix chat UX.
- Supports `specs/04-accessibility-and-inclusive-ux.md` recovery-state accessibility expectations.

## Validation
- `dart format lib/features/chat/presentation/chat_room_screen.dart test/features/chat/chat_room_screen_test.dart`
- `flutter test test/features/chat/chat_room_screen_test.dart`
- `flutter analyze --fatal-infos`

Closes #164
Part of #50
