### PR TITLE
a11y(chat): expose message retry actions to assistive tech

### DIFF
--- a/lib/features/chat/presentation/chat_room_screen.dart
+++ b/lib/features/chat/presentation/chat_room_screen.dart
@@ -613,6 +613,7 @@ class _MessageBubble extends StatelessWidget {
         constraints: const BoxConstraints(maxWidth: 420),
         child: Semantics(
           container: true,
+          explicitChildNodes: true,
           label: [
             message.senderDisplayName,
             if (archived) l10n.chatRoomArchivedMessageLabel,
@@ -622,26 +623,26 @@ class _MessageBubble extends StatelessWidget {
             ).formatTimeOfDay(TimeOfDay.fromDateTime(message.sentAt)),
             if (status != null) status,
           ].join('. '),
-          child: ExcludeSemantics(
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: bubbleColor,
-                borderRadius: BorderRadius.circular(18),
-                border: archived
-                    ? Border.all(color: theme.colorScheme.tertiary)
-                    : message.deliveryState == ChatMessageDeliveryState.failed
-                    ? Border.all(color: theme.colorScheme.error)
-                    : null,
-              ),
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Expanded(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: bubbleColor,
+              borderRadius: BorderRadius.circular(18),
+              border: archived
+                  ? Border.all(color: theme.colorScheme.tertiary)
+                  : message.deliveryState == ChatMessageDeliveryState.failed
+                  ? Border.all(color: theme.colorScheme.error)
+                  : null,
+            ),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: ExcludeSemantics(
                           child: Text(
                             message.senderDisplayName,
                             style: theme.textTheme.labelMedium?.copyWith(
@@ -649,74 +650,75 @@ class _MessageBubble extends StatelessWidget {
                             ),
                           ),
                         ),
-                        if (onRetry != null)
-                          IconButton(
-                            onPressed: onRetry,
-                            tooltip: l10n.chatRoomRetrySendAction,
-                            icon: const Icon(Icons.refresh),
+                      ),
+                      if (onRetry != null)
+                        IconButton(
+                          onPressed: onRetry,
+                          tooltip: l10n.chatRoomRetrySendAction,
+                          icon: const Icon(Icons.refresh),
+                          color: foregroundColor.withValues(alpha: 0.85),
+                        )
+                      else if (onArchive != null || onRestore != null)
+                        PopupMenuButton<_MessageAction>(
+                          tooltip: AppLocalizations.of(
+                            context,
+                          ).chatRoomMessageActionsLabel,
+                          onSelected: (value) {
+                            if (value == _MessageAction.archive) {
+                              onArchive?.call();
+                            } else if (value == _MessageAction.restore) {
+                              onRestore?.call();
+                            }
+                          },
+                          itemBuilder: (context) => [
+                            if (onArchive != null)
+                              PopupMenuItem<_MessageAction>(
+                                value: _MessageAction.archive,
+                                child: Text(
+                                  AppLocalizations.of(
+                                    context,
+                                  ).chatRoomArchiveAction,
+                                ),
+                              ),
+                            if (onRestore != null)
+                              PopupMenuItem<_MessageAction>(
+                                value: _MessageAction.restore,
+                                child: Text(
+                                  AppLocalizations.of(
+                                    context,
+                                  ).chatRoomRestoreAction,
+                                ),
+                              ),
+                          ],
+                          icon: Icon(
+                            Icons.more_vert,
                             color: foregroundColor.withValues(alpha: 0.85),
-                          )
-                        else if (onArchive != null || onRestore != null)
-                          PopupMenuButton<_MessageAction>(
-                            tooltip: AppLocalizations.of(
-                              context,
-                            ).chatRoomMessageActionsLabel,
-                            onSelected: (value) {
-                              if (value == _MessageAction.archive) {
-                                onArchive?.call();
-                              } else if (value == _MessageAction.restore) {
-                                onRestore?.call();
-                              }
-                            },
-                            itemBuilder: (context) => [
-                              if (onArchive != null)
-                                PopupMenuItem<_MessageAction>(
-                                  value: _MessageAction.archive,
-                                  child: Text(
-                                    AppLocalizations.of(
-                                      context,
-                                    ).chatRoomArchiveAction,
-                                  ),
-                                ),
-                              if (onRestore != null)
-                                PopupMenuItem<_MessageAction>(
-                                  value: _MessageAction.restore,
-                                  child: Text(
-                                    AppLocalizations.of(
-                                      context,
-                                    ).chatRoomRestoreAction,
-                                  ),
-                                ),
-                            ],
-                            icon: Icon(
-                              Icons.more_vert,
-                              color: foregroundColor.withValues(alpha: 0.85),
-                            ),
                           ),
-                      ],
-                    ),
-                    const SizedBox(height: 4),
-                    Text(
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  ExcludeSemantics(
+                    child: Text(
                       body,
                       style: theme.textTheme.bodyLarge?.copyWith(
                         color: foregroundColor,
                       ),
                     ),
-                    if (archived) ...[
-                      const SizedBox(height: 6),
-                      Semantics(
-                        label: l10n.chatRoomArchivedMessageLabel,
-                        child: ExcludeSemantics(
-                          child: Chip(
-                            avatar: const Icon(Icons.archive_outlined),
-                            label: Text(l10n.chatRoomArchivedMessageLabel),
-                            visualDensity: VisualDensity.compact,
-                          ),
-                        ),
-                      ),
-                    ],
+                  ),
+                  if (archived) ...[
                     const SizedBox(height: 6),
-                    Row(
+                    ExcludeSemantics(
+                      child: Chip(
+                        avatar: const Icon(Icons.archive_outlined),
+                        label: Text(l10n.chatRoomArchivedMessageLabel),
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    ),
+                  ],
+                  const SizedBox(height: 6),
+                  ExcludeSemantics(
+                    child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         Text(
@@ -742,8 +744,8 @@ class _MessageBubble extends StatelessWidget {
                         ],
                       ],
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/test/features/chat/chat_room_screen_test.dart
+++ b/test/features/chat/chat_room_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/core/persistence/shared_preferences_store.dart';
 import 'package:weave/features/chat/data/services/archived_message_store.dart';
@@ -174,6 +175,7 @@ void main() {
   testWidgets('keeps a failed outgoing message visible with retry actions', (
     tester,
   ) async {
+    final semantics = tester.ensureSemantics();
     var sendAttempts = 0;
     final repository = FakeChatRepository(
       loadRoomTimelineHandler: (_) async => buildTimeline(),
@@ -208,6 +210,12 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Retry send'), findsOneWidget);
+    _expectSemanticTapAction(
+      tester,
+      find.byTooltip('Retry send'),
+      label: 'Retry send',
+    );
+    semantics.dispose();
 
     await tester.tap(find.text('Retry send').first);
     await tester.pumpAndSettle();
@@ -243,6 +251,7 @@ void main() {
   });
 
   testWidgets('archives a message from the actions menu', (tester) async {
+    final semantics = tester.ensureSemantics();
     final store = InMemoryPreferencesStore();
     final repository = FakeChatRepository(
       loadRoomTimelineHandler: (_) async => buildTimeline(),
@@ -255,6 +264,13 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+
+    _expectSemanticTapAction(
+      tester,
+      find.byTooltip('Message actions'),
+      label: 'Message actions',
+    );
+    semantics.dispose();
 
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
@@ -319,4 +335,14 @@ void main() {
     expect(find.text('Hey there'), findsOneWidget);
     expect(find.byType(TextField), findsOneWidget);
   });
+}
+
+void _expectSemanticTapAction(
+  WidgetTester tester,
+  Finder finder, {
+  required String label,
+}) {
+  final data = tester.getSemantics(finder).getSemanticsData();
+  expect(data.label == label || data.tooltip == label, isTrue);
+  expect(data.hasAction(SemanticsAction.tap), isTrue);
 }


### PR DESCRIPTION
## Summary
- Keep each chat bubble's concise message summary while allowing explicit child semantics for inline controls.
- Preserve retry and message-actions affordances as screen-reader/keyboard-visible tap targets.
- Add widget coverage for retry-send and message-actions semantic tap actions.

Closes #163

## Validation
- `dart format --output=none --set-exit-if-changed lib/features/chat/presentation/chat_room_screen.dart test/features/chat/chat_room_screen_test.dart`
- `flutter analyze --fatal-infos`
- `flutter test test/features/chat/chat_room_screen_test.dart`
- `flutter test`