### PR TITLE
docs: refresh Release 2 README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,25 @@ The goal is simple: give teams and organizations a humane migration path away fr
 - **Data-sovereign collaboration** — Matrix and Nextcloud provide open protocol/data foundations behind a Weave-owned user experience.
 - **One product, not separate islands** — sign-in, profile, navigation, diagnostics, chat, files, and settings are designed to feel like one workspace.
 - **Migration-friendly** — Slack and Microsoft Teams interop are planned as controlled backend-owned migration and bridge paths, not as client-side shortcuts.
-- **Built for future personal agents** — the long-term direction includes Weaver PA: an OpenClaw-style per-user agent runtime with organization-governed skills, connectors, and group-chat agents. This is future scope, not part of Release 1.
+- **Built for future personal agents** — the long-term direction includes Weaver PA: an OpenClaw-style per-user agent runtime with organization-governed skills, connectors, and group-chat agents. This is future scope, not part of the current Release 2 product track.
 
-## Release 1 scope
+## Release 2 product maturity
 
-Release 1 is intentionally narrow and honest. The current user-facing app shell presents:
+Release 1 established the core self-hosted client shell. Release 2 is the product-maturity track: make the implemented collaboration surfaces feel dependable, accessible, and honest enough for everyday evaluation by a small team.
 
-- **Chat** — a custom Weave Matrix client surface for workspace communication.
-- **Files** — a Weave files experience backed by the product backend and Nextcloud/WebDAV/OCS contracts.
-- **Settings and OIDC sign-in** — setup, authentication, stored server configuration, and account/session controls.
+Current Release 2 focus areas:
 
-Calendar, tasks/boards, Slack/Teams interop, migration tooling, connector SDKs, and Weaver PA are future product areas unless a feature is explicitly marked as enabled. Calendar and exploratory Deck/boards code may exist in the repository while those surfaces are under construction, but they are not Release 1 promises. Prepared Calendar code consumes the Weave backend facade and labels the current backend-provided `workspace` scope honestly; it is not a private per-user calendar surface until the access model is specified and implemented. The future tasks/boards direction is a Weave-owned accessible model with provider adapters, not a product dependency on Nextcloud Deck.
+- **Dependable Chat** — a custom Weave Matrix client surface with accessible message states, explicit retry/recovery affordances, and no claims of E2EE until the later encryption milestone is implemented and validated.
+- **Explorer-grade Files** — a Weave files experience backed by the product backend and Nextcloud/WebDAV/OCS contracts, with clearer metadata, actions, and recovery states.
+- **Consistent recovery UX** — shared loading, empty, error, success, and retry patterns so setup, chat, files, settings, and preview surfaces do not end in cryptic dead states.
+- **Safe Calendar setup direction** — prepared Calendar code consumes the Weave backend facade and labels the current backend-provided `workspace` scope honestly. Private per-user calendar setup, Apple profiles, and external-client credentials stay blocked until the access model, revocation, and signing path are specified and implemented.
+- **Settings and OIDC sign-in** — setup, authentication, stored server configuration, and account/session controls remain part of the daily product shell.
+
+Release 2 still does **not** claim a complete Teams/Slack replacement, Matrix E2EE, a public connector SDK, production Slack/Teams bridge, full private calendar provisioning, or Weaver PA. Those remain roadmap areas behind explicit contracts and feature flags. The future tasks/boards direction is a Weave-owned accessible model with provider adapters, not a product dependency on Nextcloud Deck.
 
 ## Product screenshots
 
-A first look at the Release 1 experience: guided setup, chat, files, and workspace settings in one self-hosted product shell. The screenshots are generated from checked-in SVG assets, so the README stays reviewable and reproducible without turning documentation into image-only content.
+A first look at the Release 2 product-maturity experience: guided setup, dependable chat, explorer-grade files, and workspace settings in one self-hosted product shell. The screenshots are generated from checked-in SVG assets, so the README stays reviewable and reproducible without turning documentation into image-only content.
 
 ### Setup and service review
 
@@ -51,21 +55,21 @@ A first look at the Release 1 experience: guided setup, chat, files, and workspa
 
 [<img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screenshot showing OIDC issuer, client ID, Nextcloud URL, and account session controls." width="560">](docs/assets/marketing/05-settings.svg)
 
-## Future previews (not Release 1)
+## Guarded previews and roadmap screenshots
 
-These checked-in preview screenshots document in-progress shapes only. They are not part of the Release 1 product screenshot set and must stay clearly labelled as hidden previews or post-Release-1 future scope.
+These checked-in preview screenshots document in-progress shapes only. They are not unconditional product promises and must stay clearly labelled when a surface is hidden, blocked, or future-scoped.
 
-### Hidden preview: Release 2 calendar setup readiness
+### Guarded Release 2 preview: calendar setup readiness
 
-Calendar is not a Release 1 navigation promise yet. The checked-in preview screenshot documents the Release 2 preparation shape: a Weave-owned workspace-calendar surface backed by the backend facade, explicit access-model copy, private user calendars blocked until provisioning is tested, and external client setup blocked until signed profiles plus revocable read-only tokens exist.
+The checked-in Calendar preview documents the safe Release 2 preparation shape: a Weave-owned workspace-calendar surface backed by the backend facade, explicit access-model copy, private user calendars blocked until provisioning is tested, and external client setup blocked until signed profiles plus revocable read-only tokens exist.
 
 [<img src="docs/assets/marketing/06-calendar-setup-readiness-preview.svg" alt="Weave calendar setup readiness preview showing workspace calendar scope, private calendars blocked, credential status blocked_until_revocable_credentials, and Apple/Webcal setup disabled until safe credentials exist." width="560">](docs/assets/marketing/06-calendar-setup-readiness-preview.svg)
 
 ### Future preview: boards/tasks
 
-Boards/tasks are shown only as a clearly labelled design preview for the post-Release-1 direction. This preview is not part of the Release 1 product screenshot set, uses Weave-owned provider-neutral language, includes keyboard and screen-reader alternatives to drag-and-drop, and does not claim a live Vikunja, Deck, or other provider integration.
+Boards/tasks are shown only as a clearly labelled design preview for a later product track. This preview is not part of the current Release 2 product surface, uses Weave-owned provider-neutral language, includes keyboard and screen-reader alternatives to drag-and-drop, and does not claim a live Vikunja, Deck, or other provider integration.
 
-[<img src="docs/assets/marketing/07-boards-preview.svg" alt="Future Weave boards preview screenshot labelled post-Release-1 and not Release 1, showing provider-neutral task columns and non-drag movement actions." width="560">](docs/assets/marketing/07-boards-preview.svg)
+[<img src="docs/assets/marketing/07-boards-preview.svg" alt="Future Weave boards preview screenshot labelled as future scope, showing provider-neutral task columns and non-drag movement actions." width="560">](docs/assets/marketing/07-boards-preview.svg)
 
 Regenerate screenshots with `make marketing-screenshots` and review the SVG diff before committing.
 
@@ -85,10 +89,10 @@ The Weave product should feel like one collaboration platform even though sovere
 - **Keycloak** is the identity authority.
 - **Weave backend** is the product-facing API/BFF after sign-in.
 - **Matrix** provides chat protocol and storage.
-- **Nextcloud** provides files and future calendar data foundations.
+- **Nextcloud** provides files and calendar data foundations behind product-owned Weave surfaces.
 - **Caddy** exposes the local/dev HTTPS gateway.
 
-For the detailed Flutter architecture, see [docs/architecture.md](docs/architecture.md). For the post-Release-1 interop direction, see [docs/interop-gateway-and-external-collaboration.md](docs/interop-gateway-and-external-collaboration.md). For future boards/tasks provider research, see [docs/research/boards-task-module-provider-strategy.md](docs/research/boards-task-module-provider-strategy.md) and [docs/research/boards-task-domain-contract.md](docs/research/boards-task-domain-contract.md).
+For the detailed Flutter architecture, see [docs/architecture.md](docs/architecture.md). For the later interop direction, see [docs/interop-gateway-and-external-collaboration.md](docs/interop-gateway-and-external-collaboration.md). For future boards/tasks provider research, see [docs/research/boards-task-module-provider-strategy.md](docs/research/boards-task-module-provider-strategy.md) and [docs/research/boards-task-domain-contract.md](docs/research/boards-task-domain-contract.md).
 
 ## Current client foundation
 
@@ -144,6 +148,7 @@ lib/
     ├── auth/
     ├── chat/
     ├── files/
+    ├── calendar/
     ├── onboarding/
     ├── server_config/
     └── settings/
@@ -201,7 +206,7 @@ Marketing/README screenshots are deterministic SVG assets generated from a small
 make marketing-screenshots
 ```
 
-The command regenerates the Release 1 setup, endpoint review, chat, files, and settings images plus clearly labelled preview/future images, including the Release 2 calendar setup-readiness preview, in `docs/assets/marketing/`. CI runs the generator and fails if the checked-in assets drift. In GitHub Actions, run the `CI` workflow manually with `capture_marketing_screenshots=true` to also download the `weave-marketing-screenshots` artifact.
+The command regenerates the Release 2 setup, endpoint review, chat, files, and settings images plus clearly labelled guarded/future images, including the Calendar setup-readiness preview, in `docs/assets/marketing/`. CI runs the generator and fails if the checked-in assets drift. In GitHub Actions, run the `CI` workflow manually with `capture_marketing_screenshots=true` to also download the `weave-marketing-screenshots` artifact.
 
 When adding selected images to the README or docs, keep nearby prose and descriptive `alt` text so the documentation is not image-only.
 
@@ -247,4 +252,4 @@ Supported overrides:
 
 ## Status and roadmap honesty
 
-Weave is under active development. Release 1 focuses on making the core client shell and live-stack journey reliable before expanding the product surface. The roadmap is ambitious, but README claims should stay tied to implemented or explicitly future-scoped capabilities.
+Weave is under active development. Release 2 focuses on making the core client shell, chat, files, recovery states, and safe calendar setup direction feel product-ready before broadening the product surface. The roadmap is ambitious, but README claims should stay tied to implemented or explicitly future-scoped capabilities.

--- a/docs/assets/marketing/01-setup-start.svg
+++ b/docs/assets/marketing/01-setup-start.svg
@@ -36,7 +36,7 @@
   <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Set up your Weave workspace</text>
   <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Connect identity, chat, files, and backend services through one</text>
-<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">guided Release 1 setup path.</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">guided Release 2 setup path.</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">API</text>

--- a/docs/assets/marketing/02-review-service-endpoints.svg
+++ b/docs/assets/marketing/02-review-service-endpoints.svg
@@ -35,7 +35,7 @@
 
   <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Review Service Endpoints</text>
-  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Release 1 keeps raw services behind clear product boundaries and</text>
+  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">Release 2 keeps raw services behind clear product boundaries and</text>
 <text x="144" y="350" font-size="26" font-weight="400" fill="#475569">explicit local URLs.</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>

--- a/docs/assets/marketing/03-chat-room.svg
+++ b/docs/assets/marketing/03-chat-room.svg
@@ -45,7 +45,7 @@
 
     <rect x="480" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="508" y="444" font-size="21" font-weight="700" fill="#0369a1">Encryption</text>
-    <text x="508" y="480" font-size="20" font-weight="400" fill="#0f172a">MVP non-E2EE, clearly labeled</text>
+    <text x="508" y="480" font-size="20" font-weight="400" fill="#0f172a">E2EE deferred, clearly labeled</text>
 
 
     <rect x="856" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>

--- a/docs/assets/marketing/06-calendar-setup-readiness-preview.svg
+++ b/docs/assets/marketing/06-calendar-setup-readiness-preview.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
   <title id="title">Weave calendar setup readiness preview screen</title>
-  <desc id="desc">The hidden Calendar preview shows Release 2 preparation copy for access-model and external credential-readiness states.</desc>
+  <desc id="desc">The guarded Calendar preview shows Release 2 preparation copy for access-model and external credential-readiness states.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#eff6ff"/>

--- a/docs/assets/marketing/07-boards-preview.svg
+++ b/docs/assets/marketing/07-boards-preview.svg
@@ -36,12 +36,12 @@
   <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Boards/tasks preview · future scope</text>
   <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">A Weave-owned board model for future provider adapters. Hidden from</text>
-<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">Release 1 and not connected to Vikunja, Deck, or another provider</text>
-<text x="144" y="384" font-size="26" font-weight="400" fill="#475569">yet.</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">the current release and not connected to Vikunja, Deck, or another</text>
+<text x="144" y="384" font-size="26" font-weight="400" fill="#475569">provider yet.</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Release</text>
-    <text x="132" y="480" font-size="20" font-weight="400" fill="#0f172a">Post-Release-1</text>
+    <text x="132" y="480" font-size="20" font-weight="400" fill="#0f172a">Future track</text>
 
 
     <rect x="480" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>

--- a/test/architecture/readme_release_scope_contract_test.dart
+++ b/test/architecture/readme_release_scope_contract_test.dart
@@ -4,12 +4,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test(
-    'README Product screenshots stay limited to Release 1 surfaces',
+    'README Product screenshots describe the Release 2 maturity track honestly',
     () async {
       final readme = await File('README.md').readAsString();
       final productScreenshots = _section(readme, '## Product screenshots');
 
-      expect(productScreenshots, contains('Release 1 experience'));
+      expect(productScreenshots, contains('Release 2 product-maturity'));
       expect(productScreenshots, contains('01-setup-start.svg'));
       expect(productScreenshots, contains('02-review-service-endpoints.svg'));
       expect(productScreenshots, contains('03-chat-room.svg'));
@@ -20,27 +20,39 @@ void main() {
         isNot(contains('06-calendar-setup-readiness-preview.svg')),
       );
       expect(productScreenshots, isNot(contains('07-boards-preview.svg')));
-      expect(productScreenshots.toLowerCase(), isNot(contains('calendar')));
-      expect(productScreenshots.toLowerCase(), isNot(contains('boards')));
-      expect(productScreenshots.toLowerCase(), isNot(contains('deck')));
     },
   );
 
-  test('README preview screenshots are explicitly non-Release-1', () async {
-    final readme = await File('README.md').readAsString();
-    final previewSection = _section(
-      readme,
-      '## Future previews (not Release 1)',
-    );
+  test(
+    'README preview screenshots keep future and blocked scope explicit',
+    () async {
+      final readme = await File('README.md').readAsString();
+      final calendarPreview = _subsection(
+        readme,
+        '### Guarded Release 2 preview: calendar setup readiness',
+      );
+      final boardsPreview = _subsection(
+        readme,
+        '### Future preview: boards/tasks',
+      );
 
-    expect(previewSection, contains('06-calendar-setup-readiness-preview.svg'));
-    expect(previewSection, contains('07-boards-preview.svg'));
-    expect(previewSection.toLowerCase(), contains('preview'));
-    expect(previewSection.toLowerCase(), contains('not part of the release 1'));
-    expect(previewSection, contains('hidden previews'));
-    expect(previewSection, contains('post-Release-1'));
-    expect(previewSection, contains('does not claim a live Vikunja'));
-  });
+      expect(
+        calendarPreview,
+        contains('06-calendar-setup-readiness-preview.svg'),
+      );
+      expect(calendarPreview.toLowerCase(), contains('preview'));
+      expect(calendarPreview.toLowerCase(), contains('private user calendars'));
+      expect(calendarPreview, contains('blocked until'));
+      expect(calendarPreview, contains('revocable read-only tokens'));
+
+      expect(boardsPreview, contains('07-boards-preview.svg'));
+      expect(boardsPreview.toLowerCase(), contains('preview'));
+      expect(boardsPreview, contains('not part of the current Release 2'));
+      expect(boardsPreview, contains('provider-neutral'));
+      expect(boardsPreview, contains('does not claim a live Vikunja'));
+      expect(boardsPreview, contains('Deck'));
+    },
+  );
 }
 
 String _section(String markdown, String heading) {
@@ -52,6 +64,24 @@ String _section(String markdown, String heading) {
   int? nextHeading;
   for (final match in RegExp(
     r'^## ',
+    multiLine: true,
+  ).allMatches(markdown, start + heading.length)) {
+    nextHeading = match.start;
+    break;
+  }
+
+  return markdown.substring(start, nextHeading ?? markdown.length);
+}
+
+String _subsection(String markdown, String heading) {
+  final start = markdown.indexOf(heading);
+  if (start == -1) {
+    fail('Missing README heading: $heading');
+  }
+
+  int? nextHeading;
+  for (final match in RegExp(
+    r'^### ',
     multiLine: true,
   ).allMatches(markdown, start + heading.length)) {
     nextHeading = match.start;

--- a/test/architecture/release_scope_contract_test.dart
+++ b/test/architecture/release_scope_contract_test.dart
@@ -35,7 +35,7 @@ void main() {
   );
 
   test(
-    'README screenshots show only implemented Release 1 product surfaces',
+    'README screenshots keep Release 2 product surfaces separate from guarded previews',
     () async {
       final readme = await File('README.md').readAsString();
       final screenshotSection = _section(readme, '## Product screenshots');
@@ -70,6 +70,14 @@ void main() {
       expect(lowerSection, isNot(contains('deck')));
       expect(lowerSection, isNot(contains('boards')));
       expect(lowerSection, isNot(contains('tasks')));
+
+      final guardedPreviewSection = _section(
+        readme,
+        '## Guarded previews and roadmap screenshots',
+      ).toLowerCase();
+      expect(guardedPreviewSection, contains('calendar setup readiness'));
+      expect(guardedPreviewSection, contains('future preview'));
+      expect(guardedPreviewSection, contains('does not claim a live vikunja'));
     },
   );
 }

--- a/tool/generate_marketing_screenshots.py
+++ b/tool/generate_marketing_screenshots.py
@@ -2,7 +2,7 @@
 """Generate deterministic README/marketing screenshots for Weave.
 
 The assets intentionally use SVG so they are small, reviewable, and stable in CI.
-They mirror the Release 1 golden-path app states without relying on live-stack or
+They mirror the Release 2 product-maturity app states without relying on live-stack or
 pixel-golden Flutter rendering, which keeps core E2E validation isolated from
 marketing artifact generation.
 """
@@ -46,7 +46,7 @@ SCREENS: tuple[Screen, ...] = (
         description="A Weave welcome screen invites an admin to configure the self-hosted workspace.",
         active_nav="Setup",
         hero="Set up your Weave workspace",
-        subhero="Connect identity, chat, files, and backend services through one guided Release 1 setup path.",
+        subhero="Connect identity, chat, files, and backend services through one guided Release 2 setup path.",
         metrics=(
             Metric("API", "https://api.weave.local/api"),
             Metric("Auth", "https://auth.weave.local"),
@@ -65,7 +65,7 @@ SCREENS: tuple[Screen, ...] = (
         description="The setup review lists canonical local service endpoints before finishing configuration.",
         active_nav="Setup",
         hero="Review Service Endpoints",
-        subhero="Release 1 keeps raw services behind clear product boundaries and explicit local URLs.",
+        subhero="Release 2 keeps raw services behind clear product boundaries and explicit local URLs.",
         metrics=(
             Metric("Matrix", "https://matrix.weave.local"),
             Metric("Files", "https://files.weave.local"),
@@ -87,7 +87,7 @@ SCREENS: tuple[Screen, ...] = (
         subhero="Custom Matrix chat surface with room list, readable message history, and a clear composer.",
         metrics=(
             Metric("Room", "#release-room"),
-            Metric("Encryption", "MVP non-E2EE, clearly labeled"),
+            Metric("Encryption", "E2EE deferred, clearly labeled"),
             Metric("State", "Connected"),
         ),
         cards=(
@@ -140,7 +140,7 @@ SCREENS: tuple[Screen, ...] = (
     Screen(
         file_name="06-calendar-setup-readiness-preview.svg",
         title="Weave calendar setup readiness preview screen",
-        description="The hidden Calendar preview shows Release 2 preparation copy for access-model and external credential-readiness states.",
+        description="The guarded Calendar preview shows Release 2 preparation copy for access-model and external credential-readiness states.",
         active_nav="Preview",
         hero="Calendar setup readiness preview",
         subhero="Release 2 preparation stays honest: workspace scope is labelled, private calendars are blocked, and external client setup is disabled until safe credentials exist.",
@@ -162,9 +162,9 @@ SCREENS: tuple[Screen, ...] = (
         description="A clearly labelled future boards/tasks preview with provider-neutral columns, tasks, and non-drag actions.",
         active_nav="Preview",
         hero="Boards/tasks preview · future scope",
-        subhero="A Weave-owned board model for future provider adapters. Hidden from Release 1 and not connected to Vikunja, Deck, or another provider yet.",
+        subhero="A Weave-owned board model for future provider adapters. Hidden from the current release and not connected to Vikunja, Deck, or another provider yet.",
         metrics=(
-            Metric("Release", "Post-Release-1"),
+            Metric("Release", "Future track"),
             Metric("Model", "Provider-neutral Weave boards"),
             Metric("Movement", "Menu actions; no drag required"),
         ),


### PR DESCRIPTION
## Summary
- Reposition the app README around the Release 2 product-maturity track instead of old Release 1 scope copy.
- Keep roadmap honesty explicit: no E2EE, production Slack/Teams bridge, public connector SDK, full private calendar provisioning, or Weaver PA claims.
- Regenerate deterministic marketing SVGs from the checked-in generator so screenshot copy matches the README.

## Testing
- `python3 -m py_compile tool/generate_marketing_screenshots.py`
- `make marketing-screenshots`
- `git diff --check`

## Contract impact
- Documentation/marketing only; no runtime API, auth, topology, or product contract changes.
