### PR TITLE
Improve Files stale refresh recovery

### DIFF
--- a/lib/features/files/presentation/files_screen.dart
+++ b/lib/features/files/presentation/files_screen.dart
@@ -8,6 +8,7 @@ import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/file_entry.dart';
 import 'package:weave/features/files/domain/entities/files_connection_state.dart';
+import 'package:weave/features/files/domain/entities/files_failure.dart';
 import 'package:weave/features/files/presentation/providers/files_provider.dart';
 import 'package:weave/l10n/generated/app_localizations.dart';
 
@@ -213,11 +214,13 @@ class _FilesScreenState extends ConsumerState<FilesScreen> {
             ),
           );
         }
-        if (state.directoryFailure != null) {
+        final listing = state.directoryListing;
+        final directoryFailure = state.directoryFailure;
+        if (directoryFailure != null && listing == null) {
           return _fillStateSliver(
             child: ErrorState(
               message: l10n.filesLoadErrorTitle,
-              guidance: state.directoryFailure!.message,
+              guidance: directoryFailure.message,
               retryLabel: l10n.retryButton,
               onRetry: state.isBusy
                   ? null
@@ -227,8 +230,8 @@ class _FilesScreenState extends ConsumerState<FilesScreen> {
             ),
           );
         }
-        final listing = state.directoryListing;
-        if (listing == null || listing.entries.isEmpty) {
+        if (listing == null ||
+            (listing.entries.isEmpty && directoryFailure == null)) {
           return _fillStateSliver(
             child: EmptyState(
               message: l10n.filesEmptyMessage,
@@ -247,17 +250,32 @@ class _FilesScreenState extends ConsumerState<FilesScreen> {
           padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
           sliver: SliverList(
             delegate: SliverChildListDelegate.fixed([
+              if (directoryFailure != null) ...[
+                _StaleDirectoryNotice(
+                  failure: directoryFailure,
+                  onRefresh: state.isBusy
+                      ? null
+                      : () {
+                          ref.read(filesProvider.notifier).refresh();
+                        },
+                ),
+                const SizedBox(height: 12),
+              ],
               _DirectorySummary(listing: listing),
-              const SizedBox(height: 12),
-              ...List<Widget>.generate(listing.entries.length * 2 - 1, (index) {
-                if (index.isOdd) {
-                  return const Divider(height: 1);
-                }
+              if (listing.entries.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                ...List<Widget>.generate(listing.entries.length * 2 - 1, (
+                  index,
+                ) {
+                  if (index.isOdd) {
+                    return const Divider(height: 1);
+                  }
 
-                final entryIndex = index ~/ 2;
-                final entry = listing.entries[entryIndex];
-                return _FileEntryTile(entry: entry, isBusy: state.isBusy);
-              }),
+                  final entryIndex = index ~/ 2;
+                  final entry = listing.entries[entryIndex];
+                  return _FileEntryTile(entry: entry, isBusy: state.isBusy);
+                }),
+              ],
             ]),
           ),
         );
@@ -268,6 +286,82 @@ class _FilesScreenState extends ConsumerState<FilesScreen> {
     return SliverPadding(
       padding: const EdgeInsets.fromLTRB(24, 0, 24, 24),
       sliver: SliverFillRemaining(hasScrollBody: true, child: child),
+    );
+  }
+}
+
+class _StaleDirectoryNotice extends StatelessWidget {
+  const _StaleDirectoryNotice({required this.failure, required this.onRefresh});
+
+  final FilesFailure failure;
+  final VoidCallback? onRefresh;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final failureMessage = failure.message;
+
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      child: Card(
+        elevation: 0,
+        color: theme.colorScheme.tertiaryContainer,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+          side: BorderSide(color: theme.colorScheme.tertiary),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.wifi_off_outlined,
+                    color: theme.colorScheme.onTertiaryContainer,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      l10n.filesStaleDirectoryTitle,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: theme.colorScheme.onTertiaryContainer,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                l10n.filesStaleDirectoryGuidance,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onTertiaryContainer,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                failureMessage,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onTertiaryContainer,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Align(
+                alignment: AlignmentDirectional.centerEnd,
+                child: TextButton.icon(
+                  onPressed: onRefresh,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(l10n.filesStaleDirectoryRetryButton),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -109,6 +109,13 @@
   "filesScreenTitle": "Dateien",
   "filesLoadingLabel": "Dateien werden geladen…",
   "filesLoadingHint": "Der aktuelle Ordner wird aktualisiert und auf Änderungen geprüft.",
+  "filesStaleDirectoryTitle": "Letzten bekannten Ordner anzeigen",
+  "@filesStaleDirectoryTitle": {"description": "Title for a Files notice shown when refresh failed but the previous directory listing remains visible"},
+  "filesStaleDirectoryGuidance": "Weave konnte Dateien gerade nicht aktualisieren. Die letzte Ordnerliste bleibt sichtbar, damit du deinen Platz behältst und es erneut versuchen kannst, sobald die Verbindung wieder da ist.",
+  "@filesStaleDirectoryGuidance": {"description": "Guidance for a Files notice shown when refresh failed but cached folder contents remain visible"},
+  "filesStaleDirectoryRetryButton": "Ordner aktualisieren",
+  "@filesStaleDirectoryRetryButton": {"description": "Button label for retrying a stale Files directory refresh"},
+
   "filesNextcloudTitle": "Nextcloud",
   "filesConnectButton": "Nextcloud verbinden",
   "filesReconnectButton": "Nextcloud neu verbinden",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -248,6 +248,13 @@
   "filesLoadingHint": "Refreshing the current folder and checking what changed.",
   "@filesLoadingHint": { "description": "Supporting copy shown while the Files screen is loading the current directory" },
 
+  "filesStaleDirectoryTitle": "Showing last known folder",
+  "@filesStaleDirectoryTitle": {"description": "Title for a Files notice shown when refresh failed but the previous directory listing remains visible"},
+  "filesStaleDirectoryGuidance": "We could not refresh Files just now. The last folder listing stays visible so you can keep your place and retry when the connection is back.",
+  "@filesStaleDirectoryGuidance": {"description": "Guidance for a Files notice shown when refresh failed but cached folder contents remain visible"},
+  "filesStaleDirectoryRetryButton": "Refresh folder",
+  "@filesStaleDirectoryRetryButton": {"description": "Button label for retrying a stale Files directory refresh"},
+
   "filesNextcloudTitle": "Nextcloud",
   "@filesNextcloudTitle": { "description": "Section title for the Nextcloud files connection card" },
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -737,6 +737,24 @@ abstract class AppLocalizations {
   /// **'Refreshing the current folder and checking what changed.'**
   String get filesLoadingHint;
 
+  /// Title for a Files notice shown when refresh failed but the previous directory listing remains visible
+  ///
+  /// In en, this message translates to:
+  /// **'Showing last known folder'**
+  String get filesStaleDirectoryTitle;
+
+  /// Guidance for a Files notice shown when refresh failed but cached folder contents remain visible
+  ///
+  /// In en, this message translates to:
+  /// **'We could not refresh Files just now. The last folder listing stays visible so you can keep your place and retry when the connection is back.'**
+  String get filesStaleDirectoryGuidance;
+
+  /// Button label for retrying a stale Files directory refresh
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh folder'**
+  String get filesStaleDirectoryRetryButton;
+
   /// Section title for the Nextcloud files connection card
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -367,6 +367,16 @@ class AppLocalizationsDe extends AppLocalizations {
       'Der aktuelle Ordner wird aktualisiert und auf Änderungen geprüft.';
 
   @override
+  String get filesStaleDirectoryTitle => 'Letzten bekannten Ordner anzeigen';
+
+  @override
+  String get filesStaleDirectoryGuidance =>
+      'Weave konnte Dateien gerade nicht aktualisieren. Die letzte Ordnerliste bleibt sichtbar, damit du deinen Platz behältst und es erneut versuchen kannst, sobald die Verbindung wieder da ist.';
+
+  @override
+  String get filesStaleDirectoryRetryButton => 'Ordner aktualisieren';
+
+  @override
   String get filesNextcloudTitle => 'Nextcloud';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -364,6 +364,16 @@ class AppLocalizationsEn extends AppLocalizations {
       'Refreshing the current folder and checking what changed.';
 
   @override
+  String get filesStaleDirectoryTitle => 'Showing last known folder';
+
+  @override
+  String get filesStaleDirectoryGuidance =>
+      'We could not refresh Files just now. The last folder listing stays visible so you can keep your place and retry when the connection is back.';
+
+  @override
+  String get filesStaleDirectoryRetryButton => 'Refresh folder';
+
+  @override
   String get filesNextcloudTitle => 'Nextcloud';
 
   @override

--- a/test/features/files/files_screen_test.dart
+++ b/test/features/files/files_screen_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/core/a11y/semantic_button.dart';
 import 'package:weave/features/files/data/services/file_picker_files_import_picker.dart';
 import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/file_entry.dart';
@@ -282,6 +283,76 @@ void main() {
       expect(find.text('Up'), findsOneWidget);
       expect(find.text('Root'), findsOneWidget);
     });
+
+    testWidgets(
+      'keeps the last known directory visible after refresh failure',
+      (tester) async {
+        var listCalls = 0;
+        final repository = _FakeFilesRepository(
+          connectionState: FilesConnectionState.connected(
+            baseUrl: Uri.parse('https://files.home.internal'),
+            accountLabel: 'alice',
+          ),
+          listDirectoryHandler: (path) async {
+            listCalls += 1;
+            if (listCalls > 1) {
+              throw const FilesFailure.protocol(
+                'Files could not be refreshed while offline.',
+              );
+            }
+            return const DirectoryListing(
+              path: '/',
+              entries: [
+                FileEntry(
+                  id: 'file-1',
+                  name: 'Roadmap.pdf',
+                  path: '/Roadmap.pdf',
+                  isDirectory: false,
+                  sizeInBytes: 2048,
+                ),
+              ],
+            );
+          },
+        );
+
+        await tester.pumpWidget(
+          createTestApp(
+            const FilesScreen(),
+            overrides: [
+              filesRepositoryProvider.overrideWithValue(repository),
+              serverConfigurationRepositoryProvider.overrideWith(
+                (ref) => _FakeServerConfigurationRepository(
+                  buildTestConfiguration(),
+                ),
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Roadmap.pdf'), findsOneWidget);
+
+        await tester.tap(
+          find.widgetWithText(AccessibleButton, 'Refresh').first,
+        );
+        await tester.pumpAndSettle();
+
+        expect(listCalls, 2);
+        expect(find.text('Showing last known folder'), findsOneWidget);
+        expect(
+          find.text('Files could not be refreshed while offline.'),
+          findsOneWidget,
+        );
+        await tester.scrollUntilVisible(
+          find.text('Roadmap.pdf'),
+          100,
+          scrollable: find.byType(Scrollable).first,
+        );
+        expect(find.text('Roadmap.pdf'), findsOneWidget);
+        expect(find.text('2.0 KB'), findsOneWidget);
+        expect(find.text('Refresh folder'), findsOneWidget);
+      },
+    );
 
     testWidgets('marks the current breadcrumb and lets users jump back home', (
       tester,

--- a/test/features/files/presentation/providers/files_provider_test.dart
+++ b/test/features/files/presentation/providers/files_provider_test.dart
@@ -199,6 +199,64 @@ void main() {
     });
 
     test(
+      'manual refresh failure keeps the last known directory visible',
+      () async {
+        var listCalls = 0;
+        final repository = _FakeFilesRepository(
+          restoreConnectionHandler: () async => FilesConnectionState.connected(
+            baseUrl: Uri.parse('https://files.home.internal'),
+            accountLabel: 'alice',
+          ),
+          connectHandler: () async => throw UnimplementedError(),
+          disconnectHandler: () async {},
+          listDirectoryHandler: (path) async {
+            listCalls += 1;
+            if (listCalls > 1) {
+              throw const FilesFailure.protocol(
+                'Files could not be refreshed while offline.',
+              );
+            }
+            return const DirectoryListing(
+              path: '/',
+              entries: [
+                FileEntry(
+                  id: 'file-1',
+                  name: 'Roadmap.pdf',
+                  path: '/Roadmap.pdf',
+                  isDirectory: false,
+                  sizeInBytes: 2048,
+                ),
+              ],
+            );
+          },
+        );
+        final container = ProviderContainer(
+          overrides: [
+            filesRepositoryProvider.overrideWithValue(repository),
+            serverConfigurationRepositoryProvider.overrideWith(
+              (ref) =>
+                  _FakeServerConfigurationRepository(buildTestConfiguration()),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(filesProvider.future);
+        await container.read(filesProvider.notifier).refresh();
+        final state = container.read(filesProvider).requireValue;
+
+        expect(listCalls, 2);
+        expect(state.directoryListing?.entries.single.name, 'Roadmap.pdf');
+        expect(state.directoryFailure?.type, FilesFailureType.protocol);
+        expect(
+          state.directoryFailure?.message,
+          'Files could not be refreshed while offline.',
+        );
+        expect(state.isBusy, isFalse);
+      },
+    );
+
+    test(
       'marks the session invalid when restoring the root directory fails with invalid credentials',
       () async {
         final repository = _FakeFilesRepository(


### PR DESCRIPTION
## Summary
- keep the existing Files directory listing visible when a refresh/listing request fails after data was already loaded
- add an accessible live stale-folder notice with localized retry copy
- cover the controller and Files screen behavior so stale contents, metadata, and retry affordance remain visible

Part of #49.

## Testing / Evidence
- `flutter pub get`
- `flutter gen-l10n`
- `dart format --output=none --set-exit-if-changed lib/features/files/presentation/files_screen.dart test/features/files/files_screen_test.dart test/features/files/presentation/providers/files_provider_test.dart lib/l10n/generated/app_localizations.dart lib/l10n/generated/app_localizations_en.dart lib/l10n/generated/app_localizations_de.dart`
- `flutter test test/features/files/files_screen_test.dart test/features/files/presentation/providers/files_provider_test.dart`
- `flutter analyze --fatal-infos`
- `flutter test` (284 passed, 6 skipped)
- `git diff --check`

## Contract impact
- Frontend-only Files UX hardening.
- No backend, infra, API, auth, or topology contract changes.
