### PR TITLE
test: assert Matrix encrypted wire events

### DIFF
--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:integration_test/integration_test.dart';
+import 'package:matrix/matrix.dart' as sdk;
 import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
 import 'package:weave/core/persistence/flutter_secure_store.dart';
 import 'package:weave/core/persistence/secure_store.dart';
@@ -326,6 +327,18 @@ void main() {
         roomId: encryptedRoomId,
         message: encryptedMessage,
       );
+      await matrixClient.oneShotSync();
+      final rawEncryptedTimeline = await encryptedRoom?.getTimeline(limit: 50);
+      final encryptedWireEvents =
+          rawEncryptedTimeline?.events
+              .where(
+                (event) =>
+                    event.type == sdk.EventTypes.Encrypted ||
+                    event.originalSource?.type == sdk.EventTypes.Encrypted,
+              )
+              .toList(growable: false) ??
+          const <sdk.Event>[];
+      rawEncryptedTimeline?.cancelSubscriptions();
       final encryptedTimeline = await chatRepository.loadRoomTimeline(
         encryptedRoomId,
       );
@@ -343,7 +356,7 @@ void main() {
               ChatSecurityBootstrapState.ready &&
           e2eeSecurityState.secretStorageReady &&
           e2eeSecurityState.crossSigningReady;
-      final e2eeEncryptedEventObserved = encryptedTimelineMessages.isNotEmpty;
+      final e2eeEncryptedEventObserved = encryptedWireEvents.isNotEmpty;
       // ignore: avoid_print
       print(
         'E2EE_RESULT roomId=$encryptedRoomId roomName=$encryptedRoomName '
@@ -356,6 +369,7 @@ void main() {
         'crossSigningReady=${e2eeSecurityState.crossSigningReady} '
         'bootstrapGeneratedRecoveryKey=$e2eeBootstrapGeneratedRecoveryKey '
         'roomEncrypted=$e2eeRoomEncrypted '
+        'encryptedWireEvents=${encryptedWireEvents.length} '
         'encryptedTimelineMessages=${encryptedTimelineMessages.length}',
       );
 
@@ -713,6 +727,7 @@ void main() {
           'e2eeSecurityReady=$e2eeSecurityReady '
           'e2eeBootstrapState=${e2eeSecurityState.bootstrapState} '
           'e2eeRoomEncrypted=$e2eeRoomEncrypted '
+          'e2eeEncryptedWireEvents=${encryptedWireEvents.length} '
           'e2eeEncryptedEvents=${encryptedTimelineMessages.length} '
           'filesFacadeConnected=$filesFacadeConnected '
           'filesFacadeStatus=${filesState.connectionState.status} '


### PR DESCRIPTION
## Problem
The strengthened live-stack gate correctly created an encrypted Matrix room and observed ready native crypto state, but it still counted decrypted app timeline messages as encrypted. The matrix SDK decrypts events before the app timeline mapper sees them, so the live gate failed with `encryptedTimelineMessages=0` even though the raw Matrix event source was encrypted.

## Target behavior
The live E2E now inspects the raw Matrix timeline and requires either `event.type == m.room.encrypted` or `event.originalSource.type == m.room.encrypted`, while still printing the decrypted app timeline count separately.

## Validation
- `dart format integration_test/live_stack_app_e2e_test.dart`
- `flutter analyze --fatal-infos`
- `make offline-contract-test`

## Evidence from failed live run being fixed
Run https://github.com/masssi164/weave/actions/runs/25934229320 proved Calendar and Boards live behavior and native crypto readiness, but failed only because the assertion looked at the decrypted app timeline count:
- `E2EE_RESULT ... cryptoAvailable=true ... bootstrapState=ChatSecurityBootstrapState.ready ... roomEncrypted=true encryptedTimelineMessages=0`
- `CALENDAR_RESULT ... scopes=workspace,team,channel ... createdAndRead=true updatedAndRead=true deleted=true`
- `BOARDS_RESULT ... provider=in-memory ... releaseStatus=active-feature-gated-preview ... nonDragMutationWorked=true`
