### PR TITLE
feat: fail closed boards capability gate

### DIFF
--- a/lib/features/boards/presentation/providers/boards_preview_provider.dart
+++ b/lib/features/boards/presentation/providers/boards_preview_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/boards/data/repositories/backend_boards_preview_repository.dart';
 import 'package:weave/features/boards/data/repositories/static_boards_preview_repository.dart';
 import 'package:weave/features/boards/domain/entities/board_preview.dart';
@@ -23,6 +24,11 @@ final boardsPreviewProvider = FutureProvider<BoardPreview>((ref) async {
     return staticRepository.loadPreview();
   }
 
+  final backendCapabilities = await _loadBackendCapabilities(ref);
+  if (_backendBoardsCapabilityBlocksPreview(backendCapabilities)) {
+    return const BoardPreview.backendBlocked();
+  }
+
   final backendRepository = BackendBoardsPreviewRepository(
     httpClient: ref.watch(weaveApiHttpClientProvider),
     apiBaseUrl: session.apiBaseUrl,
@@ -35,3 +41,30 @@ final boardsPreviewProvider = FutureProvider<BoardPreview>((ref) async {
     return staticRepository.loadPreview();
   }
 });
+
+typedef _BackendCapabilityGate = ({
+  bool failed,
+  WorkspaceCapabilitySnapshot? snapshot,
+});
+
+Future<_BackendCapabilityGate> _loadBackendCapabilities(Ref ref) async {
+  try {
+    return (
+      failed: false,
+      snapshot: await ref.watch(
+        weaveApiWorkspaceCapabilitySnapshotProvider.future,
+      ),
+    );
+  } on AppFailure {
+    return (failed: true, snapshot: null);
+  } catch (_) {
+    return (failed: true, snapshot: null);
+  }
+}
+
+bool _backendBoardsCapabilityBlocksPreview(_BackendCapabilityGate gate) {
+  if (gate.failed) {
+    return true;
+  }
+  return gate.snapshot != null && !gate.snapshot!.boards.isReady;
+}

--- a/lib/features/boards/presentation/providers/boards_preview_provider.dart
+++ b/lib/features/boards/presentation/providers/boards_preview_provider.dart
@@ -38,7 +38,7 @@ final boardsPreviewProvider = FutureProvider<BoardPreview>((ref) async {
   try {
     return await backendRepository.loadPreview();
   } on AppFailure {
-    return staticRepository.loadPreview();
+    return const BoardPreview.backendBlocked();
   }
 });
 

--- a/lib/features/shell/presentation/shell_workspace_status.dart
+++ b/lib/features/shell/presentation/shell_workspace_status.dart
@@ -133,6 +133,10 @@ class _WorkspaceSummary extends StatelessWidget {
                   label: l10n.settingsWorkspaceCalendarLabel,
                   readiness: capabilities.calendar.readiness,
                 ),
+                _CapabilityChip(
+                  label: l10n.settingsWorkspaceBoardsLabel,
+                  readiness: capabilities.boards.readiness,
+                ),
               ],
             ),
           ],

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -432,6 +432,7 @@
   "profileEditSavingButton": "Profil wird gespeichert…",
   "profileEditSavedMessage": "Profil gespeichert.",
   "settingsWorkspaceCalendarLabel": "Kalender",
+  "settingsWorkspaceBoardsLabel": "Boards",
   "calendarWorkspaceScopeTitle": "Arbeitsbereichskalender",
   "calendarWorkspaceScopeDescription": "Dieser erste Kalender-Schnitt nutzt den gemeinsamen Weave-Arbeitsbereichskalender. Private Nutzerkalender bleiben deaktiviert, bis das Zugriffsmodell umgesetzt ist.",
   "calendarGenericScopeDescription": "Termine werden aus {scopeLabel} angezeigt.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1274,6 +1274,8 @@
   "@profileEditSavedMessage": {"description": "Live-region success message after saving profile edits"},
   "settingsWorkspaceCalendarLabel": "Calendar",
   "@settingsWorkspaceCalendarLabel": {"description": "Row label for calendar readiness in the workspace readiness summary"},
+  "settingsWorkspaceBoardsLabel": "Boards",
+  "@settingsWorkspaceBoardsLabel": {"description": "Row label for boards readiness in the workspace readiness summary"},
   "calendarWorkspaceScopeTitle": "Workspace calendar",
   "@calendarWorkspaceScopeTitle": {"description": "Title for the workspace-scoped calendar banner"},
   "calendarWorkspaceScopeDescription": "This first Calendar slice is the workspace scope of Weave shared scheduling. Team and channel calendars are the next product scopes; private personal calendars are out of scope.",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2621,6 +2621,12 @@ abstract class AppLocalizations {
   /// **'Calendar'**
   String get settingsWorkspaceCalendarLabel;
 
+  /// Row label for boards readiness in the workspace readiness summary
+  ///
+  /// In en, this message translates to:
+  /// **'Boards'**
+  String get settingsWorkspaceBoardsLabel;
+
   /// Title for the workspace-scoped calendar banner
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1529,6 +1529,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsWorkspaceCalendarLabel => 'Kalender';
 
   @override
+  String get settingsWorkspaceBoardsLabel => 'Boards';
+
+  @override
   String get calendarWorkspaceScopeTitle => 'Arbeitsbereichskalender';
 
   @override

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1505,6 +1505,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsWorkspaceCalendarLabel => 'Calendar';
 
   @override
+  String get settingsWorkspaceBoardsLabel => 'Boards';
+
+  @override
   String get calendarWorkspaceScopeTitle => 'Workspace calendar';
 
   @override

--- a/test/features/boards/boards_preview_screen_test.dart
+++ b/test/features/boards/boards_preview_screen_test.dart
@@ -145,6 +145,33 @@ void main() {
       expect(requests, isEmpty);
     });
 
+    testWidgets(
+      'fails closed when backend Boards context authorization denies',
+      (tester) async {
+        _setCompactPreviewSurface(tester);
+        final requests = <http.Request>[];
+        await tester.pumpWidget(
+          createTestApp(
+            const BoardsPreviewScreen(),
+            overrides: [
+              ..._backendPreviewOverrides((request) async {
+                requests.add(request);
+                return http.Response('{"code":"boards-forbidden"}', 403);
+              }),
+              weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+                (ref) async => _capabilities(),
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Provider runtime blocked'), findsOneWidget);
+        expect(find.text('Backend non-drag actions blocked'), findsOneWidget);
+        expect(requests, hasLength(1));
+      },
+    );
+
     testWidgets('offers non-drag task actions with preview-only feedback', (
       tester,
     ) async {

--- a/test/features/boards/boards_preview_screen_test.dart
+++ b/test/features/boards/boards_preview_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/boards/presentation/boards_preview_screen.dart';
 import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 import 'package:weave/integrations/weave_api/presentation/providers/weave_authenticated_session_provider.dart';
@@ -40,17 +41,22 @@ void main() {
       await tester.pumpWidget(
         createTestApp(
           const BoardsPreviewScreen(),
-          overrides: _backendPreviewOverrides((request) async {
-            requests.add(request);
-            if (request.method == 'POST') {
-              return http.Response('{"id":"task-1"}', 200);
-            }
-            return http.Response(
-              _backendPreviewPayload,
-              200,
-              headers: {'content-type': 'application/json'},
-            );
-          }),
+          overrides: [
+            ..._backendPreviewOverrides((request) async {
+              requests.add(request);
+              if (request.method == 'POST') {
+                return http.Response('{"id":"task-1"}', 200);
+              }
+              return http.Response(
+                _backendPreviewPayload,
+                200,
+                headers: {'content-type': 'application/json'},
+              );
+            }),
+            weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+              (ref) async => _capabilities(),
+            ),
+          ],
         ),
       );
       await tester.pumpAndSettle();
@@ -111,6 +117,33 @@ void main() {
         );
       },
     );
+
+    testWidgets('fails closed when backend Boards capability is not ready', (
+      tester,
+    ) async {
+      _setCompactPreviewSurface(tester);
+      final requests = <http.Request>[];
+      await tester.pumpWidget(
+        createTestApp(
+          const BoardsPreviewScreen(),
+          overrides: [
+            ..._backendPreviewOverrides((request) async {
+              requests.add(request);
+              return http.Response(_backendPreviewPayload, 200);
+            }),
+            weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+              (ref) async =>
+                  _capabilities(boards: WorkspaceCapabilityReadiness.blocked),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Provider runtime blocked'), findsOneWidget);
+      expect(find.text('Backend non-drag actions blocked'), findsOneWidget);
+      expect(requests, isEmpty);
+    });
 
     testWidgets('offers non-drag task actions with preview-only feedback', (
       tester,
@@ -235,6 +268,31 @@ List<dynamic> _backendPreviewOverrides(
   ),
   weaveApiHttpClientProvider.overrideWithValue(MockClient(handler)),
 ];
+
+WorkspaceCapabilitySnapshot _capabilities({
+  WorkspaceCapabilityReadiness boards = WorkspaceCapabilityReadiness.ready,
+}) => WorkspaceCapabilitySnapshot(
+  shellAccess: const WorkspaceCapabilityState(
+    capability: WorkspaceCapability.shellAccess,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+  chat: const WorkspaceCapabilityState(
+    capability: WorkspaceCapability.chat,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+  files: const WorkspaceCapabilityState(
+    capability: WorkspaceCapability.files,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+  calendar: const WorkspaceCapabilityState(
+    capability: WorkspaceCapability.calendar,
+    readiness: WorkspaceCapabilityReadiness.ready,
+  ),
+  boards: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.boards,
+    readiness: boards,
+  ),
+);
 
 void _setCompactPreviewSurface(WidgetTester tester) {
   tester.view.devicePixelRatio = 1;


### PR DESCRIPTION
## Problem
Boards preview could fall back to local/static preview even when the authenticated Weave backend capability contract explicitly reported Boards as blocked/unavailable. That is too weak for the product-maturity gate: provider/connector surfaces must fail closed when the backend readiness gate is not ready.

## Target behavior
- Authenticated Boards preview awaits the backend workspace capability snapshot before fetching `/api/boards/preview`.
- If backend capability loading fails or `boards.readiness` is not `ready`, the screen shows the blocked provider state and does not call the Boards preview facade.
- Shell workspace readiness now surfaces Boards alongside Chat, Files, and Calendar.

## Spec references
- `specs/06-api-routing-and-backend-contract.md`
- `specs/10-ci-smoke-and-e2e-contract.md`
- `specs/13-mvp-decisions-and-roadmap.md`
- `specs/14-boards-tasks-domain-and-provider-adapter-contract.md`

## Validation
- `flutter analyze`
- `flutter test test/features/boards/boards_preview_screen_test.dart test/features/app/weave_app_backend_capability_flow_test.dart`
- `git diff --check`

## Contract impact
No new route. Tightens frontend consumption of existing `/api/v1/workspace/capabilities` and Boards preview gates so blocked/unavailable backend capability status prevents preview facade fetch/mutations.
