### PR TITLE
chore(ci): use Node 24 checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Offline Flutter Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -95,19 +95,19 @@ jobs:
 
     steps:
       - name: Check out weave
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: weave
 
       - name: Check out weave-infra
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: masssi164/weave-infra
           ref: ${{ env.WEAVE_INFRA_REF }}
           path: weave-infra
 
       - name: Check out weave-backend
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: masssi164/weave-backend
           ref: ${{ env.WEAVE_BACKEND_REF }}


### PR DESCRIPTION
## Summary
- update GitHub checkout actions to v5 in repo CI and manual live-stack E2E workflows
- remove the Node.js 20 action deprecation warning from current main checks

## Validation
- ruby YAML parse for .github/workflows/*.yml
- git diff --check origin/main..HEAD

## Contract impact
- CI-only maintenance; no product/API/runtime behavior change.
- Keeps the lightweight CI and manual E2E workflow contract aligned with specs/10-ci-smoke-and-e2e-contract.md.

## Notes
- This does not promote live-stack E2E to an automatic trigger; the existing manual/confirmed workflow semantics stay unchanged.