### PR TITLE
feat(calendar): surface meeting thread ids

### DIFF
--- a/lib/features/calendar/data/services/calendar_facade_client.dart
+++ b/lib/features/calendar/data/services/calendar_facade_client.dart
@@ -368,6 +368,7 @@ class CalendarFacadeClient {
           ? rawKind.trim()
           : 'context',
       contextId: contextId,
+      meetingThreadId: _readNullableString(rawThreadRef, 'meetingThreadId'),
       channelId: _readNullableString(rawThreadRef, 'channelId'),
       matrixRoomId: _readNullableString(rawThreadRef, 'matrixRoomId'),
       matrixThreadId: _readNullableString(rawThreadRef, 'matrixThreadId'),

--- a/lib/features/calendar/domain/entities/calendar_event.dart
+++ b/lib/features/calendar/domain/entities/calendar_event.dart
@@ -66,6 +66,7 @@ class CalendarThreadRef {
   const CalendarThreadRef({
     this.kind = 'context',
     required this.contextId,
+    this.meetingThreadId,
     this.channelId,
     this.matrixRoomId,
     this.matrixThreadId,
@@ -79,6 +80,7 @@ class CalendarThreadRef {
 
   final String kind;
   final String contextId;
+  final String? meetingThreadId;
   final String? channelId;
   final String? matrixRoomId;
   final String? matrixThreadId;

--- a/lib/features/calendar/presentation/calendar_screen.dart
+++ b/lib/features/calendar/presentation/calendar_screen.dart
@@ -900,9 +900,10 @@ class _CalendarEventDetails extends StatelessWidget {
             ),
             _CalendarDetailLine(
               label: l10n.calendarDetailsMeetingThreadLabel,
-              value: event.threadRef.matrixThreadId == null
-                  ? l10n.calendarDetailsMeetingThreadPending
-                  : event.threadRef.matrixThreadId!,
+              value:
+                  event.threadRef.meetingThreadId ??
+                  event.threadRef.matrixThreadId ??
+                  l10n.calendarDetailsMeetingThreadPending,
             ),
             if (event.attendees.isNotEmpty)
               _CalendarDetailLine(

--- a/test/features/calendar/data/services/calendar_facade_client_test.dart
+++ b/test/features/calendar/data/services/calendar_facade_client_test.dart
@@ -180,6 +180,8 @@ void main() {
                   'threadRef': {
                     'kind': 'context',
                     'contextId': 'channel-engineering-general',
+                    'meetingThreadId':
+                        'meeting:channel-engineering-general:abc123def456',
                     'channelId': 'engineering-general',
                     'matrixRoomId': null,
                     'matrixThreadId': null,
@@ -243,6 +245,10 @@ void main() {
       expect(
         events.events.single.threadRef.contextId,
         'channel-engineering-general',
+      );
+      expect(
+        events.events.single.threadRef.meetingThreadId,
+        'meeting:channel-engineering-general:abc123def456',
       );
       expect(events.events.single.threadRef.channelId, 'engineering-general');
       expect(events.events.single.threadRef.matrixThreadId, isNull);


### PR DESCRIPTION
## Problem
The backend calendar facade now exposes `threadRef.meetingThreadId` for Weave-owned event agenda/follow-up linking. Flutter needs to preserve and display that product identifier instead of only showing pending Matrix thread state.

## Target behavior
- Calendar domain model carries optional `meetingThreadId`.
- Backend facade decoding preserves `threadRef.meetingThreadId`.
- Calendar event details prefer the Weave meeting-thread id, then any safe Matrix thread id, then the pending copy.

## Files changed
- `lib/features/calendar/domain/entities/calendar_event.dart`
- `lib/features/calendar/data/services/calendar_facade_client.dart`
- `lib/features/calendar/presentation/calendar_screen.dart`
- `test/features/calendar/data/services/calendar_facade_client_test.dart`

## Spec / issue
- Aligns with `specs/15-workspace-team-channel-calendar-structure-contract.md`.
- Frontend follow-up for backend PR #87 / issue masssi164/weave-backend#67.

## Validation
- `dart format lib/features/calendar/domain/entities/calendar_event.dart lib/features/calendar/data/services/calendar_facade_client.dart lib/features/calendar/presentation/calendar_screen.dart test/features/calendar/data/services/calendar_facade_client_test.dart`
- `flutter test test/features/calendar/data/services/calendar_facade_client_test.dart`
- `flutter analyze --fatal-infos`

## Contract impact
Consumes additive backend API field `threadRef.meetingThreadId`; no raw Nextcloud or Matrix internals are exposed.
