### PR TITLE
test(calendar): prove live meeting thread refs

### DIFF
--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -540,6 +540,10 @@ void main() {
       final readCreatedEvent = await calendarRepository.readEvent(
         createdEvent.id,
       );
+      final calendarCreatedThreadRefReady = _channelMeetingThreadReady(
+        readCreatedEvent,
+        channelScope,
+      );
       final calendarCreatedAndRead =
           loadedCalendar.scope.isChannel &&
           loadedCalendar.scope.teamId == channelScope.teamId &&
@@ -569,6 +573,14 @@ void main() {
       final readUpdatedEvent = await calendarRepository.readEvent(
         createdEvent.id,
       );
+      final calendarUpdatedThreadRefReady = _channelMeetingThreadReady(
+        readUpdatedEvent,
+        channelScope,
+      );
+      final calendarMeetingThreadStable =
+          readCreatedEvent.threadRef.meetingThreadId != null &&
+          readCreatedEvent.threadRef.meetingThreadId ==
+              readUpdatedEvent.threadRef.meetingThreadId;
       final calendarUpdatedAndRead =
           updatedEvent.id == createdEvent.id &&
           updatedEvent.title == updatedCalendarTitle &&
@@ -598,6 +610,10 @@ void main() {
         'channelId=${loadedCalendar.scope.channelId} '
         'createdAndRead=$calendarCreatedAndRead '
         'updatedAndRead=$calendarUpdatedAndRead '
+        'createdThreadRefReady=$calendarCreatedThreadRefReady '
+        'updatedThreadRefReady=$calendarUpdatedThreadRefReady '
+        'meetingThreadStable=$calendarMeetingThreadStable '
+        'meetingThreadId=${readCreatedEvent.threadRef.meetingThreadId} '
         'deleted=$calendarDeleted',
       );
 
@@ -733,6 +749,9 @@ void main() {
           !calendarScopesReady ||
           !calendarCreatedAndRead ||
           !calendarUpdatedAndRead ||
+          !calendarCreatedThreadRefReady ||
+          !calendarUpdatedThreadRefReady ||
+          !calendarMeetingThreadStable ||
           !calendarDeleted ||
           !boardsProviderNeutral ||
           !boardsNonDragMutationWorked) {
@@ -767,6 +786,10 @@ void main() {
           'calendarChannelId=${loadedCalendar.scope.channelId} '
           'calendarCreatedAndRead=$calendarCreatedAndRead '
           'calendarUpdatedAndRead=$calendarUpdatedAndRead '
+          'calendarCreatedThreadRefReady=$calendarCreatedThreadRefReady '
+          'calendarUpdatedThreadRefReady=$calendarUpdatedThreadRefReady '
+          'calendarMeetingThreadStable=$calendarMeetingThreadStable '
+          'calendarMeetingThreadId=${readCreatedEvent.threadRef.meetingThreadId} '
           'calendarDeleted=$calendarDeleted '
           'calendarEventId=${createdEvent.id} '
           'boardsProviderNeutral=$boardsProviderNeutral '
@@ -790,12 +813,27 @@ void main() {
       expect(calendarScopesReady, isTrue);
       expect(calendarCreatedAndRead, isTrue);
       expect(calendarUpdatedAndRead, isTrue);
+      expect(calendarCreatedThreadRefReady, isTrue);
+      expect(calendarUpdatedThreadRefReady, isTrue);
+      expect(calendarMeetingThreadStable, isTrue);
       expect(calendarDeleted, isTrue);
       expect(boardsProviderNeutral, isTrue);
       expect(boardsNonDragMutationWorked, isTrue);
     },
     semanticsEnabled: false,
   );
+}
+
+bool _channelMeetingThreadReady(CalendarEvent event, CalendarScope scope) {
+  final meetingThreadId = event.threadRef.meetingThreadId;
+  return event.scope.isChannel &&
+      event.scope.teamId == scope.teamId &&
+      event.scope.channelId == scope.channelId &&
+      event.threadRef.contextId == scope.contextId &&
+      event.threadRef.channelId == scope.channelId &&
+      meetingThreadId != null &&
+      meetingThreadId.startsWith('meeting:') &&
+      meetingThreadId.contains(scope.contextId);
 }
 
 Future<void> _pumpUntilSettled(WidgetTester tester) async {

--- a/test/features/calendar/calendar_screen_test.dart
+++ b/test/features/calendar/calendar_screen_test.dart
@@ -290,6 +290,7 @@ void main() {
           ),
           threadRef: const CalendarThreadRef(
             contextId: 'channel-engineering-general',
+            meetingThreadId: 'meeting:channel-engineering-general:abc123',
             channelId: 'engineering-general',
           ),
           attendees: const [
@@ -402,6 +403,7 @@ void main() {
           ),
           threadRef: const CalendarThreadRef(
             contextId: 'channel-engineering-general',
+            meetingThreadId: 'meeting:channel-engineering-general:abc123',
             channelId: 'engineering-general',
           ),
           attendees: const [
@@ -463,9 +465,7 @@ void main() {
       expect(
         find.descendant(
           of: find.byType(AlertDialog),
-          matching: find.textContaining(
-            'chat thread linkage is not configured',
-          ),
+          matching: find.text('meeting:channel-engineering-general:abc123'),
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
## Problem
Issue masssi164/weave-backend#67 still needs stronger frontend/live-stack proof that channel calendar events expose safe meeting-thread context, not only CRUD.

## Target behavior
- Live-stack E2E fails unless a channel calendar event returns a Weave-owned opaque `meeting:*` thread id.
- The thread ref must keep channel context through create/read/update and remain stable across the update.
- Calendar details tests show the meeting thread id rather than the pending linkage fallback.

## Files changed
- `integration_test/live_stack_app_e2e_test.dart`
- `test/features/calendar/calendar_screen_test.dart`

## Validation
- `dart format --output=none --set-exit-if-changed integration_test/live_stack_app_e2e_test.dart test/features/calendar/calendar_screen_test.dart`
- `flutter test test/features/calendar/calendar_screen_test.dart`
- `flutter analyze --fatal-infos`
- `flutter test`

## Contract impact
No API/schema change. This tightens the existing Calendar/MeetingThread acceptance gate from `specs/15-workspace-team-channel-calendar-structure-contract.md`.
