### PR TITLE
test(e2e): map live stack scenarios to executable coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-.PHONY: offline-contract-test integration-contract-test integration-app-e2e integration-test marketing-screenshots
+.PHONY: offline-contract-test acceptance-feature-mapping integration-contract-test integration-app-e2e integration-test marketing-screenshots
 
-offline-contract-test:
+offline-contract-test: acceptance-feature-mapping
 	@WEAVE_OFFLINE_CONTRACT_ONLY=true \
 	$(MAKE) integration-contract-test
+
+acceptance-feature-mapping:
+	@flutter test test/live_stack_feature_mapping_test.dart
 
 integration-contract-test:
 	@dart_defines_file=$$(mktemp); \
@@ -98,7 +101,7 @@ integration-app-e2e:
 	flutter test integration_test/live_stack_app_e2e_test.dart -d "$$test_device" \
 	  --dart-define-from-file="$$dart_defines_file"
 
-integration-test: integration-app-e2e
+integration-test: acceptance-feature-mapping integration-app-e2e
 
 marketing-screenshots:
 	@python3 tool/generate_marketing_screenshots.py

--- a/acceptance/live_stack_app.feature
+++ b/acceptance/live_stack_app.feature
@@ -1,0 +1,43 @@
+Feature: Live Stack app collaboration journey
+  The Live Stack app E2E remains the executable proof that a user can sign in once
+  and use Weave-owned product surfaces for chat, files, calendar, and boards.
+  These scenarios are mapped to integration_test/live_stack_app_e2e_test.dart and
+  guarded by test/live_stack_feature_mapping_test.dart so the readable scenario
+  layer cannot drift into decorative documentation only.
+
+  @weave-live-auth-shell
+  Scenario: Auth sign-in restores the Weave workspace shell and profile facade
+    Given the local stack exposes the canonical Weave API and Keycloak issuer
+    When the live test user signs in through the Weave app session
+    Then the authenticated backend session is restored
+    And the profile facade can load, update, reload, and restore the display name
+
+  @weave-live-matrix-e2ee
+  Scenario: Matrix chat sends messages and proves E2EE posture honestly
+    Given the signed-in user has a Matrix client from Weave platform config
+    When the user creates a room and sends a message through the Weave chat repository
+    Then the message is readable from the Weave timeline
+    And an encrypted room emits authoritative encrypted Matrix wire events without plaintext leakage
+    And recovery bootstrap and key storage posture are reported in the E2EE result evidence
+
+  @weave-live-files-boundary
+  Scenario: Files are browsed, uploaded, and downloaded through the Weave product facade
+    Given the signed-in user opens the Weave Files surface
+    When the user uploads a unique file through the backend files facade
+    Then the Weave Files listing shows the file
+    And downloading it through the facade returns the original bytes
+    And the test cleans up the uploaded file without depending on raw Nextcloud UI
+
+  @weave-live-calendar-threadrefs
+  Scenario: Channel calendar events round trip with stable meeting thread references
+    Given workspace, team, and channel calendar scopes are available
+    When the user creates, reads, updates, and deletes a channel-scoped event
+    Then the event remains in the channel scope
+    And the meeting thread reference is present and stable across the update
+
+  @weave-live-boards-preview-nondrag
+  Scenario: Boards preview stays provider-neutral and supports non-drag task operations
+    Given the Boards preview runtime is enabled for the local Weave backend facade
+    When the user reads the preview, creates a task, moves it, and completes it without drag-and-drop
+    Then the preview reports the local provider-neutral backend source
+    And the task reaches the completed column through Weave API routes

--- a/test/live_stack_feature_mapping_test.dart
+++ b/test/live_stack_feature_mapping_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('live stack feature scenarios are mapped to executable E2E evidence', () {
+    final feature = File('acceptance/live_stack_app.feature');
+    final executable = File('integration_test/live_stack_app_e2e_test.dart');
+
+    expect(
+      feature.existsSync(),
+      isTrue,
+      reason: 'Missing readable Live Stack scenarios.',
+    );
+    expect(
+      executable.existsSync(),
+      isTrue,
+      reason: 'Missing executable Live Stack E2E test.',
+    );
+
+    final featureText = feature.readAsStringSync();
+    final executableText = executable.readAsStringSync();
+    final scenarios = _scenarios(featureText);
+
+    expect(scenarios.keys, unorderedEquals(_requiredMappings.keys));
+
+    for (final entry in _requiredMappings.entries) {
+      final scenario = scenarios[entry.key];
+      expect(scenario, isNotNull, reason: 'Missing scenario: ${entry.key}');
+      expect(
+        scenario!.tags,
+        contains(entry.value.tag),
+        reason:
+            'Scenario "${entry.key}" must carry stable tag ${entry.value.tag}.',
+      );
+      for (final fragment in entry.value.executableFragments) {
+        expect(
+          executableText,
+          contains(fragment),
+          reason:
+              'Scenario "${entry.key}" must stay linked to executable Live Stack evidence fragment "$fragment".',
+        );
+      }
+    }
+  });
+}
+
+const _requiredMappings = <String, _ScenarioMapping>{
+  'Auth sign-in restores the Weave workspace shell and profile facade':
+      _ScenarioMapping(
+        tag: '@weave-live-auth-shell',
+        executableFragments: <String>[
+          'LiveOidcTestDriver(config: config)',
+          "find.text('Anmelden')",
+          'PROFILE_RESULT',
+          'profileUpdated',
+        ],
+      ),
+  'Matrix chat sends messages and proves E2EE posture honestly':
+      _ScenarioMapping(
+        tag: '@weave-live-matrix-e2ee',
+        executableFragments: <String>[
+          'MATRIX_RESULT',
+          'E2EE_RESULT',
+          '_waitForAuthoritativeEncryptedWireEvent',
+          'encryptedWirePlaintextLeaked',
+        ],
+      ),
+  'Files are browsed, uploaded, and downloaded through the Weave product facade':
+      _ScenarioMapping(
+        tag: '@weave-live-files-boundary',
+        executableFragments: <String>[
+          'filesProvider.notifier).connect',
+          'uploadFile',
+          'downloadFile',
+          'FILES_RESULT',
+        ],
+      ),
+  'Channel calendar events round trip with stable meeting thread references':
+      _ScenarioMapping(
+        tag: '@weave-live-calendar-threadrefs',
+        executableFragments: <String>[
+          'calendarRepository.loadScopes',
+          '_createCalendarEventWithReadAfterWrite',
+          '_channelMeetingThreadReady',
+          'CALENDAR_RESULT',
+        ],
+      ),
+  'Boards preview stays provider-neutral and supports non-drag task operations':
+      _ScenarioMapping(
+        tag: '@weave-live-boards-preview-nondrag',
+        executableFragments: <String>[
+          '/api/boards/preview',
+          '/api/boards/\$boardId/tasks',
+          '/api/boards/tasks/\$taskId/move',
+          'BOARDS_RESULT',
+        ],
+      ),
+};
+
+Map<String, _FeatureScenario> _scenarios(String featureText) {
+  final scenarios = <String, _FeatureScenario>{};
+  final pendingTags = <String>[];
+
+  for (final rawLine in featureText.split('\n')) {
+    final line = rawLine.trim();
+    if (line.startsWith('@')) {
+      pendingTags
+        ..clear()
+        ..addAll(line.split(RegExp(r'\s+')).where((part) => part.isNotEmpty));
+      continue;
+    }
+    if (line.startsWith('Scenario: ')) {
+      final name = line.substring('Scenario: '.length).trim();
+      scenarios[name] = _FeatureScenario(
+        name,
+        List<String>.unmodifiable(pendingTags),
+      );
+      pendingTags.clear();
+    }
+  }
+
+  return scenarios;
+}
+
+class _FeatureScenario {
+  const _FeatureScenario(this.name, this.tags);
+
+  final String name;
+  final List<String> tags;
+}
+
+class _ScenarioMapping {
+  const _ScenarioMapping({
+    required this.tag,
+    required this.executableFragments,
+  });
+
+  final String tag;
+  final List<String> executableFragments;
+}


### PR DESCRIPTION
## Summary
- add a checked-in Gherkin-style Live Stack scenario layer for auth/profile, Matrix/E2EE, files, calendar/thread refs, and boards preview flows
- add a deterministic Flutter mapping guard so scenarios stay linked to executable Live Stack E2E fragments
- wire the guard into the offline contract path used by CI

## Validation
- `flutter test test/live_stack_feature_mapping_test.dart`

## Contract impact
- no API/runtime contract changes; acceptance evidence is now readable and CI-guarded