### PR TITLE
docs: add product-flow activity diagrams

### DIFF
--- a/docs/product-flow-activity-diagrams.md
+++ b/docs/product-flow-activity-diagrams.md
@@ -1,0 +1,142 @@
+# Weave product-flow activity diagrams
+
+These diagrams are presentation-ready product flows for the North-Star MVP evidence layer. They intentionally describe Weave-owned user journeys rather than raw Matrix, Nextcloud, OpenProject, or operator-internal workflows.
+
+Executable scenario anchors:
+
+- Frontend Live Stack: `acceptance/live_stack_app.feature`
+- Backend Cucumber: `weave-backend/src/test/resources/features/openproject-boards-readonly.feature`
+- Infra Live Gates: `weave-infra/acceptance/openproject_boards_live_stack.feature` and `weave-infra/acceptance/operator_support_safety.feature`
+
+## 1. Sign-in and workspace shell
+
+Scenario anchor: `@weave-live-auth-shell`
+
+```mermaid
+flowchart TD
+  A[Open Weave app] --> B[Load platform config from canonical API]
+  B --> C{Existing valid session?}
+  C -- yes --> F[Restore workspace shell]
+  C -- no --> D[Start Keycloak OIDC sign-in]
+  D --> E{OIDC callback valid?}
+  E -- no --> X[Show accessible sign-in error and retry]
+  E -- yes --> F
+  F --> G[Load /api/me profile facade]
+  G --> H[Show workspace navigation, status, profile, modules]
+  H --> I[User can enter Chat, Files, Calendar, Boards preview]
+```
+
+## 2. Workspace, team, and channel context
+
+Scenario anchors: `@weave-live-calendar-threadrefs`, `@backend-openproject-context-space-gate`, `@infra-openproject-context-gate`
+
+```mermaid
+flowchart TD
+  A[Authenticated principal] --> B[Resolve workspace membership]
+  B --> C[Project Weave Context/Space graph]
+  C --> D[Workspace context]
+  D --> E[Team context]
+  E --> F[Channel context]
+  F --> G{Requested module action allowed?}
+  G -- yes --> H[Return context-scoped product data]
+  G -- no --> I[Fail closed with support-safe denial]
+  H --> J[Calendar event scope, chat room, file area, or board snapshot]
+  I --> K[No provider IDs, raw URLs, or secrets exposed]
+```
+
+## 3. Matrix chat and E2EE posture/recovery boundary
+
+Scenario anchor: `@weave-live-matrix-e2ee`
+
+```mermaid
+flowchart TD
+  A[User opens Weave Chat] --> B[Read Matrix homeserver from platform config]
+  B --> C[Use Matrix/MAS client auth boundary]
+  C --> D[Load room list and selected room timeline]
+  D --> E[Send and read message through Weave chat UI]
+  E --> F{Room encrypted and validated?}
+  F -- no --> G[Show honest E2EE unavailable/gated posture]
+  F -- yes --> H[Assert encrypted wire event and no plaintext leakage]
+  H --> I{Recovery and verification validated?}
+  I -- no --> J[Keep recovery claim gated; expose diagnostics only]
+  I -- yes --> K[Allow E2EE-ready user guidance]
+  G --> L[Backend may use support-safe metadata only]
+  J --> L
+  K --> L
+```
+
+## 4. Files product boundary
+
+Scenario anchor: `@weave-live-files-boundary`
+
+```mermaid
+flowchart TD
+  A[User opens Weave Files] --> B[Frontend calls backend files facade]
+  B --> C[Backend authorizes workspace/user context]
+  C --> D[Backend talks to Nextcloud WebDAV/OCS]
+  D --> E[Normalize file entries and errors]
+  E --> F[Show Weave file list]
+  F --> G[Upload unique test file]
+  G --> H[Download/open through Weave facade]
+  H --> I[Cleanup via facade]
+  D -. forbidden .-> X[Do not scrape raw Nextcloud UI or expose credentials]
+```
+
+## 5. Calendar and meeting threads
+
+Scenario anchor: `@weave-live-calendar-threadrefs`
+
+```mermaid
+flowchart TD
+  A[User opens Weave Calendar] --> B[Load workspace/team/channel scopes]
+  B --> C[User selects team or channel scope]
+  C --> D[Create scoped event through backend facade]
+  D --> E[Backend maps to shared CalDAV backing store]
+  E --> F[Return scope metadata and meetingThreadId]
+  F --> G[Read event after write]
+  G --> H[Update event]
+  H --> I{Meeting thread ref stable?}
+  I -- yes --> J[Show event connected to channel context]
+  I -- no --> X[Fail E2E evidence]
+  J --> K[Delete test event and verify cleanup]
+```
+
+## 6. Boards/OpenProject read-only, fail-closed, and context gate
+
+Scenario anchors: `@weave-live-boards-preview-nondrag`, `@backend-openproject-disabled-fail-closed`, `@backend-openproject-enabled-readonly`, `@backend-openproject-context-space-gate`, `@infra-openproject-enabled-readonly`
+
+```mermaid
+flowchart TD
+  A[User opens Boards preview] --> B[Frontend calls Weave Boards facade]
+  B --> C{Preview/provider runtime enabled?}
+  C -- no --> D[Fail closed: boards-provider_unavailable]
+  C -- yes --> E{Provider is local preview or OpenProject read-sync?}
+  E -- local preview --> F[Return provider-neutral sample board]
+  E -- OpenProject --> G{Context/Space authorization allows view?}
+  G -- no --> H[Fail closed: boards-forbidden; do not contact or expose provider data]
+  G -- yes --> I[Backend-held service token reads OpenProject]
+  I --> J[Map projects/statuses/work packages to Weave boards/columns/tasks]
+  J --> K[Return read-only support-safe sync metadata]
+  K --> L[Non-drag create/move/complete only in local preview]
+  K --> M[Provider writes/comments/archive/agent actions refused]
+```
+
+## 7. Support, redaction, and refusal gates
+
+Scenario anchors: `@backend-openproject-support-safe-metadata`, `@backend-openproject-write-refusals`, `@infra-support-bundle-redaction`, `@infra-reset-guardrails`
+
+```mermaid
+flowchart TD
+  A[Failure, diagnostics, or operator request] --> B{Action type}
+  B -- support bundle --> C[Collect public config and logs]
+  C --> D[Redact tokens, passwords, signing secrets, provider credentials]
+  D --> E{Secret pattern remains?}
+  E -- yes --> X[Fail support-safety gate]
+  E -- no --> F[Emit support-safe bundle]
+  B -- provider action --> G{Audit/consent promotion exists?}
+  G -- no --> H[Refuse writes/comments/archive/agent automation]
+  G -- yes --> I[Future promoted write path]
+  B -- destructive reset --> J{Typed confirmation and backup expectations satisfied?}
+  J -- no --> K[Preserve identity, Matrix, Nextcloud, and generated secrets]
+  J -- yes --> L[Run explicit destructive path]
+```

--- a/test/live_stack_feature_mapping_test.dart
+++ b/test/live_stack_feature_mapping_test.dart
@@ -6,6 +6,7 @@ void main() {
   test('live stack feature scenarios are mapped to executable E2E evidence', () {
     final feature = File('acceptance/live_stack_app.feature');
     final executable = File('integration_test/live_stack_app_e2e_test.dart');
+    final productFlowDoc = File('docs/product-flow-activity-diagrams.md');
 
     expect(
       feature.existsSync(),
@@ -17,9 +18,22 @@ void main() {
       isTrue,
       reason: 'Missing executable Live Stack E2E test.',
     );
+    expect(
+      productFlowDoc.existsSync(),
+      isTrue,
+      reason: 'Missing presentable product-flow activity diagrams.',
+    );
 
     final featureText = feature.readAsStringSync();
     final executableText = executable.readAsStringSync();
+    final productFlowText = productFlowDoc.readAsStringSync();
+
+    expect(
+      RegExp(r'```mermaid\s+flowchart TD').allMatches(productFlowText).length,
+      greaterThanOrEqualTo(7),
+      reason:
+          'Product-flow doc must contain the seven required activity diagrams.',
+    );
     final scenarios = _scenarios(featureText);
 
     expect(scenarios.keys, unorderedEquals(_requiredMappings.keys));
@@ -32,6 +46,12 @@ void main() {
         contains(entry.value.tag),
         reason:
             'Scenario "${entry.key}" must carry stable tag ${entry.value.tag}.',
+      );
+      expect(
+        productFlowText,
+        contains(entry.value.tag),
+        reason:
+            'Scenario "${entry.key}" must be anchored in the product-flow activity diagrams.',
       );
       for (final fragment in entry.value.executableFragments) {
         expect(


### PR DESCRIPTION
## Summary
- adds presentation-ready Mermaid activity diagrams for the sign-in shell, workspace/team/channel context, Matrix/E2EE boundary, files, calendar/meeting threads, Boards/OpenProject gates, and support/refusal gates
- links the diagrams to the existing readable acceptance scenarios across frontend, backend Cucumber, and infra live gates
- extends the frontend feature-mapping guard so the product-flow doc stays present, contains the required seven diagrams, and anchors the live-stack scenario tags

## Validation
- `flutter test test/live_stack_feature_mapping_test.dart`
- `git diff --check`

## Contract impact
No product/API contract change. This documents the current North-Star flow mapping and tightens the existing scenario-to-evidence guard.
