### PR TITLE
test: anchor Boards a11y contract evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 offline-contract-test: acceptance-feature-mapping
 	@WEAVE_OFFLINE_CONTRACT_ONLY=true \
+	WEAVE_BOOTSTRAP_ENV=/dev/null \
+	WEAVE_TEST_USERNAME= \
+	WEAVE_TEST_PASSWORD= \
 	$(MAKE) integration-contract-test
 
 acceptance-feature-mapping:
@@ -42,6 +45,7 @@ integration-contract-test:
 	if [ "$$caller_WEAVE_TEST_USERNAME_set" = x ] && [ -n "$$caller_WEAVE_TEST_USERNAME" ]; then WEAVE_TEST_USERNAME="$$caller_WEAVE_TEST_USERNAME"; fi; \
 	if [ "$$caller_WEAVE_TEST_PASSWORD_set" = x ] && [ -n "$$caller_WEAVE_TEST_PASSWORD" ]; then WEAVE_TEST_PASSWORD="$$caller_WEAVE_TEST_PASSWORD"; fi; \
 	if [ "$$caller_WEAVE_OFFLINE_CONTRACT_ONLY_set" = x ] && [ -n "$$caller_WEAVE_OFFLINE_CONTRACT_ONLY" ]; then WEAVE_OFFLINE_CONTRACT_ONLY="$$caller_WEAVE_OFFLINE_CONTRACT_ONLY"; fi; \
+	if [ "$${WEAVE_OFFLINE_CONTRACT_ONLY:-false}" = "true" ]; then WEAVE_TEST_USERNAME=""; WEAVE_TEST_PASSWORD=""; fi; \
 	WEAVE_API_BASE_URL="$${WEAVE_API_BASE_URL:-$${WEAVE_BASE_URL:-https://api.weave.local/api}}"; \
 	WEAVE_BASE_URL="$${WEAVE_API_BASE_URL}"; \
 	WEAVE_OIDC_ISSUER_URL="$${WEAVE_OIDC_ISSUER_URL:-https://auth.weave.local/realms/weave}"; \

--- a/acceptance/live_stack_app.feature
+++ b/acceptance/live_stack_app.feature
@@ -41,3 +41,4 @@ Feature: Live Stack app collaboration journey
     When the user reads the preview, creates a task, moves it, and completes it without drag-and-drop
     Then the preview reports the local provider-neutral backend source
     And the task reaches the completed column through Weave API routes
+    And mapped frontend accessibility evidence covers screen-reader summaries, tap targets, large text, and action-menu alternatives

--- a/test/live_stack_feature_mapping_test.dart
+++ b/test/live_stack_feature_mapping_test.dart
@@ -27,6 +27,7 @@ void main() {
     final featureText = feature.readAsStringSync();
     final executableText = executable.readAsStringSync();
     final productFlowText = productFlowDoc.readAsStringSync();
+    final evidenceTextByPath = <String, String>{};
 
     expect(
       RegExp(r'```mermaid\s+flowchart TD').allMatches(productFlowText).length,
@@ -60,6 +61,26 @@ void main() {
           reason:
               'Scenario "${entry.key}" must stay linked to executable Live Stack evidence fragment "$fragment".',
         );
+      }
+      for (final evidence in entry.value.additionalEvidence) {
+        final evidenceText = evidenceTextByPath.putIfAbsent(evidence.path, () {
+          final evidenceFile = File(evidence.path);
+          expect(
+            evidenceFile.existsSync(),
+            isTrue,
+            reason:
+                'Scenario "${entry.key}" references missing evidence file ${evidence.path}.',
+          );
+          return evidenceFile.readAsStringSync();
+        });
+        for (final fragment in evidence.fragments) {
+          expect(
+            evidenceText,
+            contains(fragment),
+            reason:
+                'Scenario "${entry.key}" must stay linked to ${evidence.path} evidence fragment "$fragment".',
+          );
+        }
       }
     }
   });
@@ -115,6 +136,25 @@ const _requiredMappings = <String, _ScenarioMapping>{
           '/api/boards/tasks/\$taskId/move',
           'BOARDS_RESULT',
         ],
+        additionalEvidence: <_EvidenceMapping>[
+          _EvidenceMapping(
+            path: 'test/features/boards/boards_preview_screen_test.dart',
+            fragments: <String>[
+              'offers non-drag task actions with preview-only feedback',
+              'exposes screen-reader summaries for board, columns, and tasks',
+              'meets tap-target accessibility guidelines',
+              'keeps critical preview copy reachable with large text',
+            ],
+          ),
+          _EvidenceMapping(
+            path:
+                'test/features/boards/data/backend_boards_preview_repository_test.dart',
+            fragments: <String>[
+              'posts accessible non-drag move and complete actions to backend facade',
+              '"targetColumnId":"done","targetPosition":2',
+            ],
+          ),
+        ],
       ),
 };
 
@@ -154,8 +194,17 @@ class _ScenarioMapping {
   const _ScenarioMapping({
     required this.tag,
     required this.executableFragments,
+    this.additionalEvidence = const <_EvidenceMapping>[],
   });
 
   final String tag;
   final List<String> executableFragments;
+  final List<_EvidenceMapping> additionalEvidence;
+}
+
+class _EvidenceMapping {
+  const _EvidenceMapping({required this.path, required this.fragments});
+
+  final String path;
+  final List<String> fragments;
 }


### PR DESCRIPTION
## Summary
- anchor the Boards live-stack scenario to explicit frontend accessibility/non-drag evidence without expanding live E2E
- make `make offline-contract-test` ignore generated bootstrap credentials by default and clear live credentials in offline mode

## Validation
- `flutter test test/live_stack_feature_mapping_test.dart`
- `flutter test test/features/boards/boards_preview_screen_test.dart test/features/boards/data/backend_boards_preview_repository_test.dart`
- `make offline-contract-test`
- `flutter test`

## Notes
- Live stack dispatch was not run; it remains operator-gated.
