### PR TITLE
test: anchor boards a11y evidence in live stack mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .PHONY: offline-contract-test acceptance-feature-mapping integration-contract-test integration-app-e2e integration-test marketing-screenshots
 
 offline-contract-test: acceptance-feature-mapping
-	@WEAVE_OFFLINE_CONTRACT_ONLY=true \
-	$(MAKE) integration-contract-test
+	@env -u WEAVE_TEST_USERNAME -u WEAVE_TEST_PASSWORD \
+	  WEAVE_OFFLINE_CONTRACT_ONLY=true \
+	  WEAVE_BOOTSTRAP_ENV=/dev/null \
+	  $(MAKE) integration-contract-test
 
 acceptance-feature-mapping:
 	@flutter test test/live_stack_feature_mapping_test.dart

--- a/acceptance/live_stack_app.feature
+++ b/acceptance/live_stack_app.feature
@@ -41,3 +41,4 @@ Feature: Live Stack app collaboration journey
     When the user reads the preview, creates a task, moves it, and completes it without drag-and-drop
     Then the preview reports the local provider-neutral backend source
     And the task reaches the completed column through Weave API routes
+    And the checked-in Boards accessibility tests cover screen-reader summaries, tap targets, and large text without adding a flaky live-stack dependency

--- a/test/live_stack_feature_mapping_test.dart
+++ b/test/live_stack_feature_mapping_test.dart
@@ -61,6 +61,24 @@ void main() {
               'Scenario "${entry.key}" must stay linked to executable Live Stack evidence fragment "$fragment".',
         );
       }
+      for (final evidence in entry.value.supportingEvidence) {
+        final evidenceFile = File(evidence.path);
+        expect(
+          evidenceFile.existsSync(),
+          isTrue,
+          reason:
+              'Scenario "${entry.key}" must reference existing supporting evidence file ${evidence.path}.',
+        );
+        final evidenceText = evidenceFile.readAsStringSync();
+        for (final fragment in evidence.fragments) {
+          expect(
+            evidenceText,
+            contains(fragment),
+            reason:
+                'Scenario "${entry.key}" must stay linked to supporting evidence fragment "$fragment" in ${evidence.path}.',
+          );
+        }
+      }
     }
   });
 }
@@ -115,6 +133,26 @@ const _requiredMappings = <String, _ScenarioMapping>{
           '/api/boards/tasks/\$taskId/move',
           'BOARDS_RESULT',
         ],
+        supportingEvidence: <_SupportingEvidence>[
+          _SupportingEvidence(
+            path: 'test/features/boards/boards_preview_screen_test.dart',
+            fragments: <String>[
+              'offers non-drag task actions with preview-only feedback',
+              'exposes screen-reader summaries for board, columns, and tasks',
+              'meets tap-target accessibility guidelines',
+              'keeps critical preview copy reachable with large text',
+            ],
+          ),
+          _SupportingEvidence(
+            path:
+                'test/features/boards/data/backend_boards_preview_repository_test.dart',
+            fragments: <String>[
+              'posts accessible non-drag move and complete actions to backend facade',
+              '/api/boards/tasks/task-1/move',
+              '/api/boards/tasks/task-1/complete',
+            ],
+          ),
+        ],
       ),
 };
 
@@ -154,8 +192,17 @@ class _ScenarioMapping {
   const _ScenarioMapping({
     required this.tag,
     required this.executableFragments,
+    this.supportingEvidence = const <_SupportingEvidence>[],
   });
 
   final String tag;
   final List<String> executableFragments;
+  final List<_SupportingEvidence> supportingEvidence;
+}
+
+class _SupportingEvidence {
+  const _SupportingEvidence({required this.path, required this.fragments});
+
+  final String path;
+  final List<String> fragments;
 }


### PR DESCRIPTION
## Problem
- The live-stack feature mapping guarded the Boards live E2E fragments, but did not explicitly anchor existing Boards accessibility/non-drag executable evidence.
- `make offline-contract-test` could still inherit live bootstrap credentials from the local generated bootstrap file, which made the offline gate less hermetic.

## Target behavior
- Keep the readable Boards scenario linked to both live-stack API evidence and checked-in accessibility/non-drag tests.
- Make the offline contract target PR-safe by default: no bootstrap env, no live test username/password.

## Changes
- Adds supporting-evidence checks in `test/live_stack_feature_mapping_test.dart` for:
  - Boards screen non-drag action feedback
  - screen-reader summaries
  - tap-target guidelines
  - large-text reachability
  - backend non-drag move/complete repository calls
- Notes the checked-in Boards accessibility evidence in `acceptance/live_stack_app.feature` without adding live E2E.
- Runs `offline-contract-test` through `env -u WEAVE_TEST_USERNAME -u WEAVE_TEST_PASSWORD WEAVE_BOOTSTRAP_ENV=/dev/null`.

## Validation
- `flutter test test/live_stack_feature_mapping_test.dart`
- `flutter test test/features/boards/boards_preview_screen_test.dart test/features/boards/data/backend_boards_preview_repository_test.dart`
- `make offline-contract-test`
- `WEAVE_TEST_USERNAME=should-not-leak WEAVE_TEST_PASSWORD=should-not-leak make offline-contract-test`
- `flutter test`
- `flutter analyze --fatal-infos`

## Contract impact
- No product API/runtime contract change.
- CI/E2E acceptance mapping is stricter for Boards accessibility evidence.
- Offline frontend contract validation is now credential-hermetic by default.
