### PR TITLE
fix(auth): refresh facade tokens after backend 401

### DIFF
--- a/lib/features/calendar/data/services/calendar_facade_client.dart
+++ b/lib/features/calendar/data/services/calendar_facade_client.dart
@@ -27,10 +27,11 @@ class CalendarFacadeClient {
 
   Future<CalendarScopeList> listScopes() async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.get(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.get(
         _apiUri(context.baseUrl, const ['api', 'calendar', 'scopes']),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
       ),
       fallbackMessage: 'Unable to load calendar scopes from the Weave backend.',
     );
@@ -66,14 +67,15 @@ class CalendarFacadeClient {
       if (selectedScope?.channelId case final channelId?)
         'channelId': channelId,
     };
-    final response = await _send(
-      () => _httpClient.get(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.get(
         _apiUri(context.baseUrl, const [
           'api',
           'calendar',
           'events',
         ], query: query.isEmpty ? null : query),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
       ),
       fallbackMessage: 'Unable to load calendar events from the Weave backend.',
     );
@@ -95,10 +97,11 @@ class CalendarFacadeClient {
 
   Future<CalendarClientSetup> clientSetup() async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.get(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.get(
         _apiUri(context.baseUrl, const ['api', 'calendar', 'client-setup']),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
       ),
       fallbackMessage:
           'Unable to load calendar setup metadata from the Weave backend.',
@@ -138,10 +141,11 @@ class CalendarFacadeClient {
 
   Future<CalendarEvent> readEvent(String id) async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.get(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.get(
         _apiUri(context.baseUrl, ['api', 'calendar', 'events', id]),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
       ),
       fallbackMessage: 'Unable to read the calendar event.',
     );
@@ -151,10 +155,11 @@ class CalendarFacadeClient {
 
   Future<CalendarEvent> createEvent(CalendarEventDraft draft) async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.post(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.post(
         _apiUri(context.baseUrl, const ['api', 'calendar', 'events']),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
         body: jsonEncode(draft.toJson()),
       ),
       fallbackMessage: 'Unable to create the calendar event.',
@@ -168,10 +173,11 @@ class CalendarFacadeClient {
     required CalendarEventPatch patch,
   }) async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.patch(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.patch(
         _apiUri(context.baseUrl, ['api', 'calendar', 'events', id]),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
         body: jsonEncode(patch.toJson()),
       ),
       fallbackMessage: 'Unable to update the calendar event.',
@@ -182,10 +188,11 @@ class CalendarFacadeClient {
 
   Future<void> deleteEvent(String id) async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.delete(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.delete(
         _apiUri(context.baseUrl, ['api', 'calendar', 'events', id]),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
       ),
       fallbackMessage: 'Unable to delete the calendar event.',
     );
@@ -201,8 +208,9 @@ class CalendarFacadeClient {
       );
     }
 
+    final authConfiguration = _authConfiguration(configuration);
     final authState = await _authSessionRepository.restoreSession(
-      _authConfiguration(configuration),
+      authConfiguration,
     );
     final session = authState.session;
     if (!authState.isAuthenticated || session == null) {
@@ -214,6 +222,7 @@ class CalendarFacadeClient {
     return _CalendarFacadeContext(
       baseUrl: configuration.serviceEndpoints.backendApiBaseUrl,
       accessToken: session.accessToken,
+      authConfiguration: authConfiguration,
     );
   }
 
@@ -234,6 +243,52 @@ class CalendarFacadeClient {
       rethrow;
     } catch (error) {
       throw AppFailure.unknown(fallbackMessage, cause: error);
+    }
+  }
+
+  Future<http.Response> _sendAuthenticated(
+    _CalendarFacadeContext context,
+    Future<http.Response> Function(String accessToken) request, {
+    required String fallbackMessage,
+  }) async {
+    final response = await _send(
+      () => request(context.accessToken),
+      fallbackMessage: fallbackMessage,
+    );
+    if (response.statusCode != 401) {
+      return response;
+    }
+
+    final refreshedContext = await _refreshContext(context);
+    if (refreshedContext == null ||
+        refreshedContext.accessToken == context.accessToken) {
+      return response;
+    }
+
+    return _send(
+      () => request(refreshedContext.accessToken),
+      fallbackMessage: fallbackMessage,
+    );
+  }
+
+  Future<_CalendarFacadeContext?> _refreshContext(
+    _CalendarFacadeContext context,
+  ) async {
+    try {
+      final authState = await _authSessionRepository.refreshSession(
+        context.authConfiguration,
+      );
+      final session = authState.session;
+      if (!authState.isAuthenticated || session == null) {
+        return null;
+      }
+      return _CalendarFacadeContext(
+        baseUrl: context.baseUrl,
+        accessToken: session.accessToken,
+        authConfiguration: context.authConfiguration,
+      );
+    } catch (_) {
+      return null;
     }
   }
 
@@ -592,8 +647,10 @@ class _CalendarFacadeContext {
   const _CalendarFacadeContext({
     required this.baseUrl,
     required this.accessToken,
+    required this.authConfiguration,
   });
 
   final Uri baseUrl;
   final String accessToken;
+  final AuthConfiguration authConfiguration;
 }

--- a/lib/features/files/data/repositories/backend_files_repository.dart
+++ b/lib/features/files/data/repositories/backend_files_repository.dart
@@ -81,10 +81,11 @@ class BackendFilesRepository
   @override
   Future<DirectoryListing> listDirectory(String path) async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.get(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.get(
         _apiUri(context.baseUrl, const ['api', 'files'], query: {'path': path}),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
       ),
       fallbackMessage: 'Unable to load files from the Weave backend.',
     );
@@ -147,10 +148,11 @@ class BackendFilesRepository
     required String name,
   }) async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.post(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.post(
         _apiUri(context.baseUrl, const ['api', 'files', 'folders']),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
         body: jsonEncode({'parentPath': parentPath, 'name': name}),
       ),
       fallbackMessage: 'Unable to create the folder through the Weave backend.',
@@ -161,10 +163,11 @@ class BackendFilesRepository
 
   Future<void> prepareDownload(String id) async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.get(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.get(
         _apiUri(context.baseUrl, ['api', 'files', id, 'download']),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
       ),
       fallbackMessage: 'Unable to prepare the file download.',
     );
@@ -180,10 +183,11 @@ class BackendFilesRepository
     }
 
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.get(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.get(
         _apiUri(context.baseUrl, ['api', 'files', entry.id, 'download']),
-        headers: {'Authorization': 'Bearer ${context.accessToken}'},
+        headers: {'Authorization': 'Bearer $accessToken'},
       ),
       fallbackMessage: 'Unable to download the file through the Weave backend.',
     );
@@ -215,10 +219,11 @@ class BackendFilesRepository
 
   Future<void> delete(String id) async {
     final context = await _requireContext();
-    final response = await _send(
-      () => _httpClient.delete(
+    final response = await _sendAuthenticated(
+      context,
+      (accessToken) => _httpClient.delete(
         _apiUri(context.baseUrl, ['api', 'files', id]),
-        headers: _jsonHeaders(context.accessToken),
+        headers: _jsonHeaders(accessToken),
       ),
       fallbackMessage: 'Unable to delete the file through the Weave backend.',
     );
@@ -237,8 +242,9 @@ class BackendFilesRepository
       );
     }
 
+    final authConfiguration = _authConfiguration(configuration);
     final authState = await _authSessionRepository.restoreSession(
-      _authConfiguration(configuration),
+      authConfiguration,
     );
     final session = authState.session;
     if (!authState.isAuthenticated || session == null) {
@@ -250,6 +256,7 @@ class BackendFilesRepository
     return _BackendFilesContext(
       baseUrl: configuration.serviceEndpoints.backendApiBaseUrl,
       accessToken: session.accessToken,
+      authConfiguration: authConfiguration,
     );
   }
 
@@ -283,6 +290,52 @@ class BackendFilesRepository
       rethrow;
     } catch (error) {
       throw FilesFailure.unknown(fallbackMessage, cause: error);
+    }
+  }
+
+  Future<http.Response> _sendAuthenticated(
+    _BackendFilesContext context,
+    Future<http.Response> Function(String accessToken) request, {
+    required String fallbackMessage,
+  }) async {
+    final response = await _send(
+      () => request(context.accessToken),
+      fallbackMessage: fallbackMessage,
+    );
+    if (response.statusCode != 401) {
+      return response;
+    }
+
+    final refreshedContext = await _refreshContext(context);
+    if (refreshedContext == null ||
+        refreshedContext.accessToken == context.accessToken) {
+      return response;
+    }
+
+    return _send(
+      () => request(refreshedContext.accessToken),
+      fallbackMessage: fallbackMessage,
+    );
+  }
+
+  Future<_BackendFilesContext?> _refreshContext(
+    _BackendFilesContext context,
+  ) async {
+    try {
+      final authState = await _authSessionRepository.refreshSession(
+        context.authConfiguration,
+      );
+      final session = authState.session;
+      if (!authState.isAuthenticated || session == null) {
+        return null;
+      }
+      return _BackendFilesContext(
+        baseUrl: context.baseUrl,
+        accessToken: session.accessToken,
+        authConfiguration: context.authConfiguration,
+      );
+    } catch (_) {
+      return null;
     }
   }
 
@@ -464,8 +517,10 @@ class _BackendFilesContext {
   const _BackendFilesContext({
     required this.baseUrl,
     required this.accessToken,
+    required this.authConfiguration,
   });
 
   final Uri baseUrl;
   final String accessToken;
+  final AuthConfiguration authConfiguration;
 }

--- a/test/features/calendar/data/services/calendar_facade_client_test.dart
+++ b/test/features/calendar/data/services/calendar_facade_client_test.dart
@@ -37,13 +37,17 @@ class _FakeAuthSessionRepository implements AuthSessionRepository {
   _FakeAuthSessionRepository(this.state);
 
   AuthState state;
+  AuthState? refreshedState;
+  int refreshCalls = 0;
 
   @override
   Future<void> clearLocalSession() async {}
 
   @override
-  Future<AuthState> refreshSession(AuthConfiguration configuration) async =>
-      state;
+  Future<AuthState> refreshSession(AuthConfiguration configuration) async {
+    refreshCalls++;
+    return refreshedState ?? state;
+  }
 
   @override
   Future<AuthState> restoreSession(AuthConfiguration configuration) async =>
@@ -491,6 +495,40 @@ void main() {
         });
       },
     );
+
+    test('refreshes the Weave session once after a backend 401', () async {
+      authSessionRepository.refreshedState = AuthState.authenticated(
+        buildTestAuthSession(accessToken: 'fresh-calendar-token'),
+      );
+      final authorizationHeaders = <String?>[];
+      final facade = client(
+        MockClient((request) async {
+          authorizationHeaders.add(request.headers['authorization']);
+          if (authorizationHeaders.length == 1) {
+            return http.Response(
+              jsonEncode({'message': 'Authentication is required.'}),
+              401,
+            );
+          }
+          return http.Response(
+            jsonEncode({
+              'scope': {'type': 'workspace', 'label': 'Workspace'},
+              'events': [],
+            }),
+            200,
+          );
+        }),
+      );
+
+      final events = await facade.listEvents();
+
+      expect(events.events, isEmpty);
+      expect(authSessionRepository.refreshCalls, 1);
+      expect(authorizationHeaders, [
+        'Bearer calendar-token',
+        'Bearer fresh-calendar-token',
+      ]);
+    });
 
     test('maps backend failures without direct CalDAV fallback', () async {
       final facade = client(

--- a/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
+++ b/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
@@ -42,13 +42,17 @@ class _FakeAuthSessionRepository implements AuthSessionRepository {
   _FakeAuthSessionRepository(this.state);
 
   AuthState state;
+  AuthState? refreshedState;
+  int refreshCalls = 0;
 
   @override
   Future<void> clearLocalSession() async {}
 
   @override
-  Future<AuthState> refreshSession(AuthConfiguration configuration) async =>
-      state;
+  Future<AuthState> refreshSession(AuthConfiguration configuration) async {
+    refreshCalls++;
+    return refreshedState ?? state;
+  }
 
   @override
   Future<AuthState> restoreSession(AuthConfiguration configuration) async =>
@@ -304,6 +308,35 @@ void main() {
                 ),
           ),
         );
+      },
+    );
+
+    test(
+      'refreshes the Weave session once after a backend 401 and retries',
+      () async {
+        authSessionRepository.refreshedState = AuthState.authenticated(
+          buildTestAuthSession(accessToken: 'fresh-files-token'),
+        );
+        final authorizationHeaders = <String?>[];
+        final client = MockClient((request) async {
+          authorizationHeaders.add(request.headers['authorization']);
+          if (authorizationHeaders.length == 1) {
+            return http.Response(
+              jsonEncode({'message': 'Authentication is required.'}),
+              401,
+            );
+          }
+          return http.Response(jsonEncode({'path': '/', 'items': []}), 200);
+        });
+
+        final listing = await repository(client).listDirectory('/');
+
+        expect(listing.entries, isEmpty);
+        expect(authSessionRepository.refreshCalls, 1);
+        expect(authorizationHeaders, [
+          'Bearer files-token',
+          'Bearer fresh-files-token',
+        ]);
       },
     );
 


### PR DESCRIPTION
## Summary
- Retry authenticated backend files facade requests once after a 401 by refreshing the Weave auth session.
- Apply the same one-shot refresh retry to calendar facade calls so backend facade clients share the same token-expiry behavior.
- Add regression coverage proving the original request is retried with the refreshed Bearer token and still fails closed if auth remains invalid.

## Root cause / evidence
- Live Stack E2E run https://github.com/masssi164/weave/actions/runs/26243394283 reached profile, chat, Matrix, and E2EE success, then failed only the files facade check with `filesConnected=false` and `directoryFailure=Authentication is required. directoryFailureCause=401`.
- The app restored a stored access token before long-running live-stack checks; facade clients did not refresh/retry on backend 401 even though OAuth/OIDC native clients are expected to refresh short-lived access tokens and retry the original request once.

## Verification
- `dart format lib/features/files/data/repositories/backend_files_repository.dart lib/features/calendar/data/services/calendar_facade_client.dart test/features/files/presentation/providers/files_backend_facade_provider_test.dart test/features/calendar/data/services/calendar_facade_client_test.dart`
- `flutter analyze lib/features/files/data/repositories/backend_files_repository.dart lib/features/calendar/data/services/calendar_facade_client.dart test/features/files/presentation/providers/files_backend_facade_provider_test.dart test/features/calendar/data/services/calendar_facade_client_test.dart`
- `flutter test test/features/files/presentation/providers/files_backend_facade_provider_test.dart test/features/calendar/data/services/calendar_facade_client_test.dart`
