### PR TITLE
Add Gherkin acceptance evidence guard

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -113,6 +113,16 @@ jobs:
           ref: ${{ env.WEAVE_BACKEND_REF }}
           path: weave-backend
 
+      - name: Prepare acceptance evidence directory
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/weave-live-stack-acceptance-evidence"
+          test_log="$RUNNER_TEMP/weave-live-stack-e2e.log"
+          mkdir -p "$evidence_dir"
+          : > "$test_log"
+          echo "WEAVE_ACCEPTANCE_EVIDENCE_DIR=$evidence_dir" >> "$GITHUB_ENV"
+          echo "WEAVE_ACCEPTANCE_TEST_LOG=$test_log" >> "$GITHUB_ENV"
+
       - name: Configure Docker auth without macOS Keychain
         env:
           GHCR_TOKEN: ${{ github.token }}
@@ -237,7 +247,21 @@ jobs:
         working-directory: weave
         env:
           WEAVE_BOOTSTRAP_ENV: ${{ github.workspace }}/weave-infra/weave-workspace/.generated/bootstrap.env
-        run: make integration-test
+        run: |
+          set -euo pipefail
+          make integration-test 2>&1 | tee "$WEAVE_ACCEPTANCE_TEST_LOG"
+
+      - name: Generate live stack acceptance evidence
+        if: always()
+        working-directory: weave
+        run: |
+          set -euo pipefail
+          dart run tool/acceptance_contract.dart guard \
+            --features acceptance \
+            --mapping acceptance/scenario_mappings.json \
+            --out "$WEAVE_ACCEPTANCE_EVIDENCE_DIR" \
+            --test-log "$WEAVE_ACCEPTANCE_TEST_LOG" \
+            --append-summary "$GITHUB_STEP_SUMMARY"
 
       - name: Dump stack logs on failure
         if: failure()
@@ -253,3 +277,12 @@ jobs:
         if: always()
         working-directory: weave-infra/weave-workspace
         run: bash ./teardown.sh
+
+      - name: Upload live stack acceptance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weave-live-stack-acceptance-evidence
+          path: ${{ env.WEAVE_ACCEPTANCE_EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ Useful test targets:
 - `make integration-contract-test` — live-stack contract check requiring real test credentials.
 - `make integration-app-e2e` / `make integration-test` — expensive app-level live E2E targets for manual runs.
 
+Gherkin scenarios are product acceptance contracts, not decorative BDD. See
+[docs/acceptance-contracts.md](docs/acceptance-contracts.md) for the ATDD workflow,
+scenario-to-test mapping guard, and live-stack acceptance artifact contract.
+
 Supported overrides:
 
 - `WEAVE_API_BASE_URL`: canonical base URL for the Weave backend API, defaulting to `https://api.weave.local/api`

--- a/acceptance/live_stack_app.feature
+++ b/acceptance/live_stack_app.feature
@@ -1,44 +1,51 @@
-Feature: Live Stack app collaboration journey
-  The Live Stack app E2E remains the executable proof that a user can sign in once
-  and use Weave-owned product surfaces for chat, files, calendar, and boards.
-  These scenarios are mapped to integration_test/live_stack_app_e2e_test.dart and
-  guarded by test/live_stack_feature_mapping_test.dart so the readable scenario
-  layer cannot drift into decorative documentation only.
+Feature: Live Stack product acceptance journey
+  The Live Stack app E2E is the sparse executable proof that a person can sign in
+  once and use Weave-owned product surfaces for profile, chat, files, calendar,
+  and boards. These scenarios are product contracts, not implementation notes.
+
+  Each scenario has a stable tag in acceptance/scenario_mappings.json. The mapping
+  guard fails if a scenario is not connected to an executable test and evidence
+  marker, so this readable layer cannot drift into decorative BDD.
 
   @weave-live-auth-shell
-  Scenario: Auth sign-in restores the Weave workspace shell and profile facade
-    Given the local stack exposes the canonical Weave API and Keycloak issuer
-    When the live test user signs in through the Weave app session
-    Then the authenticated backend session is restored
-    And the profile facade can load, update, reload, and restore the display name
+  Scenario: Sign-in restores the Weave workspace and profile
+    Given the Weave workspace is ready for the live test person
+    When the person signs in through Weave
+    Then Weave restores the signed-in workspace
+    And the person can load, edit, reload, and restore their profile name
+
+  @weave-live-matrix-content
+  Scenario: Matrix chat sends and reads a workspace message
+    Given the signed-in person has the Weave chat surface available
+    When the person creates a conversation and sends a message
+    Then the message is readable in Weave chat
+    And Weave reports the chat connection outcome honestly
 
   @weave-live-matrix-e2ee
-  Scenario: Matrix chat sends messages and proves E2EE posture honestly
-    Given the signed-in user has a Matrix client from Weave platform config
-    When the user creates a room and sends a message through the Weave chat repository
-    Then the message is readable from the Weave timeline
-    And an encrypted room emits authoritative encrypted Matrix wire events without plaintext leakage
-    And recovery bootstrap and key storage posture are reported in the E2EE result evidence
+  Scenario: Matrix encryption status is proved honestly
+    Given the signed-in person has encryption support available for chat
+    When the person sends a message in an encrypted conversation
+    Then Weave observes encrypted message evidence without plaintext leakage
+    And Weave reports recovery and key-storage readiness honestly
 
   @weave-live-files-boundary
-  Scenario: Files are browsed, uploaded, and downloaded through the Weave product facade
-    Given the signed-in user opens the Weave Files surface
-    When the user uploads a unique file through the backend files facade
-    Then the Weave Files listing shows the file
-    And downloading it through the facade returns the original bytes
-    And the test cleans up the uploaded file without depending on raw Nextcloud UI
+  Scenario: Files are uploaded, shown, downloaded, and cleaned up in Weave
+    Given the signed-in person opens Weave Files
+    When the person uploads a unique file
+    Then Weave shows the uploaded file
+    And downloading the file returns the original content
+    And the test removes the file it created
 
   @weave-live-calendar-threadrefs
-  Scenario: Channel calendar events round trip with stable meeting thread references
-    Given workspace, team, and channel calendar scopes are available
-    When the user creates, reads, updates, and deletes a channel-scoped event
-    Then the event remains in the channel scope
-    And the meeting thread reference is present and stable across the update
+  Scenario: Channel calendar events keep their meeting thread reference
+    Given workspace, team, and channel calendar scopes are available in Weave
+    When the person creates, reads, updates, and deletes a channel event
+    Then the event stays in its channel scope while it exists
+    And the meeting thread reference is present and stable after the update
 
   @weave-live-boards-preview-nondrag
-  Scenario: Boards preview stays provider-neutral and supports non-drag task operations
-    Given the Boards preview runtime is enabled for the local Weave backend facade
-    When the user reads the preview, creates a task, moves it, and completes it without drag-and-drop
-    Then the preview reports the local provider-neutral backend source
-    And the task reaches the completed column through Weave API routes
-    And mapped frontend accessibility evidence covers screen-reader summaries, tap targets, large text, and action-menu alternatives
+  Scenario: Boards preview supports accessible non-drag task work
+    Given the Boards preview is available in Weave
+    When the person creates, moves, and completes a task without drag-and-drop
+    Then the board still uses Weave product task concepts
+    And mapped accessibility evidence covers screen-reader summaries, tap targets, large text, and action-menu alternatives

--- a/acceptance/scenario_mappings.json
+++ b/acceptance/scenario_mappings.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "description": "Stable mapping from product-language Gherkin scenarios to executable Live Stack E2E evidence. Every feature scenario must appear here, and every marker must exist in the mapped executable test.",
+  "scenarios": [
+    {
+      "tag": "@weave-live-auth-shell",
+      "scenario": "Sign-in restores the Weave workspace and profile",
+      "feature": "acceptance/live_stack_app.feature",
+      "executableTest": "integration_test/live_stack_app_e2e_test.dart",
+      "evidenceMarkers": ["AUTH_RESULT", "PROFILE_RESULT"]
+    },
+    {
+      "tag": "@weave-live-matrix-content",
+      "scenario": "Matrix chat sends and reads a workspace message",
+      "feature": "acceptance/live_stack_app.feature",
+      "executableTest": "integration_test/live_stack_app_e2e_test.dart",
+      "evidenceMarkers": ["CHAT_RESULT", "MATRIX_RESULT"]
+    },
+    {
+      "tag": "@weave-live-matrix-e2ee",
+      "scenario": "Matrix encryption status is proved honestly",
+      "feature": "acceptance/live_stack_app.feature",
+      "executableTest": "integration_test/live_stack_app_e2e_test.dart",
+      "evidenceMarkers": ["E2EE_RESULT"]
+    },
+    {
+      "tag": "@weave-live-files-boundary",
+      "scenario": "Files are uploaded, shown, downloaded, and cleaned up in Weave",
+      "feature": "acceptance/live_stack_app.feature",
+      "executableTest": "integration_test/live_stack_app_e2e_test.dart",
+      "evidenceMarkers": ["FILES_RESULT"]
+    },
+    {
+      "tag": "@weave-live-calendar-threadrefs",
+      "scenario": "Channel calendar events keep their meeting thread reference",
+      "feature": "acceptance/live_stack_app.feature",
+      "executableTest": "integration_test/live_stack_app_e2e_test.dart",
+      "evidenceMarkers": ["CALENDAR_RESULT"]
+    },
+    {
+      "tag": "@weave-live-boards-preview-nondrag",
+      "scenario": "Boards preview supports accessible non-drag task work",
+      "feature": "acceptance/live_stack_app.feature",
+      "executableTest": "integration_test/live_stack_app_e2e_test.dart",
+      "evidenceMarkers": ["BOARDS_RESULT"],
+      "additionalEvidence": [
+        {
+          "path": "test/features/boards/boards_preview_screen_test.dart",
+          "fragments": [
+            "offers non-drag task actions with preview-only feedback",
+            "exposes screen-reader summaries for board, columns, and tasks",
+            "meets tap-target accessibility guidelines",
+            "keeps critical preview copy reachable with large text"
+          ]
+        },
+        {
+          "path": "test/features/boards/data/backend_boards_preview_repository_test.dart",
+          "fragments": [
+            "posts accessible non-drag move and complete actions to backend facade",
+            "\"targetColumnId\":\"done\",\"targetPosition\":2"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/acceptance-contracts.md
+++ b/docs/acceptance-contracts.md
@@ -1,0 +1,48 @@
+# Acceptance contracts, Gherkin, and ATDD workflow
+
+Weave uses Gherkin as a product acceptance contract and CI evidence layer. It is
+not a Cucumber theater layer: a scenario is reviewable only when it has a stable,
+machine-readable mapping to executable evidence.
+
+## Current frontend live-stack contract
+
+- Product scenarios live in `acceptance/live_stack_app.feature`.
+- Stable scenario mappings live in `acceptance/scenario_mappings.json`.
+- The mapping guard is `test/live_stack_feature_mapping_test.dart` and can also
+  be run directly with `dart run tool/acceptance_contract.dart guard`.
+- Live CI writes audit artifacts to `weave-live-stack-acceptance-evidence`:
+  - `acceptance-summary.md`
+  - `gherkin-scenarios.json`
+  - `scenario-mapping-results.json`
+  - `evidence-markers.json`
+
+The artifact includes sanitized marker summaries only. It must not include raw
+secrets, tokens, cookies, private keys, or full live E2E logs.
+
+## ATDD/TDD rule
+
+For new product behavior:
+
+1. Write or update the product-language Gherkin scenario first.
+2. Add the scenario to `acceptance/scenario_mappings.json` with an executable
+   test path and evidence marker. The guard should be red until the executable
+   evidence exists.
+3. Drive the implementation with focused unit, provider, widget, integration, or
+   backend tests. Do not push implementation details into the feature file.
+4. Keep live-stack E2E sparse. It proves critical end-to-end contracts only;
+   lower-level tests carry the detailed technical coverage.
+5. Run `make offline-contract-test` before review. Use `make integration-test`
+   only for authorized live-stack runs with runner power/storage budget.
+
+## Feature-file language rules
+
+Feature files should be readable by product, engineering, and screen-reader users:
+
+- Use short scenario names and one behavior per scenario.
+- Describe people and Weave product surfaces, not JWTs, HTTP routes, repositories,
+  provider internals, selectors, or database state.
+- Mention accessibility outcomes when they are part of the product contract, and
+  map them to widget/provider tests instead of bloating live E2E.
+- If a scenario has no deterministic executable mapping yet, keep it out of the
+  checked-in feature file or add a mapping that intentionally fails until the
+  test/evidence is implemented.

--- a/docs/product-acceptance-flows.md
+++ b/docs/product-acceptance-flows.md
@@ -49,7 +49,8 @@ flowchart TD
 
 Acceptance evidence:
 - `weave/acceptance/live_stack_app.feature` scenario `@weave-live-auth-shell`.
-- `weave/integration_test/live_stack_app_e2e_test.dart` prints `PROFILE_RESULT` and verifies profile load/update/reload/restore.
+- `weave/acceptance/scenario_mappings.json` maps the scenario to `AUTH_RESULT` and `PROFILE_RESULT`.
+- `weave/integration_test/live_stack_app_e2e_test.dart` prints the mapped markers and verifies profile load/update/reload/restore.
 - `weave/test/live_stack_feature_mapping_test.dart` prevents the readable scenario from drifting away from executable evidence.
 
 ## Flow 2: Workspace/team/channel and Context/Space selection
@@ -191,8 +192,8 @@ Acceptance evidence:
 | Product area | Readable scenario file | Executable or deterministic gate | Why it is relevant |
 | --- | --- | --- | --- |
 | Sign-in / shell / profile | `weave/acceptance/live_stack_app.feature` | Flutter live E2E + `test/live_stack_feature_mapping_test.dart` | One login must restore Weave and `/api/me`/profile facade identity. |
-| Matrix chat / E2EE | `weave/acceptance/live_stack_app.feature` | Flutter live E2E encrypted wire/timeline proof | E2EE posture must be truthful, not decorative. |
-| Files boundary | `weave/acceptance/live_stack_app.feature` | Flutter live E2E backend files facade proof | Files must be Weave product UX, not raw provider UI. |
+| Matrix chat / E2EE | `weave/acceptance/live_stack_app.feature` + `weave/acceptance/scenario_mappings.json` | Flutter live E2E encrypted wire/timeline proof + acceptance artifact | E2EE posture must be truthful, not decorative. |
+| Files boundary | `weave/acceptance/live_stack_app.feature` + `weave/acceptance/scenario_mappings.json` | Flutter live E2E product files proof + acceptance artifact | Files must be Weave product UX, not raw provider UI. |
 | Calendar event/thread | `weave/acceptance/live_stack_app.feature` | Flutter live E2E calendar CRUD + thread reference proof | Channel scheduling needs stable context and future meeting/chat linkage. |
 | Boards app preview | `weave/acceptance/live_stack_app.feature` | Flutter live E2E Boards preview/non-drag operation proof | Boards need accessible non-drag product behavior. |
 | OpenProject provider | `weave-backend/src/test/resources/features/openproject-boards-readonly.feature` | Backend Cucumber/JUnit acceptance suite | Provider runtime must be read-only, context-scoped, support-safe, and fail-closed. |

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -182,6 +182,15 @@ void main() {
           return 'weaveAuthenticatedSession=$session';
         },
       );
+      final restoredSession = container
+          .read(weaveAuthenticatedSessionProvider)
+          .asData
+          ?.value;
+      // ignore: avoid_print
+      print(
+        'AUTH_RESULT signedIn=${restoredSession != null} '
+        'accessTokenPresent=${restoredSession?.accessToken.isNotEmpty ?? false}',
+      );
 
       final profileRepository = container.read(userProfileRepositoryProvider);
       final originalProfile = await profileRepository.loadProfile();

--- a/test/live_stack_feature_mapping_test.dart
+++ b/test/live_stack_feature_mapping_test.dart
@@ -2,209 +2,131 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../tool/acceptance_contract.dart' as acceptance;
+
 void main() {
-  test('live stack feature scenarios are mapped to executable E2E evidence', () {
-    final feature = File('acceptance/live_stack_app.feature');
-    final executable = File('integration_test/live_stack_app_e2e_test.dart');
-    final productFlowDoc = File('docs/product-flow-activity-diagrams.md');
+  test(
+    'live stack feature scenarios are mapped to executable E2E evidence',
+    () {
+      final root = Directory.current;
+      final scenarios = acceptance.parseFeatureDirectory(root, 'acceptance');
+      final mappings = acceptance.loadScenarioMappings(
+        root,
+        'acceptance/scenario_mappings.json',
+      );
+      final result = acceptance.validateAcceptanceContract(
+        root: root,
+        scenarios: scenarios,
+        mappings: mappings,
+        runtimeEvidence: acceptance.RuntimeEvidence.notCollected(),
+      );
 
-    expect(
-      feature.existsSync(),
-      isTrue,
-      reason: 'Missing readable Live Stack scenarios.',
-    );
-    expect(
-      executable.existsSync(),
-      isTrue,
-      reason: 'Missing executable Live Stack E2E test.',
-    );
-    expect(
-      productFlowDoc.existsSync(),
-      isTrue,
-      reason: 'Missing presentable product-flow activity diagrams.',
-    );
-
-    final featureText = feature.readAsStringSync();
-    final executableText = executable.readAsStringSync();
-    final productFlowText = productFlowDoc.readAsStringSync();
-    final evidenceTextByPath = <String, String>{};
-
-    expect(
-      RegExp(r'```mermaid\s+flowchart TD').allMatches(productFlowText).length,
-      greaterThanOrEqualTo(7),
-      reason:
-          'Product-flow doc must contain the seven required activity diagrams.',
-    );
-    final scenarios = _scenarios(featureText);
-
-    expect(scenarios.keys, unorderedEquals(_requiredMappings.keys));
-
-    for (final entry in _requiredMappings.entries) {
-      final scenario = scenarios[entry.key];
-      expect(scenario, isNotNull, reason: 'Missing scenario: ${entry.key}');
       expect(
-        scenario!.tags,
-        contains(entry.value.tag),
-        reason:
-            'Scenario "${entry.key}" must carry stable tag ${entry.value.tag}.',
+        result.findings.map((finding) => finding.message).toList(),
+        isEmpty,
       );
       expect(
-        productFlowText,
-        contains(entry.value.tag),
-        reason:
-            'Scenario "${entry.key}" must be anchored in the product-flow activity diagrams.',
+        result.scenarios.map((scenario) => scenario.name),
+        unorderedEquals(<String>[
+          'Sign-in restores the Weave workspace and profile',
+          'Matrix chat sends and reads a workspace message',
+          'Matrix encryption status is proved honestly',
+          'Files are uploaded, shown, downloaded, and cleaned up in Weave',
+          'Channel calendar events keep their meeting thread reference',
+          'Boards preview supports accessible non-drag task work',
+        ]),
       );
-      for (final fragment in entry.value.executableFragments) {
-        expect(
-          executableText,
-          contains(fragment),
-          reason:
-              'Scenario "${entry.key}" must stay linked to executable Live Stack evidence fragment "$fragment".',
-        );
-      }
-      for (final evidence in entry.value.additionalEvidence) {
-        final evidenceText = evidenceTextByPath.putIfAbsent(evidence.path, () {
-          final evidenceFile = File(evidence.path);
-          expect(
-            evidenceFile.existsSync(),
-            isTrue,
-            reason:
-                'Scenario "${entry.key}" references missing evidence file ${evidence.path}.',
-          );
-          return evidenceFile.readAsStringSync();
-        });
-        for (final fragment in evidence.fragments) {
-          expect(
-            evidenceText,
-            contains(fragment),
-            reason:
-                'Scenario "${entry.key}" must stay linked to ${evidence.path} evidence fragment "$fragment".',
-          );
-        }
-      }
-    }
-  });
-}
+    },
+  );
 
-const _requiredMappings = <String, _ScenarioMapping>{
-  'Auth sign-in restores the Weave workspace shell and profile facade':
-      _ScenarioMapping(
-        tag: '@weave-live-auth-shell',
-        executableFragments: <String>[
-          'LiveOidcTestDriver(config: config)',
-          "find.text('Anmelden')",
-          'PROFILE_RESULT',
-          'profileUpdated',
-        ],
+  test('mapping guard fails a newly added unmapped scenario', () {
+    final root = Directory.current;
+    final scenarios = <acceptance.FeatureScenario>[
+      ...acceptance.parseFeatureDirectory(root, 'acceptance'),
+      const acceptance.FeatureScenario(
+        featurePath: 'acceptance/live_stack_app.feature',
+        line: 999,
+        name: 'A new product behavior starts here and must not be decorative',
+        tags: <String>['@weave-live-unmapped-negative-fixture'],
       ),
-  'Matrix chat sends messages and proves E2EE posture honestly':
-      _ScenarioMapping(
-        tag: '@weave-live-matrix-e2ee',
-        executableFragments: <String>[
-          'MATRIX_RESULT',
-          'E2EE_RESULT',
-          '_waitForAuthoritativeEncryptedWireEvent',
-          'encryptedWirePlaintextLeaked',
-        ],
-      ),
-  'Files are browsed, uploaded, and downloaded through the Weave product facade':
-      _ScenarioMapping(
-        tag: '@weave-live-files-boundary',
-        executableFragments: <String>[
-          'filesProvider.notifier).connect',
-          'uploadFile',
-          'downloadFile',
-          'FILES_RESULT',
-        ],
-      ),
-  'Channel calendar events round trip with stable meeting thread references':
-      _ScenarioMapping(
-        tag: '@weave-live-calendar-threadrefs',
-        executableFragments: <String>[
-          'calendarRepository.loadScopes',
-          '_createCalendarEventWithReadAfterWrite',
-          '_channelMeetingThreadReady',
-          'CALENDAR_RESULT',
-        ],
-      ),
-  'Boards preview stays provider-neutral and supports non-drag task operations':
-      _ScenarioMapping(
-        tag: '@weave-live-boards-preview-nondrag',
-        executableFragments: <String>[
-          '/api/boards/preview',
-          '/api/boards/\$boardId/tasks',
-          '/api/boards/tasks/\$taskId/move',
-          'BOARDS_RESULT',
-        ],
-        additionalEvidence: <_EvidenceMapping>[
-          _EvidenceMapping(
-            path: 'test/features/boards/boards_preview_screen_test.dart',
-            fragments: <String>[
-              'offers non-drag task actions with preview-only feedback',
-              'exposes screen-reader summaries for board, columns, and tasks',
-              'meets tap-target accessibility guidelines',
-              'keeps critical preview copy reachable with large text',
-            ],
-          ),
-          _EvidenceMapping(
-            path:
-                'test/features/boards/data/backend_boards_preview_repository_test.dart',
-            fragments: <String>[
-              'posts accessible non-drag move and complete actions to backend facade',
-              '"targetColumnId":"done","targetPosition":2',
-            ],
-          ),
-        ],
-      ),
-};
+    ];
+    final mappings = acceptance.loadScenarioMappings(
+      root,
+      'acceptance/scenario_mappings.json',
+    );
 
-Map<String, _FeatureScenario> _scenarios(String featureText) {
-  final scenarios = <String, _FeatureScenario>{};
-  final pendingTags = <String>[];
+    final result = acceptance.validateAcceptanceContract(
+      root: root,
+      scenarios: scenarios,
+      mappings: mappings,
+      runtimeEvidence: acceptance.RuntimeEvidence.notCollected(),
+    );
 
-  for (final rawLine in featureText.split('\n')) {
-    final line = rawLine.trim();
-    if (line.startsWith('@')) {
-      pendingTags
-        ..clear()
-        ..addAll(line.split(RegExp(r'\s+')).where((part) => part.isNotEmpty));
-      continue;
-    }
-    if (line.startsWith('Scenario: ')) {
-      final name = line.substring('Scenario: '.length).trim();
-      scenarios[name] = _FeatureScenario(
-        name,
-        List<String>.unmodifiable(pendingTags),
-      );
-      pendingTags.clear();
-    }
-  }
-
-  return scenarios;
-}
-
-class _FeatureScenario {
-  const _FeatureScenario(this.name, this.tags);
-
-  final String name;
-  final List<String> tags;
-}
-
-class _ScenarioMapping {
-  const _ScenarioMapping({
-    required this.tag,
-    required this.executableFragments,
-    this.additionalEvidence = const <_EvidenceMapping>[],
+    expect(result.isValid, isFalse);
+    expect(
+      result.findings.map((finding) => finding.message).join('\n'),
+      contains('has no executable mapping'),
+    );
   });
 
-  final String tag;
-  final List<String> executableFragments;
-  final List<_EvidenceMapping> additionalEvidence;
-}
+  test('mapping guard fails when an evidence marker is not executable', () {
+    final root = Directory.current;
+    final scenarios = acceptance.parseFeatureDirectory(root, 'acceptance');
+    final mappings = acceptance
+        .loadScenarioMappings(root, 'acceptance/scenario_mappings.json')
+        .map((mapping) {
+          if (mapping.tag != '@weave-live-auth-shell') {
+            return mapping;
+          }
+          return acceptance.ScenarioMapping(
+            tag: mapping.tag,
+            scenario: mapping.scenario,
+            featurePath: mapping.featurePath,
+            executableTest: mapping.executableTest,
+            evidenceMarkers: <String>['MISSING_NEGATIVE_FIXTURE_MARKER'],
+            additionalEvidence: mapping.additionalEvidence,
+          );
+        })
+        .toList(growable: false);
 
-class _EvidenceMapping {
-  const _EvidenceMapping({required this.path, required this.fragments});
+    final result = acceptance.validateAcceptanceContract(
+      root: root,
+      scenarios: scenarios,
+      mappings: mappings,
+      runtimeEvidence: acceptance.RuntimeEvidence.notCollected(),
+    );
 
-  final String path;
-  final List<String> fragments;
+    expect(result.isValid, isFalse);
+    expect(
+      result.findings.map((finding) => finding.message).join('\n'),
+      contains('references missing evidence marker'),
+    );
+  });
+
+  test(
+    'mapping guard fails when collected runtime evidence misses a marker',
+    () {
+      final root = Directory.current;
+      final scenarios = acceptance.parseFeatureDirectory(root, 'acceptance');
+      final mappings = acceptance.loadScenarioMappings(
+        root,
+        'acceptance/scenario_mappings.json',
+      );
+      final result = acceptance.validateAcceptanceContract(
+        root: root,
+        scenarios: scenarios,
+        mappings: mappings,
+        runtimeEvidence: const acceptance.RuntimeEvidence(
+          wasCollected: true,
+          markers: <String, acceptance.SanitizedEvidenceMarker>{},
+        ),
+      );
+
+      expect(result.isValid, isFalse);
+      expect(
+        result.findings.map((finding) => finding.message).join('\n'),
+        contains('runtime evidence did not observe marker AUTH_RESULT'),
+      );
+    },
+  );
 }

--- a/test/live_stack_feature_mapping_test.dart
+++ b/test/live_stack_feature_mapping_test.dart
@@ -129,4 +129,64 @@ void main() {
       );
     },
   );
+
+  test('feature parser accumulates consecutive tag lines', () {
+    final directory = Directory.systemTemp.createTempSync(
+      'weave_feature_tags_',
+    );
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final featureFile =
+        File('${directory.path}${Platform.pathSeparator}tags.feature')
+          ..writeAsStringSync('''
+Feature: Split tags
+
+@weave-live @acceptance
+@critical
+Scenario: Tagged over several lines
+  Given something useful
+''');
+
+    final scenarios = acceptance.parseFeatureFile(directory, featureFile);
+
+    expect(scenarios, hasLength(1));
+    expect(scenarios.single.tags, <String>[
+      '@weave-live',
+      '@acceptance',
+      '@critical',
+    ]);
+  });
+
+  test('runtime evidence sanitizer keeps accessibility fields', () {
+    final directory = Directory.systemTemp.createTempSync('weave_evidence_');
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final logFile = File('${directory.path}${Platform.pathSeparator}e2e.log')
+      ..writeAsStringSync('''
+ACCESSIBILITY_RESULT accessible=true accessibility=ok accessToken=redacted accessKey=redacted apiKey=redacted token=redacted accessTokenPresent=true durationMs=42 id=123 displayName=Massimo
+''');
+    const mapping = acceptance.ScenarioMapping(
+      tag: '@weave-live-a11y',
+      scenario: 'Accessibility evidence is useful',
+      featurePath: 'acceptance/live_stack_app.feature',
+      executableTest: 'integration_test/live_stack_e2e_test.dart',
+      evidenceMarkers: <String>['ACCESSIBILITY_RESULT'],
+      additionalEvidence: <acceptance.AdditionalEvidenceMapping>[],
+    );
+
+    final evidence = acceptance.extractRuntimeEvidence(
+      logFile,
+      <acceptance.ScenarioMapping>[mapping],
+    );
+    final sanitized = evidence.markers['ACCESSIBILITY_RESULT']!.sanitizedFields;
+
+    expect(sanitized['accessible'], 'true');
+    expect(sanitized['accessibility'], 'ok');
+    expect(sanitized['accessTokenPresent'], 'true');
+    expect(sanitized['durationMs'], '42');
+    expect(sanitized, isNot(contains('accessToken')));
+    expect(sanitized, isNot(contains('accessKey')));
+    expect(sanitized, isNot(contains('apiKey')));
+    expect(sanitized, isNot(contains('token')));
+    expect(sanitized, isNot(contains('id')));
+    expect(sanitized, isNot(contains('displayName')));
+  });
 }

--- a/tool/acceptance_contract.dart
+++ b/tool/acceptance_contract.dart
@@ -1,8 +1,36 @@
 import 'dart:convert';
 import 'dart:io';
 
-const _sensitiveKeyPattern =
-    r'(token|secret|password|authorization|cookie|session|credential|username|userid|displayname|roomid|eventid|threadid|filename|access)';
+const _sensitiveKeyNames = <String>{
+  'token',
+  'secret',
+  'password',
+  'authorization',
+  'cookie',
+  'session',
+  'credential',
+  'username',
+  'userid',
+  'displayname',
+  'roomid',
+  'eventid',
+  'threadid',
+  'filename',
+  'accesstoken',
+  'accesskey',
+  'apikey',
+};
+
+const _sensitiveKeySuffixes = <String>{
+  'token',
+  'secret',
+  'password',
+  'authorization',
+  'cookie',
+  'credential',
+  'accesskey',
+  'apikey',
+};
 
 void main(List<String> args) {
   if (args.isEmpty || args.first == '--help' || args.first == '-h') {
@@ -90,9 +118,9 @@ List<FeatureScenario> parseFeatureFile(Directory root, File file) {
   for (var index = 0; index < lines.length; index += 1) {
     final line = lines[index].trim();
     if (line.startsWith('@')) {
-      pendingTags
-        ..clear()
-        ..addAll(line.split(RegExp(r'\s+')).where((part) => part.isNotEmpty));
+      pendingTags.addAll(
+        line.split(RegExp(r'\s+')).where((part) => part.isNotEmpty),
+      );
       continue;
     }
     if (line.startsWith('Scenario: ')) {
@@ -443,12 +471,11 @@ bool _lineContainsMarker(String line, String marker) =>
 Map<String, String> _sanitizeMarkerFields(String line) {
   final fields = <String, String>{};
   final keyValuePattern = RegExp(r'([A-Za-z][A-Za-z0-9_]*)=([^\s]+)');
-  final sensitive = RegExp(_sensitiveKeyPattern, caseSensitive: false);
   for (final match in keyValuePattern.allMatches(line)) {
     final key = match.group(1)!;
     final value = match.group(2)!;
     final lowerKey = key.toLowerCase();
-    if (sensitive.hasMatch(key) ||
+    if (_isSensitiveMarkerKey(key) ||
         lowerKey == 'id' ||
         lowerKey.endsWith('id') ||
         lowerKey.endsWith('name')) {
@@ -460,6 +487,14 @@ Map<String, String> _sanitizeMarkerFields(String line) {
     fields[key] = value;
   }
   return fields;
+}
+
+bool _isSensitiveMarkerKey(String key) {
+  final normalizedKey = key.toLowerCase().replaceAll(RegExp(r'[_-]'), '');
+  if (_sensitiveKeyNames.contains(normalizedKey)) {
+    return true;
+  }
+  return _sensitiveKeySuffixes.any(normalizedKey.endsWith);
 }
 
 Map<String, String> _parseOptions(List<String> args) {
@@ -497,17 +532,23 @@ Options:
 }
 
 String _join(String first, String second) {
-  if (second.startsWith('/')) {
+  if (File(second).isAbsolute) {
     return second;
   }
-  return '$first/$second';
+  if (first.endsWith(Platform.pathSeparator)) {
+    return '$first$second';
+  }
+  return '$first${Platform.pathSeparator}$second';
 }
 
 String _relativePath(String rootPath, String path) {
-  final normalizedRoot = rootPath.endsWith('/') ? rootPath : '$rootPath/';
-  return path.startsWith(normalizedRoot)
+  final normalizedRoot = rootPath.endsWith(Platform.pathSeparator)
+      ? rootPath
+      : '$rootPath${Platform.pathSeparator}';
+  final relativePath = path.startsWith(normalizedRoot)
       ? path.substring(normalizedRoot.length)
       : path;
+  return relativePath.replaceAll(Platform.pathSeparator, '/');
 }
 
 String _escapeMarkdown(String value) => value.replaceAll('|', r'\|');

--- a/tool/acceptance_contract.dart
+++ b/tool/acceptance_contract.dart
@@ -1,0 +1,736 @@
+import 'dart:convert';
+import 'dart:io';
+
+const _sensitiveKeyPattern =
+    r'(token|secret|password|authorization|cookie|session|credential|username|userid|displayname|roomid|eventid|threadid|filename|access)';
+
+void main(List<String> args) {
+  if (args.isEmpty || args.first == '--help' || args.first == '-h') {
+    _printUsage();
+    return;
+  }
+
+  final command = args.first;
+  final options = _parseOptions(args.skip(1).toList());
+  if (command != 'guard') {
+    stderr.writeln('Unknown acceptance contract command: $command');
+    _printUsage();
+    exitCode = 64;
+    return;
+  }
+
+  final root = Directory.current;
+  final featuresDir = options['features'] ?? 'acceptance';
+  final mappingPath = options['mapping'] ?? 'acceptance/scenario_mappings.json';
+  final outputDir = options['out'];
+  final testLogPath = options['test-log'];
+  final appendSummaryPath = options['append-summary'];
+
+  final scenarios = parseFeatureDirectory(root, featuresDir);
+  final mappings = loadScenarioMappings(root, mappingPath);
+  final runtimeEvidence = testLogPath == null
+      ? RuntimeEvidence.notCollected()
+      : extractRuntimeEvidence(File(_join(root.path, testLogPath)), mappings);
+  final result = validateAcceptanceContract(
+    root: root,
+    scenarios: scenarios,
+    mappings: mappings,
+    runtimeEvidence: runtimeEvidence,
+  );
+
+  if (outputDir != null) {
+    writeAcceptanceArtifacts(
+      Directory(_join(root.path, outputDir)),
+      result,
+      runtimeEvidence,
+    );
+  }
+
+  final summary = renderMarkdownSummary(result, runtimeEvidence);
+  stdout.write(summary);
+  if (appendSummaryPath != null) {
+    final summaryFile = File(appendSummaryPath);
+    summaryFile.writeAsStringSync('\n$summary', mode: FileMode.append);
+  }
+
+  if (!result.isValid) {
+    for (final finding in result.findings) {
+      stderr.writeln('acceptance-contract: ${finding.message}');
+    }
+    exitCode = 1;
+  }
+}
+
+List<FeatureScenario> parseFeatureDirectory(
+  Directory root,
+  String relativeDir,
+) {
+  final directory = Directory(_join(root.path, relativeDir));
+  if (!directory.existsSync()) {
+    return const <FeatureScenario>[];
+  }
+  final files =
+      directory
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.feature'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+  return <FeatureScenario>[
+    for (final file in files) ...parseFeatureFile(root, file),
+  ];
+}
+
+List<FeatureScenario> parseFeatureFile(Directory root, File file) {
+  final relativePath = _relativePath(root.path, file.path);
+  final scenarios = <FeatureScenario>[];
+  final pendingTags = <String>[];
+  final lines = file.readAsLinesSync();
+
+  for (var index = 0; index < lines.length; index += 1) {
+    final line = lines[index].trim();
+    if (line.startsWith('@')) {
+      pendingTags
+        ..clear()
+        ..addAll(line.split(RegExp(r'\s+')).where((part) => part.isNotEmpty));
+      continue;
+    }
+    if (line.startsWith('Scenario: ')) {
+      final scenarioName = line.substring('Scenario: '.length).trim();
+      scenarios.add(
+        FeatureScenario(
+          featurePath: relativePath,
+          line: index + 1,
+          name: scenarioName,
+          tags: List<String>.unmodifiable(pendingTags),
+        ),
+      );
+      pendingTags.clear();
+    }
+  }
+
+  return scenarios;
+}
+
+List<ScenarioMapping> loadScenarioMappings(
+  Directory root,
+  String relativePath,
+) {
+  final file = File(_join(root.path, relativePath));
+  if (!file.existsSync()) {
+    return const <ScenarioMapping>[];
+  }
+  final decoded = jsonDecode(file.readAsStringSync());
+  if (decoded is! Map<String, Object?>) {
+    throw const FormatException('Scenario mapping root must be a JSON object.');
+  }
+  final rawScenarios = decoded['scenarios'];
+  if (rawScenarios is! List) {
+    throw const FormatException(
+      'Scenario mapping must contain a scenarios list.',
+    );
+  }
+  return rawScenarios
+      .map(
+        (raw) => ScenarioMapping.fromJson((raw as Map).cast<String, Object?>()),
+      )
+      .toList(growable: false);
+}
+
+AcceptanceContractResult validateAcceptanceContract({
+  required Directory root,
+  required List<FeatureScenario> scenarios,
+  required List<ScenarioMapping> mappings,
+  required RuntimeEvidence runtimeEvidence,
+}) {
+  final findings = <AcceptanceFinding>[];
+  if (scenarios.isEmpty) {
+    findings.add(const AcceptanceFinding('No .feature scenarios were found.'));
+  }
+  if (mappings.isEmpty) {
+    findings.add(const AcceptanceFinding('No scenario mappings were found.'));
+  }
+
+  final scenariosByTag = <String, FeatureScenario>{};
+  for (final scenario in scenarios) {
+    if (scenario.tags.isEmpty) {
+      findings.add(
+        AcceptanceFinding(
+          '${scenario.featurePath}:${scenario.line} "${scenario.name}" has no stable tag.',
+        ),
+      );
+    }
+    for (final tag in scenario.tags) {
+      final existing = scenariosByTag[tag];
+      if (existing != null) {
+        findings.add(
+          AcceptanceFinding(
+            'Duplicate feature tag $tag on "${existing.name}" and "${scenario.name}".',
+          ),
+        );
+      } else {
+        scenariosByTag[tag] = scenario;
+      }
+    }
+  }
+
+  final mappingsByTag = <String, ScenarioMapping>{};
+  for (final mapping in mappings) {
+    final existing = mappingsByTag[mapping.tag];
+    if (existing != null) {
+      findings.add(
+        AcceptanceFinding(
+          'Duplicate mapping tag ${mapping.tag} for "${existing.scenario}" and "${mapping.scenario}".',
+        ),
+      );
+    } else {
+      mappingsByTag[mapping.tag] = mapping;
+    }
+  }
+
+  final scenarioResults = <ScenarioMappingResult>[];
+  for (final scenario in scenarios) {
+    final tagMappings = scenario.tags
+        .map((tag) => mappingsByTag[tag])
+        .whereType<ScenarioMapping>()
+        .toList(growable: false);
+    if (tagMappings.isEmpty) {
+      findings.add(
+        AcceptanceFinding(
+          '${scenario.featurePath}:${scenario.line} "${scenario.name}" has no executable mapping.',
+        ),
+      );
+      scenarioResults.add(
+        ScenarioMappingResult.unmapped(
+          scenario: scenario,
+          runtimeEvidence: runtimeEvidence,
+        ),
+      );
+      continue;
+    }
+    for (final mapping in tagMappings) {
+      scenarioResults.add(
+        _validateScenarioMapping(
+          root,
+          scenario,
+          mapping,
+          findings,
+          runtimeEvidence,
+        ),
+      );
+    }
+  }
+
+  for (final mapping in mappings) {
+    final scenario = scenariosByTag[mapping.tag];
+    if (scenario == null) {
+      findings.add(
+        AcceptanceFinding(
+          'Mapping ${mapping.tag} references no checked-in feature scenario.',
+        ),
+      );
+      continue;
+    }
+    if (mapping.scenario != scenario.name) {
+      findings.add(
+        AcceptanceFinding(
+          'Mapping ${mapping.tag} names "${mapping.scenario}" but feature names "${scenario.name}".',
+        ),
+      );
+    }
+    if (mapping.featurePath != scenario.featurePath) {
+      findings.add(
+        AcceptanceFinding(
+          'Mapping ${mapping.tag} points to ${mapping.featurePath} but feature scenario is in ${scenario.featurePath}.',
+        ),
+      );
+    }
+  }
+
+  return AcceptanceContractResult(
+    scenarios: List<FeatureScenario>.unmodifiable(scenarios),
+    mappings: List<ScenarioMapping>.unmodifiable(mappings),
+    scenarioResults: List<ScenarioMappingResult>.unmodifiable(scenarioResults),
+    findings: List<AcceptanceFinding>.unmodifiable(findings),
+  );
+}
+
+ScenarioMappingResult _validateScenarioMapping(
+  Directory root,
+  FeatureScenario scenario,
+  ScenarioMapping mapping,
+  List<AcceptanceFinding> findings,
+  RuntimeEvidence runtimeEvidence,
+) {
+  final executableFile = File(_join(root.path, mapping.executableTest));
+  final executableExists = executableFile.existsSync();
+  final executableText = executableExists
+      ? executableFile.readAsStringSync()
+      : '';
+  if (!executableExists) {
+    findings.add(
+      AcceptanceFinding(
+        'Mapping ${mapping.tag} references missing executable test ${mapping.executableTest}.',
+      ),
+    );
+  }
+  if (mapping.evidenceMarkers.isEmpty) {
+    findings.add(
+      AcceptanceFinding('Mapping ${mapping.tag} has no evidence markers.'),
+    );
+  }
+
+  final markerResults = <EvidenceMarkerResult>[];
+  for (final marker in mapping.evidenceMarkers) {
+    final sourcePresent = executableText.contains(marker);
+    final runtimeObserved = runtimeEvidence.observedMarkers.contains(marker);
+    if (!sourcePresent) {
+      findings.add(
+        AcceptanceFinding(
+          'Mapping ${mapping.tag} references missing evidence marker $marker in ${mapping.executableTest}.',
+        ),
+      );
+    }
+    if (runtimeEvidence.wasCollected && !runtimeObserved) {
+      findings.add(
+        AcceptanceFinding(
+          'Mapping ${mapping.tag} runtime evidence did not observe marker $marker.',
+        ),
+      );
+    }
+    markerResults.add(
+      EvidenceMarkerResult(
+        marker: marker,
+        sourcePresent: sourcePresent,
+        runtimeObserved: runtimeObserved,
+      ),
+    );
+  }
+
+  for (final evidence in mapping.additionalEvidence) {
+    final file = File(_join(root.path, evidence.path));
+    if (!file.existsSync()) {
+      findings.add(
+        AcceptanceFinding(
+          'Mapping ${mapping.tag} references missing additional evidence ${evidence.path}.',
+        ),
+      );
+      continue;
+    }
+    final evidenceText = file.readAsStringSync();
+    for (final fragment in evidence.fragments) {
+      if (!evidenceText.contains(fragment)) {
+        findings.add(
+          AcceptanceFinding(
+            'Mapping ${mapping.tag} is missing evidence fragment "$fragment" in ${evidence.path}.',
+          ),
+        );
+      }
+    }
+  }
+
+  final runtimeStatus = runtimeEvidence.wasCollected
+      ? markerResults.every((marker) => marker.runtimeObserved)
+            ? RuntimeScenarioStatus.passed
+            : RuntimeScenarioStatus.failedOrIncomplete
+      : RuntimeScenarioStatus.notCollected;
+
+  return ScenarioMappingResult(
+    scenario: scenario,
+    mapping: mapping,
+    markerResults: List<EvidenceMarkerResult>.unmodifiable(markerResults),
+    runtimeStatus: runtimeStatus,
+  );
+}
+
+RuntimeEvidence extractRuntimeEvidence(
+  File logFile,
+  List<ScenarioMapping> mappings,
+) {
+  if (!logFile.existsSync()) {
+    return RuntimeEvidence.notCollected();
+  }
+  final expectedMarkers = mappings
+      .expand((mapping) => mapping.evidenceMarkers)
+      .toSet();
+  final markers = <String, SanitizedEvidenceMarker>{};
+  for (final line in logFile.readAsLinesSync()) {
+    for (final marker in expectedMarkers) {
+      if (_lineContainsMarker(line, marker)) {
+        final existing = markers[marker];
+        markers[marker] = SanitizedEvidenceMarker(
+          marker: marker,
+          count: (existing?.count ?? 0) + 1,
+          sanitizedFields: _sanitizeMarkerFields(line),
+        );
+      }
+    }
+  }
+  return RuntimeEvidence(
+    wasCollected: true,
+    markers: Map<String, SanitizedEvidenceMarker>.unmodifiable(markers),
+  );
+}
+
+void writeAcceptanceArtifacts(
+  Directory outputDir,
+  AcceptanceContractResult result,
+  RuntimeEvidence runtimeEvidence,
+) {
+  outputDir.createSync(recursive: true);
+  File(_join(outputDir.path, 'gherkin-scenarios.json')).writeAsStringSync(
+    const JsonEncoder.withIndent(
+      '  ',
+    ).convert(result.scenarios.map((scenario) => scenario.toJson()).toList()),
+  );
+  File(
+    _join(outputDir.path, 'scenario-mapping-results.json'),
+  ).writeAsStringSync(
+    const JsonEncoder.withIndent('  ').convert(result.toJson()),
+  );
+  File(_join(outputDir.path, 'evidence-markers.json')).writeAsStringSync(
+    const JsonEncoder.withIndent('  ').convert(runtimeEvidence.toJson()),
+  );
+  File(
+    _join(outputDir.path, 'acceptance-summary.md'),
+  ).writeAsStringSync(renderMarkdownSummary(result, runtimeEvidence));
+}
+
+String renderMarkdownSummary(
+  AcceptanceContractResult result,
+  RuntimeEvidence runtimeEvidence,
+) {
+  final buffer = StringBuffer()
+    ..writeln('## Live Stack acceptance contract')
+    ..writeln()
+    ..writeln('- Mapping guard: ${result.isValid ? 'passed' : 'failed'}')
+    ..writeln('- Scenarios: ${result.scenarios.length}')
+    ..writeln(
+      '- Runtime evidence: ${runtimeEvidence.wasCollected ? 'collected' : 'not collected'}',
+    )
+    ..writeln()
+    ..writeln('| Scenario | Mapping | Runtime evidence | Markers |')
+    ..writeln('| --- | --- | --- | --- |');
+  for (final scenarioResult in result.scenarioResults) {
+    final markers = scenarioResult.markerResults.isEmpty
+        ? 'none'
+        : scenarioResult.markerResults
+              .map(
+                (marker) => runtimeEvidence.wasCollected
+                    ? '${marker.marker}:${marker.runtimeObserved ? 'seen' : 'missing'}'
+                    : '${marker.marker}:mapped',
+              )
+              .join('<br>');
+    buffer.writeln(
+      '| ${_escapeMarkdown(scenarioResult.scenario.name)} | ${scenarioResult.mapping == null ? 'missing' : 'mapped'} | ${scenarioResult.runtimeStatus.label} | $markers |',
+    );
+  }
+  if (result.findings.isNotEmpty) {
+    buffer
+      ..writeln()
+      ..writeln('### Guard findings');
+    for (final finding in result.findings) {
+      buffer.writeln('- ${finding.message}');
+    }
+  }
+  buffer.writeln();
+  return buffer.toString();
+}
+
+bool _lineContainsMarker(String line, String marker) =>
+    line == marker || line.startsWith('$marker ') || line.contains(' $marker ');
+
+Map<String, String> _sanitizeMarkerFields(String line) {
+  final fields = <String, String>{};
+  final keyValuePattern = RegExp(r'([A-Za-z][A-Za-z0-9_]*)=([^\s]+)');
+  final sensitive = RegExp(_sensitiveKeyPattern, caseSensitive: false);
+  for (final match in keyValuePattern.allMatches(line)) {
+    final key = match.group(1)!;
+    final value = match.group(2)!;
+    final lowerKey = key.toLowerCase();
+    if (sensitive.hasMatch(key) ||
+        lowerKey == 'id' ||
+        lowerKey.endsWith('id') ||
+        lowerKey.endsWith('name')) {
+      continue;
+    }
+    if (value.length > 120 || value.contains('://')) {
+      continue;
+    }
+    fields[key] = value;
+  }
+  return fields;
+}
+
+Map<String, String> _parseOptions(List<String> args) {
+  final options = <String, String>{};
+  for (var index = 0; index < args.length; index += 1) {
+    final arg = args[index];
+    if (!arg.startsWith('--')) {
+      throw FormatException('Unexpected positional argument: $arg');
+    }
+    final equalsIndex = arg.indexOf('=');
+    if (equalsIndex >= 0) {
+      options[arg.substring(2, equalsIndex)] = arg.substring(equalsIndex + 1);
+      continue;
+    }
+    if (index + 1 >= args.length) {
+      throw FormatException('Missing value for option $arg');
+    }
+    options[arg.substring(2)] = args[index + 1];
+    index += 1;
+  }
+  return options;
+}
+
+void _printUsage() {
+  stdout.writeln('''
+Usage: dart run tool/acceptance_contract.dart guard [options]
+
+Options:
+  --features <dir>        Feature directory (default: acceptance)
+  --mapping <file>        Scenario mapping JSON (default: acceptance/scenario_mappings.json)
+  --out <dir>             Optional artifact output directory
+  --test-log <file>       Optional live E2E log to extract sanitized evidence markers
+  --append-summary <file> Optional markdown file to append the acceptance summary to
+''');
+}
+
+String _join(String first, String second) {
+  if (second.startsWith('/')) {
+    return second;
+  }
+  return '$first/$second';
+}
+
+String _relativePath(String rootPath, String path) {
+  final normalizedRoot = rootPath.endsWith('/') ? rootPath : '$rootPath/';
+  return path.startsWith(normalizedRoot)
+      ? path.substring(normalizedRoot.length)
+      : path;
+}
+
+String _escapeMarkdown(String value) => value.replaceAll('|', r'\|');
+
+class FeatureScenario {
+  const FeatureScenario({
+    required this.featurePath,
+    required this.line,
+    required this.name,
+    required this.tags,
+  });
+
+  final String featurePath;
+  final int line;
+  final String name;
+  final List<String> tags;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'feature': featurePath,
+    'line': line,
+    'name': name,
+    'tags': tags,
+  };
+}
+
+class ScenarioMapping {
+  const ScenarioMapping({
+    required this.tag,
+    required this.scenario,
+    required this.featurePath,
+    required this.executableTest,
+    required this.evidenceMarkers,
+    required this.additionalEvidence,
+  });
+
+  factory ScenarioMapping.fromJson(Map<String, Object?> json) {
+    return ScenarioMapping(
+      tag: json['tag']! as String,
+      scenario: json['scenario']! as String,
+      featurePath: json['feature']! as String,
+      executableTest: json['executableTest']! as String,
+      evidenceMarkers: (json['evidenceMarkers']! as List).cast<String>(),
+      additionalEvidence:
+          ((json['additionalEvidence'] as List?) ?? const <Object>[])
+              .map(
+                (raw) => AdditionalEvidenceMapping.fromJson(
+                  (raw as Map).cast<String, Object?>(),
+                ),
+              )
+              .toList(growable: false),
+    );
+  }
+
+  final String tag;
+  final String scenario;
+  final String featurePath;
+  final String executableTest;
+  final List<String> evidenceMarkers;
+  final List<AdditionalEvidenceMapping> additionalEvidence;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'tag': tag,
+    'scenario': scenario,
+    'feature': featurePath,
+    'executableTest': executableTest,
+    'evidenceMarkers': evidenceMarkers,
+    if (additionalEvidence.isNotEmpty)
+      'additionalEvidence': additionalEvidence
+          .map((evidence) => evidence.toJson())
+          .toList(growable: false),
+  };
+}
+
+class AdditionalEvidenceMapping {
+  const AdditionalEvidenceMapping({
+    required this.path,
+    required this.fragments,
+  });
+
+  factory AdditionalEvidenceMapping.fromJson(Map<String, Object?> json) {
+    return AdditionalEvidenceMapping(
+      path: json['path']! as String,
+      fragments: (json['fragments']! as List).cast<String>(),
+    );
+  }
+
+  final String path;
+  final List<String> fragments;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'path': path,
+    'fragments': fragments,
+  };
+}
+
+class AcceptanceContractResult {
+  const AcceptanceContractResult({
+    required this.scenarios,
+    required this.mappings,
+    required this.scenarioResults,
+    required this.findings,
+  });
+
+  final List<FeatureScenario> scenarios;
+  final List<ScenarioMapping> mappings;
+  final List<ScenarioMappingResult> scenarioResults;
+  final List<AcceptanceFinding> findings;
+
+  bool get isValid => findings.isEmpty;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'valid': isValid,
+    'scenarios': scenarios.map((scenario) => scenario.toJson()).toList(),
+    'mappings': mappings.map((mapping) => mapping.toJson()).toList(),
+    'results': scenarioResults.map((result) => result.toJson()).toList(),
+    'findings': findings.map((finding) => finding.toJson()).toList(),
+  };
+}
+
+class ScenarioMappingResult {
+  const ScenarioMappingResult({
+    required this.scenario,
+    required this.mapping,
+    required this.markerResults,
+    required this.runtimeStatus,
+  });
+
+  factory ScenarioMappingResult.unmapped({
+    required FeatureScenario scenario,
+    required RuntimeEvidence runtimeEvidence,
+  }) {
+    return ScenarioMappingResult(
+      scenario: scenario,
+      mapping: null,
+      markerResults: const <EvidenceMarkerResult>[],
+      runtimeStatus: runtimeEvidence.wasCollected
+          ? RuntimeScenarioStatus.failedOrIncomplete
+          : RuntimeScenarioStatus.notCollected,
+    );
+  }
+
+  final FeatureScenario scenario;
+  final ScenarioMapping? mapping;
+  final List<EvidenceMarkerResult> markerResults;
+  final RuntimeScenarioStatus runtimeStatus;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'scenario': scenario.toJson(),
+    'mapping': mapping?.toJson(),
+    'markers': markerResults.map((marker) => marker.toJson()).toList(),
+    'runtimeStatus': runtimeStatus.name,
+  };
+}
+
+class EvidenceMarkerResult {
+  const EvidenceMarkerResult({
+    required this.marker,
+    required this.sourcePresent,
+    required this.runtimeObserved,
+  });
+
+  final String marker;
+  final bool sourcePresent;
+  final bool runtimeObserved;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'marker': marker,
+    'sourcePresent': sourcePresent,
+    'runtimeObserved': runtimeObserved,
+  };
+}
+
+enum RuntimeScenarioStatus {
+  notCollected('not collected'),
+  passed('passed'),
+  failedOrIncomplete('failed or incomplete');
+
+  const RuntimeScenarioStatus(this.label);
+
+  final String label;
+}
+
+class RuntimeEvidence {
+  const RuntimeEvidence({required this.wasCollected, required this.markers});
+
+  factory RuntimeEvidence.notCollected() => const RuntimeEvidence(
+    wasCollected: false,
+    markers: <String, SanitizedEvidenceMarker>{},
+  );
+
+  final bool wasCollected;
+  final Map<String, SanitizedEvidenceMarker> markers;
+
+  Set<String> get observedMarkers => markers.keys.toSet();
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'wasCollected': wasCollected,
+    'markers': markers.map((key, value) => MapEntry(key, value.toJson())),
+  };
+}
+
+class SanitizedEvidenceMarker {
+  const SanitizedEvidenceMarker({
+    required this.marker,
+    required this.count,
+    required this.sanitizedFields,
+  });
+
+  final String marker;
+  final int count;
+  final Map<String, String> sanitizedFields;
+
+  Map<String, Object?> toJson() => <String, Object?>{
+    'marker': marker,
+    'count': count,
+    'sanitizedFields': sanitizedFields,
+  };
+}
+
+class AcceptanceFinding {
+  const AcceptanceFinding(this.message);
+
+  final String message;
+
+  Map<String, Object?> toJson() => <String, Object?>{'message': message};
+}


### PR DESCRIPTION
## Problem

The Live Stack E2E can currently prove the critical app journey, but the readable Gherkin/product contract layer was not a first-class CI artifact. The previous evidence was effectively a log line, which made scenario drift too easy.

## Target behavior

Gherkin is now treated as a product acceptance contract plus CI evidence layer:

- product-readable scenarios live in `acceptance/live_stack_app.feature`;
- `acceptance/scenario_mappings.json` maps every scenario to executable tests and evidence markers;
- `tool/acceptance_contract.dart` validates feature scenarios, mapping drift, missing tests, missing source markers, additional lower-level evidence, and collected runtime markers;
- the Live Stack E2E workflow writes and uploads sanitized acceptance evidence on success and failure.

This is intentionally not a broad Cucumber layer. Feature files stay product-language only; implementation detail coverage remains in unit/provider/widget/integration tests.

## Files changed

- `acceptance/live_stack_app.feature` — tightened product-language Live Stack scenarios.
- `acceptance/scenario_mappings.json` — stable machine-readable scenario-to-evidence contract.
- `tool/acceptance_contract.dart` — guard/artifact generator.
- `test/live_stack_feature_mapping_test.dart` — positive guard plus negative drift fixtures for unmapped scenarios, missing source markers, and missing runtime markers.
- `integration_test/live_stack_app_e2e_test.dart` — adds `AUTH_RESULT` marker to complete scenario evidence.
- `.github/workflows/live-stack-e2e.yml` — captures live E2E output to a temp log, generates sanitized acceptance artifacts, appends `$GITHUB_STEP_SUMMARY`, uploads `weave-live-stack-acceptance-evidence` with 30-day retention.
- `docs/acceptance-contracts.md`, `README.md`, `docs/product-acceptance-flows.md` — document ATDD/TDD workflow and artifact contract.

## Acceptance evidence artifacts

The workflow artifact contains only sanitized acceptance files:

- `acceptance-summary.md`
- `gherkin-scenarios.json`
- `scenario-mapping-results.json`
- `evidence-markers.json`

Raw live E2E logs are not uploaded as part of the artifact. Sensitive marker fields such as tokens, secrets, passwords, usernames/user IDs, room/event/thread/file IDs and names are dropped from artifact output.

## Validation run locally

- `dart format --output=none --set-exit-if-changed acceptance tool/acceptance_contract.dart test/live_stack_feature_mapping_test.dart integration_test/live_stack_app_e2e_test.dart`
- `flutter test test/live_stack_feature_mapping_test.dart`
- `dart run tool/acceptance_contract.dart guard --features acceptance --mapping acceptance/scenario_mappings.json --out build/acceptance`
- synthetic sanitized-log check: `dart run tool/acceptance_contract.dart guard --features acceptance --mapping acceptance/scenario_mappings.json --out /tmp/weave-acceptance-artifact --test-log /tmp/weave-live-test.log` plus `rg` for sensitive sample values returned no matches
- `flutter analyze --fatal-infos`
- `make offline-contract-test`
- `flutter test` — all tests passed; live-credential tests skipped as expected without live defines

## Live Stack E2E

Not run locally in this PR because it mutates a real local live stack and consumes self-hosted runner power/storage budget. The workflow is wired to upload acceptance evidence on both success and failure when manually dispatched or invoked through workflow reuse.

## Contract changes

No app/backend API contract changes. This PR adds a frontend repository acceptance-evidence contract and CI artifact contract for the existing critical Live Stack product journey.
