### PR TITLE
feat: surface provider stack readiness

### DIFF
--- a/lib/features/app/domain/entities/provider_stack_snapshot.dart
+++ b/lib/features/app/domain/entities/provider_stack_snapshot.dart
@@ -371,6 +371,7 @@ class OfficeLaunchSnapshot {
     this.sessionId,
     this.launchMode,
     this.providerKey,
+    this.expiresAt,
     this.grantedPermissions = const <String>[],
     this.errorCode,
     this.message,
@@ -382,12 +383,14 @@ class OfficeLaunchSnapshot {
     required String launchMode,
     required String providerKey,
     required List<String> grantedPermissions,
+    DateTime? expiresAt,
   }) : this._(
          launched: true,
          failClosed: false,
          sessionId: sessionId,
          launchMode: launchMode,
          providerKey: providerKey,
+         expiresAt: expiresAt,
          grantedPermissions: grantedPermissions,
        );
 
@@ -408,6 +411,7 @@ class OfficeLaunchSnapshot {
   final String? sessionId;
   final String? launchMode;
   final String? providerKey;
+  final DateTime? expiresAt;
   final List<String> grantedPermissions;
   final String? errorCode;
   final String? message;

--- a/lib/features/app/domain/entities/provider_stack_snapshot.dart
+++ b/lib/features/app/domain/entities/provider_stack_snapshot.dart
@@ -15,12 +15,14 @@ class ProviderStackSnapshot {
     required this.flutterDirectProviderCallsAllowed,
     required this.supportSafe,
     required this.providers,
+    this.generatedAt,
   });
 
   final String releaseStatus;
   final bool backendOwnedFacades;
   final bool flutterDirectProviderCallsAllowed;
   final bool supportSafe;
+  final DateTime? generatedAt;
   final List<ProviderStatusSnapshot> providers;
 
   bool get failClosed =>
@@ -53,6 +55,7 @@ class ProviderStatusSnapshot {
     required this.supportSafeErrorCodes,
     required this.redactionPolicy,
     required this.candidates,
+    this.diagnostics = const <String, Object?>{},
   });
 
   final String module;
@@ -71,8 +74,13 @@ class ProviderStatusSnapshot {
   final List<String> supportSafeErrorCodes;
   final String redactionPolicy;
   final List<String> candidates;
+  final Map<String, Object?> diagnostics;
 
   bool get available => enabled && configured && state == ProviderState.ready;
+
+  bool get disabled => !enabled || state == ProviderState.disabled;
+
+  bool get unconfigured => !configured || state == ProviderState.notConfigured;
 }
 
 class DevopsProviderSummarySnapshot {
@@ -84,6 +92,12 @@ class DevopsProviderSummarySnapshot {
     required this.paidFeaturesRequired,
     required this.supportSafe,
     required this.providerReadiness,
+    this.linkedProjects = const <LinkedSourceProjectSnapshot>[],
+    this.repositories = const <SourceRepositorySnapshot>[],
+    this.openIssues = const <DevopsIssueSummarySnapshot>[],
+    this.mergeRequests = const <DevopsMergeRequestSummarySnapshot>[],
+    this.pipelines = const <DevopsPipelineSummarySnapshot>[],
+    this.releases = const <DevopsReleaseSummarySnapshot>[],
   });
 
   final String workspaceId;
@@ -93,6 +107,145 @@ class DevopsProviderSummarySnapshot {
   final bool paidFeaturesRequired;
   final bool supportSafe;
   final List<ProviderStatusSnapshot> providerReadiness;
+  final List<LinkedSourceProjectSnapshot> linkedProjects;
+  final List<SourceRepositorySnapshot> repositories;
+  final List<DevopsIssueSummarySnapshot> openIssues;
+  final List<DevopsMergeRequestSummarySnapshot> mergeRequests;
+  final List<DevopsPipelineSummarySnapshot> pipelines;
+  final List<DevopsReleaseSummarySnapshot> releases;
+
+  bool get failClosed =>
+      readOnly || providerReadiness.any((provider) => provider.failClosed);
+}
+
+class LinkedSourceProjectSnapshot {
+  const LinkedSourceProjectSnapshot({
+    required this.id,
+    required this.displayName,
+    required this.providerKey,
+    required this.visibility,
+    required this.repositoryIds,
+  });
+
+  final String id;
+  final String displayName;
+  final String providerKey;
+  final String visibility;
+  final List<String> repositoryIds;
+}
+
+class SourceRepositorySnapshot {
+  const SourceRepositorySnapshot({
+    required this.id,
+    required this.projectId,
+    required this.displayName,
+    required this.defaultBranch,
+    required this.providerKey,
+    required this.archived,
+  });
+
+  final String id;
+  final String projectId;
+  final String displayName;
+  final String defaultBranch;
+  final String providerKey;
+  final bool archived;
+}
+
+class DevopsIssueSummarySnapshot {
+  const DevopsIssueSummarySnapshot({
+    required this.id,
+    required this.projectId,
+    required this.title,
+    required this.state,
+    required this.providerKey,
+    required this.updatedAt,
+    required this.labels,
+  });
+
+  final String id;
+  final String projectId;
+  final String title;
+  final String state;
+  final String providerKey;
+  final DateTime? updatedAt;
+  final List<String> labels;
+}
+
+class DevopsMergeRequestSummarySnapshot {
+  const DevopsMergeRequestSummarySnapshot({
+    required this.id,
+    required this.repositoryId,
+    required this.title,
+    required this.sourceBranch,
+    required this.targetBranch,
+    required this.state,
+    required this.providerKey,
+    required this.updatedAt,
+  });
+
+  final String id;
+  final String repositoryId;
+  final String title;
+  final String sourceBranch;
+  final String targetBranch;
+  final String state;
+  final String providerKey;
+  final DateTime? updatedAt;
+}
+
+class DevopsPipelineSummarySnapshot {
+  const DevopsPipelineSummarySnapshot({
+    required this.id,
+    required this.repositoryId,
+    required this.ref,
+    required this.state,
+    required this.providerKey,
+    required this.updatedAt,
+    required this.jobs,
+  });
+
+  final String id;
+  final String repositoryId;
+  final String ref;
+  final String state;
+  final String providerKey;
+  final DateTime? updatedAt;
+  final List<DevopsJobSummarySnapshot> jobs;
+}
+
+class DevopsJobSummarySnapshot {
+  const DevopsJobSummarySnapshot({
+    required this.id,
+    required this.name,
+    required this.state,
+    required this.startedAt,
+    required this.finishedAt,
+  });
+
+  final String id;
+  final String name;
+  final String state;
+  final DateTime? startedAt;
+  final DateTime? finishedAt;
+}
+
+class DevopsReleaseSummarySnapshot {
+  const DevopsReleaseSummarySnapshot({
+    required this.id,
+    required this.repositoryId,
+    required this.name,
+    required this.tagName,
+    required this.providerKey,
+    required this.releasedAt,
+  });
+
+  final String id;
+  final String repositoryId;
+  final String name;
+  final String tagName;
+  final String providerKey;
+  final DateTime? releasedAt;
 }
 
 class OfficeCapabilitiesSnapshot {
@@ -105,6 +258,10 @@ class OfficeCapabilitiesSnapshot {
     required this.defaultProvider,
     required this.providerReadiness,
     required this.supportedFileTypes,
+    required this.candidates,
+    required this.capabilities,
+    required this.permissions,
+    required this.lockSessionReadiness,
   });
 
   final String releaseStatus;
@@ -115,20 +272,144 @@ class OfficeCapabilitiesSnapshot {
   final String defaultProvider;
   final List<ProviderStatusSnapshot> providerReadiness;
   final List<String> supportedFileTypes;
+  final List<OfficeProviderCandidateSnapshot> candidates;
+  final OfficeCapabilityFlagsSnapshot capabilities;
+  final OfficePermissionModelSnapshot permissions;
+  final OfficeLockSessionReadinessSnapshot lockSessionReadiness;
 
-  bool get launchAvailable => enabled && configured && launchMode != 'disabled';
+  bool get launchAvailable =>
+      enabled &&
+      configured &&
+      launchMode != 'disabled' &&
+      launchMode != 'unavailable';
+
+  bool get launchFailClosed =>
+      !launchAvailable ||
+      providerReadiness.any((provider) => provider.failClosed);
+}
+
+class OfficeProviderCandidateSnapshot {
+  const OfficeProviderCandidateSnapshot({
+    required this.providerKey,
+    required this.displayName,
+    required this.defaultCandidate,
+    required this.runtimeFit,
+    required this.licensingPosture,
+    required this.integrationPath,
+    required this.notes,
+  });
+
+  final String providerKey;
+  final String displayName;
+  final bool defaultCandidate;
+  final String runtimeFit;
+  final String licensingPosture;
+  final String integrationPath;
+  final List<String> notes;
+}
+
+class OfficeCapabilityFlagsSnapshot {
+  const OfficeCapabilityFlagsSnapshot({
+    required this.view,
+    required this.edit,
+    required this.comment,
+    required this.review,
+    required this.formFill,
+  });
+
+  final bool view;
+  final bool edit;
+  final bool comment;
+  final bool review;
+  final bool formFill;
+
+  List<String> get enabledModes => <String>[
+    if (view) 'view',
+    if (edit) 'edit',
+    if (comment) 'comment',
+    if (review) 'review',
+    if (formFill) 'form-fill',
+  ];
+}
+
+class OfficePermissionModelSnapshot {
+  const OfficePermissionModelSnapshot({
+    required this.canView,
+    required this.canEdit,
+    required this.canComment,
+    required this.canReview,
+    required this.canFillForms,
+    required this.reason,
+  });
+
+  final bool canView;
+  final bool canEdit;
+  final bool canComment;
+  final bool canReview;
+  final bool canFillForms;
+  final String reason;
+}
+
+class OfficeLockSessionReadinessSnapshot {
+  const OfficeLockSessionReadinessSnapshot({
+    required this.documentLocks,
+    required this.sessionTokens,
+    required this.callbackVerification,
+    required this.supportSafe,
+  });
+
+  final String documentLocks;
+  final String sessionTokens;
+  final String callbackVerification;
+  final bool supportSafe;
 }
 
 class OfficeLaunchSnapshot {
-  const OfficeLaunchSnapshot({
-    required this.sessionId,
-    required this.launchMode,
-    required this.providerKey,
-    required this.grantedPermissions,
+  const OfficeLaunchSnapshot._({
+    required this.launched,
+    required this.failClosed,
+    this.sessionId,
+    this.launchMode,
+    this.providerKey,
+    this.grantedPermissions = const <String>[],
+    this.errorCode,
+    this.message,
+    this.requestId,
   });
 
-  final String sessionId;
-  final String launchMode;
-  final String providerKey;
+  const OfficeLaunchSnapshot.launched({
+    required String sessionId,
+    required String launchMode,
+    required String providerKey,
+    required List<String> grantedPermissions,
+  }) : this._(
+         launched: true,
+         failClosed: false,
+         sessionId: sessionId,
+         launchMode: launchMode,
+         providerKey: providerKey,
+         grantedPermissions: grantedPermissions,
+       );
+
+  const OfficeLaunchSnapshot.failClosed({
+    required String errorCode,
+    required String message,
+    String? requestId,
+  }) : this._(
+         launched: false,
+         failClosed: true,
+         errorCode: errorCode,
+         message: message,
+         requestId: requestId,
+       );
+
+  final bool launched;
+  final bool failClosed;
+  final String? sessionId;
+  final String? launchMode;
+  final String? providerKey;
   final List<String> grantedPermissions;
+  final String? errorCode;
+  final String? message;
+  final String? requestId;
 }

--- a/lib/features/app/domain/entities/provider_stack_snapshot.dart
+++ b/lib/features/app/domain/entities/provider_stack_snapshot.dart
@@ -1,0 +1,134 @@
+enum ProviderState {
+  disabled,
+  notConfigured,
+  configured,
+  ready,
+  degraded,
+  unsupported,
+  unknown,
+}
+
+class ProviderStackSnapshot {
+  const ProviderStackSnapshot({
+    required this.releaseStatus,
+    required this.backendOwnedFacades,
+    required this.flutterDirectProviderCallsAllowed,
+    required this.supportSafe,
+    required this.providers,
+  });
+
+  final String releaseStatus;
+  final bool backendOwnedFacades;
+  final bool flutterDirectProviderCallsAllowed;
+  final bool supportSafe;
+  final List<ProviderStatusSnapshot> providers;
+
+  bool get failClosed =>
+      backendOwnedFacades && !flutterDirectProviderCallsAllowed && supportSafe;
+
+  Iterable<ProviderStatusSnapshot> get unavailableProviders => providers.where(
+    (provider) =>
+        provider.failClosed &&
+        (provider.state == ProviderState.disabled ||
+            provider.state == ProviderState.notConfigured ||
+            provider.state == ProviderState.unsupported),
+  );
+}
+
+class ProviderStatusSnapshot {
+  const ProviderStatusSnapshot({
+    required this.module,
+    required this.providerKey,
+    required this.state,
+    required this.readiness,
+    required this.enabled,
+    required this.configured,
+    required this.readOnly,
+    required this.failClosed,
+    required this.supportSafe,
+    required this.paidFeaturesRequired,
+    required this.summary,
+    required this.supportedCapabilities,
+    required this.unsupportedOperations,
+    required this.supportSafeErrorCodes,
+    required this.redactionPolicy,
+    required this.candidates,
+  });
+
+  final String module;
+  final String providerKey;
+  final ProviderState state;
+  final String readiness;
+  final bool enabled;
+  final bool configured;
+  final bool readOnly;
+  final bool failClosed;
+  final bool supportSafe;
+  final bool paidFeaturesRequired;
+  final String summary;
+  final List<String> supportedCapabilities;
+  final List<String> unsupportedOperations;
+  final List<String> supportSafeErrorCodes;
+  final String redactionPolicy;
+  final List<String> candidates;
+
+  bool get available => enabled && configured && state == ProviderState.ready;
+}
+
+class DevopsProviderSummarySnapshot {
+  const DevopsProviderSummarySnapshot({
+    required this.workspaceId,
+    required this.channelId,
+    required this.releaseStatus,
+    required this.readOnly,
+    required this.paidFeaturesRequired,
+    required this.supportSafe,
+    required this.providerReadiness,
+  });
+
+  final String workspaceId;
+  final String channelId;
+  final String releaseStatus;
+  final bool readOnly;
+  final bool paidFeaturesRequired;
+  final bool supportSafe;
+  final List<ProviderStatusSnapshot> providerReadiness;
+}
+
+class OfficeCapabilitiesSnapshot {
+  const OfficeCapabilitiesSnapshot({
+    required this.releaseStatus,
+    required this.enabled,
+    required this.configured,
+    required this.supportSafe,
+    required this.launchMode,
+    required this.defaultProvider,
+    required this.providerReadiness,
+    required this.supportedFileTypes,
+  });
+
+  final String releaseStatus;
+  final bool enabled;
+  final bool configured;
+  final bool supportSafe;
+  final String launchMode;
+  final String defaultProvider;
+  final List<ProviderStatusSnapshot> providerReadiness;
+  final List<String> supportedFileTypes;
+
+  bool get launchAvailable => enabled && configured && launchMode != 'disabled';
+}
+
+class OfficeLaunchSnapshot {
+  const OfficeLaunchSnapshot({
+    required this.sessionId,
+    required this.launchMode,
+    required this.providerKey,
+    required this.grantedPermissions,
+  });
+
+  final String sessionId;
+  final String launchMode;
+  final String providerKey;
+  final List<String> grantedPermissions;
+}

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -832,6 +832,9 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
     final backendState = ref.watch(weaveBackendConnectionStateProvider);
     final matrixDiagnostic = ref.watch(weaveApiMatrixE2eeDiagnosticProvider);
     final providerStack = ref.watch(weaveApiProviderStackSnapshotProvider);
+    final officeCapabilities = ref.watch(
+      weaveApiOfficeCapabilitiesSnapshotProvider,
+    );
 
     return Card(
       elevation: 0,
@@ -881,7 +884,10 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                 ),
                 if (providerStack.asData?.value case final stack?) ...[
                   const SizedBox(height: 20),
-                  _ProviderStackReadinessSummary(stack: stack),
+                  _ProviderStackReadinessSummary(
+                    stack: stack,
+                    officeCapabilities: officeCapabilities.asData?.value,
+                  ),
                 ],
                 const SizedBox(height: 20),
                 _WorkspaceReadinessRow(
@@ -972,9 +978,13 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
 }
 
 class _ProviderStackReadinessSummary extends StatelessWidget {
-  const _ProviderStackReadinessSummary({required this.stack});
+  const _ProviderStackReadinessSummary({
+    required this.stack,
+    this.officeCapabilities,
+  });
 
   final ProviderStackSnapshot stack;
+  final OfficeCapabilitiesSnapshot? officeCapabilities;
 
   @override
   Widget build(BuildContext context) {
@@ -1029,14 +1039,39 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
                   ),
                 ],
               ),
+              if (officeCapabilities case final office?) ...[
+                const SizedBox(height: 12),
+                _OfficeProviderReadinessSummary(office: office),
+              ],
               if (providers.isNotEmpty) ...[
                 const SizedBox(height: 12),
                 for (final provider in providers)
                   Padding(
                     padding: const EdgeInsets.only(top: 6),
-                    child: Text(
-                      '${provider.module}: ${_providerStateLabel(provider.state)} — ${provider.summary}',
-                      style: theme.textTheme.bodySmall,
+                    child: Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Text(
+                          '${_providerModuleLabel(provider.module)}: ${_providerStateLabel(provider.state)}',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        if (provider.disabled)
+                          const _CompactStatusBadge(label: 'disabled'),
+                        if (provider.unconfigured)
+                          const _CompactStatusBadge(label: 'unconfigured'),
+                        if (provider.failClosed)
+                          const _CompactStatusBadge(label: 'fail-closed'),
+                        if (provider.readOnly)
+                          const _CompactStatusBadge(label: 'read-only'),
+                        if (provider.paidFeaturesRequired)
+                          const _CompactStatusBadge(
+                            label: 'paid features required',
+                          ),
+                      ],
                     ),
                   ),
               ],
@@ -1045,6 +1080,23 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String _providerModuleLabel(String module) {
+    return switch (module) {
+      'identity-realm' => 'Identity realm',
+      'source-control' => 'Source control',
+      'issue-tracker' => 'Issue tracker',
+      'ci' => 'CI',
+      'release' => 'Release',
+      'office' => 'Office',
+      'files' => 'Files',
+      'calendar' => 'Calendar',
+      'contacts' => 'Contacts',
+      'forms' => 'Forms',
+      'boards' => 'Boards',
+      _ => 'Provider',
+    };
   }
 
   String _providerStateLabel(ProviderState state) {
@@ -1057,6 +1109,79 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
       ProviderState.unsupported => 'unsupported',
       ProviderState.unknown => 'unknown',
     };
+  }
+}
+
+class _OfficeProviderReadinessSummary extends StatelessWidget {
+  const _OfficeProviderReadinessSummary({required this.office});
+
+  final OfficeCapabilitiesSnapshot office;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final enabledModes = office.capabilities.enabledModes;
+
+    return Semantics(
+      container: true,
+      label:
+          'Office readiness. Launch is ${office.launchFailClosed ? 'fail-closed' : 'available'}. Provider is ${office.configured ? 'configured' : 'unconfigured'}.',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Office readiness', style: theme.textTheme.titleSmall),
+          const SizedBox(height: 6),
+          Text(
+            office.launchFailClosed
+                ? 'Office launch is fail-closed until a backend-owned provider adapter, session tokens, callbacks and permissions are configured.'
+                : 'Office launch is available through the backend facade.',
+            style: theme.textTheme.bodySmall,
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _CompactStatusBadge(
+                label: office.enabled ? 'enabled' : 'disabled',
+              ),
+              _CompactStatusBadge(
+                label: office.configured ? 'configured' : 'unconfigured',
+              ),
+              if (office.launchFailClosed)
+                const _CompactStatusBadge(label: 'fail-closed'),
+              _CompactStatusBadge(
+                label: enabledModes.isEmpty
+                    ? 'no launch modes'
+                    : 'modes: ${enabledModes.join(', ')}',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CompactStatusBadge extends StatelessWidget {
+  const _CompactStatusBadge({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        child: Text(label, style: theme.textTheme.labelSmall),
+      ),
+    );
   }
 }
 

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -874,6 +874,11 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                       ref.invalidate(
                         weaveApiWorkspaceCapabilitySnapshotProvider,
                       );
+                      ref.invalidate(weaveApiMatrixE2eeDiagnosticProvider);
+                      ref.invalidate(weaveApiProviderStackSnapshotProvider);
+                      ref.invalidate(
+                        weaveApiOfficeCapabilitiesSnapshotProvider,
+                      );
                     },
                   ),
                 ],
@@ -926,6 +931,10 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
               ref.invalidate(appAuthIntegrationConnectionProvider);
               ref.invalidate(matrixIntegrationConnectionProvider);
               ref.invalidate(nextcloudIntegrationConnectionProvider);
+              ref.invalidate(weaveApiWorkspaceCapabilitySnapshotProvider);
+              ref.invalidate(weaveApiMatrixE2eeDiagnosticProvider);
+              ref.invalidate(weaveApiProviderStackSnapshotProvider);
+              ref.invalidate(weaveApiOfficeCapabilitiesSnapshotProvider);
             },
           ),
           _ => LoadingState(message: l10n.loadingLabel),
@@ -988,14 +997,22 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final providers = stack.providers.take(6).toList(growable: false);
+    final flutterCalls = stack.flutterDirectProviderCallsAllowed
+        ? l10n.settingsProviderStackFlutterCallsAllowed
+        : l10n.settingsProviderStackFlutterCallsBlocked;
 
     return Semantics(
       container: true,
       explicitChildNodes: true,
-      label:
-          'Provider stack readiness. Backend-owned facades: ${stack.backendOwnedFacades ? 'yes' : 'no'}. Flutter direct provider calls: ${stack.flutterDirectProviderCallsAllowed ? 'allowed' : 'blocked'}.',
+      label: l10n.settingsProviderStackSemanticLabel(
+        stack.backendOwnedFacades
+            ? l10n.settingsProviderStackYes
+            : l10n.settingsProviderStackNo,
+        flutterCalls,
+      ),
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.22),
@@ -1008,14 +1025,14 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                'Provider stack readiness',
+                l10n.settingsProviderStackTitle,
                 style: theme.textTheme.titleMedium,
               ),
               const SizedBox(height: 6),
               Text(
                 stack.failClosed
-                    ? 'Provider access is backend-owned and fail-closed; Flutter never calls GitLab, Forgejo, Nextcloud, ONLYOFFICE or Keycloak directly.'
-                    : 'Provider stack needs review before enabling provider-backed features.',
+                    ? l10n.settingsProviderStackFailClosedDescription
+                    : l10n.settingsProviderStackNeedsReviewDescription,
                 style: theme.textTheme.bodyMedium,
               ),
               const SizedBox(height: 12),
@@ -1024,18 +1041,22 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
                 runSpacing: 8,
                 children: [
                   _StatusPill(
-                    label: 'Backend facades',
-                    value: stack.backendOwnedFacades ? 'Owned' : 'Missing',
+                    label: l10n.settingsProviderStackBackendFacadesLabel,
+                    value: stack.backendOwnedFacades
+                        ? l10n.settingsProviderStackOwned
+                        : l10n.settingsProviderStackMissing,
                   ),
                   _StatusPill(
-                    label: 'Flutter provider calls',
+                    label: l10n.settingsProviderStackFlutterCallsLabel,
                     value: stack.flutterDirectProviderCallsAllowed
-                        ? 'Needs review'
-                        : 'Blocked',
+                        ? l10n.settingsProviderStackNeedsReview
+                        : l10n.settingsProviderStackBlocked,
                   ),
                   _StatusPill(
-                    label: 'Support safety',
-                    value: stack.supportSafe ? 'Redacted' : 'Needs review',
+                    label: l10n.settingsProviderStackSupportSafetyLabel,
+                    value: stack.supportSafe
+                        ? l10n.settingsProviderStackRedacted
+                        : l10n.settingsProviderStackNeedsReview,
                   ),
                 ],
               ),
@@ -1054,22 +1075,31 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
                       crossAxisAlignment: WrapCrossAlignment.center,
                       children: [
                         Text(
-                          '${_providerModuleLabel(provider.module)}: ${_providerStateLabel(provider.state)}',
+                          '${_providerModuleLabel(l10n, provider.module)}: ${_providerStateLabel(l10n, provider.state)}',
                           style: theme.textTheme.bodySmall?.copyWith(
                             fontWeight: FontWeight.w700,
                           ),
                         ),
                         if (provider.disabled)
-                          const _CompactStatusBadge(label: 'disabled'),
+                          _CompactStatusBadge(
+                            label: l10n.settingsProviderStateDisabled,
+                          ),
                         if (provider.unconfigured)
-                          const _CompactStatusBadge(label: 'unconfigured'),
+                          _CompactStatusBadge(
+                            label: l10n.settingsProviderStateNotConfigured,
+                          ),
                         if (provider.failClosed)
-                          const _CompactStatusBadge(label: 'fail-closed'),
+                          _CompactStatusBadge(
+                            label: l10n.settingsProviderStackFailClosedBadge,
+                          ),
                         if (provider.readOnly)
-                          const _CompactStatusBadge(label: 'read-only'),
+                          _CompactStatusBadge(
+                            label: l10n.settingsProviderStackReadOnlyBadge,
+                          ),
                         if (provider.paidFeaturesRequired)
-                          const _CompactStatusBadge(
-                            label: 'paid features required',
+                          _CompactStatusBadge(
+                            label: l10n
+                                .settingsProviderStackPaidFeaturesRequiredBadge,
                           ),
                       ],
                     ),
@@ -1082,32 +1112,32 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
     );
   }
 
-  String _providerModuleLabel(String module) {
+  String _providerModuleLabel(AppLocalizations l10n, String module) {
     return switch (module) {
-      'identity-realm' => 'Identity realm',
-      'source-control' => 'Source control',
-      'issue-tracker' => 'Issue tracker',
-      'ci' => 'CI',
-      'release' => 'Release',
-      'office' => 'Office',
-      'files' => 'Files',
-      'calendar' => 'Calendar',
-      'contacts' => 'Contacts',
-      'forms' => 'Forms',
-      'boards' => 'Boards',
-      _ => 'Provider',
+      'identity-realm' => l10n.settingsProviderModuleIdentityRealm,
+      'source-control' => l10n.settingsProviderModuleSourceControl,
+      'issue-tracker' => l10n.settingsProviderModuleIssueTracker,
+      'ci' => l10n.settingsProviderModuleCi,
+      'release' => l10n.settingsProviderModuleRelease,
+      'office' => l10n.settingsProviderModuleOffice,
+      'files' => l10n.settingsProviderModuleFiles,
+      'calendar' => l10n.settingsProviderModuleCalendar,
+      'contacts' => l10n.settingsProviderModuleContacts,
+      'forms' => l10n.settingsProviderModuleForms,
+      'boards' => l10n.settingsProviderModuleBoards,
+      _ => l10n.settingsProviderModuleProvider,
     };
   }
 
-  String _providerStateLabel(ProviderState state) {
+  String _providerStateLabel(AppLocalizations l10n, ProviderState state) {
     return switch (state) {
-      ProviderState.disabled => 'disabled',
-      ProviderState.notConfigured => 'not configured',
-      ProviderState.configured => 'configured',
-      ProviderState.ready => 'ready',
-      ProviderState.degraded => 'degraded',
-      ProviderState.unsupported => 'unsupported',
-      ProviderState.unknown => 'unknown',
+      ProviderState.disabled => l10n.settingsProviderStateDisabled,
+      ProviderState.notConfigured => l10n.settingsProviderStateNotConfigured,
+      ProviderState.configured => l10n.settingsProviderStateConfigured,
+      ProviderState.ready => l10n.settingsProviderStateReady,
+      ProviderState.degraded => l10n.settingsProviderStateDegraded,
+      ProviderState.unsupported => l10n.settingsProviderStateUnsupported,
+      ProviderState.unknown => l10n.settingsProviderStateUnknown,
     };
   }
 }
@@ -1119,22 +1149,32 @@ class _OfficeProviderReadinessSummary extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final enabledModes = office.capabilities.enabledModes;
 
     return Semantics(
       container: true,
-      label:
-          'Office readiness. Launch is ${office.launchFailClosed ? 'fail-closed' : 'available'}. Provider is ${office.configured ? 'configured' : 'unconfigured'}.',
+      label: l10n.settingsOfficeReadinessSemanticLabel(
+        office.launchFailClosed
+            ? l10n.settingsProviderStackFailClosedBadge
+            : l10n.settingsOfficeReadinessAvailable,
+        office.configured
+            ? l10n.settingsProviderStateConfigured
+            : l10n.settingsProviderStateNotConfigured,
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Office readiness', style: theme.textTheme.titleSmall),
+          Text(
+            l10n.settingsOfficeReadinessTitle,
+            style: theme.textTheme.titleSmall,
+          ),
           const SizedBox(height: 6),
           Text(
             office.launchFailClosed
-                ? 'Office launch is fail-closed until a backend-owned provider adapter, session tokens, callbacks and permissions are configured.'
-                : 'Office launch is available through the backend facade.',
+                ? l10n.settingsOfficeReadinessFailClosedDescription
+                : l10n.settingsOfficeReadinessAvailableDescription,
             style: theme.textTheme.bodySmall,
           ),
           const SizedBox(height: 8),
@@ -1143,17 +1183,25 @@ class _OfficeProviderReadinessSummary extends StatelessWidget {
             runSpacing: 8,
             children: [
               _CompactStatusBadge(
-                label: office.enabled ? 'enabled' : 'disabled',
+                label: office.enabled
+                    ? l10n.settingsOfficeReadinessEnabled
+                    : l10n.settingsProviderStateDisabled,
               ),
               _CompactStatusBadge(
-                label: office.configured ? 'configured' : 'unconfigured',
+                label: office.configured
+                    ? l10n.settingsProviderStateConfigured
+                    : l10n.settingsProviderStateNotConfigured,
               ),
               if (office.launchFailClosed)
-                const _CompactStatusBadge(label: 'fail-closed'),
+                _CompactStatusBadge(
+                  label: l10n.settingsProviderStackFailClosedBadge,
+                ),
               _CompactStatusBadge(
                 label: enabledModes.isEmpty
-                    ? 'no launch modes'
-                    : 'modes: ${enabledModes.join(', ')}',
+                    ? l10n.settingsOfficeReadinessNoLaunchModes
+                    : l10n.settingsOfficeReadinessModes(
+                        enabledModes.join(', '),
+                      ),
               ),
             ],
           ),

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -15,6 +15,7 @@ import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/core/widgets/weave_logo.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
 import 'package:weave/features/agents/presentation/providers/agent_capability_policy_provider.dart';
@@ -830,6 +831,7 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
     final capabilities = ref.watch(workspaceCapabilitySnapshotProvider);
     final backendState = ref.watch(weaveBackendConnectionStateProvider);
     final matrixDiagnostic = ref.watch(weaveApiMatrixE2eeDiagnosticProvider);
+    final providerStack = ref.watch(weaveApiProviderStackSnapshotProvider);
 
     return Card(
       elevation: 0,
@@ -877,6 +879,10 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                   _workspaceSummary(l10n, workspaceState),
                   style: theme.textTheme.bodyMedium,
                 ),
+                if (providerStack.asData?.value case final stack?) ...[
+                  const SizedBox(height: 20),
+                  _ProviderStackReadinessSummary(stack: stack),
+                ],
                 const SizedBox(height: 20),
                 _WorkspaceReadinessRow(
                   label: l10n.settingsWorkspaceShellAccessLabel,
@@ -961,6 +967,95 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
         l10n.settingsWorkspaceSummaryNeedsSignIn,
       IntegrationConnectionStatus.connected =>
         l10n.settingsWorkspaceSummaryConnected,
+    };
+  }
+}
+
+class _ProviderStackReadinessSummary extends StatelessWidget {
+  const _ProviderStackReadinessSummary({required this.stack});
+
+  final ProviderStackSnapshot stack;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final providers = stack.providers.take(6).toList(growable: false);
+
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      label:
+          'Provider stack readiness. Backend-owned facades: ${stack.backendOwnedFacades ? 'yes' : 'no'}. Flutter direct provider calls: ${stack.flutterDirectProviderCallsAllowed ? 'allowed' : 'blocked'}.',
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.22),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: theme.colorScheme.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Provider stack readiness',
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 6),
+              Text(
+                stack.failClosed
+                    ? 'Provider access is backend-owned and fail-closed; Flutter never calls GitLab, Forgejo, Nextcloud, ONLYOFFICE or Keycloak directly.'
+                    : 'Provider stack needs review before enabling provider-backed features.',
+                style: theme.textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _StatusPill(
+                    label: 'Backend facades',
+                    value: stack.backendOwnedFacades ? 'Owned' : 'Missing',
+                  ),
+                  _StatusPill(
+                    label: 'Flutter provider calls',
+                    value: stack.flutterDirectProviderCallsAllowed
+                        ? 'Needs review'
+                        : 'Blocked',
+                  ),
+                  _StatusPill(
+                    label: 'Support safety',
+                    value: stack.supportSafe ? 'Redacted' : 'Needs review',
+                  ),
+                ],
+              ),
+              if (providers.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                for (final provider in providers)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 6),
+                    child: Text(
+                      '${provider.module}: ${_providerStateLabel(provider.state)} — ${provider.summary}',
+                      style: theme.textTheme.bodySmall,
+                    ),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _providerStateLabel(ProviderState state) {
+    return switch (state) {
+      ProviderState.disabled => 'disabled',
+      ProviderState.notConfigured => 'not configured',
+      ProviderState.configured => 'configured',
+      ProviderState.ready => 'ready',
+      ProviderState.degraded => 'degraded',
+      ProviderState.unsupported => 'unsupported',
+      ProviderState.unknown => 'unknown',
     };
   }
 }

--- a/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
@@ -807,18 +807,15 @@ String _string(Object? value, {required String fallback}) {
 
 String _safeProviderKey(Object? value) {
   final key = _string(value, fallback: 'unknown');
-  return _containsSensitiveText(key) ? 'redacted-provider' : key;
+  return _containsSensitiveText(key) ? 'unknown' : key;
 }
 
 String _safeText(Object? value) {
   if (value is! String || value.trim().isEmpty) {
-    return 'Not reported by the Weave backend.';
+    return '';
   }
   final text = value.trim();
-  if (_containsSensitiveText(text)) {
-    return 'Support-safe details only; raw provider data was redacted.';
-  }
-  return text;
+  return _containsSensitiveText(text) ? '' : text;
 }
 
 bool _containsSensitiveText(String text) {
@@ -841,8 +838,7 @@ List<String> _safeStringList(Object? value) {
   return value
       .whereType<String>()
       .map((item) => item.trim())
-      .where((item) => item.isNotEmpty)
-      .map((item) => _containsSensitiveText(item) ? 'redacted' : item)
+      .where((item) => item.isNotEmpty && !_containsSensitiveText(item))
       .toList(growable: false);
 }
 
@@ -850,14 +846,34 @@ Map<String, Object?> _safeDiagnostics(Object? value) {
   if (value is! Map<String, dynamic>) {
     return const <String, Object?>{};
   }
-  return Map<String, Object?>.unmodifiable(
-    value.map(
-      (key, item) => MapEntry(
-        _containsSensitiveText(key) ? 'redacted' : key,
-        item is String && _containsSensitiveText(item) ? 'redacted' : item,
-      ),
-    ),
-  );
+
+  final sanitized = <String, Object?>{};
+  for (final entry in value.entries) {
+    if (_containsSensitiveText(entry.key)) {
+      continue;
+    }
+    final safeValue = _safeDiagnosticValue(entry.value);
+    if (safeValue != null) {
+      sanitized[entry.key] = safeValue;
+    }
+  }
+
+  return Map<String, Object?>.unmodifiable(sanitized);
+}
+
+Object? _safeDiagnosticValue(Object? value) {
+  return switch (value) {
+    String text when text.trim().isNotEmpty && !_containsSensitiveText(text) =>
+      text.trim(),
+    bool value => value,
+    num value => value,
+    List value => [
+      for (final item in value)
+        if (_safeDiagnosticValue(item) case final safeItem?) safeItem,
+    ],
+    Map<String, dynamic> value => _safeDiagnostics(value),
+    _ => null,
+  };
 }
 
 List<Map<String, dynamic>> _listOfMaps(Object? value) {

--- a/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
@@ -1,0 +1,301 @@
+import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
+
+class ProviderRegistryResponseDto {
+  const ProviderRegistryResponseDto({
+    required this.releaseStatus,
+    required this.backendOwnedFacades,
+    required this.flutterDirectProviderCallsAllowed,
+    required this.supportSafe,
+    required this.providers,
+  });
+
+  factory ProviderRegistryResponseDto.fromJson(Map<String, dynamic> json) {
+    return ProviderRegistryResponseDto(
+      releaseStatus: _string(json['releaseStatus'], fallback: 'unknown'),
+      backendOwnedFacades: _bool(json['backendOwnedFacades']),
+      flutterDirectProviderCallsAllowed: _bool(
+        json['flutterDirectProviderCallsAllowed'],
+      ),
+      supportSafe: _bool(json['supportSafe']),
+      providers: _listOfMaps(
+        json['providers'],
+      ).map(ProviderStatusResponseDto.fromJson).toList(growable: false),
+    );
+  }
+
+  final String releaseStatus;
+  final bool backendOwnedFacades;
+  final bool flutterDirectProviderCallsAllowed;
+  final bool supportSafe;
+  final List<ProviderStatusResponseDto> providers;
+
+  ProviderStackSnapshot toSnapshot() => ProviderStackSnapshot(
+    releaseStatus: releaseStatus,
+    backendOwnedFacades: backendOwnedFacades,
+    flutterDirectProviderCallsAllowed: flutterDirectProviderCallsAllowed,
+    supportSafe: supportSafe,
+    providers: providers.map((provider) => provider.toSnapshot()).toList(),
+  );
+}
+
+class ProviderStatusResponseDto {
+  const ProviderStatusResponseDto({
+    required this.module,
+    required this.providerKey,
+    required this.state,
+    required this.readiness,
+    required this.enabled,
+    required this.configured,
+    required this.readOnly,
+    required this.failClosed,
+    required this.supportSafe,
+    required this.paidFeaturesRequired,
+    required this.summary,
+    required this.supportedCapabilities,
+    required this.unsupportedOperations,
+    required this.supportSafeErrorCodes,
+    required this.redactionPolicy,
+    required this.candidates,
+  });
+
+  factory ProviderStatusResponseDto.fromJson(Map<String, dynamic> json) {
+    return ProviderStatusResponseDto(
+      module: _string(json['module'], fallback: 'unknown'),
+      providerKey: _string(json['providerKey'], fallback: 'unknown'),
+      state: _providerState(_string(json['state'], fallback: 'unknown')),
+      readiness: _string(json['readiness'], fallback: 'unknown'),
+      enabled: _bool(json['enabled']),
+      configured: _bool(json['configured']),
+      readOnly: _bool(json['readOnly']),
+      failClosed: _bool(json['failClosed']),
+      supportSafe: _bool(json['supportSafe']),
+      paidFeaturesRequired: _bool(json['paidFeaturesRequired']),
+      summary: _safeText(json['summary']),
+      supportedCapabilities: _stringList(json['supportedCapabilities']),
+      unsupportedOperations: _stringList(json['unsupportedOperations']),
+      supportSafeErrorCodes: _stringList(json['supportSafeErrorCodes']),
+      redactionPolicy: _safeText(json['redactionPolicy']),
+      candidates: _stringList(json['candidates']),
+    );
+  }
+
+  final String module;
+  final String providerKey;
+  final ProviderState state;
+  final String readiness;
+  final bool enabled;
+  final bool configured;
+  final bool readOnly;
+  final bool failClosed;
+  final bool supportSafe;
+  final bool paidFeaturesRequired;
+  final String summary;
+  final List<String> supportedCapabilities;
+  final List<String> unsupportedOperations;
+  final List<String> supportSafeErrorCodes;
+  final String redactionPolicy;
+  final List<String> candidates;
+
+  ProviderStatusSnapshot toSnapshot() => ProviderStatusSnapshot(
+    module: module,
+    providerKey: providerKey,
+    state: state,
+    readiness: readiness,
+    enabled: enabled,
+    configured: configured,
+    readOnly: readOnly,
+    failClosed: failClosed,
+    supportSafe: supportSafe,
+    paidFeaturesRequired: paidFeaturesRequired,
+    summary: summary,
+    supportedCapabilities: supportedCapabilities,
+    unsupportedOperations: unsupportedOperations,
+    supportSafeErrorCodes: supportSafeErrorCodes,
+    redactionPolicy: redactionPolicy,
+    candidates: candidates,
+  );
+}
+
+class DevopsSummaryResponseDto {
+  const DevopsSummaryResponseDto({
+    required this.workspaceId,
+    required this.channelId,
+    required this.releaseStatus,
+    required this.readOnly,
+    required this.paidFeaturesRequired,
+    required this.supportSafe,
+    required this.providerReadiness,
+  });
+
+  factory DevopsSummaryResponseDto.fromJson(Map<String, dynamic> json) {
+    return DevopsSummaryResponseDto(
+      workspaceId: _string(json['workspaceId'], fallback: 'unknown'),
+      channelId: _string(json['channelId'], fallback: 'unknown'),
+      releaseStatus: _string(json['releaseStatus'], fallback: 'unknown'),
+      readOnly: _bool(json['readOnly']),
+      paidFeaturesRequired: _bool(json['paidFeaturesRequired']),
+      supportSafe: _bool(json['supportSafe']),
+      providerReadiness: _listOfMaps(
+        json['providerReadiness'],
+      ).map(ProviderStatusResponseDto.fromJson).toList(growable: false),
+    );
+  }
+
+  final String workspaceId;
+  final String channelId;
+  final String releaseStatus;
+  final bool readOnly;
+  final bool paidFeaturesRequired;
+  final bool supportSafe;
+  final List<ProviderStatusResponseDto> providerReadiness;
+
+  DevopsProviderSummarySnapshot toSnapshot() => DevopsProviderSummarySnapshot(
+    workspaceId: workspaceId,
+    channelId: channelId,
+    releaseStatus: releaseStatus,
+    readOnly: readOnly,
+    paidFeaturesRequired: paidFeaturesRequired,
+    supportSafe: supportSafe,
+    providerReadiness: providerReadiness
+        .map((provider) => provider.toSnapshot())
+        .toList(growable: false),
+  );
+}
+
+class OfficeCapabilitiesResponseDto {
+  const OfficeCapabilitiesResponseDto({
+    required this.releaseStatus,
+    required this.enabled,
+    required this.configured,
+    required this.supportSafe,
+    required this.launchMode,
+    required this.defaultProvider,
+    required this.providerReadiness,
+    required this.supportedFileTypes,
+  });
+
+  factory OfficeCapabilitiesResponseDto.fromJson(Map<String, dynamic> json) {
+    return OfficeCapabilitiesResponseDto(
+      releaseStatus: _string(json['releaseStatus'], fallback: 'unknown'),
+      enabled: _bool(json['enabled']),
+      configured: _bool(json['configured']),
+      supportSafe: _bool(json['supportSafe']),
+      launchMode: _string(json['launchMode'], fallback: 'disabled'),
+      defaultProvider: _string(json['defaultProvider'], fallback: 'none'),
+      providerReadiness: _listOfMaps(
+        json['providerReadiness'],
+      ).map(ProviderStatusResponseDto.fromJson).toList(growable: false),
+      supportedFileTypes: _stringList(json['supportedFileTypes']),
+    );
+  }
+
+  final String releaseStatus;
+  final bool enabled;
+  final bool configured;
+  final bool supportSafe;
+  final String launchMode;
+  final String defaultProvider;
+  final List<ProviderStatusResponseDto> providerReadiness;
+  final List<String> supportedFileTypes;
+
+  OfficeCapabilitiesSnapshot toSnapshot() => OfficeCapabilitiesSnapshot(
+    releaseStatus: releaseStatus,
+    enabled: enabled,
+    configured: configured,
+    supportSafe: supportSafe,
+    launchMode: launchMode,
+    defaultProvider: defaultProvider,
+    providerReadiness: providerReadiness
+        .map((provider) => provider.toSnapshot())
+        .toList(growable: false),
+    supportedFileTypes: supportedFileTypes,
+  );
+}
+
+class OfficeLaunchResponseDto {
+  const OfficeLaunchResponseDto({
+    required this.sessionId,
+    required this.launchMode,
+    required this.providerKey,
+    required this.grantedPermissions,
+  });
+
+  factory OfficeLaunchResponseDto.fromJson(Map<String, dynamic> json) {
+    return OfficeLaunchResponseDto(
+      sessionId: _string(json['sessionId'], fallback: ''),
+      launchMode: _string(json['launchMode'], fallback: 'disabled'),
+      providerKey: _string(json['providerKey'], fallback: 'none'),
+      grantedPermissions: _stringList(json['grantedPermissions']),
+    );
+  }
+
+  final String sessionId;
+  final String launchMode;
+  final String providerKey;
+  final List<String> grantedPermissions;
+
+  OfficeLaunchSnapshot toSnapshot() => OfficeLaunchSnapshot(
+    sessionId: sessionId,
+    launchMode: launchMode,
+    providerKey: providerKey,
+    grantedPermissions: grantedPermissions,
+  );
+}
+
+ProviderState _providerState(String value) {
+  return switch (value) {
+    'disabled' => ProviderState.disabled,
+    'not_configured' => ProviderState.notConfigured,
+    'configured' => ProviderState.configured,
+    'ready' => ProviderState.ready,
+    'degraded' => ProviderState.degraded,
+    'unsupported' => ProviderState.unsupported,
+    _ => ProviderState.unknown,
+  };
+}
+
+String _string(Object? value, {required String fallback}) {
+  if (value is String && value.trim().isNotEmpty) {
+    return value.trim();
+  }
+  return fallback;
+}
+
+String _safeText(Object? value) {
+  if (value is! String || value.trim().isEmpty) {
+    return 'Not reported by the Weave backend.';
+  }
+  final text = value.trim();
+  final lower = text.toLowerCase();
+  if (lower.contains('token') ||
+      lower.contains('secret') ||
+      lower.contains('password') ||
+      lower.contains('authorization:') ||
+      lower.contains('http://') ||
+      lower.contains('https://')) {
+    return 'Support-safe details only; raw provider data was redacted.';
+  }
+  return text;
+}
+
+bool _bool(Object? value) => value == true;
+
+List<String> _stringList(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value
+      .whereType<String>()
+      .map((item) => item.trim())
+      .where((item) {
+        return item.isNotEmpty;
+      })
+      .toList(growable: false);
+}
+
+List<Map<String, dynamic>> _listOfMaps(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value.whereType<Map<String, dynamic>>().toList(growable: false);
+}

--- a/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
@@ -732,6 +732,7 @@ class OfficeLaunchResponseDto {
     required this.launchMode,
     required this.providerKey,
     required this.grantedPermissions,
+    required this.expiresAt,
   });
 
   factory OfficeLaunchResponseDto.fromJson(Map<String, dynamic> json) {
@@ -740,6 +741,7 @@ class OfficeLaunchResponseDto {
       launchMode: _string(json['launchMode'], fallback: 'disabled'),
       providerKey: _safeProviderKey(json['providerKey']),
       grantedPermissions: _safeStringList(json['grantedPermissions']),
+      expiresAt: _dateTime(json['expiresAt']),
     );
   }
 
@@ -747,12 +749,14 @@ class OfficeLaunchResponseDto {
   final String launchMode;
   final String providerKey;
   final List<String> grantedPermissions;
+  final DateTime? expiresAt;
 
   OfficeLaunchSnapshot toSnapshot() => OfficeLaunchSnapshot.launched(
     sessionId: sessionId,
     launchMode: launchMode,
     providerKey: providerKey,
     grantedPermissions: grantedPermissions,
+    expiresAt: expiresAt,
   );
 }
 

--- a/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
@@ -6,6 +6,7 @@ class ProviderRegistryResponseDto {
     required this.backendOwnedFacades,
     required this.flutterDirectProviderCallsAllowed,
     required this.supportSafe,
+    required this.generatedAt,
     required this.providers,
   });
 
@@ -17,6 +18,7 @@ class ProviderRegistryResponseDto {
         json['flutterDirectProviderCallsAllowed'],
       ),
       supportSafe: _bool(json['supportSafe']),
+      generatedAt: _dateTime(json['generatedAt']),
       providers: _listOfMaps(
         json['providers'],
       ).map(ProviderStatusResponseDto.fromJson).toList(growable: false),
@@ -27,6 +29,7 @@ class ProviderRegistryResponseDto {
   final bool backendOwnedFacades;
   final bool flutterDirectProviderCallsAllowed;
   final bool supportSafe;
+  final DateTime? generatedAt;
   final List<ProviderStatusResponseDto> providers;
 
   ProviderStackSnapshot toSnapshot() => ProviderStackSnapshot(
@@ -34,6 +37,7 @@ class ProviderRegistryResponseDto {
     backendOwnedFacades: backendOwnedFacades,
     flutterDirectProviderCallsAllowed: flutterDirectProviderCallsAllowed,
     supportSafe: supportSafe,
+    generatedAt: generatedAt,
     providers: providers.map((provider) => provider.toSnapshot()).toList(),
   );
 }
@@ -56,12 +60,13 @@ class ProviderStatusResponseDto {
     required this.supportSafeErrorCodes,
     required this.redactionPolicy,
     required this.candidates,
+    required this.diagnostics,
   });
 
   factory ProviderStatusResponseDto.fromJson(Map<String, dynamic> json) {
     return ProviderStatusResponseDto(
       module: _string(json['module'], fallback: 'unknown'),
-      providerKey: _string(json['providerKey'], fallback: 'unknown'),
+      providerKey: _safeProviderKey(json['providerKey']),
       state: _providerState(_string(json['state'], fallback: 'unknown')),
       readiness: _string(json['readiness'], fallback: 'unknown'),
       enabled: _bool(json['enabled']),
@@ -71,11 +76,12 @@ class ProviderStatusResponseDto {
       supportSafe: _bool(json['supportSafe']),
       paidFeaturesRequired: _bool(json['paidFeaturesRequired']),
       summary: _safeText(json['summary']),
-      supportedCapabilities: _stringList(json['supportedCapabilities']),
-      unsupportedOperations: _stringList(json['unsupportedOperations']),
-      supportSafeErrorCodes: _stringList(json['supportSafeErrorCodes']),
+      supportedCapabilities: _safeStringList(json['supportedCapabilities']),
+      unsupportedOperations: _safeStringList(json['unsupportedOperations']),
+      supportSafeErrorCodes: _safeStringList(json['supportSafeErrorCodes']),
       redactionPolicy: _safeText(json['redactionPolicy']),
-      candidates: _stringList(json['candidates']),
+      candidates: _safeStringList(json['candidates']),
+      diagnostics: _safeDiagnostics(json['diagnostics']),
     );
   }
 
@@ -95,6 +101,7 @@ class ProviderStatusResponseDto {
   final List<String> supportSafeErrorCodes;
   final String redactionPolicy;
   final List<String> candidates;
+  final Map<String, Object?> diagnostics;
 
   ProviderStatusSnapshot toSnapshot() => ProviderStatusSnapshot(
     module: module,
@@ -113,6 +120,7 @@ class ProviderStatusResponseDto {
     supportSafeErrorCodes: supportSafeErrorCodes,
     redactionPolicy: redactionPolicy,
     candidates: candidates,
+    diagnostics: diagnostics,
   );
 }
 
@@ -125,6 +133,12 @@ class DevopsSummaryResponseDto {
     required this.paidFeaturesRequired,
     required this.supportSafe,
     required this.providerReadiness,
+    required this.linkedProjects,
+    required this.repositories,
+    required this.openIssues,
+    required this.mergeRequests,
+    required this.pipelines,
+    required this.releases,
   });
 
   factory DevopsSummaryResponseDto.fromJson(Map<String, dynamic> json) {
@@ -138,6 +152,24 @@ class DevopsSummaryResponseDto {
       providerReadiness: _listOfMaps(
         json['providerReadiness'],
       ).map(ProviderStatusResponseDto.fromJson).toList(growable: false),
+      linkedProjects: _listOfMaps(
+        json['linkedProjects'],
+      ).map(LinkedSourceProjectResponseDto.fromJson).toList(growable: false),
+      repositories: _listOfMaps(
+        json['repositories'],
+      ).map(SourceRepositoryResponseDto.fromJson).toList(growable: false),
+      openIssues: _listOfMaps(
+        json['openIssues'],
+      ).map(DevopsIssueSummaryResponseDto.fromJson).toList(growable: false),
+      mergeRequests: _listOfMaps(json['mergeRequests'])
+          .map(DevopsMergeRequestSummaryResponseDto.fromJson)
+          .toList(growable: false),
+      pipelines: _listOfMaps(
+        json['pipelines'],
+      ).map(DevopsPipelineSummaryResponseDto.fromJson).toList(growable: false),
+      releases: _listOfMaps(
+        json['releases'],
+      ).map(DevopsReleaseSummaryResponseDto.fromJson).toList(growable: false),
     );
   }
 
@@ -148,6 +180,12 @@ class DevopsSummaryResponseDto {
   final bool paidFeaturesRequired;
   final bool supportSafe;
   final List<ProviderStatusResponseDto> providerReadiness;
+  final List<LinkedSourceProjectResponseDto> linkedProjects;
+  final List<SourceRepositoryResponseDto> repositories;
+  final List<DevopsIssueSummaryResponseDto> openIssues;
+  final List<DevopsMergeRequestSummaryResponseDto> mergeRequests;
+  final List<DevopsPipelineSummaryResponseDto> pipelines;
+  final List<DevopsReleaseSummaryResponseDto> releases;
 
   DevopsProviderSummarySnapshot toSnapshot() => DevopsProviderSummarySnapshot(
     workspaceId: workspaceId,
@@ -159,6 +197,303 @@ class DevopsSummaryResponseDto {
     providerReadiness: providerReadiness
         .map((provider) => provider.toSnapshot())
         .toList(growable: false),
+    linkedProjects: linkedProjects
+        .map((project) => project.toSnapshot())
+        .toList(growable: false),
+    repositories: repositories
+        .map((repository) => repository.toSnapshot())
+        .toList(growable: false),
+    openIssues: openIssues
+        .map((issue) => issue.toSnapshot())
+        .toList(growable: false),
+    mergeRequests: mergeRequests
+        .map((mergeRequest) => mergeRequest.toSnapshot())
+        .toList(growable: false),
+    pipelines: pipelines
+        .map((pipeline) => pipeline.toSnapshot())
+        .toList(growable: false),
+    releases: releases
+        .map((release) => release.toSnapshot())
+        .toList(growable: false),
+  );
+}
+
+class LinkedSourceProjectResponseDto {
+  const LinkedSourceProjectResponseDto({
+    required this.id,
+    required this.displayName,
+    required this.providerKey,
+    required this.visibility,
+    required this.repositoryIds,
+  });
+
+  factory LinkedSourceProjectResponseDto.fromJson(Map<String, dynamic> json) {
+    return LinkedSourceProjectResponseDto(
+      id: _string(json['id'], fallback: 'unknown'),
+      displayName: _safeText(json['displayName']),
+      providerKey: _safeProviderKey(json['providerKey']),
+      visibility: _string(json['visibility'], fallback: 'unknown'),
+      repositoryIds: _safeStringList(json['repositoryIds']),
+    );
+  }
+
+  final String id;
+  final String displayName;
+  final String providerKey;
+  final String visibility;
+  final List<String> repositoryIds;
+
+  LinkedSourceProjectSnapshot toSnapshot() => LinkedSourceProjectSnapshot(
+    id: id,
+    displayName: displayName,
+    providerKey: providerKey,
+    visibility: visibility,
+    repositoryIds: repositoryIds,
+  );
+}
+
+class SourceRepositoryResponseDto {
+  const SourceRepositoryResponseDto({
+    required this.id,
+    required this.projectId,
+    required this.displayName,
+    required this.defaultBranch,
+    required this.providerKey,
+    required this.archived,
+  });
+
+  factory SourceRepositoryResponseDto.fromJson(Map<String, dynamic> json) {
+    return SourceRepositoryResponseDto(
+      id: _string(json['id'], fallback: 'unknown'),
+      projectId: _string(json['projectId'], fallback: 'unknown'),
+      displayName: _safeText(json['displayName']),
+      defaultBranch: _string(json['defaultBranch'], fallback: 'unknown'),
+      providerKey: _safeProviderKey(json['providerKey']),
+      archived: _bool(json['archived']),
+    );
+  }
+
+  final String id;
+  final String projectId;
+  final String displayName;
+  final String defaultBranch;
+  final String providerKey;
+  final bool archived;
+
+  SourceRepositorySnapshot toSnapshot() => SourceRepositorySnapshot(
+    id: id,
+    projectId: projectId,
+    displayName: displayName,
+    defaultBranch: defaultBranch,
+    providerKey: providerKey,
+    archived: archived,
+  );
+}
+
+class DevopsIssueSummaryResponseDto {
+  const DevopsIssueSummaryResponseDto({
+    required this.id,
+    required this.projectId,
+    required this.title,
+    required this.state,
+    required this.providerKey,
+    required this.updatedAt,
+    required this.labels,
+  });
+
+  factory DevopsIssueSummaryResponseDto.fromJson(Map<String, dynamic> json) {
+    return DevopsIssueSummaryResponseDto(
+      id: _string(json['id'], fallback: 'unknown'),
+      projectId: _string(json['projectId'], fallback: 'unknown'),
+      title: _safeText(json['title']),
+      state: _string(json['state'], fallback: 'unknown'),
+      providerKey: _safeProviderKey(json['providerKey']),
+      updatedAt: _dateTime(json['updatedAt']),
+      labels: _safeStringList(json['labels']),
+    );
+  }
+
+  final String id;
+  final String projectId;
+  final String title;
+  final String state;
+  final String providerKey;
+  final DateTime? updatedAt;
+  final List<String> labels;
+
+  DevopsIssueSummarySnapshot toSnapshot() => DevopsIssueSummarySnapshot(
+    id: id,
+    projectId: projectId,
+    title: title,
+    state: state,
+    providerKey: providerKey,
+    updatedAt: updatedAt,
+    labels: labels,
+  );
+}
+
+class DevopsMergeRequestSummaryResponseDto {
+  const DevopsMergeRequestSummaryResponseDto({
+    required this.id,
+    required this.repositoryId,
+    required this.title,
+    required this.sourceBranch,
+    required this.targetBranch,
+    required this.state,
+    required this.providerKey,
+    required this.updatedAt,
+  });
+
+  factory DevopsMergeRequestSummaryResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return DevopsMergeRequestSummaryResponseDto(
+      id: _string(json['id'], fallback: 'unknown'),
+      repositoryId: _string(json['repositoryId'], fallback: 'unknown'),
+      title: _safeText(json['title']),
+      sourceBranch: _string(json['sourceBranch'], fallback: 'unknown'),
+      targetBranch: _string(json['targetBranch'], fallback: 'unknown'),
+      state: _string(json['state'], fallback: 'unknown'),
+      providerKey: _safeProviderKey(json['providerKey']),
+      updatedAt: _dateTime(json['updatedAt']),
+    );
+  }
+
+  final String id;
+  final String repositoryId;
+  final String title;
+  final String sourceBranch;
+  final String targetBranch;
+  final String state;
+  final String providerKey;
+  final DateTime? updatedAt;
+
+  DevopsMergeRequestSummarySnapshot toSnapshot() =>
+      DevopsMergeRequestSummarySnapshot(
+        id: id,
+        repositoryId: repositoryId,
+        title: title,
+        sourceBranch: sourceBranch,
+        targetBranch: targetBranch,
+        state: state,
+        providerKey: providerKey,
+        updatedAt: updatedAt,
+      );
+}
+
+class DevopsPipelineSummaryResponseDto {
+  const DevopsPipelineSummaryResponseDto({
+    required this.id,
+    required this.repositoryId,
+    required this.ref,
+    required this.state,
+    required this.providerKey,
+    required this.updatedAt,
+    required this.jobs,
+  });
+
+  factory DevopsPipelineSummaryResponseDto.fromJson(Map<String, dynamic> json) {
+    return DevopsPipelineSummaryResponseDto(
+      id: _string(json['id'], fallback: 'unknown'),
+      repositoryId: _string(json['repositoryId'], fallback: 'unknown'),
+      ref: _string(json['ref'], fallback: 'unknown'),
+      state: _string(json['state'], fallback: 'unknown'),
+      providerKey: _safeProviderKey(json['providerKey']),
+      updatedAt: _dateTime(json['updatedAt']),
+      jobs: _listOfMaps(
+        json['jobs'],
+      ).map(DevopsJobSummaryResponseDto.fromJson).toList(growable: false),
+    );
+  }
+
+  final String id;
+  final String repositoryId;
+  final String ref;
+  final String state;
+  final String providerKey;
+  final DateTime? updatedAt;
+  final List<DevopsJobSummaryResponseDto> jobs;
+
+  DevopsPipelineSummarySnapshot toSnapshot() => DevopsPipelineSummarySnapshot(
+    id: id,
+    repositoryId: repositoryId,
+    ref: ref,
+    state: state,
+    providerKey: providerKey,
+    updatedAt: updatedAt,
+    jobs: jobs.map((job) => job.toSnapshot()).toList(growable: false),
+  );
+}
+
+class DevopsJobSummaryResponseDto {
+  const DevopsJobSummaryResponseDto({
+    required this.id,
+    required this.name,
+    required this.state,
+    required this.startedAt,
+    required this.finishedAt,
+  });
+
+  factory DevopsJobSummaryResponseDto.fromJson(Map<String, dynamic> json) {
+    return DevopsJobSummaryResponseDto(
+      id: _string(json['id'], fallback: 'unknown'),
+      name: _safeText(json['name']),
+      state: _string(json['state'], fallback: 'unknown'),
+      startedAt: _dateTime(json['startedAt']),
+      finishedAt: _dateTime(json['finishedAt']),
+    );
+  }
+
+  final String id;
+  final String name;
+  final String state;
+  final DateTime? startedAt;
+  final DateTime? finishedAt;
+
+  DevopsJobSummarySnapshot toSnapshot() => DevopsJobSummarySnapshot(
+    id: id,
+    name: name,
+    state: state,
+    startedAt: startedAt,
+    finishedAt: finishedAt,
+  );
+}
+
+class DevopsReleaseSummaryResponseDto {
+  const DevopsReleaseSummaryResponseDto({
+    required this.id,
+    required this.repositoryId,
+    required this.name,
+    required this.tagName,
+    required this.providerKey,
+    required this.releasedAt,
+  });
+
+  factory DevopsReleaseSummaryResponseDto.fromJson(Map<String, dynamic> json) {
+    return DevopsReleaseSummaryResponseDto(
+      id: _string(json['id'], fallback: 'unknown'),
+      repositoryId: _string(json['repositoryId'], fallback: 'unknown'),
+      name: _safeText(json['name']),
+      tagName: _string(json['tagName'], fallback: 'unknown'),
+      providerKey: _safeProviderKey(json['providerKey']),
+      releasedAt: _dateTime(json['releasedAt']),
+    );
+  }
+
+  final String id;
+  final String repositoryId;
+  final String name;
+  final String tagName;
+  final String providerKey;
+  final DateTime? releasedAt;
+
+  DevopsReleaseSummarySnapshot toSnapshot() => DevopsReleaseSummarySnapshot(
+    id: id,
+    repositoryId: repositoryId,
+    name: name,
+    tagName: tagName,
+    providerKey: providerKey,
+    releasedAt: releasedAt,
   );
 }
 
@@ -172,6 +507,10 @@ class OfficeCapabilitiesResponseDto {
     required this.defaultProvider,
     required this.providerReadiness,
     required this.supportedFileTypes,
+    required this.candidates,
+    required this.capabilities,
+    required this.permissions,
+    required this.lockSessionReadiness,
   });
 
   factory OfficeCapabilitiesResponseDto.fromJson(Map<String, dynamic> json) {
@@ -181,11 +520,23 @@ class OfficeCapabilitiesResponseDto {
       configured: _bool(json['configured']),
       supportSafe: _bool(json['supportSafe']),
       launchMode: _string(json['launchMode'], fallback: 'disabled'),
-      defaultProvider: _string(json['defaultProvider'], fallback: 'none'),
+      defaultProvider: _safeProviderKey(json['defaultProvider']),
       providerReadiness: _listOfMaps(
         json['providerReadiness'],
       ).map(ProviderStatusResponseDto.fromJson).toList(growable: false),
-      supportedFileTypes: _stringList(json['supportedFileTypes']),
+      supportedFileTypes: _safeStringList(json['supportedFileTypes']),
+      candidates: _listOfMaps(json['candidates'])
+          .map(OfficeProviderCandidateResponseDto.fromJson)
+          .toList(growable: false),
+      capabilities: OfficeCapabilityFlagsResponseDto.fromJson(
+        _map(json['capabilities']),
+      ),
+      permissions: OfficePermissionModelResponseDto.fromJson(
+        _map(json['permissions']),
+      ),
+      lockSessionReadiness: OfficeLockSessionReadinessResponseDto.fromJson(
+        _map(json['lockSessionReadiness']),
+      ),
     );
   }
 
@@ -197,6 +548,10 @@ class OfficeCapabilitiesResponseDto {
   final String defaultProvider;
   final List<ProviderStatusResponseDto> providerReadiness;
   final List<String> supportedFileTypes;
+  final List<OfficeProviderCandidateResponseDto> candidates;
+  final OfficeCapabilityFlagsResponseDto capabilities;
+  final OfficePermissionModelResponseDto permissions;
+  final OfficeLockSessionReadinessResponseDto lockSessionReadiness;
 
   OfficeCapabilitiesSnapshot toSnapshot() => OfficeCapabilitiesSnapshot(
     releaseStatus: releaseStatus,
@@ -209,7 +564,166 @@ class OfficeCapabilitiesResponseDto {
         .map((provider) => provider.toSnapshot())
         .toList(growable: false),
     supportedFileTypes: supportedFileTypes,
+    candidates: candidates
+        .map((candidate) => candidate.toSnapshot())
+        .toList(growable: false),
+    capabilities: capabilities.toSnapshot(),
+    permissions: permissions.toSnapshot(),
+    lockSessionReadiness: lockSessionReadiness.toSnapshot(),
   );
+}
+
+class OfficeProviderCandidateResponseDto {
+  const OfficeProviderCandidateResponseDto({
+    required this.providerKey,
+    required this.displayName,
+    required this.defaultCandidate,
+    required this.runtimeFit,
+    required this.licensingPosture,
+    required this.integrationPath,
+    required this.notes,
+  });
+
+  factory OfficeProviderCandidateResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return OfficeProviderCandidateResponseDto(
+      providerKey: _safeProviderKey(json['providerKey']),
+      displayName: _safeText(json['displayName']),
+      defaultCandidate: _bool(json['defaultCandidate']),
+      runtimeFit: _safeText(json['runtimeFit']),
+      licensingPosture: _safeText(json['licensingPosture']),
+      integrationPath: _safeText(json['integrationPath']),
+      notes: _safeStringList(json['notes']),
+    );
+  }
+
+  final String providerKey;
+  final String displayName;
+  final bool defaultCandidate;
+  final String runtimeFit;
+  final String licensingPosture;
+  final String integrationPath;
+  final List<String> notes;
+
+  OfficeProviderCandidateSnapshot toSnapshot() =>
+      OfficeProviderCandidateSnapshot(
+        providerKey: providerKey,
+        displayName: displayName,
+        defaultCandidate: defaultCandidate,
+        runtimeFit: runtimeFit,
+        licensingPosture: licensingPosture,
+        integrationPath: integrationPath,
+        notes: notes,
+      );
+}
+
+class OfficeCapabilityFlagsResponseDto {
+  const OfficeCapabilityFlagsResponseDto({
+    required this.view,
+    required this.edit,
+    required this.comment,
+    required this.review,
+    required this.formFill,
+  });
+
+  factory OfficeCapabilityFlagsResponseDto.fromJson(Map<String, dynamic> json) {
+    return OfficeCapabilityFlagsResponseDto(
+      view: _bool(json['view']),
+      edit: _bool(json['edit']),
+      comment: _bool(json['comment']),
+      review: _bool(json['review']),
+      formFill: _bool(json['formFill']),
+    );
+  }
+
+  final bool view;
+  final bool edit;
+  final bool comment;
+  final bool review;
+  final bool formFill;
+
+  OfficeCapabilityFlagsSnapshot toSnapshot() => OfficeCapabilityFlagsSnapshot(
+    view: view,
+    edit: edit,
+    comment: comment,
+    review: review,
+    formFill: formFill,
+  );
+}
+
+class OfficePermissionModelResponseDto {
+  const OfficePermissionModelResponseDto({
+    required this.canView,
+    required this.canEdit,
+    required this.canComment,
+    required this.canReview,
+    required this.canFillForms,
+    required this.reason,
+  });
+
+  factory OfficePermissionModelResponseDto.fromJson(Map<String, dynamic> json) {
+    return OfficePermissionModelResponseDto(
+      canView: _bool(json['canView']),
+      canEdit: _bool(json['canEdit']),
+      canComment: _bool(json['canComment']),
+      canReview: _bool(json['canReview']),
+      canFillForms: _bool(json['canFillForms']),
+      reason: _safeText(json['reason']),
+    );
+  }
+
+  final bool canView;
+  final bool canEdit;
+  final bool canComment;
+  final bool canReview;
+  final bool canFillForms;
+  final String reason;
+
+  OfficePermissionModelSnapshot toSnapshot() => OfficePermissionModelSnapshot(
+    canView: canView,
+    canEdit: canEdit,
+    canComment: canComment,
+    canReview: canReview,
+    canFillForms: canFillForms,
+    reason: reason,
+  );
+}
+
+class OfficeLockSessionReadinessResponseDto {
+  const OfficeLockSessionReadinessResponseDto({
+    required this.documentLocks,
+    required this.sessionTokens,
+    required this.callbackVerification,
+    required this.supportSafe,
+  });
+
+  factory OfficeLockSessionReadinessResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return OfficeLockSessionReadinessResponseDto(
+      documentLocks: _string(json['documentLocks'], fallback: 'unavailable'),
+      sessionTokens: _string(json['sessionTokens'], fallback: 'unavailable'),
+      callbackVerification: _string(
+        json['callbackVerification'],
+        fallback: 'unavailable',
+      ),
+      supportSafe: _bool(json['supportSafe']),
+    );
+  }
+
+  final String documentLocks;
+  final String sessionTokens;
+  final String callbackVerification;
+  final bool supportSafe;
+
+  OfficeLockSessionReadinessSnapshot toSnapshot() =>
+      OfficeLockSessionReadinessSnapshot(
+        documentLocks: documentLocks,
+        sessionTokens: sessionTokens,
+        callbackVerification: callbackVerification,
+        supportSafe: supportSafe,
+      );
 }
 
 class OfficeLaunchResponseDto {
@@ -224,8 +738,8 @@ class OfficeLaunchResponseDto {
     return OfficeLaunchResponseDto(
       sessionId: _string(json['sessionId'], fallback: ''),
       launchMode: _string(json['launchMode'], fallback: 'disabled'),
-      providerKey: _string(json['providerKey'], fallback: 'none'),
-      grantedPermissions: _stringList(json['grantedPermissions']),
+      providerKey: _safeProviderKey(json['providerKey']),
+      grantedPermissions: _safeStringList(json['grantedPermissions']),
     );
   }
 
@@ -234,11 +748,37 @@ class OfficeLaunchResponseDto {
   final String providerKey;
   final List<String> grantedPermissions;
 
-  OfficeLaunchSnapshot toSnapshot() => OfficeLaunchSnapshot(
+  OfficeLaunchSnapshot toSnapshot() => OfficeLaunchSnapshot.launched(
     sessionId: sessionId,
     launchMode: launchMode,
     providerKey: providerKey,
     grantedPermissions: grantedPermissions,
+  );
+}
+
+class OfficeLaunchErrorResponseDto {
+  const OfficeLaunchErrorResponseDto({
+    required this.code,
+    required this.message,
+    required this.requestId,
+  });
+
+  factory OfficeLaunchErrorResponseDto.fromJson(Map<String, dynamic> json) {
+    return OfficeLaunchErrorResponseDto(
+      code: _string(json['code'], fallback: 'office-launch-fail-closed'),
+      message: _safeText(json['message']),
+      requestId: _nullableString(json['requestId']),
+    );
+  }
+
+  final String code;
+  final String message;
+  final String? requestId;
+
+  OfficeLaunchSnapshot toSnapshot() => OfficeLaunchSnapshot.failClosed(
+    errorCode: code,
+    message: message,
+    requestId: requestId,
   );
 }
 
@@ -261,36 +801,59 @@ String _string(Object? value, {required String fallback}) {
   return fallback;
 }
 
+String _safeProviderKey(Object? value) {
+  final key = _string(value, fallback: 'unknown');
+  return _containsSensitiveText(key) ? 'redacted-provider' : key;
+}
+
 String _safeText(Object? value) {
   if (value is! String || value.trim().isEmpty) {
     return 'Not reported by the Weave backend.';
   }
   final text = value.trim();
-  final lower = text.toLowerCase();
-  if (lower.contains('token') ||
-      lower.contains('secret') ||
-      lower.contains('password') ||
-      lower.contains('authorization:') ||
-      lower.contains('http://') ||
-      lower.contains('https://')) {
+  if (_containsSensitiveText(text)) {
     return 'Support-safe details only; raw provider data was redacted.';
   }
   return text;
 }
 
+bool _containsSensitiveText(String text) {
+  final lower = text.toLowerCase();
+  return lower.contains('token') ||
+      lower.contains('secret') ||
+      lower.contains('password') ||
+      lower.contains('authorization:') ||
+      lower.contains('bearer ') ||
+      lower.contains('http://') ||
+      lower.contains('https://');
+}
+
 bool _bool(Object? value) => value == true;
 
-List<String> _stringList(Object? value) {
+List<String> _safeStringList(Object? value) {
   if (value is! List) {
     return const [];
   }
   return value
       .whereType<String>()
       .map((item) => item.trim())
-      .where((item) {
-        return item.isNotEmpty;
-      })
+      .where((item) => item.isNotEmpty)
+      .map((item) => _containsSensitiveText(item) ? 'redacted' : item)
       .toList(growable: false);
+}
+
+Map<String, Object?> _safeDiagnostics(Object? value) {
+  if (value is! Map<String, dynamic>) {
+    return const <String, Object?>{};
+  }
+  return Map<String, Object?>.unmodifiable(
+    value.map(
+      (key, item) => MapEntry(
+        _containsSensitiveText(key) ? 'redacted' : key,
+        item is String && _containsSensitiveText(item) ? 'redacted' : item,
+      ),
+    ),
+  );
 }
 
 List<Map<String, dynamic>> _listOfMaps(Object? value) {
@@ -298,4 +861,25 @@ List<Map<String, dynamic>> _listOfMaps(Object? value) {
     return const [];
   }
   return value.whereType<Map<String, dynamic>>().toList(growable: false);
+}
+
+Map<String, dynamic> _map(Object? value) {
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+  return const <String, dynamic>{};
+}
+
+DateTime? _dateTime(Object? value) {
+  if (value is String && value.trim().isNotEmpty) {
+    return DateTime.tryParse(value.trim());
+  }
+  return null;
+}
+
+String? _nullableString(Object? value) {
+  if (value is String && value.trim().isNotEmpty) {
+    return value.trim();
+  }
+  return null;
 }

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -41,7 +41,8 @@ abstract interface class WeaveApiClient {
   Future<OfficeLaunchSnapshot> launchOfficeSession({
     required Uri baseUrl,
     required String accessToken,
-    required String documentId,
+    required String fileId,
+    required String requestedMode,
   });
 }
 
@@ -152,20 +153,26 @@ class HttpWeaveApiClient implements WeaveApiClient {
   Future<OfficeLaunchSnapshot> launchOfficeSession({
     required Uri baseUrl,
     required String accessToken,
-    required String documentId,
+    required String fileId,
+    required String requestedMode,
   }) async {
     final payload = await _postJson(
       requestUri: _officeLaunchUri(baseUrl),
       accessToken: accessToken,
-      body: {'documentId': documentId},
+      body: {'fileId': fileId, 'requestedMode': requestedMode},
       failureMessage: 'The Weave backend refused the Office launch request.',
       invalidPayloadMessage:
           'The Weave backend returned an invalid Office launch payload.',
       decodeFailureMessage:
           'Unable to decode Office launch from the Weave backend.',
+      failClosedStatusCodes: const {503},
     );
 
-    return OfficeLaunchResponseDto.fromJson(payload).toSnapshot();
+    if (payload.failClosed) {
+      return OfficeLaunchErrorResponseDto.fromJson(payload.json).toSnapshot();
+    }
+
+    return OfficeLaunchResponseDto.fromJson(payload.json).toSnapshot();
   }
 
   Future<Map<String, dynamic>> _getJson({
@@ -217,58 +224,6 @@ class HttpWeaveApiClient implements WeaveApiClient {
     }
   }
 
-  Future<Map<String, dynamic>> _postJson({
-    required Uri requestUri,
-    required String accessToken,
-    required Map<String, Object?> body,
-    required String failureMessage,
-    required String invalidPayloadMessage,
-    required String decodeFailureMessage,
-  }) async {
-    late http.Response response;
-    try {
-      response = await _httpClient
-          .post(
-            requestUri,
-            headers: {
-              'Accept': 'application/json',
-              'Authorization': 'Bearer $accessToken',
-              'Content-Type': 'application/json',
-            },
-            body: jsonEncode(body),
-          )
-          .timeout(const Duration(seconds: 5));
-    } catch (error) {
-      throw AppFailure.unknown(
-        'Unable to reach the Weave backend right now.',
-        cause: error,
-      );
-    }
-
-    if (response.statusCode == 401 || response.statusCode == 403) {
-      throw const AppFailure.unknown(
-        'The Weave backend rejected the current session.',
-      );
-    }
-
-    if (response.statusCode != 200) {
-      throw AppFailure.unknown(failureMessage, cause: response.statusCode);
-    }
-
-    try {
-      final payload = jsonDecode(response.body);
-      if (payload is! Map<String, dynamic>) {
-        throw AppFailure.unknown(invalidPayloadMessage);
-      }
-
-      return payload;
-    } on AppFailure {
-      rethrow;
-    } catch (error) {
-      throw AppFailure.unknown(decodeFailureMessage, cause: error);
-    }
-  }
-
   Future<_HttpJsonPayload> _postJson({
     required Uri requestUri,
     required String accessToken,
@@ -285,8 +240,8 @@ class HttpWeaveApiClient implements WeaveApiClient {
             requestUri,
             headers: {
               'Accept': 'application/json',
-              'Content-Type': 'application/json',
               'Authorization': 'Bearer $accessToken',
+              'Content-Type': 'application/json',
             },
             body: jsonEncode(body),
           )

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -4,8 +4,10 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/integrations/weave_api/data/dtos/platform_status_response_dto.dart';
+import 'package:weave/integrations/weave_api/data/dtos/provider_stack_response_dto.dart';
 import 'package:weave/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart';
 
 abstract interface class WeaveApiClient {
@@ -17,6 +19,29 @@ abstract interface class WeaveApiClient {
   Future<MatrixE2eeDiagnostic> fetchMatrixE2eeDiagnostic({
     required Uri baseUrl,
     required String accessToken,
+  });
+
+  Future<ProviderStackSnapshot> fetchProviderStackStatus({
+    required Uri baseUrl,
+    required String accessToken,
+  });
+
+  Future<DevopsProviderSummarySnapshot> fetchDevopsSummary({
+    required Uri baseUrl,
+    required String accessToken,
+    required String workspaceId,
+    required String channelId,
+  });
+
+  Future<OfficeCapabilitiesSnapshot> fetchOfficeCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  });
+
+  Future<OfficeLaunchSnapshot> launchOfficeSession({
+    required Uri baseUrl,
+    required String accessToken,
+    required String documentId,
   });
 }
 
@@ -61,6 +86,86 @@ class HttpWeaveApiClient implements WeaveApiClient {
     );
 
     return PlatformStatusResponseDto.fromJson(payload).toMatrixDiagnostic();
+  }
+
+  @override
+  Future<ProviderStackSnapshot> fetchProviderStackStatus({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    final payload = await _getJson(
+      requestUri: _providerStatusUri(baseUrl),
+      accessToken: accessToken,
+      failureMessage: 'The Weave backend failed to return provider status.',
+      invalidPayloadMessage:
+          'The Weave backend returned an invalid provider status payload.',
+      decodeFailureMessage:
+          'Unable to decode provider status from the Weave backend.',
+    );
+
+    return ProviderRegistryResponseDto.fromJson(payload).toSnapshot();
+  }
+
+  @override
+  Future<DevopsProviderSummarySnapshot> fetchDevopsSummary({
+    required Uri baseUrl,
+    required String accessToken,
+    required String workspaceId,
+    required String channelId,
+  }) async {
+    final payload = await _getJson(
+      requestUri: _devopsSummaryUri(
+        baseUrl,
+        workspaceId: workspaceId,
+        channelId: channelId,
+      ),
+      accessToken: accessToken,
+      failureMessage: 'The Weave backend failed to return DevOps readiness.',
+      invalidPayloadMessage:
+          'The Weave backend returned an invalid DevOps readiness payload.',
+      decodeFailureMessage:
+          'Unable to decode DevOps readiness from the Weave backend.',
+    );
+
+    return DevopsSummaryResponseDto.fromJson(payload).toSnapshot();
+  }
+
+  @override
+  Future<OfficeCapabilitiesSnapshot> fetchOfficeCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    final payload = await _getJson(
+      requestUri: _officeCapabilitiesUri(baseUrl),
+      accessToken: accessToken,
+      failureMessage: 'The Weave backend failed to return Office capabilities.',
+      invalidPayloadMessage:
+          'The Weave backend returned an invalid Office capabilities payload.',
+      decodeFailureMessage:
+          'Unable to decode Office capabilities from the Weave backend.',
+    );
+
+    return OfficeCapabilitiesResponseDto.fromJson(payload).toSnapshot();
+  }
+
+  @override
+  Future<OfficeLaunchSnapshot> launchOfficeSession({
+    required Uri baseUrl,
+    required String accessToken,
+    required String documentId,
+  }) async {
+    final payload = await _postJson(
+      requestUri: _officeLaunchUri(baseUrl),
+      accessToken: accessToken,
+      body: {'documentId': documentId},
+      failureMessage: 'The Weave backend refused the Office launch request.',
+      invalidPayloadMessage:
+          'The Weave backend returned an invalid Office launch payload.',
+      decodeFailureMessage:
+          'Unable to decode Office launch from the Weave backend.',
+    );
+
+    return OfficeLaunchResponseDto.fromJson(payload).toSnapshot();
   }
 
   Future<Map<String, dynamic>> _getJson({
@@ -112,6 +217,112 @@ class HttpWeaveApiClient implements WeaveApiClient {
     }
   }
 
+  Future<Map<String, dynamic>> _postJson({
+    required Uri requestUri,
+    required String accessToken,
+    required Map<String, Object?> body,
+    required String failureMessage,
+    required String invalidPayloadMessage,
+    required String decodeFailureMessage,
+  }) async {
+    late http.Response response;
+    try {
+      response = await _httpClient
+          .post(
+            requestUri,
+            headers: {
+              'Accept': 'application/json',
+              'Authorization': 'Bearer $accessToken',
+              'Content-Type': 'application/json',
+            },
+            body: jsonEncode(body),
+          )
+          .timeout(const Duration(seconds: 5));
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to reach the Weave backend right now.',
+        cause: error,
+      );
+    }
+
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw const AppFailure.unknown(
+        'The Weave backend rejected the current session.',
+      );
+    }
+
+    if (response.statusCode != 200) {
+      throw AppFailure.unknown(failureMessage, cause: response.statusCode);
+    }
+
+    try {
+      final payload = jsonDecode(response.body);
+      if (payload is! Map<String, dynamic>) {
+        throw AppFailure.unknown(invalidPayloadMessage);
+      }
+
+      return payload;
+    } on AppFailure {
+      rethrow;
+    } catch (error) {
+      throw AppFailure.unknown(decodeFailureMessage, cause: error);
+    }
+  }
+
+  Future<_HttpJsonPayload> _postJson({
+    required Uri requestUri,
+    required String accessToken,
+    required Map<String, Object?> body,
+    required String failureMessage,
+    required String invalidPayloadMessage,
+    required String decodeFailureMessage,
+    Set<int> failClosedStatusCodes = const {},
+  }) async {
+    late http.Response response;
+    try {
+      response = await _httpClient
+          .post(
+            requestUri,
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $accessToken',
+            },
+            body: jsonEncode(body),
+          )
+          .timeout(const Duration(seconds: 5));
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to reach the Weave backend right now.',
+        cause: error,
+      );
+    }
+
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw const AppFailure.unknown(
+        'The Weave backend rejected the current session.',
+      );
+    }
+
+    final failClosed = failClosedStatusCodes.contains(response.statusCode);
+    if (response.statusCode != 200 && !failClosed) {
+      throw AppFailure.unknown(failureMessage, cause: response.statusCode);
+    }
+
+    try {
+      final payload = jsonDecode(response.body);
+      if (payload is! Map<String, dynamic>) {
+        throw AppFailure.unknown(invalidPayloadMessage);
+      }
+
+      return _HttpJsonPayload(json: payload, failClosed: failClosed);
+    } on AppFailure {
+      rethrow;
+    } catch (error) {
+      throw AppFailure.unknown(decodeFailureMessage, cause: error);
+    }
+  }
+
   Uri _workspaceCapabilitiesUri(Uri baseUrl) {
     return baseUrl.replace(
       pathSegments: _apiPath(baseUrl, const [
@@ -129,6 +340,42 @@ class HttpWeaveApiClient implements WeaveApiClient {
     );
   }
 
+  Uri _providerStatusUri(Uri baseUrl) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, const ['api', 'providers', 'status']),
+    );
+  }
+
+  Uri _devopsSummaryUri(
+    Uri baseUrl, {
+    required String workspaceId,
+    required String channelId,
+  }) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, [
+        'api',
+        'workspaces',
+        workspaceId,
+        'channels',
+        channelId,
+        'devops',
+        'summary',
+      ]),
+    );
+  }
+
+  Uri _officeCapabilitiesUri(Uri baseUrl) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, const ['api', 'office', 'capabilities']),
+    );
+  }
+
+  Uri _officeLaunchUri(Uri baseUrl) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, const ['api', 'office', 'launch']),
+    );
+  }
+
   List<String> _apiPath(Uri baseUrl, List<String> pathSegments) {
     final baseSegments = baseUrl.pathSegments
         .where((segment) => segment.isNotEmpty)
@@ -142,4 +389,11 @@ class HttpWeaveApiClient implements WeaveApiClient {
 
     return [...baseSegments, ...pathSegments];
   }
+}
+
+class _HttpJsonPayload {
+  const _HttpJsonPayload({required this.json, required this.failClosed});
+
+  final Map<String, dynamic> json;
+  final bool failClosed;
 }

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -9,6 +9,7 @@ import 'package:weave/features/app/domain/entities/workspace_capability_snapshot
 import 'package:weave/integrations/weave_api/data/dtos/platform_status_response_dto.dart';
 import 'package:weave/integrations/weave_api/data/dtos/provider_stack_response_dto.dart';
 import 'package:weave/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart';
+import 'package:weave/integrations/weave_api/data/services/weave_api_uri_builder.dart';
 
 abstract interface class WeaveApiClient {
   Future<WorkspaceCapabilitySnapshot> fetchWorkspaceCapabilities({
@@ -279,26 +280,20 @@ class HttpWeaveApiClient implements WeaveApiClient {
   }
 
   Uri _workspaceCapabilitiesUri(Uri baseUrl) {
-    return baseUrl.replace(
-      pathSegments: _apiPath(baseUrl, const [
-        'api',
-        'v1',
-        'workspace',
-        'capabilities',
-      ]),
-    );
+    return weaveApiUri(baseUrl, const [
+      'api',
+      'v1',
+      'workspace',
+      'capabilities',
+    ]);
   }
 
   Uri _platformStatusUri(Uri baseUrl) {
-    return baseUrl.replace(
-      pathSegments: _apiPath(baseUrl, const ['api', 'platform', 'status']),
-    );
+    return weaveApiUri(baseUrl, const ['api', 'platform', 'status']);
   }
 
   Uri _providerStatusUri(Uri baseUrl) {
-    return baseUrl.replace(
-      pathSegments: _apiPath(baseUrl, const ['api', 'providers', 'status']),
-    );
+    return weaveApiUri(baseUrl, const ['api', 'providers', 'status']);
   }
 
   Uri _devopsSummaryUri(
@@ -306,43 +301,23 @@ class HttpWeaveApiClient implements WeaveApiClient {
     required String workspaceId,
     required String channelId,
   }) {
-    return baseUrl.replace(
-      pathSegments: _apiPath(baseUrl, [
-        'api',
-        'workspaces',
-        workspaceId,
-        'channels',
-        channelId,
-        'devops',
-        'summary',
-      ]),
-    );
+    return weaveApiUri(baseUrl, [
+      'api',
+      'workspaces',
+      workspaceId,
+      'channels',
+      channelId,
+      'devops',
+      'summary',
+    ]);
   }
 
   Uri _officeCapabilitiesUri(Uri baseUrl) {
-    return baseUrl.replace(
-      pathSegments: _apiPath(baseUrl, const ['api', 'office', 'capabilities']),
-    );
+    return weaveApiUri(baseUrl, const ['api', 'office', 'capabilities']);
   }
 
   Uri _officeLaunchUri(Uri baseUrl) {
-    return baseUrl.replace(
-      pathSegments: _apiPath(baseUrl, const ['api', 'office', 'launch']),
-    );
-  }
-
-  List<String> _apiPath(Uri baseUrl, List<String> pathSegments) {
-    final baseSegments = baseUrl.pathSegments
-        .where((segment) => segment.isNotEmpty)
-        .toList(growable: false);
-    if (baseSegments.isNotEmpty &&
-        pathSegments.isNotEmpty &&
-        baseSegments.last == 'api' &&
-        pathSegments.first == 'api') {
-      return [...baseSegments, ...pathSegments.skip(1)];
-    }
-
-    return [...baseSegments, ...pathSegments];
+    return weaveApiUri(baseUrl, const ['api', 'office', 'launch']);
   }
 }
 

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -268,6 +268,9 @@ class HttpWeaveApiClient implements WeaveApiClient {
     try {
       final payload = jsonDecode(response.body);
       if (payload is! Map<String, dynamic>) {
+        if (failClosed) {
+          return const _HttpJsonPayload(json: {}, failClosed: true);
+        }
         throw AppFailure.unknown(invalidPayloadMessage);
       }
 
@@ -275,6 +278,9 @@ class HttpWeaveApiClient implements WeaveApiClient {
     } on AppFailure {
       rethrow;
     } catch (error) {
+      if (failClosed) {
+        return const _HttpJsonPayload(json: {}, failClosed: true);
+      }
       throw AppFailure.unknown(decodeFailureMessage, cause: error);
     }
   }

--- a/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
+++ b/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
@@ -85,6 +85,16 @@ final weaveApiProviderStackSnapshotProvider =
       });
     });
 
+final weaveApiOfficeCapabilitiesSnapshotProvider =
+    FutureProvider<OfficeCapabilitiesSnapshot?>((ref) async {
+      return _withWeaveApiSession(ref, (client, baseUrl, accessToken) {
+        return client.fetchOfficeCapabilities(
+          baseUrl: baseUrl,
+          accessToken: accessToken,
+        );
+      });
+    });
+
 Future<T?> _withWeaveApiSession<T>(
   Ref ref,
   Future<T> Function(WeaveApiClient client, Uri baseUrl, String accessToken)

--- a/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
+++ b/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
@@ -5,6 +5,7 @@ import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provid
 import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/presentation/providers/workspace_invalidation_provider.dart';
 import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
@@ -68,6 +69,16 @@ final weaveApiMatrixE2eeDiagnosticProvider =
     FutureProvider<MatrixE2eeDiagnostic?>((ref) async {
       return _withWeaveApiSession(ref, (client, baseUrl, accessToken) {
         return client.fetchMatrixE2eeDiagnostic(
+          baseUrl: baseUrl,
+          accessToken: accessToken,
+        );
+      });
+    });
+
+final weaveApiProviderStackSnapshotProvider =
+    FutureProvider<ProviderStackSnapshot?>((ref) async {
+      return _withWeaveApiSession(ref, (client, baseUrl, accessToken) {
+        return client.fetchProviderStackStatus(
           baseUrl: baseUrl,
           accessToken: accessToken,
         );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -27,7 +27,6 @@
   "bootstrapLoadingHint": "Arbeitsbereichsdienste werden geprüft und die Shell vorbereitet.",
   "shellErrorTitle": "Weave konnte nicht vorbereitet werden",
   "shellErrorGuidance": "Versuche es erneut. Wenn das weiterhin passiert, prüfe, ob deine Arbeitsbereichsdienste erreichbar sind.",
-
   "shellRecentActivityTitle": "Letzte Aktivität",
   "shellRecentActivityDescription": "Schnellzugriff auf aktuelle Räume und Dateiänderungen.",
   "shellRecentActivitySemanticLabel": "Schnellzugriffe für letzte Aktivität",
@@ -60,7 +59,6 @@
   "semanticDeckIcon": "Boards-Vorschau",
   "semanticSettingsIcon": "App-Einstellungen",
   "semanticWeaveLogo": "Weave-Logo",
-
   "firstRunAppBarTitle": "Erststart-Status",
   "firstRunLoadingLabel": "Weave-Arbeitsbereich wird geprüft…",
   "firstRunLoadingHint": "Profil, Rolle und Modulbereitschaft werden vom Weave-Backend geladen.",
@@ -89,13 +87,11 @@
   "firstRunNextStepsTitle": "Nächste Schritte",
   "firstRunRefreshButton": "Status aktualisieren",
   "firstRunContinueButton": "Weiter zum Chat",
-
   "chatProvisioningReadyTitle": "Chat ist bereit",
   "chatProvisioningPendingTitle": "Chaträume werden noch vorbereitet",
   "chatProvisioningDegradedTitle": "Chat ist eingeschränkt verfügbar",
   "chatProvisioningActionNeededTitle": "Chat-Einrichtung benötigt Admin-Hilfe",
   "chatProvisioningRetryButton": "Status erneut prüfen",
-
   "chatScreenTitle": "Chat",
   "chatOverviewTitle": "Weave Home",
   "chatOverviewDescription": "Deine persönlichen Nachrichten, Favoriten, Kanäle und KI-Chats sind hier gruppiert, damit der Workspace nach Absicht startet statt als flache Raumliste.",
@@ -146,12 +142,17 @@
   "filesLoadingLabel": "Dateien werden geladen…",
   "filesLoadingHint": "Der aktuelle Ordner wird aktualisiert und auf Änderungen geprüft.",
   "filesStaleDirectoryTitle": "Letzten bekannten Ordner anzeigen",
-  "@filesStaleDirectoryTitle": {"description": "Title for a Files notice shown when refresh failed but the previous directory listing remains visible"},
+  "@filesStaleDirectoryTitle": {
+    "description": "Title for a Files notice shown when refresh failed but the previous directory listing remains visible"
+  },
   "filesStaleDirectoryGuidance": "Weave konnte Dateien gerade nicht aktualisieren. Die letzte Ordnerliste bleibt sichtbar, damit du deinen Platz behältst und es erneut versuchen kannst, sobald die Verbindung wieder da ist.",
-  "@filesStaleDirectoryGuidance": {"description": "Guidance for a Files notice shown when refresh failed but cached folder contents remain visible"},
+  "@filesStaleDirectoryGuidance": {
+    "description": "Guidance for a Files notice shown when refresh failed but cached folder contents remain visible"
+  },
   "filesStaleDirectoryRetryButton": "Ordner aktualisieren",
-  "@filesStaleDirectoryRetryButton": {"description": "Button label for retrying a stale Files directory refresh"},
-
+  "@filesStaleDirectoryRetryButton": {
+    "description": "Button label for retrying a stale Files directory refresh"
+  },
   "filesNextcloudTitle": "Weave-Dateien",
   "filesProductTitle": "Weave-Dateien",
   "filesProductBoundaryTitle": "Weave-Produktgrenze",
@@ -252,13 +253,10 @@
   "helpPrivacySecurityBody": "Dein Workspace kontrolliert seine eigenen Dienste und Daten. Weave nutzt SSO für den Zugriff und zeigt den Matrix-Sicherheitsstatus ehrlich an. Gehe nicht davon aus, dass Chat vollständig Ende-zu-Ende-verschlüsselt ist, solange Weave nicht meldet, dass Matrix-Verschlüsselung, Wiederherstellung und Gerätevertrauen gesund sind. Bewahre Wiederherstellungsschlüssel sicher auf und melde verlorene Geräte deinem Admin.",
   "settingsShellModulesTitle": "Shell-Module",
   "settingsShellModulesDescription": "Wähle, welche Workspace-Shell-Module sichtbar bleiben. Die Navigation bleibt verfügbar, auch wenn ein Modul ausgeblendet ist.",
-
   "settingsShellWorkspaceStatusToggleTitle": "Workspace-Statusübersicht",
   "settingsShellWorkspaceStatusToggleDescription": "Zeigt Dienstbereitschaft und Wiederherstellungsabkürzungen oberhalb der unteren Navigation an.",
   "settingsShellMoveModuleUp": "{moduleName} nach oben verschieben",
   "settingsShellMoveModuleDown": "{moduleName} nach unten verschieben",
-
-
   "settingsPreviewSurfacesTitle": "Vorschau-Oberflächen",
   "settingsPreviewSurfacesDescription": "Diese feature-gegateten Bereiche bleiben ehrlich darüber, was aktiv, blockiert oder noch von Backend-Verträgen abhängig ist.",
   "settingsGuestPortalPreviewTitle": "Gastportal",
@@ -267,7 +265,6 @@
   "settingsInteropAdminPreviewDescription": "Der Status externer Anbieter erklärt Datenbewegung und Einwilligung; Anbieter-Secrets werden in diesem Client nie erfasst.",
   "settingsMigrationDryRunPreviewTitle": "Migrationsbericht als Trockenlauf",
   "settingsMigrationDryRunPreviewDescription": "Admins können Inventar, Risiken, Berechtigungsbereiche und Zuordnungen prüfen, bevor ein Import startet.",
-
   "settingsShellRecentActivityToggleTitle": "Schnellzugriffe für letzte Aktivität",
   "settingsShellRecentActivityToggleDescription": "Zeigt aktuelle Räume und Dateiänderungen oberhalb der unteren Navigation an.",
   "settingsShellModulesLoading": "Shell-Modul-Einstellungen werden geladen…",
@@ -311,7 +308,7 @@
   "settingsWorkspaceInvalidationNextcloudBaseUrlChanged": "Nextcloud-Basis-URL geändert",
   "settingsWorkspaceInvalidationExplicitSignOut": "Manuell abgemeldet",
   "settingsWorkspaceInvalidationRestartSetup": "Einrichtung neu gestartet",
-  "settingsWorkspaceInvalidationBackendApiBaseUrlChanged": "Backend-API-URL ge\u00e4ndert",
+  "settingsWorkspaceInvalidationBackendApiBaseUrlChanged": "Backend-API-URL geändert",
   "chatSecuritySectionTitle": "Matrix-Sicherheit",
   "chatSecuritySectionDescription": "Weave behandelt Matrix-Verschlüsselung nur dann als gesund, wenn Secret Storage, Cross-Signing, Wiederherstellung und Gerätevertrauen vollständig eingerichtet sind.",
   "chatSecurityRecoveryKeyTitle": "Diesen Matrix-Wiederherstellungsschlüssel jetzt sichern",
@@ -406,6 +403,52 @@
   "chatSecurityEmojiSummaryLabel": "Sicherheits-Emojis",
   "chatSecurityNumbersSummaryLabel": "Sicherheitszahlen {value}",
   "settingsServerConfigurationTitle": "Serverkonfiguration",
+  "settingsProviderStackTitle": "Provider-Stack-Bereitschaft",
+  "settingsProviderStackSemanticLabel": "Bereitschaft des Provider-Stacks. Backend-Fassaden: {backendOwnedFacades}. Flutter-Provider-Aufrufe: {flutterCalls}.",
+  "settingsProviderStackFailClosedDescription": "Provider-Integrationen bleiben fail-closed hinter Backend-eigenen Fassaden. Flutter ruft GitLab, Office oder andere Provider-APIs nicht direkt auf.",
+  "settingsProviderStackNeedsReviewDescription": "Die Provider-Bereitschaft muss geprüft werden, bevor direkte Starts oder Workspace-Aktionen aktiviert werden.",
+  "settingsProviderStackBackendFacadesLabel": "Backend-Fassaden",
+  "settingsProviderStackFlutterCallsLabel": "Flutter-Provider-Aufrufe",
+  "settingsProviderStackSupportSafetyLabel": "Support-Sicherheit",
+  "settingsProviderStackOwned": "Backend-eigen",
+  "settingsProviderStackMissing": "Fehlt",
+  "settingsProviderStackNeedsReview": "Prüfung nötig",
+  "settingsProviderStackBlocked": "Blockiert",
+  "settingsProviderStackRedacted": "Redigiert",
+  "settingsProviderStackYes": "Ja",
+  "settingsProviderStackNo": "Nein",
+  "settingsProviderStackFlutterCallsAllowed": "Erlaubt",
+  "settingsProviderStackFlutterCallsBlocked": "Blockiert",
+  "settingsProviderStackFailClosedBadge": "fail-closed",
+  "settingsProviderStackReadOnlyBadge": "nur lesend",
+  "settingsProviderStackPaidFeaturesRequiredBadge": "kostenpflichtige Features nötig",
+  "settingsProviderModuleIdentityRealm": "Identity-Realm",
+  "settingsProviderModuleSourceControl": "Quellcodeverwaltung",
+  "settingsProviderModuleIssueTracker": "Issue-Tracker",
+  "settingsProviderModuleCi": "CI",
+  "settingsProviderModuleRelease": "Release",
+  "settingsProviderModuleOffice": "Office",
+  "settingsProviderModuleFiles": "Dateien",
+  "settingsProviderModuleCalendar": "Kalender",
+  "settingsProviderModuleContacts": "Kontakte",
+  "settingsProviderModuleForms": "Formulare",
+  "settingsProviderModuleBoards": "Boards",
+  "settingsProviderModuleProvider": "Provider",
+  "settingsProviderStateDisabled": "deaktiviert",
+  "settingsProviderStateNotConfigured": "unkonfiguriert",
+  "settingsProviderStateConfigured": "konfiguriert",
+  "settingsProviderStateReady": "bereit",
+  "settingsProviderStateDegraded": "eingeschränkt",
+  "settingsProviderStateUnsupported": "nicht unterstützt",
+  "settingsProviderStateUnknown": "unbekannt",
+  "settingsOfficeReadinessTitle": "Office-Bereitschaft",
+  "settingsOfficeReadinessSemanticLabel": "Office-Bereitschaft. Start ist {launchState}. Provider ist {providerState}.",
+  "settingsOfficeReadinessFailClosedDescription": "Office-Start bleibt fail-closed, bis ein Backend-eigener Provider-Adapter, Session-Tokens, Callbacks und Berechtigungen konfiguriert sind.",
+  "settingsOfficeReadinessAvailableDescription": "Office-Start ist über die Backend-Fassade verfügbar.",
+  "settingsOfficeReadinessAvailable": "verfügbar",
+  "settingsOfficeReadinessEnabled": "aktiviert",
+  "settingsOfficeReadinessNoLaunchModes": "keine Startmodi",
+  "settingsOfficeReadinessModes": "Modi: {modes}",
   "settingsServerConfigurationDescription": "Aktualisiere den Anbieter und die Dienst-URLs, die Weave für deine selbst gehostete Umgebung verwenden soll.",
   "settingsSaveButton": "Änderungen speichern",
   "settingsSaveInProgress": "Wird gespeichert…",
@@ -573,8 +616,7 @@
   "signInInProgress": "Melde an…",
   "signInBackToSetupButton": "Zurück zur Einrichtung",
   "signInMissingConfigurationTitle": "Einrichtung abschließen, um dich anzumelden",
-  "signInMissingConfigurationDescription": "Weave benötigt noch eine gültige Issuer-URL und Client-ID, bevor der Browser-Anmeldefluss gestartet werden kann."
-,
+  "signInMissingConfigurationDescription": "Weave benötigt noch eine gültige Issuer-URL und Client-ID, bevor der Browser-Anmeldefluss gestartet werden kann.",
   "profileSectionTitle": "Weave-Profil",
   "profileSectionDescription": "Dieses Profil kommt aus der Weave-Backend-Identitätsfassade und wird von Produktmodulen gemeinsam genutzt.",
   "profileLoadFailure": "Das Weave-Profil konnte gerade nicht geladen werden.",
@@ -618,25 +660,55 @@
   "calendarClientSetupPrincipalUrlLabel": "Principal-URL",
   "calendarClientSetupCredentialPolicyTitle": "Zugangsdaten-Sicherheit",
   "calendarClientSetupAccessModelTitle": "Zugriffsmodell",
-  "@calendarClientSetupAccessModelTitle": {"description": "Heading for the calendar external client access model"},
+  "@calendarClientSetupAccessModelTitle": {
+    "description": "Heading for the calendar external client access model"
+  },
   "calendarClientSetupPrivateCalendarsAvailable": "Private Benutzerkalender verfügbar",
-  "@calendarClientSetupPrivateCalendarsAvailable": {"description": "Status text when private personal calendars are available"},
+  "@calendarClientSetupPrivateCalendarsAvailable": {
+    "description": "Status text when private personal calendars are available"
+  },
   "calendarClientSetupPrivateCalendarsBlocked": "Private Benutzerkalender blockiert",
-  "@calendarClientSetupPrivateCalendarsBlocked": {"description": "Status text when private personal calendars are blocked"},
+  "@calendarClientSetupPrivateCalendarsBlocked": {
+    "description": "Status text when private personal calendars are blocked"
+  },
   "calendarClientSetupExternalCredentialModel": "Externes Zugangsdatenmodell: {model}",
-  "@calendarClientSetupExternalCredentialModel": {"description": "Calendar external credential model label", "placeholders": {"model": {"type": "String"}}},
+  "@calendarClientSetupExternalCredentialModel": {
+    "description": "Calendar external credential model label",
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
   "calendarClientSetupCredentialReadinessTitle": "Bereitschaft der Zugangsdaten",
-  "@calendarClientSetupCredentialReadinessTitle": {"description": "Heading for calendar credential readiness details"},
+  "@calendarClientSetupCredentialReadinessTitle": {
+    "description": "Heading for calendar credential readiness details"
+  },
   "calendarClientSetupCredentialReadinessStatus": "Status: {status}",
-  "@calendarClientSetupCredentialReadinessStatus": {"description": "Calendar credential readiness status", "placeholders": {"status": {"type": "String"}}},
+  "@calendarClientSetupCredentialReadinessStatus": {
+    "description": "Calendar credential readiness status",
+    "placeholders": {
+      "status": {
+        "type": "String"
+      }
+    }
+  },
   "calendarClientSetupAppleProfileBlocked": "Apple-Profile bleiben deaktiviert, bis Profile signiert sind und sichere Zugangsdaten existieren.",
-  "@calendarClientSetupAppleProfileBlocked": {"description": "Blocked state explanation for Apple calendar profiles"},
+  "@calendarClientSetupAppleProfileBlocked": {
+    "description": "Blocked state explanation for Apple calendar profiles"
+  },
   "calendarClientSetupSubscriptionsBlocked": "Webcal/ICS-Abos bleiben deaktiviert, bis widerrufbare Read-only-Tokens existieren.",
-  "@calendarClientSetupSubscriptionsBlocked": {"description": "Blocked state explanation for calendar subscriptions"},
+  "@calendarClientSetupSubscriptionsBlocked": {
+    "description": "Blocked state explanation for calendar subscriptions"
+  },
   "calendarClientSetupCredentialsSafe": "Backend-Actor-Zugangsdaten werden nicht in Client-Einrichtungsdaten offengelegt.",
-  "@calendarClientSetupCredentialsSafe": {"description": "Safe credential boundary statement for calendar client setup"},
+  "@calendarClientSetupCredentialsSafe": {
+    "description": "Safe credential boundary statement for calendar client setup"
+  },
   "calendarClientSetupCredentialsUnsafe": "Die Einrichtung ist blockiert, weil Backend-Actor-Zugangsdaten offengelegt würden.",
-  "@calendarClientSetupCredentialsUnsafe": {"description": "Unsafe credential boundary warning for calendar client setup"},
+  "@calendarClientSetupCredentialsUnsafe": {
+    "description": "Unsafe credential boundary warning for calendar client setup"
+  },
   "calendarClientSetupPlatformsTitle": "Plattform-Einrichtung",
   "calendarClientSetupAvailableStatus": "verfügbar",
   "calendarClientSetupPlannedStatus": "geplant",
@@ -675,8 +747,7 @@
   "calendarCreateSuccess": "Kalendertermin erstellt.",
   "calendarUpdateSuccess": "Kalendertermin aktualisiert.",
   "calendarDeleteSuccess": "Kalendertermin gelöscht.",
-  "calendarOperationFailure": "Der Kalender konnte diese Änderung gerade nicht speichern."
-,
+  "calendarOperationFailure": "Der Kalender konnte diese Änderung gerade nicht speichern.",
   "boardsPreviewScreenTitle": "Boards-Vorschau",
   "boardsPreviewIconSemantic": "Boards-Vorschau",
   "boardsPreviewBoundaryTitle": "Zukünftige Boards-/Aufgaben-Vorschau",
@@ -720,7 +791,6 @@
   "boardsPreviewActionCompleted": "Aufgabe über die Backend-Fassade als erledigt markiert.",
   "boardsPreviewActionFailed": "Die Backend-Fassade konnte diese Boards-Vorschau-Aktion nicht speichern.",
   "boardsPreviewActionNoNextColumn": "Diese Aufgabe ist bereits in der letzten Vorschau-Spalte.",
-
   "settingsAdminSetupTitle": "Owner- und Admin-Einrichtung",
   "settingsAdminSetupDescription": "Workspace-Owner und Admins verwalten hier OIDC, Realm, Organisation und Dienstendpunkte. Mitglieder und Gäste sehen nur Anmeldung und Produkteinstellungen.",
   "settingsAdminPermissionTitle": "Admin-Steuerung freigeschaltet",
@@ -739,41 +809,71 @@
   "chatContextAgentHintTitle": "Agent-Kontextpakete",
   "chatContextAgentHintDescription": "Assistenten erhalten nur das begrenzte Paket für Anfrage, Erwähnung oder Zeitplan.",
   "firstRunAdminSetupTitle": "Owner-/Admin-Verantwortung bei der Einrichtung",
-  "firstRunAdminSetupDescription": "Deine Rolle darf die Workspace-Einrichtung verwalten. OIDC-, Realm-, Organisations-, Einladungs- und Dienstendpunkt-Änderungen gehören hier oder in die Einstellungen; normale Nutzer sollen nur eine Weave-Anmeldung brauchen."
-,
+  "firstRunAdminSetupDescription": "Deine Rolle darf die Workspace-Einrichtung verwalten. OIDC-, Realm-, Organisations-, Einladungs- und Dienstendpunkt-Änderungen gehören hier oder in die Einstellungen; normale Nutzer sollen nur eine Weave-Anmeldung brauchen.",
   "agentCapabilityPolicyTitle": "Governance für KI-Agenten-Funktionen",
-  "@agentCapabilityPolicyTitle": { "description": "Settings card title for AI agent capability governance" },
+  "@agentCapabilityPolicyTitle": {
+    "description": "Settings card title for AI agent capability governance"
+  },
   "agentCapabilityPolicyAdminDescription": "Owner und Admins entscheiden, welche Agentenpakete und Verbindungen genutzt werden dürfen. Diese Vorschau bleibt aus, bis Berechtigungen, Einwilligung und Audit-Kontrollen verbunden sind.",
-  "@agentCapabilityPolicyAdminDescription": { "description": "Admin-facing description for AI agent capability governance" },
+  "@agentCapabilityPolicyAdminDescription": {
+    "description": "Admin-facing description for AI agent capability governance"
+  },
   "agentCapabilityPolicyUserDescription": "KI-Agentenchats sind für diesen Workspace noch nicht aktiviert. Du kannst Weave normal weiter nutzen; zuerst müssen Owner oder Admins diese Funktion freigeben.",
-  "@agentCapabilityPolicyUserDescription": { "description": "Member-facing description for AI agent capability governance" },
+  "@agentCapabilityPolicyUserDescription": {
+    "description": "Member-facing description for AI agent capability governance"
+  },
   "agentCapabilityPolicyFailClosedNotice": "Agenten-Funktionen sind blockiert, bis Weave deine Rolle und die Workspace-Richtlinie bestätigen kann.",
-  "@agentCapabilityPolicyFailClosedNotice": { "description": "Fail-closed notice when policy cannot be trusted" },
+  "@agentCapabilityPolicyFailClosedNotice": {
+    "description": "Fail-closed notice when policy cannot be trusted"
+  },
   "agentCapabilityPolicyManageDisabledButton": "Verwaltung in dieser Vorschau nicht verfügbar",
-  "@agentCapabilityPolicyManageDisabledButton": { "description": "Disabled button label for future agent capability management" },
+  "@agentCapabilityPolicyManageDisabledButton": {
+    "description": "Disabled button label for future agent capability management"
+  },
   "agentCapabilityPolicyAskAdminHint": "Braucht dein Team einen Agenten? Bitte Owner oder Admins, Agenten-Funktionen zu prüfen, sobald sie verfügbar sind.",
-  "@agentCapabilityPolicyAskAdminHint": { "description": "Hint for non-admin users" },
+  "@agentCapabilityPolicyAskAdminHint": {
+    "description": "Hint for non-admin users"
+  },
   "agentCapabilityPolicyAdminStateHint": "Aktueller Zustand: standardmäßig aus. Künftige Kontrollen brauchen eine Owner-/Admin-Prüfung, bevor Nutzer einen Agenten starten können.",
-  "@agentCapabilityPolicyAdminStateHint": { "description": "Admin state hint for disabled agent capabilities" },
+  "@agentCapabilityPolicyAdminStateHint": {
+    "description": "Admin state hint for disabled agent capabilities"
+  },
   "agentCapabilityPersonalAssistantTitle": "Persönlicher Assistent",
-  "@agentCapabilityPersonalAssistantTitle": { "description": "Agent capability title for personal assistant" },
+  "@agentCapabilityPersonalAssistantTitle": {
+    "description": "Agent capability title for personal assistant"
+  },
   "agentCapabilityPersonalAssistantDescription": "Nutzt nur Kontext, den du für eine Anfrage auswählst, nachdem dein Workspace die Funktion aktiviert hat.",
-  "@agentCapabilityPersonalAssistantDescription": { "description": "Agent capability description for personal assistant" },
+  "@agentCapabilityPersonalAssistantDescription": {
+    "description": "Agent capability description for personal assistant"
+  },
   "agentCapabilityChannelAgentTitle": "Kanal-Agent",
-  "@agentCapabilityChannelAgentTitle": { "description": "Agent capability title for channel agent" },
+  "@agentCapabilityChannelAgentTitle": {
+    "description": "Agent capability title for channel agent"
+  },
   "agentCapabilityChannelAgentDescription": "Erfordert, dass Owner oder Admins auswählen, welche Kanäle, Dateien, Kalendertermine oder Boards der Agent nutzen darf.",
-  "@agentCapabilityChannelAgentDescription": { "description": "Agent capability description for channel agent" },
+  "@agentCapabilityChannelAgentDescription": {
+    "description": "Agent capability description for channel agent"
+  },
   "agentCapabilityAvailabilityPreviewOnly": "Nur Vorschau",
-  "@agentCapabilityAvailabilityPreviewOnly": { "description": "Agent capability availability label for preview-only state" },
+  "@agentCapabilityAvailabilityPreviewOnly": {
+    "description": "Agent capability availability label for preview-only state"
+  },
   "agentCapabilityAvailabilityAdminSetupRequired": "Admin-Einrichtung nötig",
-  "@agentCapabilityAvailabilityAdminSetupRequired": { "description": "Agent capability availability label when admin setup is required" },
+  "@agentCapabilityAvailabilityAdminSetupRequired": {
+    "description": "Agent capability availability label when admin setup is required"
+  },
   "agentCapabilityAvailabilityBlocked": "Blockiert",
-  "@agentCapabilityAvailabilityBlocked": { "description": "Agent capability availability label for blocked state" },
+  "@agentCapabilityAvailabilityBlocked": {
+    "description": "Agent capability availability label for blocked state"
+  },
   "agentCapabilityPolicyErrorTitle": "Agenten-Funktionsrichtlinie ist nicht verfügbar.",
-  "@agentCapabilityPolicyErrorTitle": { "description": "Error message for AI agent capability policy settings section" },
+  "@agentCapabilityPolicyErrorTitle": {
+    "description": "Error message for AI agent capability policy settings section"
+  },
   "agentCapabilityPolicyLoading": "Agenten-Funktionsrichtlinie wird geprüft…",
-  "@agentCapabilityPolicyLoading": { "description": "Loading message for AI agent capability policy settings section" }
-,
+  "@agentCapabilityPolicyLoading": {
+    "description": "Loading message for AI agent capability policy settings section"
+  },
   "workflowPreviewTitle": "Aktive Workflows",
   "workflowPreviewDescription": "Eine lineare Ansicht der aktuellen Schritte, Verantwortlichen, Blockaden und Evidenz. Diagramme können später dazukommen; diese Ansicht muss zuerst mit Tastatur und Screenreadern funktionieren.",
   "workflowPreviewLinearViewChip": "Lineare Ansicht zuerst",
@@ -802,7 +902,35 @@
   "workflowPreviewApprovalRequired": "Owner-Freigabe ist nötig, bevor diese Aktion ausgeführt werden kann.",
   "workflowPreviewAgentDryRunOnly": "Agentenhilfe bleibt ein Trockenlauf, bis Admin-Richtlinie und Freigabe verbunden sind.",
   "workflowPreviewOpenStepButton": "Schritt öffnen",
-  "workflowPreviewReviewEvidenceButton": "Evidenz prüfen"
-
-
+  "workflowPreviewReviewEvidenceButton": "Evidenz prüfen",
+  "@settingsProviderStackSemanticLabel": {
+    "description": "Accessibility label for provider readiness summary",
+    "placeholders": {
+      "backendOwnedFacades": {
+        "type": "String"
+      },
+      "flutterCalls": {
+        "type": "String"
+      }
+    }
+  },
+  "@settingsOfficeReadinessSemanticLabel": {
+    "description": "Accessibility label for Office readiness summary",
+    "placeholders": {
+      "launchState": {
+        "type": "String"
+      },
+      "providerState": {
+        "type": "String"
+      }
+    }
+  },
+  "@settingsOfficeReadinessModes": {
+    "description": "Enabled Office launch modes",
+    "placeholders": {
+      "modes": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,186 +1,279 @@
 {
   "@@locale": "en",
   "appTitle": "Weave",
-  "@appTitle": { "description": "Application title shown in the app bar and system task switcher" },
-
+  "@appTitle": {
+    "description": "Application title shown in the app bar and system task switcher"
+  },
   "welcomeTitle": "Welcome to Weave",
-  "@welcomeTitle": { "description": "Main heading on the welcome screen" },
-
+  "@welcomeTitle": {
+    "description": "Main heading on the welcome screen"
+  },
   "welcomeSubtitle": "Your unified collaboration hub for messaging, files, and secure self-hosted access.",
-  "@welcomeSubtitle": { "description": "Subtitle text below the welcome heading" },
-
+  "@welcomeSubtitle": {
+    "description": "Subtitle text below the welcome heading"
+  },
   "continueButton": "Get Started",
-  "@continueButton": { "description": "Label for the primary CTA on the welcome screen" },
-
+  "@continueButton": {
+    "description": "Label for the primary CTA on the welcome screen"
+  },
   "setupTitle": "Setup",
-  "@setupTitle": { "description": "Title for the setup flow screen" },
-
+  "@setupTitle": {
+    "description": "Title for the setup flow screen"
+  },
   "setupProviderStepTitle": "Connect Your Server",
-  "@setupProviderStepTitle": { "description": "Title for the setup provider and issuer step" },
-
+  "@setupProviderStepTitle": {
+    "description": "Title for the setup provider and issuer step"
+  },
   "setupProviderStepDescription": "Choose your OIDC provider and enter the issuer URL for your self-hosted setup.",
-  "@setupProviderStepDescription": { "description": "Description shown in the setup provider step" },
-
+  "@setupProviderStepDescription": {
+    "description": "Description shown in the setup provider step"
+  },
   "setupServicesStepTitle": "Review Service Endpoints",
-  "@setupServicesStepTitle": { "description": "Title for the setup services step" },
-
+  "@setupServicesStepTitle": {
+    "description": "Title for the setup services step"
+  },
   "setupServicesStepDescription": "Weave derives Matrix, Nextcloud, and backend API URLs from the issuer host. Review and edit them before finishing setup.",
-  "@setupServicesStepDescription": { "description": "Description shown in the setup services step" },
-
+  "@setupServicesStepDescription": {
+    "description": "Description shown in the setup services step"
+  },
   "setupLanguageStepTitle": "Your Language",
-  "@setupLanguageStepTitle": { "description": "Title for the language preference step" },
-
+  "@setupLanguageStepTitle": {
+    "description": "Title for the language preference step"
+  },
   "setupLanguageStepDescription": "Weave uses your device language. You can change it later in settings.",
-  "@setupLanguageStepDescription": { "description": "Description shown in the language step" },
-
+  "@setupLanguageStepDescription": {
+    "description": "Description shown in the language step"
+  },
   "setupConfirmStepTitle": "You're All Set",
-  "@setupConfirmStepTitle": { "description": "Title for the confirmation step" },
-
+  "@setupConfirmStepTitle": {
+    "description": "Title for the confirmation step"
+  },
   "setupConfirmStepDescription": "Tap Finish to start using Weave.",
-  "@setupConfirmStepDescription": { "description": "Description shown in the confirmation step" },
-
+  "@setupConfirmStepDescription": {
+    "description": "Description shown in the confirmation step"
+  },
   "setupNextButton": "Next",
-  "@setupNextButton": { "description": "Button to advance to the next setup step" },
-
+  "@setupNextButton": {
+    "description": "Button to advance to the next setup step"
+  },
   "setupFinishButton": "Finish",
-  "@setupFinishButton": { "description": "Button to complete setup" },
-
+  "@setupFinishButton": {
+    "description": "Button to complete setup"
+  },
   "setupBackButton": "Back",
-  "@setupBackButton": { "description": "Button to go back to the previous setup step" },
-
+  "@setupBackButton": {
+    "description": "Button to go back to the previous setup step"
+  },
   "setupStepIndicator": "Step {current} of {total}",
   "@setupStepIndicator": {
     "description": "Accessibility label for setup step progress",
     "placeholders": {
-      "current": { "type": "int" },
-      "total": { "type": "int" }
+      "current": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
     }
   },
-
   "navChat": "Chat",
-  "@navChat": { "description": "Label for the Chat navigation destination" },
-
+  "@navChat": {
+    "description": "Label for the Chat navigation destination"
+  },
   "navFiles": "Files",
-  "@navFiles": { "description": "Label for the Files navigation destination" },
-
+  "@navFiles": {
+    "description": "Label for the Files navigation destination"
+  },
   "navCalendar": "Calendar",
-  "@navCalendar": { "description": "Label for the Calendar navigation destination" },
-
+  "@navCalendar": {
+    "description": "Label for the Calendar navigation destination"
+  },
   "navDeck": "Boards preview",
-  "@navDeck": { "description": "Label for the hidden legacy Deck route, now provider-neutral boards preview" },
-
+  "@navDeck": {
+    "description": "Label for the hidden legacy Deck route, now provider-neutral boards preview"
+  },
   "navSettings": "Settings",
-  "@navSettings": { "description": "Label for the Settings navigation destination" },
-
+  "@navSettings": {
+    "description": "Label for the Settings navigation destination"
+  },
   "loadingLabel": "Loading…",
-  "@loadingLabel": { "description": "Screen reader label for loading indicators" },
-
+  "@loadingLabel": {
+    "description": "Screen reader label for loading indicators"
+  },
   "bootstrapLoadingLabel": "Preparing Weave…",
-  "@bootstrapLoadingLabel": { "description": "Message shown while bootstrap state is resolving" },
+  "@bootstrapLoadingLabel": {
+    "description": "Message shown while bootstrap state is resolving"
+  },
   "bootstrapLoadingHint": "Checking your workspace services and getting the shell ready.",
-  "@bootstrapLoadingHint": { "description": "Supporting copy shown while the workspace bootstrap state is resolving" },
+  "@bootstrapLoadingHint": {
+    "description": "Supporting copy shown while the workspace bootstrap state is resolving"
+  },
   "shellErrorTitle": "We could not get Weave ready",
-  "@shellErrorTitle": { "description": "Friendly error-state title shown when the app shell cannot finish bootstrap" },
+  "@shellErrorTitle": {
+    "description": "Friendly error-state title shown when the app shell cannot finish bootstrap"
+  },
   "shellErrorGuidance": "Try again. If this keeps happening, check that your workspace services are reachable.",
-  "@shellErrorGuidance": { "description": "Friendly recovery guidance shown when app shell bootstrap fails" },
-
+  "@shellErrorGuidance": {
+    "description": "Friendly recovery guidance shown when app shell bootstrap fails"
+  },
   "shellRecentActivityTitle": "Recent activity",
-  "@shellRecentActivityTitle": { "description": "Title for the compact recent activity card in the app shell" },
+  "@shellRecentActivityTitle": {
+    "description": "Title for the compact recent activity card in the app shell"
+  },
   "shellRecentActivityDescription": "Quick links to recent rooms and file changes.",
-  "@shellRecentActivityDescription": { "description": "Description for the recent activity card in the app shell" },
+  "@shellRecentActivityDescription": {
+    "description": "Description for the recent activity card in the app shell"
+  },
   "shellRecentActivitySemanticLabel": "Recent activity quick links",
-  "@shellRecentActivitySemanticLabel": { "description": "Semantic label for the recent activity card" },
+  "@shellRecentActivitySemanticLabel": {
+    "description": "Semantic label for the recent activity card"
+  },
   "shellRecentRoomsTitle": "Rooms",
-  "@shellRecentRoomsTitle": { "description": "Section title for recent room quick links in the app shell" },
+  "@shellRecentRoomsTitle": {
+    "description": "Section title for recent room quick links in the app shell"
+  },
   "shellRecentFilesTitle": "Files",
-  "@shellRecentFilesTitle": { "description": "Section title for recent file quick links in the app shell" },
+  "@shellRecentFilesTitle": {
+    "description": "Section title for recent file quick links in the app shell"
+  },
   "shellRecentRoomsLoading": "Loading recent rooms…",
-  "@shellRecentRoomsLoading": { "description": "Loading label for recent room quick links" },
+  "@shellRecentRoomsLoading": {
+    "description": "Loading label for recent room quick links"
+  },
   "shellRecentRoomsEmpty": "No recent rooms yet.",
-  "@shellRecentRoomsEmpty": { "description": "Empty state for recent room quick links" },
+  "@shellRecentRoomsEmpty": {
+    "description": "Empty state for recent room quick links"
+  },
   "shellRecentRoomsUnavailable": "Recent rooms are unavailable until chat is connected.",
-  "@shellRecentRoomsUnavailable": { "description": "Unavailable/error state for recent room quick links" },
+  "@shellRecentRoomsUnavailable": {
+    "description": "Unavailable/error state for recent room quick links"
+  },
   "shellRecentFilesLoading": "Loading recent file changes…",
-  "@shellRecentFilesLoading": { "description": "Loading label for recent file quick links" },
+  "@shellRecentFilesLoading": {
+    "description": "Loading label for recent file quick links"
+  },
   "shellRecentFilesEmpty": "No recent file changes yet.",
-  "@shellRecentFilesEmpty": { "description": "Empty state for recent file quick links" },
+  "@shellRecentFilesEmpty": {
+    "description": "Empty state for recent file quick links"
+  },
   "shellRecentFilesError": "Recent file changes could not be loaded.",
-  "@shellRecentFilesError": { "description": "Error state for recent file quick links" },
+  "@shellRecentFilesError": {
+    "description": "Error state for recent file quick links"
+  },
   "shellRecentFilesUnavailable": "Recent files are unavailable until files are connected.",
-  "@shellRecentFilesUnavailable": { "description": "Unavailable state for recent file quick links" },
+  "@shellRecentFilesUnavailable": {
+    "description": "Unavailable state for recent file quick links"
+  },
   "shellRecentActivityUnknownRecency": "recent",
-  "@shellRecentActivityUnknownRecency": { "description": "Fallback recency hint for activity items without a timestamp" },
+  "@shellRecentActivityUnknownRecency": {
+    "description": "Fallback recency hint for activity items without a timestamp"
+  },
   "shellRecentActivityNow": "now",
-  "@shellRecentActivityNow": { "description": "Recency hint for activity that just happened" },
+  "@shellRecentActivityNow": {
+    "description": "Recency hint for activity that just happened"
+  },
   "shellRecentActivityMinutesAgo": "{minutes}m ago",
   "@shellRecentActivityMinutesAgo": {
     "description": "Recency hint for activity from the past hour",
     "placeholders": {
-      "minutes": { "type": "int" }
+      "minutes": {
+        "type": "int"
+      }
     }
   },
   "shellRecentActivityToday": "today",
-  "@shellRecentActivityToday": { "description": "Recency hint for activity from today" },
+  "@shellRecentActivityToday": {
+    "description": "Recency hint for activity from today"
+  },
   "shellRecentActivityYesterday": "yesterday",
-  "@shellRecentActivityYesterday": { "description": "Recency hint for activity from yesterday" },
+  "@shellRecentActivityYesterday": {
+    "description": "Recency hint for activity from yesterday"
+  },
   "shellRecentRoomItemSemantic": "Open room {roomName}. Latest activity: {preview}. {recency}.",
   "@shellRecentRoomItemSemantic": {
     "description": "Semantic label for a recent room quick link",
     "placeholders": {
-      "roomName": { "type": "String" },
-      "preview": { "type": "String" },
-      "recency": { "type": "String" }
+      "roomName": {
+        "type": "String"
+      },
+      "preview": {
+        "type": "String"
+      },
+      "recency": {
+        "type": "String"
+      }
     }
   },
   "shellRecentFileItemSemantic": "Open {itemType} {itemName} in {path}. Changed {recency}.",
   "@shellRecentFileItemSemantic": {
     "description": "Semantic label for a recent file quick link",
     "placeholders": {
-      "itemType": { "type": "String" },
-      "itemName": { "type": "String" },
-      "path": { "type": "String" },
-      "recency": { "type": "String" }
+      "itemType": {
+        "type": "String"
+      },
+      "itemName": {
+        "type": "String"
+      },
+      "path": {
+        "type": "String"
+      },
+      "recency": {
+        "type": "String"
+      }
     }
   },
   "shellRecentFileFolderType": "folder",
-  "@shellRecentFileFolderType": { "description": "File activity type label for folders" },
+  "@shellRecentFileFolderType": {
+    "description": "File activity type label for folders"
+  },
   "shellRecentFileFileType": "file",
-  "@shellRecentFileFileType": { "description": "File activity type label for files" },
-
+  "@shellRecentFileFileType": {
+    "description": "File activity type label for files"
+  },
   "emptyStateLabel": "Nothing here yet",
-  "@emptyStateLabel": { "description": "Message shown when a list has no items" },
-
+  "@emptyStateLabel": {
+    "description": "Message shown when a list has no items"
+  },
   "errorStateLabel": "Something went wrong",
-  "@errorStateLabel": { "description": "Message shown when an error occurs" },
-
+  "@errorStateLabel": {
+    "description": "Message shown when an error occurs"
+  },
   "retryButton": "Retry",
-  "@retryButton": { "description": "Label for the retry action button" },
-
+  "@retryButton": {
+    "description": "Label for the retry action button"
+  },
   "semanticBackButton": "Go back",
-  "@semanticBackButton": { "description": "Semantic label for back navigation buttons" },
-
+  "@semanticBackButton": {
+    "description": "Semantic label for back navigation buttons"
+  },
   "semanticCloseButton": "Close",
-  "@semanticCloseButton": { "description": "Semantic label for close buttons" },
-
+  "@semanticCloseButton": {
+    "description": "Semantic label for close buttons"
+  },
   "semanticChatIcon": "Chat messages",
-  "@semanticChatIcon": { "description": "Semantic label for the chat icon" },
-
+  "@semanticChatIcon": {
+    "description": "Semantic label for the chat icon"
+  },
   "semanticFilesIcon": "File browser",
-  "@semanticFilesIcon": { "description": "Semantic label for the files icon" },
-
+  "@semanticFilesIcon": {
+    "description": "Semantic label for the files icon"
+  },
   "semanticCalendarIcon": "Calendar events",
-  "@semanticCalendarIcon": { "description": "Semantic label for the calendar icon" },
-
+  "@semanticCalendarIcon": {
+    "description": "Semantic label for the calendar icon"
+  },
   "semanticDeckIcon": "Boards preview",
-  "@semanticDeckIcon": { "description": "Semantic label for the hidden future boards preview icon" },
-
+  "@semanticDeckIcon": {
+    "description": "Semantic label for the hidden future boards preview icon"
+  },
   "semanticSettingsIcon": "Application settings",
-  "@semanticSettingsIcon": { "description": "Semantic label for the settings icon" },
-
+  "@semanticSettingsIcon": {
+    "description": "Semantic label for the settings icon"
+  },
   "semanticWeaveLogo": "Weave logo",
-  "@semanticWeaveLogo": { "description": "Semantic label for the Weave brand logo image" },
-
-
+  "@semanticWeaveLogo": {
+    "description": "Semantic label for the Weave brand logo image"
+  },
   "firstRunAppBarTitle": "First-run status",
   "firstRunLoadingLabel": "Checking your Weave workspace…",
   "firstRunLoadingHint": "Loading your profile, role, and module readiness from the Weave backend.",
@@ -209,284 +302,482 @@
   "firstRunNextStepsTitle": "Next steps",
   "firstRunRefreshButton": "Refresh status",
   "firstRunContinueButton": "Continue to chat",
-
   "chatProvisioningReadyTitle": "Chat is ready",
   "chatProvisioningPendingTitle": "Chat rooms are still being prepared",
   "chatProvisioningDegradedTitle": "Chat is available with degraded setup",
   "chatProvisioningActionNeededTitle": "Chat setup needs admin attention",
   "chatProvisioningRetryButton": "Retry status",
-
   "chatScreenTitle": "Chat",
-  "@chatScreenTitle": { "description": "Title for the chat screen app bar" },
-
+  "@chatScreenTitle": {
+    "description": "Title for the chat screen app bar"
+  },
   "chatOverviewTitle": "Weave Home",
-  "@chatOverviewTitle": { "description": "Title for the chat overview/home surface" },
+  "@chatOverviewTitle": {
+    "description": "Title for the chat overview/home surface"
+  },
   "chatOverviewDescription": "Your personal messages, favorites, channels, and AI chats are grouped here so the workspace starts from intent instead of a flat room list.",
-  "@chatOverviewDescription": { "description": "Description for the chat overview/home surface" },
+  "@chatOverviewDescription": {
+    "description": "Description for the chat overview/home surface"
+  },
   "chatFavoritesSectionTitle": "Favorites",
-  "@chatFavoritesSectionTitle": { "description": "Title for the favorites section in the chat overview" },
+  "@chatFavoritesSectionTitle": {
+    "description": "Title for the favorites section in the chat overview"
+  },
   "chatFavoritesSectionDescription": "Pinned people, channels, and AI chats you want to reach first.",
-  "@chatFavoritesSectionDescription": { "description": "Description for the favorites section in the chat overview" },
+  "@chatFavoritesSectionDescription": {
+    "description": "Description for the favorites section in the chat overview"
+  },
   "chatFavoritesSectionEmpty": "No favorites yet. When favorites sync is available, important direct messages, channels, and AI chats will stay here.",
-  "@chatFavoritesSectionEmpty": { "description": "Empty state for the favorites section in the chat overview" },
+  "@chatFavoritesSectionEmpty": {
+    "description": "Empty state for the favorites section in the chat overview"
+  },
   "chatPersonalMessagesSectionTitle": "Personal messages",
-  "@chatPersonalMessagesSectionTitle": { "description": "Title for the personal messages section in the chat overview" },
+  "@chatPersonalMessagesSectionTitle": {
+    "description": "Title for the personal messages section in the chat overview"
+  },
   "chatPersonalMessagesSectionDescription": "Direct conversations with people in your workspace.",
-  "@chatPersonalMessagesSectionDescription": { "description": "Description for the personal messages section in the chat overview" },
+  "@chatPersonalMessagesSectionDescription": {
+    "description": "Description for the personal messages section in the chat overview"
+  },
   "chatPersonalMessagesSectionEmpty": "No personal messages are available yet.",
-  "@chatPersonalMessagesSectionEmpty": { "description": "Empty state for the personal messages section in the chat overview" },
+  "@chatPersonalMessagesSectionEmpty": {
+    "description": "Empty state for the personal messages section in the chat overview"
+  },
   "chatChannelsSectionTitle": "Channels",
-  "@chatChannelsSectionTitle": { "description": "Title for the channel section in the chat overview" },
+  "@chatChannelsSectionTitle": {
+    "description": "Title for the channel section in the chat overview"
+  },
   "chatChannelsSectionDescription": "Team and topic rooms for shared work.",
-  "@chatChannelsSectionDescription": { "description": "Description for the channel section in the chat overview" },
+  "@chatChannelsSectionDescription": {
+    "description": "Description for the channel section in the chat overview"
+  },
   "chatChannelsSectionEmpty": "No channels are available yet.",
-  "@chatChannelsSectionEmpty": { "description": "Empty state for the channel section in the chat overview" },
+  "@chatChannelsSectionEmpty": {
+    "description": "Empty state for the channel section in the chat overview"
+  },
   "chatAiChatsSectionTitle": "AI chats",
-  "@chatAiChatsSectionTitle": { "description": "Title for the AI chats section in the chat overview" },
+  "@chatAiChatsSectionTitle": {
+    "description": "Title for the AI chats section in the chat overview"
+  },
   "chatAiChatsSectionDescription": "Specialized assistant and agent chats live in their own area.",
-  "@chatAiChatsSectionDescription": { "description": "Description for the AI chats section in the chat overview" },
+  "@chatAiChatsSectionDescription": {
+    "description": "Description for the AI chats section in the chat overview"
+  },
   "chatAiChatsSectionEmpty": "No AI chats are connected yet. Future specialized agents will appear here instead of being mixed into personal messages.",
-  "@chatAiChatsSectionEmpty": { "description": "Empty state for the AI chats section in the chat overview" },
-
+  "@chatAiChatsSectionEmpty": {
+    "description": "Empty state for the AI chats section in the chat overview"
+  },
   "chatAgentGovernanceTitle": "Agent chats are governed by your workspace",
-  "@chatAgentGovernanceTitle": { "description": "Title for the governed agent chat preview panel" },
+  "@chatAgentGovernanceTitle": {
+    "description": "Title for the governed agent chat preview panel"
+  },
   "chatAgentGovernanceDescription": "Agents can help inside Weave only after an owner or admin enables a package, chooses scopes, and keeps consent and audit visible.",
-  "@chatAgentGovernanceDescription": { "description": "Description for the governed agent chat preview panel" },
+  "@chatAgentGovernanceDescription": {
+    "description": "Description for the governed agent chat preview panel"
+  },
   "chatAgentContextPackTitle": "Context pack before action",
-  "@chatAgentContextPackTitle": { "description": "Title for the agent context pack explanation card" },
+  "@chatAgentContextPackTitle": {
+    "description": "Title for the agent context pack explanation card"
+  },
   "chatAgentContextPackDescription": "When an agent is available, Weave will show what context is sent for this request before the agent uses it.",
-  "@chatAgentContextPackDescription": { "description": "Description for the agent context pack explanation card" },
+  "@chatAgentContextPackDescription": {
+    "description": "Description for the agent context pack explanation card"
+  },
   "chatAgentContextPackScopedBullet": "Context is scoped to a selected chat, file, calendar event, board, or explicit workspace source.",
-  "@chatAgentContextPackScopedBullet": { "description": "Bullet explaining scoped agent context" },
+  "@chatAgentContextPackScopedBullet": {
+    "description": "Bullet explaining scoped agent context"
+  },
   "chatAgentContextPackConsentBullet": "You will see permission hints before starting or approving an agent action.",
-  "@chatAgentContextPackConsentBullet": { "description": "Bullet explaining consent and permission hints for agent context" },
+  "@chatAgentContextPackConsentBullet": {
+    "description": "Bullet explaining consent and permission hints for agent context"
+  },
   "chatAgentContextPackNoSurveillanceBullet": "Agents do not continuously read rooms in the background.",
-  "@chatAgentContextPackNoSurveillanceBullet": { "description": "Bullet explaining that agents are not surveillance-aware" },
+  "@chatAgentContextPackNoSurveillanceBullet": {
+    "description": "Bullet explaining that agents are not surveillance-aware"
+  },
   "chatAgentGovernanceAuditNote": "Audit placeholders are part of this preview: agent creation, context access, tool/action execution, approval, and revocation must be recorded before runtime promotion.",
-  "@chatAgentGovernanceAuditNote": { "description": "Audit and approval note for the governed agent chat preview panel" },
+  "@chatAgentGovernanceAuditNote": {
+    "description": "Audit and approval note for the governed agent chat preview panel"
+  },
   "chatAgentAvailabilityPreview": "Preview only",
-  "@chatAgentAvailabilityPreview": { "description": "Agent availability label for a preview-only agent" },
+  "@chatAgentAvailabilityPreview": {
+    "description": "Agent availability label for a preview-only agent"
+  },
   "chatAgentAvailabilityAdminSetup": "Admin setup required",
-  "@chatAgentAvailabilityAdminSetup": { "description": "Agent availability label when setup must be done by an admin" },
+  "@chatAgentAvailabilityAdminSetup": {
+    "description": "Agent availability label when setup must be done by an admin"
+  },
   "chatAgentAvailabilityBlocked": "Blocked by policy",
-  "@chatAgentAvailabilityBlocked": { "description": "Agent availability label when policy blocks an agent" },
+  "@chatAgentAvailabilityBlocked": {
+    "description": "Agent availability label when policy blocks an agent"
+  },
   "chatAgentPersonalAssistantTitle": "Personal assistant",
-  "@chatAgentPersonalAssistantTitle": { "description": "Title for the personal assistant preview tile" },
+  "@chatAgentPersonalAssistantTitle": {
+    "description": "Title for the personal assistant preview tile"
+  },
   "chatAgentPersonalAssistantDescription": "A future private assistant chat for drafting, summaries, and reminders inside Weave.",
-  "@chatAgentPersonalAssistantDescription": { "description": "Description for the personal assistant preview tile" },
+  "@chatAgentPersonalAssistantDescription": {
+    "description": "Description for the personal assistant preview tile"
+  },
   "chatAgentChannelAgentTitle": "Channel agent",
-  "@chatAgentChannelAgentTitle": { "description": "Title for the channel agent preview tile" },
+  "@chatAgentChannelAgentTitle": {
+    "description": "Title for the channel agent preview tile"
+  },
   "chatAgentChannelAgentDescription": "A future helper for a channel or project space, governed by an admin-approved package.",
-  "@chatAgentChannelAgentDescription": { "description": "Description for the channel agent preview tile" },
+  "@chatAgentChannelAgentDescription": {
+    "description": "Description for the channel agent preview tile"
+  },
   "chatAgentPersonalScope": "Uses only context you choose for the current request; workspace policy decides which skills are available.",
-  "@chatAgentPersonalScope": { "description": "Scope explanation for personal assistant preview" },
+  "@chatAgentPersonalScope": {
+    "description": "Scope explanation for personal assistant preview"
+  },
   "chatAgentPersonalBoundary": "No continuous room reading; a context pack is assembled only after you start or approve a request.",
-  "@chatAgentPersonalBoundary": { "description": "Boundary explanation for personal assistant preview" },
+  "@chatAgentPersonalBoundary": {
+    "description": "Boundary explanation for personal assistant preview"
+  },
   "chatAgentPersonalAudit": "Creation, context access, tool use, and permission changes will be auditable before runtime use.",
-  "@chatAgentPersonalAudit": { "description": "Audit explanation for personal assistant preview" },
+  "@chatAgentPersonalAudit": {
+    "description": "Audit explanation for personal assistant preview"
+  },
   "chatAgentChannelScope": "An owner or admin must enable the package and choose allowed chat, files, calendar, and board scopes.",
-  "@chatAgentChannelScope": { "description": "Scope explanation for channel agent preview" },
+  "@chatAgentChannelScope": {
+    "description": "Scope explanation for channel agent preview"
+  },
   "chatAgentChannelBoundary": "The agent sees named spaces and explicit context packs, not every message in the workspace.",
-  "@chatAgentChannelBoundary": { "description": "Boundary explanation for channel agent preview" },
+  "@chatAgentChannelBoundary": {
+    "description": "Boundary explanation for channel agent preview"
+  },
   "chatAgentChannelAudit": "Approvals, revocations, and action attempts stay visible to admins without exposing secrets to the app.",
-  "@chatAgentChannelAudit": { "description": "Audit explanation for channel agent preview" },
+  "@chatAgentChannelAudit": {
+    "description": "Audit explanation for channel agent preview"
+  },
   "chatAgentStartDisabledButton": "Unavailable until enabled",
-  "@chatAgentStartDisabledButton": { "description": "Disabled action label for preview agent chats" },
-
+  "@chatAgentStartDisabledButton": {
+    "description": "Disabled action label for preview agent chats"
+  },
   "chatLoadingLabel": "Loading conversations…",
-  "@chatLoadingLabel": { "description": "Message shown while the chat room list is loading" },
+  "@chatLoadingLabel": {
+    "description": "Message shown while the chat room list is loading"
+  },
   "chatLoadingHint": "Gathering your latest rooms and recent conversation state.",
-  "@chatLoadingHint": { "description": "Supporting copy shown while the chat conversation list is loading" },
-
+  "@chatLoadingHint": {
+    "description": "Supporting copy shown while the chat conversation list is loading"
+  },
   "chatConnectingLabel": "Connecting to Matrix…",
-  "@chatConnectingLabel": { "description": "Message shown while Matrix OAuth sign-in is in progress" },
+  "@chatConnectingLabel": {
+    "description": "Message shown while Matrix OAuth sign-in is in progress"
+  },
   "chatConnectingHint": "We are opening your secure Matrix session and syncing the first room list.",
-  "@chatConnectingHint": { "description": "Supporting copy shown while Matrix sign-in is connecting" },
-
+  "@chatConnectingHint": {
+    "description": "Supporting copy shown while Matrix sign-in is connecting"
+  },
   "chatConnectButton": "Connect Matrix",
-  "@chatConnectButton": { "description": "Button label to start or retry Matrix sign-in" },
-
+  "@chatConnectButton": {
+    "description": "Button label to start or retry Matrix sign-in"
+  },
   "chatRefreshingRoomsLabel": "Refreshing chat rooms",
-  "@chatRefreshingRoomsLabel": { "description": "Accessibility label for the progress indicator shown while the existing chat room list is refreshing" },
+  "@chatRefreshingRoomsLabel": {
+    "description": "Accessibility label for the progress indicator shown while the existing chat room list is refreshing"
+  },
   "chatStaleRoomsTitle": "Showing last known rooms",
-  "@chatStaleRoomsTitle": { "description": "Title for a chat notice shown when refresh failed but cached conversations remain visible" },
+  "@chatStaleRoomsTitle": {
+    "description": "Title for a chat notice shown when refresh failed but cached conversations remain visible"
+  },
   "chatStaleRoomsGuidance": "We could not refresh Matrix just now. Your room list is preserved so you can keep your place and retry when the connection is back.",
-  "@chatStaleRoomsGuidance": { "description": "Guidance for a chat notice shown when refresh failed but cached conversations remain visible" },
+  "@chatStaleRoomsGuidance": {
+    "description": "Guidance for a chat notice shown when refresh failed but cached conversations remain visible"
+  },
   "chatStaleRoomsRetryButton": "Refresh rooms",
-  "@chatStaleRoomsRetryButton": { "description": "Button label for retrying a stale chat room list refresh" },
-
+  "@chatStaleRoomsRetryButton": {
+    "description": "Button label for retrying a stale chat room list refresh"
+  },
   "channelWorkspaceSummaryTitle": "{channelName} workspace",
   "@channelWorkspaceSummaryTitle": {
     "description": "Title for the channel workspace summary card",
-    "placeholders": { "channelName": { "type": "String" } }
+    "placeholders": {
+      "channelName": {
+        "type": "String"
+      }
+    }
   },
   "channelWorkspaceSummaryDescription": "This channel is a work room with tabs for chat, files, boards, calendar, and meetings where the workspace has enabled them.",
-  "@channelWorkspaceSummaryDescription": { "description": "Description for the channel workspace summary card" },
+  "@channelWorkspaceSummaryDescription": {
+    "description": "Description for the channel workspace summary card"
+  },
   "channelWorkspaceGovernanceNote": "Context stays explicit: no hidden continuous room reading and no ordinary member access to admin setup.",
-  "@channelWorkspaceGovernanceNote": { "description": "Governance note for channel workspace tabs" },
+  "@channelWorkspaceGovernanceNote": {
+    "description": "Governance note for channel workspace tabs"
+  },
   "channelWorkspaceTabsSemanticLabel": "Channel workspace tabs for {channelName}",
   "@channelWorkspaceTabsSemanticLabel": {
     "description": "Semantic label for the channel workspace tab list",
-    "placeholders": { "channelName": { "type": "String" } }
+    "placeholders": {
+      "channelName": {
+        "type": "String"
+      }
+    }
   },
   "channelWorkspaceChatTab": "Chat",
-  "@channelWorkspaceChatTab": { "description": "Channel workspace chat tab label" },
+  "@channelWorkspaceChatTab": {
+    "description": "Channel workspace chat tab label"
+  },
   "channelWorkspaceFilesTab": "Files",
-  "@channelWorkspaceFilesTab": { "description": "Channel workspace files tab label" },
+  "@channelWorkspaceFilesTab": {
+    "description": "Channel workspace files tab label"
+  },
   "channelWorkspaceBoardsTab": "Boards",
-  "@channelWorkspaceBoardsTab": { "description": "Channel workspace boards tab label" },
+  "@channelWorkspaceBoardsTab": {
+    "description": "Channel workspace boards tab label"
+  },
   "channelWorkspaceCalendarTab": "Calendar",
-  "@channelWorkspaceCalendarTab": { "description": "Channel workspace calendar tab label" },
+  "@channelWorkspaceCalendarTab": {
+    "description": "Channel workspace calendar tab label"
+  },
   "channelWorkspaceMeetingsTab": "Meetings",
-  "@channelWorkspaceMeetingsTab": { "description": "Channel workspace meetings tab label" },
+  "@channelWorkspaceMeetingsTab": {
+    "description": "Channel workspace meetings tab label"
+  },
   "channelWorkspaceChatTitle": "Channel chat",
-  "@channelWorkspaceChatTitle": { "description": "Title for the chat surface in a channel workspace" },
+  "@channelWorkspaceChatTitle": {
+    "description": "Title for the chat surface in a channel workspace"
+  },
   "channelWorkspaceFilesTitle": "Channel files",
-  "@channelWorkspaceFilesTitle": { "description": "Title for the files surface in a channel workspace" },
+  "@channelWorkspaceFilesTitle": {
+    "description": "Title for the files surface in a channel workspace"
+  },
   "channelWorkspaceBoardsTitle": "Channel boards and tasks",
-  "@channelWorkspaceBoardsTitle": { "description": "Title for the boards/tasks surface in a channel workspace" },
+  "@channelWorkspaceBoardsTitle": {
+    "description": "Title for the boards/tasks surface in a channel workspace"
+  },
   "channelWorkspaceCalendarTitle": "Channel calendar",
-  "@channelWorkspaceCalendarTitle": { "description": "Title for the calendar surface in a channel workspace" },
+  "@channelWorkspaceCalendarTitle": {
+    "description": "Title for the calendar surface in a channel workspace"
+  },
   "channelWorkspaceMeetingsTitle": "Channel meeting preview",
-  "@channelWorkspaceMeetingsTitle": { "description": "Title for the meetings preview surface in a channel workspace" },
+  "@channelWorkspaceMeetingsTitle": {
+    "description": "Title for the meetings preview surface in a channel workspace"
+  },
   "channelWorkspaceChatDescription": "Messages remain the default live context for this channel.",
-  "@channelWorkspaceChatDescription": { "description": "Description for the channel chat surface" },
+  "@channelWorkspaceChatDescription": {
+    "description": "Description for the channel chat surface"
+  },
   "channelWorkspaceFilesDescription": "Channel file linking is a preview seam. Files will attach through the Weave files facade instead of raw provider paths once the backend contract is ready.",
-  "@channelWorkspaceFilesDescription": { "description": "Description for the channel files preview placeholder" },
+  "@channelWorkspaceFilesDescription": {
+    "description": "Description for the channel files preview placeholder"
+  },
   "channelWorkspaceBoardsDescription": "Linked boards and tasks are shown as an honest preview until provider-neutral board state is connected to this channel context.",
-  "@channelWorkspaceBoardsDescription": { "description": "Description for the channel boards/tasks preview placeholder" },
+  "@channelWorkspaceBoardsDescription": {
+    "description": "Description for the channel boards/tasks preview placeholder"
+  },
   "channelWorkspaceCalendarDescription": "Channel events stay gated until calendar scope capability is available for this workspace.",
-  "@channelWorkspaceCalendarDescription": { "description": "Description for the gated channel calendar placeholder" },
+  "@channelWorkspaceCalendarDescription": {
+    "description": "Description for the gated channel calendar placeholder"
+  },
   "channelWorkspaceMeetingsDescription": "Meetings will attach to this channel's calendar, agenda, decisions, tasks, files, and follow-up evidence. No live video meeting backend is connected yet.",
-  "@channelWorkspaceMeetingsDescription": { "description": "Description for the gated channel meetings preview placeholder" },
+  "@channelWorkspaceMeetingsDescription": {
+    "description": "Description for the gated channel meetings preview placeholder"
+  },
   "channelWorkspaceMeetingsCapabilityTitle": "Video and encryption capability not connected",
-  "@channelWorkspaceMeetingsCapabilityTitle": { "description": "Title explaining that channel meetings are fail-closed until backend and encryption evidence exist" },
+  "@channelWorkspaceMeetingsCapabilityTitle": {
+    "description": "Title explaining that channel meetings are fail-closed until backend and encryption evidence exist"
+  },
   "channelWorkspaceMeetingsCapabilityBody": "Join and start stay disabled until Weave has a documented meeting provider plus evidence for signaling, media, captions, recordings, and metadata boundaries. This preview does not claim secure or encrypted calls are available.",
-  "@channelWorkspaceMeetingsCapabilityBody": { "description": "Body explaining honest fail-closed channel meeting capability state" },
+  "@channelWorkspaceMeetingsCapabilityBody": {
+    "description": "Body explaining honest fail-closed channel meeting capability state"
+  },
   "channelWorkspaceMeetingsPrivacyTitle": "Explicit meeting context only",
-  "@channelWorkspaceMeetingsPrivacyTitle": { "description": "Title for the explicit context rule in the channel meetings preview" },
+  "@channelWorkspaceMeetingsPrivacyTitle": {
+    "description": "Title for the explicit context rule in the channel meetings preview"
+  },
   "channelWorkspaceMeetingsPrivacyBody": "Only context explicitly selected from {channelName} is prepared for a meeting. Weave does not continuously read, record, or transcribe the room in the background.",
   "@channelWorkspaceMeetingsPrivacyBody": {
     "description": "Privacy/context note for the channel meetings preview",
-    "placeholders": { "channelName": { "type": "String" } }
+    "placeholders": {
+      "channelName": {
+        "type": "String"
+      }
+    }
   },
   "channelWorkspaceMeetingsRecordingOff": "Recording and transcription off",
-  "@channelWorkspaceMeetingsRecordingOff": { "description": "Status chip for recording/transcription off in channel meetings preview" },
+  "@channelWorkspaceMeetingsRecordingOff": {
+    "description": "Status chip for recording/transcription off in channel meetings preview"
+  },
   "channelWorkspaceMeetingsContextTitle": "Context pack for this meeting",
-  "@channelWorkspaceMeetingsContextTitle": { "description": "Title for the channel meeting context pack preview" },
+  "@channelWorkspaceMeetingsContextTitle": {
+    "description": "Title for the channel meeting context pack preview"
+  },
   "channelWorkspaceMeetingsContextBody": "A meeting pack is explicit and reviewable before anyone joins.",
-  "@channelWorkspaceMeetingsContextBody": { "description": "Body for the channel meeting context pack preview" },
+  "@channelWorkspaceMeetingsContextBody": {
+    "description": "Body for the channel meeting context pack preview"
+  },
   "channelWorkspaceMeetingsContextAgenda": "Agenda",
-  "@channelWorkspaceMeetingsContextAgenda": { "description": "Meeting context chip for agenda" },
+  "@channelWorkspaceMeetingsContextAgenda": {
+    "description": "Meeting context chip for agenda"
+  },
   "channelWorkspaceMeetingsContextFiles": "Files",
-  "@channelWorkspaceMeetingsContextFiles": { "description": "Meeting context chip for files" },
+  "@channelWorkspaceMeetingsContextFiles": {
+    "description": "Meeting context chip for files"
+  },
   "channelWorkspaceMeetingsContextDecisions": "Decisions",
-  "@channelWorkspaceMeetingsContextDecisions": { "description": "Meeting context chip for decisions" },
+  "@channelWorkspaceMeetingsContextDecisions": {
+    "description": "Meeting context chip for decisions"
+  },
   "channelWorkspaceMeetingsContextTasks": "Tasks",
-  "@channelWorkspaceMeetingsContextTasks": { "description": "Meeting context chip for tasks" },
+  "@channelWorkspaceMeetingsContextTasks": {
+    "description": "Meeting context chip for tasks"
+  },
   "channelWorkspaceMeetingsContextEvidence": "Follow-up evidence",
-  "@channelWorkspaceMeetingsContextEvidence": { "description": "Meeting context chip for follow-up evidence" },
+  "@channelWorkspaceMeetingsContextEvidence": {
+    "description": "Meeting context chip for follow-up evidence"
+  },
   "channelWorkspaceMeetingsJoinButton": "Join meeting",
-  "@channelWorkspaceMeetingsJoinButton": { "description": "Disabled join button in channel meetings preview" },
+  "@channelWorkspaceMeetingsJoinButton": {
+    "description": "Disabled join button in channel meetings preview"
+  },
   "channelWorkspaceMeetingsStartButton": "Start meeting",
-  "@channelWorkspaceMeetingsStartButton": { "description": "Disabled start button in channel meetings preview" },
+  "@channelWorkspaceMeetingsStartButton": {
+    "description": "Disabled start button in channel meetings preview"
+  },
   "channelWorkspaceMeetingsBackendUnavailableReason": "Meeting provider capability is not available yet.",
-  "@channelWorkspaceMeetingsBackendUnavailableReason": { "description": "Disabled reason for meeting controls when backend capability is absent" },
+  "@channelWorkspaceMeetingsBackendUnavailableReason": {
+    "description": "Disabled reason for meeting controls when backend capability is absent"
+  },
   "channelWorkspaceStatusAvailable": "Available",
-  "@channelWorkspaceStatusAvailable": { "description": "Status label for an available channel workspace surface" },
+  "@channelWorkspaceStatusAvailable": {
+    "description": "Status label for an available channel workspace surface"
+  },
   "channelWorkspaceStatusPreview": "Preview contract",
-  "@channelWorkspaceStatusPreview": { "description": "Status label for a preview-only channel workspace surface" },
+  "@channelWorkspaceStatusPreview": {
+    "description": "Status label for a preview-only channel workspace surface"
+  },
   "channelWorkspaceStatusGated": "Gated by capability",
-  "@channelWorkspaceStatusGated": { "description": "Status label for a gated channel workspace surface" },
+  "@channelWorkspaceStatusGated": {
+    "description": "Status label for a gated channel workspace surface"
+  },
   "channelWorkspaceProviderContract": "Provider seam: {contractId}",
   "@channelWorkspaceProviderContract": {
     "description": "Provider/domain seam label for a channel workspace surface",
-    "placeholders": { "contractId": { "type": "String" } }
+    "placeholders": {
+      "contractId": {
+        "type": "String"
+      }
+    }
   },
   "channelWorkspaceExplicitContextNote": "Only explicit context from {channelName} is shown here; Weave does not continuously read the room in the background.",
   "@channelWorkspaceExplicitContextNote": {
     "description": "Privacy/context note for a channel workspace surface",
-    "placeholders": { "channelName": { "type": "String" } }
+    "placeholders": {
+      "channelName": {
+        "type": "String"
+      }
+    }
   },
-
   "filesScreenTitle": "Files",
-  "@filesScreenTitle": { "description": "Title for the files screen app bar" },
+  "@filesScreenTitle": {
+    "description": "Title for the files screen app bar"
+  },
   "filesLoadingLabel": "Loading files…",
-  "@filesLoadingLabel": { "description": "Message shown while the Files screen is loading the current directory" },
+  "@filesLoadingLabel": {
+    "description": "Message shown while the Files screen is loading the current directory"
+  },
   "filesLoadingHint": "Refreshing the current folder and checking what changed.",
-  "@filesLoadingHint": { "description": "Supporting copy shown while the Files screen is loading the current directory" },
-
+  "@filesLoadingHint": {
+    "description": "Supporting copy shown while the Files screen is loading the current directory"
+  },
   "filesStaleDirectoryTitle": "Showing last known folder",
-  "@filesStaleDirectoryTitle": {"description": "Title for a Files notice shown when refresh failed but the previous directory listing remains visible"},
+  "@filesStaleDirectoryTitle": {
+    "description": "Title for a Files notice shown when refresh failed but the previous directory listing remains visible"
+  },
   "filesStaleDirectoryGuidance": "We could not refresh Files just now. The last folder listing stays visible so you can keep your place and retry when the connection is back.",
-  "@filesStaleDirectoryGuidance": {"description": "Guidance for a Files notice shown when refresh failed but cached folder contents remain visible"},
+  "@filesStaleDirectoryGuidance": {
+    "description": "Guidance for a Files notice shown when refresh failed but cached folder contents remain visible"
+  },
   "filesStaleDirectoryRetryButton": "Refresh folder",
-  "@filesStaleDirectoryRetryButton": {"description": "Button label for retrying a stale Files directory refresh"},
-
+  "@filesStaleDirectoryRetryButton": {
+    "description": "Button label for retrying a stale Files directory refresh"
+  },
   "filesNextcloudTitle": "Weave Files",
-  "@filesNextcloudTitle": { "description": "Deprecated alias for the Weave Files connection card title" },
-
+  "@filesNextcloudTitle": {
+    "description": "Deprecated alias for the Weave Files connection card title"
+  },
   "filesProductTitle": "Weave Files",
-  "@filesProductTitle": { "description": "Section title for the Weave Files connection card" },
-
+  "@filesProductTitle": {
+    "description": "Section title for the Weave Files connection card"
+  },
   "filesProductBoundaryTitle": "Weave product boundary",
-  "@filesProductBoundaryTitle": { "description": "Title for a Files card explaining the product/provider boundary" },
-
+  "@filesProductBoundaryTitle": {
+    "description": "Title for a Files card explaining the product/provider boundary"
+  },
   "filesProductBoundaryBody": "Files actions use the Weave backend facade. Nextcloud remains the storage provider and admin/fallback surface; raw provider paths and credentials are not part of the normal Files UX.",
-  "@filesProductBoundaryBody": { "description": "Body for a Files card explaining the product/provider boundary" },
-
+  "@filesProductBoundaryBody": {
+    "description": "Body for a Files card explaining the product/provider boundary"
+  },
   "filesConnectButton": "Connect Files",
-  "@filesConnectButton": { "description": "Button label used to start the Files connection flow" },
-
+  "@filesConnectButton": {
+    "description": "Button label used to start the Files connection flow"
+  },
   "filesReconnectButton": "Reconnect Files",
-  "@filesReconnectButton": { "description": "Button label used to reconnect an invalid Files session" },
-
+  "@filesReconnectButton": {
+    "description": "Button label used to reconnect an invalid Files session"
+  },
   "filesDisconnectButton": "Disconnect",
-  "@filesDisconnectButton": { "description": "Button label used to disconnect the saved Files session" },
-
+  "@filesDisconnectButton": {
+    "description": "Button label used to disconnect the saved Files session"
+  },
   "filesRefreshButton": "Refresh",
-  "@filesRefreshButton": { "description": "Button label used to refresh the current Nextcloud directory" },
-
+  "@filesRefreshButton": {
+    "description": "Button label used to refresh the current Nextcloud directory"
+  },
   "filesUpButton": "Up",
-  "@filesUpButton": { "description": "Button label used to open the parent Nextcloud directory" },
-
+  "@filesUpButton": {
+    "description": "Button label used to open the parent Nextcloud directory"
+  },
   "filesRootBreadcrumb": "Root",
-  "@filesRootBreadcrumb": { "description": "Label for the root breadcrumb in the files browser" },
-
+  "@filesRootBreadcrumb": {
+    "description": "Label for the root breadcrumb in the files browser"
+  },
   "filesOpenFolderSemantic": "Open folder: {name}",
   "@filesOpenFolderSemantic": {
     "description": "Semantic label for a breadcrumb that opens a folder in the files browser",
     "placeholders": {
-      "name": { "type": "String" }
+      "name": {
+        "type": "String"
+      }
     }
   },
-
   "filesCurrentFolderSemantic": "Current folder: {name}",
   "@filesCurrentFolderSemantic": {
     "description": "Semantic label for the current breadcrumb in the files browser",
     "placeholders": {
-      "name": { "type": "String" }
+      "name": {
+        "type": "String"
+      }
     }
   },
-
   "filesDirectorySummary": "{folderCount, plural, =0{No folders} one{1 folder} other{{folderCount} folders}} • {fileCount, plural, =0{no files} one{1 file} other{{fileCount} files}}",
   "@filesDirectorySummary": {
     "description": "Summary for the current directory contents",
     "placeholders": {
-      "folderCount": { "type": "int" },
-      "fileCount": { "type": "int" }
+      "folderCount": {
+        "type": "int"
+      },
+      "fileCount": {
+        "type": "int"
+      }
     }
   },
-
   "filesDisconnectedMessage": "Connect Weave Files to browse workspace files.",
-  "@filesDisconnectedMessage": { "description": "Message shown when the Files screen is disconnected" },
-
+  "@filesDisconnectedMessage": {
+    "description": "Message shown when the Files screen is disconnected"
+  },
   "filesInvalidSessionMessage": "Reconnect Files because the Weave session is no longer valid.",
-  "@filesInvalidSessionMessage": { "description": "Message shown when the saved Files session is no longer valid" },
-
+  "@filesInvalidSessionMessage": {
+    "description": "Message shown when the saved Files session is no longer valid"
+  },
   "filesMisconfiguredMessage": "Finish Weave server setup before connecting files.",
-  "@filesMisconfiguredMessage": { "description": "Message shown when the Files feature is missing required server setup" },
-
+  "@filesMisconfiguredMessage": {
+    "description": "Message shown when the Files feature is missing required server setup"
+  },
   "filesConnectionConnected": "Connected as {accountLabel}",
   "@filesConnectionConnected": {
     "description": "Status message shown when the Files feature is connected through Weave",
@@ -496,184 +787,253 @@
       }
     }
   },
-
   "filesConnectionDisconnected": "Files are not connected for this Weave session.",
-  "@filesConnectionDisconnected": { "description": "Status message shown when Files are not connected" },
-
+  "@filesConnectionDisconnected": {
+    "description": "Status message shown when Files are not connected"
+  },
   "filesConnectionInvalid": "The Weave Files session needs attention.",
-  "@filesConnectionInvalid": { "description": "Status message shown when the Files session is invalid" },
-
+  "@filesConnectionInvalid": {
+    "description": "Status message shown when the Files session is invalid"
+  },
   "filesConnectionMisconfigured": "Server setup is incomplete for Weave Files.",
-  "@filesConnectionMisconfigured": { "description": "Status message shown when Weave Files server setup is incomplete" },
-
+  "@filesConnectionMisconfigured": {
+    "description": "Status message shown when Weave Files server setup is incomplete"
+  },
   "filesOpenParentSemantic": "Open parent folder",
-  "@filesOpenParentSemantic": { "description": "Semantic label for the action that opens the parent Nextcloud directory" },
-
+  "@filesOpenParentSemantic": {
+    "description": "Semantic label for the action that opens the parent Nextcloud directory"
+  },
   "filesRefreshCurrentFolderSemantic": "Refresh the current folder",
-  "@filesRefreshCurrentFolderSemantic": { "description": "Semantic label for the action that refreshes the current Nextcloud directory" },
-
+  "@filesRefreshCurrentFolderSemantic": {
+    "description": "Semantic label for the action that refreshes the current Nextcloud directory"
+  },
   "filesUploadButton": "Upload",
-  "@filesUploadButton": { "description": "Button label for uploading a file to the current folder" },
-
+  "@filesUploadButton": {
+    "description": "Button label for uploading a file to the current folder"
+  },
   "filesUploadCurrentFolderSemantic": "Upload a file to the current folder",
-  "@filesUploadCurrentFolderSemantic": { "description": "Semantic label for the action that uploads a file to the current folder" },
-
+  "@filesUploadCurrentFolderSemantic": {
+    "description": "Semantic label for the action that uploads a file to the current folder"
+  },
   "filesCreateFolderButton": "New folder",
-  "@filesCreateFolderButton": { "description": "Button label for creating a folder in the current files directory" },
-
+  "@filesCreateFolderButton": {
+    "description": "Button label for creating a folder in the current files directory"
+  },
   "filesCreateFolderCurrentFolderSemantic": "Create a folder in the current folder",
-  "@filesCreateFolderCurrentFolderSemantic": { "description": "Semantic label for the action that creates a folder in the current directory" },
-
+  "@filesCreateFolderCurrentFolderSemantic": {
+    "description": "Semantic label for the action that creates a folder in the current directory"
+  },
   "filesCreateFolderDialogTitle": "Create folder",
-  "@filesCreateFolderDialogTitle": { "description": "Title for the create-folder dialog" },
-
+  "@filesCreateFolderDialogTitle": {
+    "description": "Title for the create-folder dialog"
+  },
   "filesCreateFolderNameLabel": "Folder name",
-  "@filesCreateFolderNameLabel": { "description": "Input label for a new folder name" },
-
+  "@filesCreateFolderNameLabel": {
+    "description": "Input label for a new folder name"
+  },
   "filesCreateFolderNameHint": "e.g. Project docs",
-  "@filesCreateFolderNameHint": { "description": "Input hint for a new folder name" },
-
+  "@filesCreateFolderNameHint": {
+    "description": "Input hint for a new folder name"
+  },
   "filesCreateFolderConfirmButton": "Create",
-  "@filesCreateFolderConfirmButton": { "description": "Button label to confirm folder creation" },
-
+  "@filesCreateFolderConfirmButton": {
+    "description": "Button label to confirm folder creation"
+  },
   "filesCancelButton": "Cancel",
-  "@filesCancelButton": { "description": "Button label to cancel a files action" },
-
+  "@filesCancelButton": {
+    "description": "Button label to cancel a files action"
+  },
   "filesDeleteButton": "Delete",
-  "@filesDeleteButton": { "description": "Button label to confirm deletion of a file or folder" },
-
+  "@filesDeleteButton": {
+    "description": "Button label to confirm deletion of a file or folder"
+  },
   "filesExportEntrySemantic": "Export {name} to native files",
   "@filesExportEntrySemantic": {
     "description": "Tooltip/semantic label for exporting a file to native platform file surfaces",
-    "placeholders": { "name": { "type": "String" } }
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
   },
-
   "filesExportProgressMessage": "Exporting {name}…",
   "@filesExportProgressMessage": {
     "description": "Status message while a file is exported",
-    "placeholders": { "name": { "type": "String" } }
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
   },
-
   "filesExportProgressUnknownMessage": "Exporting file…",
-  "@filesExportProgressUnknownMessage": { "description": "Status message while an unnamed file is exported" },
-
+  "@filesExportProgressUnknownMessage": {
+    "description": "Status message while an unnamed file is exported"
+  },
   "filesExportCompletedMessage": "Exported {name} to {destination}.",
   "@filesExportCompletedMessage": {
     "description": "Status message after a file is exported to a native file surface",
     "placeholders": {
-      "name": { "type": "String" },
-      "destination": { "type": "String" }
+      "name": {
+        "type": "String"
+      },
+      "destination": {
+        "type": "String"
+      }
     }
   },
-
   "filesExportCompletedUnknownMessage": "Exported file to native files.",
-  "@filesExportCompletedUnknownMessage": { "description": "Status message after an unnamed file is exported" },
-
+  "@filesExportCompletedUnknownMessage": {
+    "description": "Status message after an unnamed file is exported"
+  },
   "filesExportUserVisibleFallback": "a user-visible files location",
-  "@filesExportUserVisibleFallback": { "description": "Fallback destination label when the platform does not expose an export path" },
-
+  "@filesExportUserVisibleFallback": {
+    "description": "Fallback destination label when the platform does not expose an export path"
+  },
   "filesDeleteEntrySemantic": "Delete {name}",
   "@filesDeleteEntrySemantic": {
     "description": "Semantic label for deleting a file or folder",
-    "placeholders": { "name": { "type": "String" } }
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
   },
-
   "filesDeleteEntryDialogTitle": "Delete {name}?",
   "@filesDeleteEntryDialogTitle": {
     "description": "Title for the delete confirmation dialog",
-    "placeholders": { "name": { "type": "String" } }
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
   },
-
   "filesDeleteEntryDialogMessage": "This removes it from Weave files for everyone with access. This cannot be undone.",
-  "@filesDeleteEntryDialogMessage": { "description": "Warning shown before deleting a file or folder" },
-
+  "@filesDeleteEntryDialogMessage": {
+    "description": "Warning shown before deleting a file or folder"
+  },
   "filesCreateFolderProgressUnknownMessage": "Creating folder…",
-  "@filesCreateFolderProgressUnknownMessage": { "description": "Status shown while creating a folder when no name is available" },
-
+  "@filesCreateFolderProgressUnknownMessage": {
+    "description": "Status shown while creating a folder when no name is available"
+  },
   "filesCreateFolderProgressMessage": "Creating folder {folderName}…",
   "@filesCreateFolderProgressMessage": {
     "description": "Status shown while creating a folder",
-    "placeholders": { "folderName": { "type": "String" } }
+    "placeholders": {
+      "folderName": {
+        "type": "String"
+      }
+    }
   },
-
   "filesCreateFolderCompletedUnknownMessage": "Folder created.",
-  "@filesCreateFolderCompletedUnknownMessage": { "description": "Status shown after creating a folder when no name is available" },
-
+  "@filesCreateFolderCompletedUnknownMessage": {
+    "description": "Status shown after creating a folder when no name is available"
+  },
   "filesCreateFolderCompletedMessage": "Created folder {folderName}.",
   "@filesCreateFolderCompletedMessage": {
     "description": "Status shown after creating a folder",
-    "placeholders": { "folderName": { "type": "String" } }
+    "placeholders": {
+      "folderName": {
+        "type": "String"
+      }
+    }
   },
-
   "filesDeleteProgressUnknownMessage": "Deleting item…",
-  "@filesDeleteProgressUnknownMessage": { "description": "Status shown while deleting a file or folder when no name is available" },
-
+  "@filesDeleteProgressUnknownMessage": {
+    "description": "Status shown while deleting a file or folder when no name is available"
+  },
   "filesDeleteProgressMessage": "Deleting {name}…",
   "@filesDeleteProgressMessage": {
     "description": "Status shown while deleting a file or folder",
-    "placeholders": { "name": { "type": "String" } }
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
   },
-
   "filesDeleteCompletedUnknownMessage": "Item deleted.",
-  "@filesDeleteCompletedUnknownMessage": { "description": "Status shown after deleting a file or folder when no name is available" },
-
+  "@filesDeleteCompletedUnknownMessage": {
+    "description": "Status shown after deleting a file or folder when no name is available"
+  },
   "filesDeleteCompletedMessage": "Deleted {name}.",
   "@filesDeleteCompletedMessage": {
     "description": "Status shown after deleting a file or folder",
-    "placeholders": { "name": { "type": "String" } }
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
   },
-
   "filesEntryActionFailedMessage": "File action failed.",
-  "@filesEntryActionFailedMessage": { "description": "Fallback status shown when a file operation fails" },
-
+  "@filesEntryActionFailedMessage": {
+    "description": "Fallback status shown when a file operation fails"
+  },
   "filesUploadPickingMessage": "Choose a file to upload…",
-  "@filesUploadPickingMessage": { "description": "Status shown while the native file picker is open" },
-
+  "@filesUploadPickingMessage": {
+    "description": "Status shown while the native file picker is open"
+  },
   "filesUploadProgressUnknownMessage": "Uploading file…",
-  "@filesUploadProgressUnknownMessage": { "description": "Status shown while uploading when no filename is available" },
-
+  "@filesUploadProgressUnknownMessage": {
+    "description": "Status shown while uploading when no filename is available"
+  },
   "filesUploadProgressIndeterminateMessage": "Uploading {fileName}…",
   "@filesUploadProgressIndeterminateMessage": {
     "description": "Status shown while uploading when total progress is unavailable",
-    "placeholders": { "fileName": { "type": "String" } }
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
   },
-
   "filesUploadProgressMessage": "Uploading {fileName}: {percent}%",
   "@filesUploadProgressMessage": {
     "description": "Status shown while a file upload is in progress",
     "placeholders": {
-      "fileName": { "type": "String" },
-      "percent": { "type": "int" }
+      "fileName": {
+        "type": "String"
+      },
+      "percent": {
+        "type": "int"
+      }
     }
   },
-
   "filesUploadProgressSemantic": "Upload progress for {fileName}: {percent} percent",
   "@filesUploadProgressSemantic": {
     "description": "Semantic label for file upload progress",
     "placeholders": {
-      "fileName": { "type": "String" },
-      "percent": { "type": "int" }
+      "fileName": {
+        "type": "String"
+      },
+      "percent": {
+        "type": "int"
+      }
     }
   },
-
   "filesUploadCompletedUnknownMessage": "Upload complete.",
-  "@filesUploadCompletedUnknownMessage": { "description": "Status shown after an upload completes when no filename is available" },
-
+  "@filesUploadCompletedUnknownMessage": {
+    "description": "Status shown after an upload completes when no filename is available"
+  },
   "filesUploadCompletedMessage": "Uploaded {fileName}.",
   "@filesUploadCompletedMessage": {
     "description": "Status shown after a file upload completes",
-    "placeholders": { "fileName": { "type": "String" } }
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
   },
-
   "filesUploadFailedUnknownMessage": "Upload failed.",
-  "@filesUploadFailedUnknownMessage": { "description": "Status shown after an upload fails when no filename is available" },
-
+  "@filesUploadFailedUnknownMessage": {
+    "description": "Status shown after an upload fails when no filename is available"
+  },
   "filesUploadFailedMessage": "Upload failed for {fileName}.",
   "@filesUploadFailedMessage": {
     "description": "Status shown after a file upload fails",
-    "placeholders": { "fileName": { "type": "String" } }
+    "placeholders": {
+      "fileName": {
+        "type": "String"
+      }
+    }
   },
-
   "filesFolderSemantic": "{name}, folder",
   "@filesFolderSemantic": {
     "description": "Semantic label for a folder row in the Files list",
@@ -683,7 +1043,6 @@
       }
     }
   },
-
   "filesFileSemantic": "{name}, file",
   "@filesFileSemantic": {
     "description": "Semantic label for a file row in the Files list",
@@ -693,1378 +1052,2611 @@
       }
     }
   },
-
   "calendarScreenTitle": "Calendar",
-  "@calendarScreenTitle": { "description": "Title for the calendar screen app bar" },
-
+  "@calendarScreenTitle": {
+    "description": "Title for the calendar screen app bar"
+  },
   "deckScreenTitle": "Boards preview",
-  "@deckScreenTitle": { "description": "Compatibility title for the hidden legacy Deck route" },
-
+  "@deckScreenTitle": {
+    "description": "Compatibility title for the hidden legacy Deck route"
+  },
   "settingsScreenTitle": "Settings",
-  "@settingsScreenTitle": { "description": "Title for the settings screen app bar" },
-
+  "@settingsScreenTitle": {
+    "description": "Title for the settings screen app bar"
+  },
   "settingsBrandSectionDescription": "Weave focuses on accessible, data-sovereign collaboration: chat, files, shared calendars, E2EE architecture, and boards behind clear gates.",
-  "@settingsBrandSectionDescription": { "description": "Subtle branded copy shown in the settings header card" },
-
+  "@settingsBrandSectionDescription": {
+    "description": "Subtle branded copy shown in the settings header card"
+  },
   "settingsThemeTitle": "Appearance",
-  "@settingsThemeTitle": { "description": "Settings section title for personal theme selection" },
-
+  "@settingsThemeTitle": {
+    "description": "Settings section title for personal theme selection"
+  },
   "settingsThemeDescription": "Choose the visual style for this profile. Workspace brand defaults stay separate, so your personal choice is not overwritten by admin setup.",
-  "@settingsThemeDescription": { "description": "Settings description explaining personal theme selection and workspace defaults" },
-
+  "@settingsThemeDescription": {
+    "description": "Settings description explaining personal theme selection and workspace defaults"
+  },
   "settingsThemeSystemTitle": "Use device setting",
-  "@settingsThemeSystemTitle": { "description": "Theme option title for system/default mode" },
-
+  "@settingsThemeSystemTitle": {
+    "description": "Theme option title for system/default mode"
+  },
   "settingsThemeSystemDescription": "Follow your device light or dark appearance.",
-  "@settingsThemeSystemDescription": { "description": "Theme option description for system/default mode" },
-
+  "@settingsThemeSystemDescription": {
+    "description": "Theme option description for system/default mode"
+  },
   "settingsThemeLightTitle": "Light",
-  "@settingsThemeLightTitle": { "description": "Theme option title for light mode" },
-
+  "@settingsThemeLightTitle": {
+    "description": "Theme option title for light mode"
+  },
   "settingsThemeLightDescription": "Use a bright professional palette.",
-  "@settingsThemeLightDescription": { "description": "Theme option description for light mode" },
-
+  "@settingsThemeLightDescription": {
+    "description": "Theme option description for light mode"
+  },
   "settingsThemeDarkTitle": "Dark",
-  "@settingsThemeDarkTitle": { "description": "Theme option title for dark mode" },
-
+  "@settingsThemeDarkTitle": {
+    "description": "Theme option title for dark mode"
+  },
   "settingsThemeDarkDescription": "Use a darker palette for low-light work.",
-  "@settingsThemeDarkDescription": { "description": "Theme option description for dark mode" },
-
+  "@settingsThemeDarkDescription": {
+    "description": "Theme option description for dark mode"
+  },
   "settingsThemeHighContrastTitle": "High contrast",
-  "@settingsThemeHighContrastTitle": { "description": "Theme option title for high-contrast mode" },
-
+  "@settingsThemeHighContrastTitle": {
+    "description": "Theme option title for high-contrast mode"
+  },
   "settingsThemeHighContrastDescription": "Use stronger contrast while still following your device light or dark appearance.",
-  "@settingsThemeHighContrastDescription": { "description": "Theme option description for high-contrast mode" },
-
+  "@settingsThemeHighContrastDescription": {
+    "description": "Theme option description for high-contrast mode"
+  },
   "settingsThemeLoading": "Loading appearance preferences…",
-  "@settingsThemeLoading": { "description": "Loading state for theme preference settings" },
-
+  "@settingsThemeLoading": {
+    "description": "Loading state for theme preference settings"
+  },
   "settingsThemeError": "Appearance preferences could not be saved. Try changing the setting again.",
-  "@settingsThemeError": { "description": "Error shown when theme preferences cannot load or save" },
-
+  "@settingsThemeError": {
+    "description": "Error shown when theme preferences cannot load or save"
+  },
   "settingsHelpTitle": "Help and user handbook",
-  "@settingsHelpTitle": { "description": "Title for the settings entry point to in-app help" },
-
+  "@settingsHelpTitle": {
+    "description": "Title for the settings entry point to in-app help"
+  },
   "settingsHelpDescription": "Open practical guidance for using Weave, recovering from issues, and understanding privacy basics.",
-  "@settingsHelpDescription": { "description": "Description for the settings entry point to in-app help" },
-
+  "@settingsHelpDescription": {
+    "description": "Description for the settings entry point to in-app help"
+  },
   "helpScreenTitle": "Help",
-  "@helpScreenTitle": { "description": "Title for the in-app help screen app bar" },
-
+  "@helpScreenTitle": {
+    "description": "Title for the in-app help screen app bar"
+  },
   "helpHandbookTitle": "User handbook",
-  "@helpHandbookTitle": { "description": "Hero title for the in-app user handbook" },
-
+  "@helpHandbookTitle": {
+    "description": "Hero title for the in-app user handbook"
+  },
   "helpHandbookDescription": "This handbook explains the everyday Weave app in plain language. It is available offline with the app and will grow as more surfaces become ready.",
-  "@helpHandbookDescription": { "description": "Introductory text for the in-app user handbook" },
-
+  "@helpHandbookDescription": {
+    "description": "Introductory text for the in-app user handbook"
+  },
   "helpWhatIsWeaveTitle": "What Weave is",
-  "@helpWhatIsWeaveTitle": { "description": "Help section title explaining the product" },
-
+  "@helpWhatIsWeaveTitle": {
+    "description": "Help section title explaining the product"
+  },
   "helpWhatIsWeaveBody": "Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and future collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.",
-  "@helpWhatIsWeaveBody": { "description": "Help copy explaining what Weave is" },
-
+  "@helpWhatIsWeaveBody": {
+    "description": "Help copy explaining what Weave is"
+  },
   "helpSignInTitle": "Sign in basics",
-  "@helpSignInTitle": { "description": "Help section title for sign-in basics" },
-
+  "@helpSignInTitle": {
+    "description": "Help section title for sign-in basics"
+  },
   "helpSignInBody": "Use the workspace address provided by your admin, then sign in once with Weave SSO. You should not need separate Matrix or Nextcloud passwords for normal use. If sign-in loops or fails, check your connection, confirm the server address in Settings, and ask an admin whether your invite or account is active.",
-  "@helpSignInBody": { "description": "Help copy for sign-in basics and recovery" },
-
+  "@helpSignInBody": {
+    "description": "Help copy for sign-in basics and recovery"
+  },
   "helpChatTitle": "Chat",
-  "@helpChatTitle": { "description": "Help section title for chat" },
-
+  "@helpChatTitle": {
+    "description": "Help section title for chat"
+  },
   "helpChatBody": "Chat is the daily place for rooms and messages. Open Chat from the main navigation, connect Matrix if asked, then choose a room. Weave keeps room and recovery states visible so you can see when chat is connected, waiting, degraded, or needs admin attention.",
-  "@helpChatBody": { "description": "Help copy for chat basics" },
-
+  "@helpChatBody": {
+    "description": "Help copy for chat basics"
+  },
   "helpFilesTitle": "Files",
-  "@helpFilesTitle": { "description": "Help section title for files" },
-
+  "@helpFilesTitle": {
+    "description": "Help section title for files"
+  },
   "helpFilesBody": "Files lets you browse workspace documents through the Weave app. Open Files from the main navigation, move through folders, and retry if the folder could not refresh. The underlying storage is provided by your workspace services, but everyday browsing should stay inside Weave.",
-  "@helpFilesBody": { "description": "Help copy for files basics" },
-
+  "@helpFilesBody": {
+    "description": "Help copy for files basics"
+  },
   "helpSettingsTitle": "Settings, account, and session",
-  "@helpSettingsTitle": { "description": "Help section title for settings and account basics" },
-
+  "@helpSettingsTitle": {
+    "description": "Help section title for settings and account basics"
+  },
   "helpSettingsBody": "Settings shows your profile summary, workspace readiness, server configuration, Matrix security information, and sign-out control. Use it to check whether Chat, Files, Calendar, or other modules are ready, and sign out before handing a device to someone else.",
-  "@helpSettingsBody": { "description": "Help copy for settings, account, and session basics" },
-
+  "@helpSettingsBody": {
+    "description": "Help copy for settings, account, and session basics"
+  },
   "helpCalendarBoardsTitle": "Calendar and Boards availability",
-  "@helpCalendarBoardsTitle": { "description": "Help section title for gated Calendar and Boards availability" },
-
+  "@helpCalendarBoardsTitle": {
+    "description": "Help section title for gated Calendar and Boards availability"
+  },
   "helpCalendarBoardsBody": "Calendar and Boards are active Weave product scope, but they may be hidden or marked unavailable until your workspace has the required backend contracts and feature gates enabled. If they are not visible in navigation, use Chat, Files, and Settings for now and watch workspace readiness for changes.",
-  "@helpCalendarBoardsBody": { "description": "Help copy honestly explaining gated Calendar and Boards availability" },
-
+  "@helpCalendarBoardsBody": {
+    "description": "Help copy honestly explaining gated Calendar and Boards availability"
+  },
   "helpTroubleshootingTitle": "Troubleshooting and recovery",
-  "@helpTroubleshootingTitle": { "description": "Help section title for troubleshooting and recovery" },
-
+  "@helpTroubleshootingTitle": {
+    "description": "Help section title for troubleshooting and recovery"
+  },
   "helpTroubleshootingBody": "When something does not load, use Retry first. If a stale chat room list or folder remains visible, Weave is preserving your place while refresh fails. Persistent setup, sign-in, Matrix, files, or backend errors should be shared with your admin together with the visible message and the server address from Settings.",
-  "@helpTroubleshootingBody": { "description": "Help copy for troubleshooting and recovery states" },
-
+  "@helpTroubleshootingBody": {
+    "description": "Help copy for troubleshooting and recovery states"
+  },
   "helpPrivacySecurityTitle": "Privacy and security basics",
-  "@helpPrivacySecurityTitle": { "description": "Help section title for privacy and security basics" },
-
+  "@helpPrivacySecurityTitle": {
+    "description": "Help section title for privacy and security basics"
+  },
   "helpPrivacySecurityBody": "Your workspace controls its own services and data. Weave uses SSO for access and shows Matrix security status honestly. Do not assume chat is fully end-to-end encrypted unless Weave says the Matrix encryption, recovery, and device-trust gates are healthy. Keep recovery keys in a safe place and report lost devices to your admin.",
-  "@helpPrivacySecurityBody": { "description": "Help copy for privacy and security basics" },
-
+  "@helpPrivacySecurityBody": {
+    "description": "Help copy for privacy and security basics"
+  },
   "settingsShellModulesTitle": "Shell modules",
-  "@settingsShellModulesTitle": { "description": "Section title for user-configurable shell module visibility" },
-
+  "@settingsShellModulesTitle": {
+    "description": "Section title for user-configurable shell module visibility"
+  },
   "settingsShellModulesDescription": "Choose which workspace shell modules stay visible. Navigation remains available even when a module is hidden.",
-  "@settingsShellModulesDescription": { "description": "Description for shell module visibility settings" },
-
-
+  "@settingsShellModulesDescription": {
+    "description": "Description for shell module visibility settings"
+  },
   "settingsShellWorkspaceStatusToggleTitle": "Workspace status summary",
-  "@settingsShellWorkspaceStatusToggleTitle": { "description": "Switch title for the workspace status shell module visibility preference" },
-
+  "@settingsShellWorkspaceStatusToggleTitle": {
+    "description": "Switch title for the workspace status shell module visibility preference"
+  },
   "settingsShellWorkspaceStatusToggleDescription": "Show service readiness and recovery shortcuts above the bottom navigation.",
-  "@settingsShellWorkspaceStatusToggleDescription": { "description": "Switch description for the workspace status shell module visibility preference" },
-
+  "@settingsShellWorkspaceStatusToggleDescription": {
+    "description": "Switch description for the workspace status shell module visibility preference"
+  },
   "settingsShellMoveModuleUp": "Move {moduleName} up",
   "@settingsShellMoveModuleUp": {
     "description": "Tooltip for moving a shell module earlier in the shell order",
-    "placeholders": { "moduleName": { "type": "String" } }
+    "placeholders": {
+      "moduleName": {
+        "type": "String"
+      }
+    }
   },
-
   "settingsShellMoveModuleDown": "Move {moduleName} down",
   "@settingsShellMoveModuleDown": {
     "description": "Tooltip for moving a shell module later in the shell order",
-    "placeholders": { "moduleName": { "type": "String" } }
+    "placeholders": {
+      "moduleName": {
+        "type": "String"
+      }
+    }
   },
-
   "settingsShellRecentActivityToggleTitle": "Recent activity quick links",
-  "@settingsShellRecentActivityToggleTitle": { "description": "Switch title for the recent activity shell module visibility preference" },
-
+  "@settingsShellRecentActivityToggleTitle": {
+    "description": "Switch title for the recent activity shell module visibility preference"
+  },
   "settingsShellRecentActivityToggleDescription": "Show recent rooms and file changes above the bottom navigation.",
-  "@settingsShellRecentActivityToggleDescription": { "description": "Switch description for the recent activity shell module visibility preference" },
-
+  "@settingsShellRecentActivityToggleDescription": {
+    "description": "Switch description for the recent activity shell module visibility preference"
+  },
   "settingsShellModulesLoading": "Loading shell module preferences…",
-  "@settingsShellModulesLoading": { "description": "Loading state for shell module visibility settings" },
-
+  "@settingsShellModulesLoading": {
+    "description": "Loading state for shell module visibility settings"
+  },
   "settingsShellModulesError": "Shell module preferences could not be saved. Try changing the setting again.",
-  "@settingsShellModulesError": { "description": "Error shown when shell module preferences cannot load or save" },
-
+  "@settingsShellModulesError": {
+    "description": "Error shown when shell module preferences cannot load or save"
+  },
   "chatSecuritySectionTitle": "Matrix security",
-  "@chatSecuritySectionTitle": { "description": "Section title for Matrix security status and actions in settings" },
-
+  "@chatSecuritySectionTitle": {
+    "description": "Section title for Matrix security status and actions in settings"
+  },
   "chatSecuritySectionDescription": "Weave only treats Matrix encryption as healthy when secret storage, cross-signing, recovery, and device trust are all in place.",
-  "@chatSecuritySectionDescription": { "description": "Description shown above the Matrix security section in settings" },
-
+  "@chatSecuritySectionDescription": {
+    "description": "Description shown above the Matrix security section in settings"
+  },
   "chatSecurityRecoveryKeyTitle": "Save this Matrix recovery key now",
-  "@chatSecurityRecoveryKeyTitle": { "description": "Title shown when the app displays the generated Matrix recovery key" },
-
+  "@chatSecurityRecoveryKeyTitle": {
+    "description": "Title shown when the app displays the generated Matrix recovery key"
+  },
   "chatSecurityRecoveryKeyDescription": "Weave does not rely on app-only storage for this key because secure storage can disappear after reinstall, device replacement, or some platform restores. Keep it in your password manager or another secure place.",
-  "@chatSecurityRecoveryKeyDescription": { "description": "Warning text shown alongside the generated Matrix recovery key" },
-
+  "@chatSecurityRecoveryKeyDescription": {
+    "description": "Warning text shown alongside the generated Matrix recovery key"
+  },
   "chatSecurityBannerTitle": "Matrix security needs attention",
-  "@chatSecurityBannerTitle": { "description": "Title for the in-chat warning banner about Matrix security" },
-
+  "@chatSecurityBannerTitle": {
+    "description": "Title for the in-chat warning banner about Matrix security"
+  },
   "chatSecurityBannerSetupMessage": "Encrypted Matrix rooms are available, but this account still needs initial security setup.",
-  "@chatSecurityBannerSetupMessage": { "description": "Banner body when Matrix encryption setup has not been completed yet" },
-
+  "@chatSecurityBannerSetupMessage": {
+    "description": "Banner body when Matrix encryption setup has not been completed yet"
+  },
   "chatSecurityBannerRecoveryMessage": "This device needs your Matrix recovery key before older encrypted messages can be trusted again.",
-  "@chatSecurityBannerRecoveryMessage": { "description": "Banner body when Matrix recovery is required on the current device" },
-
+  "@chatSecurityBannerRecoveryMessage": {
+    "description": "Banner body when Matrix recovery is required on the current device"
+  },
   "chatSecurityBannerVerificationMessage": "This device or account is not fully verified yet. Compare security emoji with another signed-in Matrix device.",
-  "@chatSecurityBannerVerificationMessage": { "description": "Banner body when Matrix device or account verification still needs attention" },
-
+  "@chatSecurityBannerVerificationMessage": {
+    "description": "Banner body when Matrix device or account verification still needs attention"
+  },
   "chatSecurityBannerMissingBackupMessage": "Matrix key backup is still missing. Set it up before relying on encrypted chat recovery.",
-  "@chatSecurityBannerMissingBackupMessage": { "description": "Banner body when Matrix key backup has not been configured" },
-
+  "@chatSecurityBannerMissingBackupMessage": {
+    "description": "Banner body when Matrix key backup has not been configured"
+  },
   "chatSecurityOpenSettingsButton": "Open security settings",
-  "@chatSecurityOpenSettingsButton": { "description": "Button label that opens settings from the Matrix security banner" },
-
+  "@chatSecurityOpenSettingsButton": {
+    "description": "Button label that opens settings from the Matrix security banner"
+  },
   "chatSecuritySetupCardTitle": "Setup",
-  "@chatSecuritySetupCardTitle": { "description": "Title for the Matrix security setup status card" },
-
+  "@chatSecuritySetupCardTitle": {
+    "description": "Title for the Matrix security setup status card"
+  },
   "chatSecurityCurrentDeviceCardTitle": "Current device",
-  "@chatSecurityCurrentDeviceCardTitle": { "description": "Title for the Matrix security current device status card" },
-
+  "@chatSecurityCurrentDeviceCardTitle": {
+    "description": "Title for the Matrix security current device status card"
+  },
   "chatSecurityRecoveryCardTitle": "Recovery and key backup",
-  "@chatSecurityRecoveryCardTitle": { "description": "Title for the Matrix security recovery status card" },
-
+  "@chatSecurityRecoveryCardTitle": {
+    "description": "Title for the Matrix security recovery status card"
+  },
   "chatSecurityRecoveryCardBody": "The recovery key is needed when this device is replaced, reinstalled, or loses local crypto secrets.",
-  "@chatSecurityRecoveryCardBody": { "description": "Description in the Matrix recovery card" },
-
+  "@chatSecurityRecoveryCardBody": {
+    "description": "Description in the Matrix recovery card"
+  },
   "chatSecurityEncryptedRoomsCardTitle": "Encrypted rooms",
-  "@chatSecurityEncryptedRoomsCardTitle": { "description": "Title for the Matrix encrypted rooms status card" },
-
+  "@chatSecurityEncryptedRoomsCardTitle": {
+    "description": "Title for the Matrix encrypted rooms status card"
+  },
   "chatSecurityEncryptedRoomsCardBodyExisting": "Encrypted rooms already exist on this account. Warnings stay visible until trust and recovery are healthy.",
-  "@chatSecurityEncryptedRoomsCardBodyExisting": { "description": "Description when encrypted rooms exist on the Matrix account" },
-
+  "@chatSecurityEncryptedRoomsCardBodyExisting": {
+    "description": "Description when encrypted rooms exist on the Matrix account"
+  },
   "chatSecurityEncryptedRoomsCardBodyNone": "No encrypted rooms are known yet, but the account security state is still tracked here.",
-  "@chatSecurityEncryptedRoomsCardBodyNone": { "description": "Description when no encrypted rooms are known yet" },
-
+  "@chatSecurityEncryptedRoomsCardBodyNone": {
+    "description": "Description when no encrypted rooms are known yet"
+  },
   "chatSecurityBoundaryCardTitle": "Backend and agent boundary",
-  "@chatSecurityBoundaryCardTitle": { "description": "Matrix E2EE diagnostics card title explaining backend and agent boundaries" },
-
+  "@chatSecurityBoundaryCardTitle": {
+    "description": "Matrix E2EE diagnostics card title explaining backend and agent boundaries"
+  },
   "chatSecurityBoundaryCardValue": "Blocked until consent/audit",
-  "@chatSecurityBoundaryCardValue": { "description": "Matrix E2EE diagnostics card status for agent or connector participation" },
-
+  "@chatSecurityBoundaryCardValue": {
+    "description": "Matrix E2EE diagnostics card status for agent or connector participation"
+  },
   "chatSecurityBoundaryCardBody": "Encrypted message contents stay on Matrix devices. Backend diagnostics may use support-safe metadata such as room ID, encryption status, device trust, and timestamps, but not decrypted message bodies. Bots and connectors stay blocked from encrypted rooms until consent, audit, device-trust, and client-identity gates are implemented.",
-  "@chatSecurityBoundaryCardBody": { "description": "Matrix E2EE diagnostics card body explaining server-readable metadata and bot connector limits" },
-
+  "@chatSecurityBoundaryCardBody": {
+    "description": "Matrix E2EE diagnostics card body explaining server-readable metadata and bot connector limits"
+  },
   "chatSecurityRecoveryGuidanceCardTitle": "Device recovery checklist",
-  "@chatSecurityRecoveryGuidanceCardTitle": { "description": "Matrix E2EE recovery checklist card title" },
-
+  "@chatSecurityRecoveryGuidanceCardTitle": {
+    "description": "Matrix E2EE recovery checklist card title"
+  },
   "chatSecurityRecoveryGuidanceValueActionRequired": "Action required",
-  "@chatSecurityRecoveryGuidanceValueActionRequired": { "description": "Matrix E2EE recovery checklist status when user action is required" },
-
+  "@chatSecurityRecoveryGuidanceValueActionRequired": {
+    "description": "Matrix E2EE recovery checklist status when user action is required"
+  },
   "chatSecurityRecoveryGuidanceValueReady": "Ready for device changes",
-  "@chatSecurityRecoveryGuidanceValueReady": { "description": "Matrix E2EE recovery checklist status when recovery and verification are healthy" },
-
+  "@chatSecurityRecoveryGuidanceValueReady": {
+    "description": "Matrix E2EE recovery checklist status when recovery and verification are healthy"
+  },
   "chatSecurityRecoveryGuidanceIntro": "Before relying on encrypted chat across devices:",
-  "@chatSecurityRecoveryGuidanceIntro": { "description": "Intro text for Matrix E2EE device recovery checklist" },
-
+  "@chatSecurityRecoveryGuidanceIntro": {
+    "description": "Intro text for Matrix E2EE device recovery checklist"
+  },
   "chatSecurityRecoveryGuidanceSaveRecovery": "Save the recovery key or passphrase outside Weave, preferably in a password manager.",
-  "@chatSecurityRecoveryGuidanceSaveRecovery": { "description": "Matrix E2EE recovery checklist item about saving recovery material" },
-
+  "@chatSecurityRecoveryGuidanceSaveRecovery": {
+    "description": "Matrix E2EE recovery checklist item about saving recovery material"
+  },
   "chatSecurityRecoveryGuidanceVerifyDevice": "Verify this device with another signed-in Matrix device when possible.",
-  "@chatSecurityRecoveryGuidanceVerifyDevice": { "description": "Matrix E2EE recovery checklist item about device verification" },
-
+  "@chatSecurityRecoveryGuidanceVerifyDevice": {
+    "description": "Matrix E2EE recovery checklist item about device verification"
+  },
   "chatSecurityRecoveryGuidanceNewDevice": "On a new or reinstalled device, use the recovery key first, then verify the device.",
-  "@chatSecurityRecoveryGuidanceNewDevice": { "description": "Matrix E2EE recovery checklist item about new device recovery order" },
-
+  "@chatSecurityRecoveryGuidanceNewDevice": {
+    "description": "Matrix E2EE recovery checklist item about new device recovery order"
+  },
   "chatSecurityRecoveryGuidanceLostDevice": "If a device is lost, remove or distrust it from Matrix before trusting new encrypted rooms.",
-  "@chatSecurityRecoveryGuidanceLostDevice": { "description": "Matrix E2EE recovery checklist item about lost device handling" },
-
+  "@chatSecurityRecoveryGuidanceLostDevice": {
+    "description": "Matrix E2EE recovery checklist item about lost device handling"
+  },
   "chatSecurityRecoveryGuidanceServerCannotRecover": "Weave servers can report safe metadata, but cannot recover encrypted message contents for you.",
-  "@chatSecurityRecoveryGuidanceServerCannotRecover": { "description": "Matrix E2EE recovery checklist item explaining server recovery limits" },
-
+  "@chatSecurityRecoveryGuidanceServerCannotRecover": {
+    "description": "Matrix E2EE recovery checklist item explaining server recovery limits"
+  },
   "chatSecurityStatusSignedOut": "Matrix not connected",
-  "@chatSecurityStatusSignedOut": { "description": "Status label when Matrix is not connected" },
-
+  "@chatSecurityStatusSignedOut": {
+    "description": "Status label when Matrix is not connected"
+  },
   "chatSecurityStatusSetupRequired": "Setup required",
-  "@chatSecurityStatusSetupRequired": { "description": "Status label when Matrix encrypted chat setup is required" },
-
+  "@chatSecurityStatusSetupRequired": {
+    "description": "Status label when Matrix encrypted chat setup is required"
+  },
   "chatSecurityStatusSetupIncomplete": "Setup incomplete",
-  "@chatSecurityStatusSetupIncomplete": { "description": "Status label when Matrix encrypted chat setup is only partially complete" },
-
+  "@chatSecurityStatusSetupIncomplete": {
+    "description": "Status label when Matrix encrypted chat setup is only partially complete"
+  },
   "chatSecurityStatusRecoveryRequired": "Recovery required",
-  "@chatSecurityStatusRecoveryRequired": { "description": "Status label when Matrix recovery is required" },
-
+  "@chatSecurityStatusRecoveryRequired": {
+    "description": "Status label when Matrix recovery is required"
+  },
   "chatSecurityStatusHealthy": "Healthy",
-  "@chatSecurityStatusHealthy": { "description": "Status label when Matrix security is healthy" },
-
+  "@chatSecurityStatusHealthy": {
+    "description": "Status label when Matrix security is healthy"
+  },
   "chatSecurityStatusUnavailable": "Unavailable",
-  "@chatSecurityStatusUnavailable": { "description": "Generic status label when Matrix security data is unavailable" },
-
+  "@chatSecurityStatusUnavailable": {
+    "description": "Generic status label when Matrix security data is unavailable"
+  },
   "chatSecurityStatusVerified": "Verified",
-  "@chatSecurityStatusVerified": { "description": "Status label for a verified Matrix device" },
-
+  "@chatSecurityStatusVerified": {
+    "description": "Status label for a verified Matrix device"
+  },
   "chatSecurityStatusUnverified": "Unverified",
-  "@chatSecurityStatusUnverified": { "description": "Status label for an unverified Matrix device" },
-
+  "@chatSecurityStatusUnverified": {
+    "description": "Status label for an unverified Matrix device"
+  },
   "chatSecurityStatusBlocked": "Blocked",
-  "@chatSecurityStatusBlocked": { "description": "Status label for a blocked Matrix device" },
-
+  "@chatSecurityStatusBlocked": {
+    "description": "Status label for a blocked Matrix device"
+  },
   "chatSecurityStatusMissing": "Missing",
-  "@chatSecurityStatusMissing": { "description": "Status label when Matrix key backup is missing" },
-
+  "@chatSecurityStatusMissing": {
+    "description": "Status label when Matrix key backup is missing"
+  },
   "chatSecurityStatusNeedsReconnect": "Needs reconnect",
-  "@chatSecurityStatusNeedsReconnect": { "description": "Status label when Matrix recovery material needs to be reconnected on the device" },
-
+  "@chatSecurityStatusNeedsReconnect": {
+    "description": "Status label when Matrix recovery material needs to be reconnected on the device"
+  },
   "chatSecurityStatusReady": "Ready",
-  "@chatSecurityStatusReady": { "description": "Status label when a Matrix security feature is ready" },
-
+  "@chatSecurityStatusReady": {
+    "description": "Status label when a Matrix security feature is ready"
+  },
   "chatSecurityEncryptedRoomsStatusNone": "No encrypted rooms yet",
-  "@chatSecurityEncryptedRoomsStatusNone": { "description": "Status label when there are no encrypted Matrix rooms yet" },
-
+  "@chatSecurityEncryptedRoomsStatusNone": {
+    "description": "Status label when there are no encrypted Matrix rooms yet"
+  },
   "chatSecurityEncryptedRoomsStatusAttention": "Encrypted rooms need attention",
-  "@chatSecurityEncryptedRoomsStatusAttention": { "description": "Status label when encrypted Matrix rooms need user attention" },
-
+  "@chatSecurityEncryptedRoomsStatusAttention": {
+    "description": "Status label when encrypted Matrix rooms need user attention"
+  },
   "chatSecuritySetupDescriptionSignedOut": "Open Chat and connect Matrix before managing encryption.",
-  "@chatSecuritySetupDescriptionSignedOut": { "description": "Setup card description when Matrix is not connected" },
-
+  "@chatSecuritySetupDescriptionSignedOut": {
+    "description": "Setup card description when Matrix is not connected"
+  },
   "chatSecuritySetupDescriptionNotInitialized": "Set up secret storage, cross-signing, and online key backup before trusting encrypted rooms.",
-  "@chatSecuritySetupDescriptionNotInitialized": { "description": "Setup card description when Matrix encryption has not been initialized" },
-
+  "@chatSecuritySetupDescriptionNotInitialized": {
+    "description": "Setup card description when Matrix encryption has not been initialized"
+  },
   "chatSecuritySetupDescriptionPartiallyInitialized": "Some encryption parts exist, but recovery or cross-signing is still incomplete.",
-  "@chatSecuritySetupDescriptionPartiallyInitialized": { "description": "Setup card description when Matrix encryption setup is incomplete" },
-
+  "@chatSecuritySetupDescriptionPartiallyInitialized": {
+    "description": "Setup card description when Matrix encryption setup is incomplete"
+  },
   "chatSecuritySetupDescriptionRecoveryRequired": "This account was set up before, but this device needs the recovery key or passphrase to reconnect safely.",
-  "@chatSecuritySetupDescriptionRecoveryRequired": { "description": "Setup card description when Matrix recovery is required" },
-
+  "@chatSecuritySetupDescriptionRecoveryRequired": {
+    "description": "Setup card description when Matrix recovery is required"
+  },
   "chatSecuritySetupDescriptionReady": "This device can use the current Matrix crypto identity and recovery setup.",
-  "@chatSecuritySetupDescriptionReady": { "description": "Setup card description when Matrix setup is healthy" },
-
+  "@chatSecuritySetupDescriptionReady": {
+    "description": "Setup card description when Matrix setup is healthy"
+  },
   "chatSecuritySetupDescriptionUnavailable": "Matrix encryption is not available on this platform.",
-  "@chatSecuritySetupDescriptionUnavailable": { "description": "Setup card description when Matrix encryption is unavailable" },
-
+  "@chatSecuritySetupDescriptionUnavailable": {
+    "description": "Setup card description when Matrix encryption is unavailable"
+  },
   "chatSecurityCurrentDeviceDescriptionVerified": "Another trusted Matrix device has verified this session.",
-  "@chatSecurityCurrentDeviceDescriptionVerified": { "description": "Current device card description when the device is verified" },
-
+  "@chatSecurityCurrentDeviceDescriptionVerified": {
+    "description": "Current device card description when the device is verified"
+  },
   "chatSecurityCurrentDeviceDescriptionUnverified": "Compare security emoji or numbers with another signed-in Matrix device.",
-  "@chatSecurityCurrentDeviceDescriptionUnverified": { "description": "Current device card description when the device is unverified" },
-
+  "@chatSecurityCurrentDeviceDescriptionUnverified": {
+    "description": "Current device card description when the device is unverified"
+  },
   "chatSecurityCurrentDeviceDescriptionBlocked": "This device is blocked or its trust chain is broken.",
-  "@chatSecurityCurrentDeviceDescriptionBlocked": { "description": "Current device card description when the device is blocked" },
-
+  "@chatSecurityCurrentDeviceDescriptionBlocked": {
+    "description": "Current device card description when the device is blocked"
+  },
   "chatSecurityCurrentDeviceDescriptionUnavailable": "The current device key is not available yet.",
-  "@chatSecurityCurrentDeviceDescriptionUnavailable": { "description": "Current device card description when the device key is unavailable" },
-
+  "@chatSecurityCurrentDeviceDescriptionUnavailable": {
+    "description": "Current device card description when the device key is unavailable"
+  },
   "chatSecurityActionsUnavailableSignedOut": "Matrix security actions unlock after the Matrix session is connected.",
-  "@chatSecurityActionsUnavailableSignedOut": { "description": "Message shown instead of actions when Matrix is not connected" },
-
+  "@chatSecurityActionsUnavailableSignedOut": {
+    "description": "Message shown instead of actions when Matrix is not connected"
+  },
   "chatSecurityWorkingButton": "Working…",
-  "@chatSecurityWorkingButton": { "description": "Button label shown while a Matrix security action is running" },
-
+  "@chatSecurityWorkingButton": {
+    "description": "Button label shown while a Matrix security action is running"
+  },
   "chatSecuritySetupButton": "Set up encrypted chat",
-  "@chatSecuritySetupButton": { "description": "Button label to initialize Matrix encrypted chat" },
-
+  "@chatSecuritySetupButton": {
+    "description": "Button label to initialize Matrix encrypted chat"
+  },
   "chatSecurityReconnectButton": "Reconnect with recovery key",
-  "@chatSecurityReconnectButton": { "description": "Button label to reconnect Matrix encrypted chat with recovery material" },
-
+  "@chatSecurityReconnectButton": {
+    "description": "Button label to reconnect Matrix encrypted chat with recovery material"
+  },
   "chatSecurityVerifyDeviceButton": "Verify this device",
-  "@chatSecurityVerifyDeviceButton": { "description": "Button label to start Matrix device verification" },
-
+  "@chatSecurityVerifyDeviceButton": {
+    "description": "Button label to start Matrix device verification"
+  },
   "chatSecurityAcceptVerificationButton": "Accept verification",
-  "@chatSecurityAcceptVerificationButton": { "description": "Button label to accept a Matrix verification request" },
-
+  "@chatSecurityAcceptVerificationButton": {
+    "description": "Button label to accept a Matrix verification request"
+  },
   "chatSecurityDeclineVerificationButton": "Decline",
-  "@chatSecurityDeclineVerificationButton": { "description": "Button label to decline a Matrix verification request" },
-
+  "@chatSecurityDeclineVerificationButton": {
+    "description": "Button label to decline a Matrix verification request"
+  },
   "chatSecurityCompareEmojiButton": "Compare security emoji",
-  "@chatSecurityCompareEmojiButton": { "description": "Button label to continue Matrix verification with SAS emoji" },
-
+  "@chatSecurityCompareEmojiButton": {
+    "description": "Button label to continue Matrix verification with SAS emoji"
+  },
   "chatSecurityUnlockVerificationButton": "Continue verification with recovery key",
-  "@chatSecurityUnlockVerificationButton": { "description": "Button label to continue Matrix verification by unlocking existing secret storage" },
-
+  "@chatSecurityUnlockVerificationButton": {
+    "description": "Button label to continue Matrix verification by unlocking existing secret storage"
+  },
   "chatSecurityEmojiMatchButton": "Emoji match",
-  "@chatSecurityEmojiMatchButton": { "description": "Button label confirming the Matrix SAS emoji match" },
-
+  "@chatSecurityEmojiMatchButton": {
+    "description": "Button label confirming the Matrix SAS emoji match"
+  },
   "chatSecurityEmojiMismatchButton": "They do not match",
-  "@chatSecurityEmojiMismatchButton": { "description": "Button label when the Matrix SAS emoji do not match" },
-
+  "@chatSecurityEmojiMismatchButton": {
+    "description": "Button label when the Matrix SAS emoji do not match"
+  },
   "chatSecurityDismissButton": "Dismiss",
-  "@chatSecurityDismissButton": { "description": "Button label to dismiss a Matrix verification result" },
-
+  "@chatSecurityDismissButton": {
+    "description": "Button label to dismiss a Matrix verification result"
+  },
   "chatSecurityNoActionNeeded": "No action is needed right now.",
-  "@chatSecurityNoActionNeeded": { "description": "Message shown when there are no Matrix security actions to take" },
-
+  "@chatSecurityNoActionNeeded": {
+    "description": "Message shown when there are no Matrix security actions to take"
+  },
   "chatSecurityGenericFailure": "Unable to update Matrix security right now.",
-  "@chatSecurityGenericFailure": { "description": "Fallback error shown when Matrix security actions fail without a more specific message" },
-
+  "@chatSecurityGenericFailure": {
+    "description": "Fallback error shown when Matrix security actions fail without a more specific message"
+  },
   "chatSecurityNoticeSetupComplete": "Encrypted chat is now set up. Save your recovery key before closing this screen.",
-  "@chatSecurityNoticeSetupComplete": { "description": "Feedback message shown after encrypted chat setup completes" },
-
+  "@chatSecurityNoticeSetupComplete": {
+    "description": "Feedback message shown after encrypted chat setup completes"
+  },
   "chatSecurityNoticeRecoveryRestored": "Encrypted chat was reconnected for this device.",
-  "@chatSecurityNoticeRecoveryRestored": { "description": "Feedback message shown after Matrix recovery succeeds" },
-
+  "@chatSecurityNoticeRecoveryRestored": {
+    "description": "Feedback message shown after Matrix recovery succeeds"
+  },
   "chatSecurityNoticeVerificationRequestSent": "Verification request sent. Continue on your other Matrix device.",
-  "@chatSecurityNoticeVerificationRequestSent": { "description": "Feedback message shown after starting Matrix device verification" },
-
+  "@chatSecurityNoticeVerificationRequestSent": {
+    "description": "Feedback message shown after starting Matrix device verification"
+  },
   "chatSecurityNoticeVerificationCancelled": "Verification cancelled.",
-  "@chatSecurityNoticeVerificationCancelled": { "description": "Feedback message shown after cancelling Matrix verification" },
-
+  "@chatSecurityNoticeVerificationCancelled": {
+    "description": "Feedback message shown after cancelling Matrix verification"
+  },
   "chatSecurityVerificationIncomingMessage": "Another device wants to verify this session.",
-  "@chatSecurityVerificationIncomingMessage": { "description": "Message shown for an incoming Matrix verification request" },
-
+  "@chatSecurityVerificationIncomingMessage": {
+    "description": "Message shown for an incoming Matrix verification request"
+  },
   "chatSecurityVerificationChooseMethodMessage": "Choose a verification method to compare both devices.",
-  "@chatSecurityVerificationChooseMethodMessage": { "description": "Message shown when the user should choose a Matrix verification method" },
-
+  "@chatSecurityVerificationChooseMethodMessage": {
+    "description": "Message shown when the user should choose a Matrix verification method"
+  },
   "chatSecurityVerificationWaitingMessage": "Waiting for the other device to continue verification.",
-  "@chatSecurityVerificationWaitingMessage": { "description": "Message shown while Matrix verification waits for the other device" },
-
+  "@chatSecurityVerificationWaitingMessage": {
+    "description": "Message shown while Matrix verification waits for the other device"
+  },
   "chatSecurityVerificationRecoveryMessage": "This verification needs your Matrix recovery key or passphrase before it can continue.",
-  "@chatSecurityVerificationRecoveryMessage": { "description": "Message shown when Matrix verification needs access to secret storage before continuing" },
-
+  "@chatSecurityVerificationRecoveryMessage": {
+    "description": "Message shown when Matrix verification needs access to secret storage before continuing"
+  },
   "chatSecurityVerificationRecoveryHelp": "Unlock the existing Matrix secret storage to let this device complete verification safely.",
-  "@chatSecurityVerificationRecoveryHelp": { "description": "Help text shown when Matrix verification needs secret storage access" },
-
+  "@chatSecurityVerificationRecoveryHelp": {
+    "description": "Help text shown when Matrix verification needs secret storage access"
+  },
   "chatSecurityVerificationCompareMessage": "Compare the security emoji or numbers on both devices.",
-  "@chatSecurityVerificationCompareMessage": { "description": "Message shown while Matrix SAS values should be compared" },
-
+  "@chatSecurityVerificationCompareMessage": {
+    "description": "Message shown while Matrix SAS values should be compared"
+  },
   "chatSecurityVerificationDoneMessage": "This device is now verified.",
-  "@chatSecurityVerificationDoneMessage": { "description": "Message shown after Matrix verification succeeds" },
-
+  "@chatSecurityVerificationDoneMessage": {
+    "description": "Message shown after Matrix verification succeeds"
+  },
   "chatSecurityVerificationCancelledMessage": "Verification was cancelled before it finished.",
-  "@chatSecurityVerificationCancelledMessage": { "description": "Message shown after Matrix verification is cancelled" },
-
+  "@chatSecurityVerificationCancelledMessage": {
+    "description": "Message shown after Matrix verification is cancelled"
+  },
   "chatSecurityVerificationFailedMessage": "Verification could not be completed.",
-  "@chatSecurityVerificationFailedMessage": { "description": "Message shown after Matrix verification fails" },
-
+  "@chatSecurityVerificationFailedMessage": {
+    "description": "Message shown after Matrix verification fails"
+  },
   "chatSecuritySetupDialogTitle": "Set up encrypted chat",
-  "@chatSecuritySetupDialogTitle": { "description": "Dialog title for initializing Matrix encrypted chat" },
-
+  "@chatSecuritySetupDialogTitle": {
+    "description": "Dialog title for initializing Matrix encrypted chat"
+  },
   "chatSecuritySetupDialogDescription": "You can optionally protect the Matrix recovery key with a memorable passphrase. Leave this blank to use a generated recovery key instead.",
-  "@chatSecuritySetupDialogDescription": { "description": "Dialog description for the Matrix encrypted chat setup flow" },
-
+  "@chatSecuritySetupDialogDescription": {
+    "description": "Dialog description for the Matrix encrypted chat setup flow"
+  },
   "chatSecurityOptionalPassphraseLabel": "Optional passphrase",
-  "@chatSecurityOptionalPassphraseLabel": { "description": "Field label for an optional Matrix recovery passphrase" },
-
+  "@chatSecurityOptionalPassphraseLabel": {
+    "description": "Field label for an optional Matrix recovery passphrase"
+  },
   "chatSecurityDialogCancelButton": "Cancel",
-  "@chatSecurityDialogCancelButton": { "description": "Generic cancel button for Matrix security dialogs" },
-
+  "@chatSecurityDialogCancelButton": {
+    "description": "Generic cancel button for Matrix security dialogs"
+  },
   "chatSecurityDialogContinueButton": "Continue",
-  "@chatSecurityDialogContinueButton": { "description": "Continue button for the Matrix security setup dialog" },
-
+  "@chatSecurityDialogContinueButton": {
+    "description": "Continue button for the Matrix security setup dialog"
+  },
   "chatSecurityRestoreDialogTitle": "Reconnect encrypted chat",
-  "@chatSecurityRestoreDialogTitle": { "description": "Dialog title for reconnecting Matrix encrypted chat" },
-
+  "@chatSecurityRestoreDialogTitle": {
+    "description": "Dialog title for reconnecting Matrix encrypted chat"
+  },
   "chatSecurityRestoreDialogDescription": "Enter the Matrix recovery key or recovery passphrase that was created when encrypted chat was first set up.",
-  "@chatSecurityRestoreDialogDescription": { "description": "Dialog description for reconnecting Matrix encrypted chat" },
-
+  "@chatSecurityRestoreDialogDescription": {
+    "description": "Dialog description for reconnecting Matrix encrypted chat"
+  },
   "chatSecurityVerificationRecoveryDialogTitle": "Continue verification",
-  "@chatSecurityVerificationRecoveryDialogTitle": { "description": "Dialog title for continuing Matrix verification with recovery material" },
-
+  "@chatSecurityVerificationRecoveryDialogTitle": {
+    "description": "Dialog title for continuing Matrix verification with recovery material"
+  },
   "chatSecurityVerificationRecoveryDialogDescription": "Enter your Matrix recovery key or passphrase to continue this verification. This unlocks the secrets needed for verification rather than reconnecting the whole account.",
-  "@chatSecurityVerificationRecoveryDialogDescription": { "description": "Dialog description for continuing Matrix verification with recovery material" },
-
+  "@chatSecurityVerificationRecoveryDialogDescription": {
+    "description": "Dialog description for continuing Matrix verification with recovery material"
+  },
   "chatSecurityRecoveryKeyFieldLabel": "Recovery key or passphrase",
-  "@chatSecurityRecoveryKeyFieldLabel": { "description": "Field label for Matrix recovery material" },
-
+  "@chatSecurityRecoveryKeyFieldLabel": {
+    "description": "Field label for Matrix recovery material"
+  },
   "chatSecurityRecoveryKeyDismissButton": "I saved it",
-  "@chatSecurityRecoveryKeyDismissButton": { "description": "Button label confirming the Matrix recovery key was saved" },
-
+  "@chatSecurityRecoveryKeyDismissButton": {
+    "description": "Button label confirming the Matrix recovery key was saved"
+  },
   "chatSecurityEmojiSummaryLabel": "Security emoji",
-  "@chatSecurityEmojiSummaryLabel": { "description": "Accessibility label prefix for Matrix SAS emoji" },
-
+  "@chatSecurityEmojiSummaryLabel": {
+    "description": "Accessibility label prefix for Matrix SAS emoji"
+  },
   "chatSecurityNumbersSummaryLabel": "Security numbers {value}",
   "@chatSecurityNumbersSummaryLabel": {
     "description": "Accessibility label for Matrix SAS numbers",
     "placeholders": {
-      "value": { "type": "String" }
+      "value": {
+        "type": "String"
+      }
     }
   },
-
   "settingsPreviewSurfacesTitle": "Preview surfaces",
-  "@settingsPreviewSurfacesTitle": { "description": "Settings section title for feature-flagged feature-gated product surfaces" },
-
+  "@settingsPreviewSurfacesTitle": {
+    "description": "Settings section title for feature-flagged feature-gated product surfaces"
+  },
   "settingsPreviewSurfacesDescription": "These feature-gated surfaces stay honest about what is active, blocked, or still waiting for backend contracts.",
-  "@settingsPreviewSurfacesDescription": { "description": "Description for feature-flagged feature-gated surfaces" },
-
+  "@settingsPreviewSurfacesDescription": {
+    "description": "Description for feature-flagged feature-gated surfaces"
+  },
   "settingsGuestPortalPreviewTitle": "Guest Portal",
-  "@settingsGuestPortalPreviewTitle": { "description": "Feature-flagged Guest Portal preview title" },
-
+  "@settingsGuestPortalPreviewTitle": {
+    "description": "Feature-flagged Guest Portal preview title"
+  },
   "settingsGuestPortalPreviewDescription": "Guest invitations and constrained access will appear here without exposing member-only affordances.",
-  "@settingsGuestPortalPreviewDescription": { "description": "Feature-flagged Guest Portal preview description" },
-
+  "@settingsGuestPortalPreviewDescription": {
+    "description": "Feature-flagged Guest Portal preview description"
+  },
   "settingsInteropAdminPreviewTitle": "External connections admin status",
-  "@settingsInteropAdminPreviewTitle": { "description": "Feature-flagged interop admin status preview title" },
-
+  "@settingsInteropAdminPreviewTitle": {
+    "description": "Feature-flagged interop admin status preview title"
+  },
   "settingsInteropAdminPreviewDescription": "External provider status will explain data movement and consent; provider secrets are never collected in this client.",
-  "@settingsInteropAdminPreviewDescription": { "description": "Feature-flagged interop admin preview description" },
-
+  "@settingsInteropAdminPreviewDescription": {
+    "description": "Feature-flagged interop admin preview description"
+  },
   "settingsMigrationDryRunPreviewTitle": "Migration dry-run report",
-  "@settingsMigrationDryRunPreviewTitle": { "description": "Feature-flagged migration dry-run preview title" },
-
+  "@settingsMigrationDryRunPreviewTitle": {
+    "description": "Feature-flagged migration dry-run preview title"
+  },
   "settingsMigrationDryRunPreviewDescription": "Admins will be able to review inventory, risks, scopes, and mappings before any import starts.",
-  "@settingsMigrationDryRunPreviewDescription": { "description": "Feature-flagged migration dry-run preview description" },
-
+  "@settingsMigrationDryRunPreviewDescription": {
+    "description": "Feature-flagged migration dry-run preview description"
+  },
   "settingsServerConfigurationTitle": "Server Configuration",
-  "@settingsServerConfigurationTitle": { "description": "Section title for server configuration in settings" },
-
+  "@settingsServerConfigurationTitle": {
+    "description": "Section title for server configuration in settings"
+  },
   "settingsWorkspaceReadinessTitle": "Workspace Readiness",
-  "@settingsWorkspaceReadinessTitle": { "description": "Section title for the shared workspace readiness summary in settings" },
-
+  "@settingsWorkspaceReadinessTitle": {
+    "description": "Section title for the shared workspace readiness summary in settings"
+  },
   "settingsWorkspaceReadinessDescription": "Shell access is tracked separately from each service connection so Weave can show degraded integrations honestly.",
-  "@settingsWorkspaceReadinessDescription": { "description": "Description for the shared workspace readiness summary in settings" },
-
+  "@settingsWorkspaceReadinessDescription": {
+    "description": "Description for the shared workspace readiness summary in settings"
+  },
   "settingsWorkspaceBackendUnreachable": "Backend API is unreachable. Check that the Weave stack is running and the configured backend URL is correct.",
-  "@settingsWorkspaceBackendUnreachable": { "description": "Error shown when the Weave backend API cannot be reached from the app" },
-
+  "@settingsWorkspaceBackendUnreachable": {
+    "description": "Error shown when the Weave backend API cannot be reached from the app"
+  },
   "settingsWorkspaceBackendUnauthorized": "Backend API rejected the current session. Sign in again before retrying.",
-  "@settingsWorkspaceBackendUnauthorized": { "description": "Error shown when the Weave backend API rejects the current session" },
-
+  "@settingsWorkspaceBackendUnauthorized": {
+    "description": "Error shown when the Weave backend API rejects the current session"
+  },
   "settingsWorkspaceBackendServerError": "Backend API returned an unexpected response. Check the Weave stack logs before retrying.",
-  "@settingsWorkspaceBackendServerError": { "description": "Error shown when the Weave backend API returns an unexpected error" },
-
+  "@settingsWorkspaceBackendServerError": {
+    "description": "Error shown when the Weave backend API returns an unexpected error"
+  },
   "settingsWorkspaceSummaryConnected": "Shell access and the mapped services are ready.",
-  "@settingsWorkspaceSummaryConnected": { "description": "Summary shown when shell access and mapped services are all ready" },
-
+  "@settingsWorkspaceSummaryConnected": {
+    "description": "Summary shown when shell access and mapped services are all ready"
+  },
   "settingsWorkspaceSummaryDegraded": "Shell access is ready, but one or more services still need attention.",
-  "@settingsWorkspaceSummaryDegraded": { "description": "Summary shown when shell access is available but one or more services are degraded" },
-
+  "@settingsWorkspaceSummaryDegraded": {
+    "description": "Summary shown when shell access is available but one or more services are degraded"
+  },
   "settingsWorkspaceSummaryNeedsSetup": "Finish setup before the workspace shell can become available.",
-  "@settingsWorkspaceSummaryNeedsSetup": { "description": "Summary shown when workspace shell access is blocked by missing setup" },
-
+  "@settingsWorkspaceSummaryNeedsSetup": {
+    "description": "Summary shown when workspace shell access is blocked by missing setup"
+  },
   "settingsWorkspaceSummaryNeedsSignIn": "Sign in again to restore workspace shell access.",
-  "@settingsWorkspaceSummaryNeedsSignIn": { "description": "Summary shown when workspace shell access needs another sign-in" },
-
+  "@settingsWorkspaceSummaryNeedsSignIn": {
+    "description": "Summary shown when workspace shell access needs another sign-in"
+  },
   "settingsWorkspaceShellAccessLabel": "Shell access",
-  "@settingsWorkspaceShellAccessLabel": { "description": "Row label for workspace shell access in the readiness summary" },
-
+  "@settingsWorkspaceShellAccessLabel": {
+    "description": "Row label for workspace shell access in the readiness summary"
+  },
   "settingsWorkspaceChatLabel": "Chat",
-  "@settingsWorkspaceChatLabel": { "description": "Row label for chat readiness in the workspace readiness summary" },
-
+  "@settingsWorkspaceChatLabel": {
+    "description": "Row label for chat readiness in the workspace readiness summary"
+  },
   "settingsWorkspaceFilesLabel": "Files",
-  "@settingsWorkspaceFilesLabel": { "description": "Row label for files readiness in the workspace readiness summary" },
-
+  "@settingsWorkspaceFilesLabel": {
+    "description": "Row label for files readiness in the workspace readiness summary"
+  },
   "settingsWorkspaceCapabilityLabel": "Readiness",
-  "@settingsWorkspaceCapabilityLabel": { "description": "Label used for readiness pills in the workspace summary" },
-
+  "@settingsWorkspaceCapabilityLabel": {
+    "description": "Label used for readiness pills in the workspace summary"
+  },
   "settingsWorkspaceConnectionLabel": "Connection",
-  "@settingsWorkspaceConnectionLabel": { "description": "Label used for connection-state pills in the workspace summary" },
-
+  "@settingsWorkspaceConnectionLabel": {
+    "description": "Label used for connection-state pills in the workspace summary"
+  },
   "settingsWorkspaceLastChangeLabel": "Last change",
-  "@settingsWorkspaceLastChangeLabel": { "description": "Label used for invalidation-reason pills in the workspace summary" },
-
+  "@settingsWorkspaceLastChangeLabel": {
+    "description": "Label used for invalidation-reason pills in the workspace summary"
+  },
   "settingsWorkspaceMatrixE2eeGateLabel": "E2EE gate",
-  "@settingsWorkspaceMatrixE2eeGateLabel": { "description": "Label for Matrix E2EE validation status in workspace readiness" },
-
+  "@settingsWorkspaceMatrixE2eeGateLabel": {
+    "description": "Label for Matrix E2EE validation status in workspace readiness"
+  },
   "settingsWorkspaceMatrixE2eeValidated": "Validated",
-  "@settingsWorkspaceMatrixE2eeValidated": { "description": "Value when all Matrix E2EE validation gates are complete" },
-
+  "@settingsWorkspaceMatrixE2eeValidated": {
+    "description": "Value when all Matrix E2EE validation gates are complete"
+  },
   "settingsWorkspaceMatrixE2eeNotValidated": "Not validated",
-  "@settingsWorkspaceMatrixE2eeNotValidated": { "description": "Value when Matrix E2EE validation gates are not complete" },
-
+  "@settingsWorkspaceMatrixE2eeNotValidated": {
+    "description": "Value when Matrix E2EE validation gates are not complete"
+  },
   "settingsWorkspaceMatrixServerBodiesLabel": "Server-readable bodies",
-  "@settingsWorkspaceMatrixServerBodiesLabel": { "description": "Label for whether backend diagnostics can read Matrix message bodies" },
-
+  "@settingsWorkspaceMatrixServerBodiesLabel": {
+    "description": "Label for whether backend diagnostics can read Matrix message bodies"
+  },
   "settingsWorkspaceMatrixServerBodiesOpaque": "No",
-  "@settingsWorkspaceMatrixServerBodiesOpaque": { "description": "Value when encrypted Matrix message bodies remain opaque to backend diagnostics" },
-
+  "@settingsWorkspaceMatrixServerBodiesOpaque": {
+    "description": "Value when encrypted Matrix message bodies remain opaque to backend diagnostics"
+  },
   "settingsWorkspaceMatrixServerBodiesReadable": "Review",
-  "@settingsWorkspaceMatrixServerBodiesReadable": { "description": "Value shown if backend diagnostics claim Matrix message bodies are server-readable" },
-
+  "@settingsWorkspaceMatrixServerBodiesReadable": {
+    "description": "Value shown if backend diagnostics claim Matrix message bodies are server-readable"
+  },
   "settingsWorkspaceMatrixAgentWritesLabel": "Agent writes",
-  "@settingsWorkspaceMatrixAgentWritesLabel": { "description": "Label for bot, assistant, or connector write policy in Matrix readiness" },
-
+  "@settingsWorkspaceMatrixAgentWritesLabel": {
+    "description": "Label for bot, assistant, or connector write policy in Matrix readiness"
+  },
   "settingsWorkspaceMatrixAgentWritesBlocked": "Blocked/fail-closed",
-  "@settingsWorkspaceMatrixAgentWritesBlocked": { "description": "Value when Matrix bot/connector writes are blocked or fail closed" },
-
+  "@settingsWorkspaceMatrixAgentWritesBlocked": {
+    "description": "Value when Matrix bot/connector writes are blocked or fail closed"
+  },
   "settingsWorkspaceMatrixAgentWritesReview": "Review policy",
-  "@settingsWorkspaceMatrixAgentWritesReview": { "description": "Value shown when Matrix bot/connector write policy is not clearly fail-closed" },
-
+  "@settingsWorkspaceMatrixAgentWritesReview": {
+    "description": "Value shown when Matrix bot/connector write policy is not clearly fail-closed"
+  },
   "settingsWorkspaceCapabilityReady": "Ready",
-  "@settingsWorkspaceCapabilityReady": { "description": "Readiness label for a ready capability" },
-
+  "@settingsWorkspaceCapabilityReady": {
+    "description": "Readiness label for a ready capability"
+  },
   "settingsWorkspaceCapabilityDegraded": "Degraded",
-  "@settingsWorkspaceCapabilityDegraded": { "description": "Readiness label for a degraded capability" },
-
+  "@settingsWorkspaceCapabilityDegraded": {
+    "description": "Readiness label for a degraded capability"
+  },
   "settingsWorkspaceCapabilityBlocked": "Blocked",
-  "@settingsWorkspaceCapabilityBlocked": { "description": "Readiness label for a blocked capability" },
-
+  "@settingsWorkspaceCapabilityBlocked": {
+    "description": "Readiness label for a blocked capability"
+  },
   "settingsWorkspaceCapabilityUnavailable": "Unavailable",
-  "@settingsWorkspaceCapabilityUnavailable": { "description": "Readiness label for an unavailable capability" },
-
+  "@settingsWorkspaceCapabilityUnavailable": {
+    "description": "Readiness label for an unavailable capability"
+  },
   "settingsWorkspaceConnectionConnected": "Connected",
-  "@settingsWorkspaceConnectionConnected": { "description": "Connection label for a connected integration" },
-
+  "@settingsWorkspaceConnectionConnected": {
+    "description": "Connection label for a connected integration"
+  },
   "settingsWorkspaceConnectionDisconnected": "Disconnected",
-  "@settingsWorkspaceConnectionDisconnected": { "description": "Connection label for a disconnected integration" },
-
+  "@settingsWorkspaceConnectionDisconnected": {
+    "description": "Connection label for a disconnected integration"
+  },
   "settingsWorkspaceConnectionDegraded": "Degraded",
-  "@settingsWorkspaceConnectionDegraded": { "description": "Connection label for a degraded integration" },
-
+  "@settingsWorkspaceConnectionDegraded": {
+    "description": "Connection label for a degraded integration"
+  },
   "settingsWorkspaceConnectionMisconfigured": "Misconfigured",
-  "@settingsWorkspaceConnectionMisconfigured": { "description": "Connection label for a misconfigured integration" },
-
+  "@settingsWorkspaceConnectionMisconfigured": {
+    "description": "Connection label for a misconfigured integration"
+  },
   "settingsWorkspaceConnectionRequiresReauthentication": "Needs sign-in",
-  "@settingsWorkspaceConnectionRequiresReauthentication": { "description": "Connection label for an integration that requires another sign-in" },
-
+  "@settingsWorkspaceConnectionRequiresReauthentication": {
+    "description": "Connection label for an integration that requires another sign-in"
+  },
   "settingsWorkspaceConnectionUnavailableOnPlatform": "Unavailable on this platform",
-  "@settingsWorkspaceConnectionUnavailableOnPlatform": { "description": "Connection label for an integration that is unavailable on the current platform" },
-
+  "@settingsWorkspaceConnectionUnavailableOnPlatform": {
+    "description": "Connection label for an integration that is unavailable on the current platform"
+  },
   "settingsWorkspaceInvalidationAuthConfigurationChanged": "Auth configuration changed",
-  "@settingsWorkspaceInvalidationAuthConfigurationChanged": { "description": "Invalidation label for auth configuration changes" },
-
+  "@settingsWorkspaceInvalidationAuthConfigurationChanged": {
+    "description": "Invalidation label for auth configuration changes"
+  },
   "settingsWorkspaceInvalidationMatrixHomeserverChanged": "Matrix homeserver changed",
-  "@settingsWorkspaceInvalidationMatrixHomeserverChanged": { "description": "Invalidation label for Matrix homeserver changes" },
-
+  "@settingsWorkspaceInvalidationMatrixHomeserverChanged": {
+    "description": "Invalidation label for Matrix homeserver changes"
+  },
   "settingsWorkspaceInvalidationNextcloudBaseUrlChanged": "Nextcloud base URL changed",
-  "@settingsWorkspaceInvalidationNextcloudBaseUrlChanged": { "description": "Invalidation label for Nextcloud base URL changes" },
-
+  "@settingsWorkspaceInvalidationNextcloudBaseUrlChanged": {
+    "description": "Invalidation label for Nextcloud base URL changes"
+  },
   "settingsWorkspaceInvalidationExplicitSignOut": "Explicit sign-out",
-  "@settingsWorkspaceInvalidationExplicitSignOut": { "description": "Invalidation label for explicit sign-outs" },
-
+  "@settingsWorkspaceInvalidationExplicitSignOut": {
+    "description": "Invalidation label for explicit sign-outs"
+  },
   "settingsWorkspaceInvalidationRestartSetup": "Restarted setup",
-  "@settingsWorkspaceInvalidationRestartSetup": { "description": "Invalidation label for restart-setup actions" },
-
+  "@settingsWorkspaceInvalidationRestartSetup": {
+    "description": "Invalidation label for restart-setup actions"
+  },
   "settingsWorkspaceInvalidationBackendApiBaseUrlChanged": "Backend API URL changed",
-  "@settingsWorkspaceInvalidationBackendApiBaseUrlChanged": { "description": "Invalidation label for backend API base URL changes" },
-
+  "@settingsWorkspaceInvalidationBackendApiBaseUrlChanged": {
+    "description": "Invalidation label for backend API base URL changes"
+  },
+  "settingsProviderStackTitle": "Provider stack readiness",
+  "@settingsProviderStackTitle": {
+    "description": "Title for provider stack readiness summary in settings"
+  },
+  "settingsProviderStackSemanticLabel": "Provider stack readiness. Backend-owned facades: {backendOwnedFacades}. Flutter provider calls: {flutterCalls}.",
+  "@settingsProviderStackSemanticLabel": {
+    "description": "Accessibility label for provider readiness summary",
+    "placeholders": {
+      "backendOwnedFacades": {
+        "type": "String"
+      },
+      "flutterCalls": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsProviderStackFailClosedDescription": "Provider integrations stay fail-closed behind backend-owned facades. Flutter does not call GitLab, Office, or other provider APIs directly.",
+  "@settingsProviderStackFailClosedDescription": {
+    "description": "Provider stack description when backend facade and fail-closed rules are satisfied"
+  },
+  "settingsProviderStackNeedsReviewDescription": "Provider readiness needs review before enabling direct launch or workspace actions.",
+  "@settingsProviderStackNeedsReviewDescription": {
+    "description": "Provider stack description when readiness needs review"
+  },
+  "settingsProviderStackBackendFacadesLabel": "Backend facades",
+  "@settingsProviderStackBackendFacadesLabel": {
+    "description": "Pill label for backend-owned provider facades"
+  },
+  "settingsProviderStackFlutterCallsLabel": "Flutter provider calls",
+  "@settingsProviderStackFlutterCallsLabel": {
+    "description": "Pill label for whether Flutter calls provider APIs directly"
+  },
+  "settingsProviderStackSupportSafetyLabel": "Support safety",
+  "@settingsProviderStackSupportSafetyLabel": {
+    "description": "Pill label for support-safe provider diagnostics"
+  },
+  "settingsProviderStackOwned": "Owned by backend",
+  "@settingsProviderStackOwned": {
+    "description": "Value when provider facades are backend-owned"
+  },
+  "settingsProviderStackMissing": "Missing",
+  "@settingsProviderStackMissing": {
+    "description": "Value when provider facades are missing"
+  },
+  "settingsProviderStackNeedsReview": "Needs review",
+  "@settingsProviderStackNeedsReview": {
+    "description": "Value when provider stack needs review"
+  },
+  "settingsProviderStackBlocked": "Blocked",
+  "@settingsProviderStackBlocked": {
+    "description": "Value when direct provider calls are blocked"
+  },
+  "settingsProviderStackRedacted": "Redacted",
+  "@settingsProviderStackRedacted": {
+    "description": "Value when provider diagnostics are support-safe/redacted"
+  },
+  "settingsProviderStackYes": "Yes",
+  "@settingsProviderStackYes": {
+    "description": "Short yes value in provider stack semantics"
+  },
+  "settingsProviderStackNo": "No",
+  "@settingsProviderStackNo": {
+    "description": "Short no value in provider stack semantics"
+  },
+  "settingsProviderStackFlutterCallsAllowed": "Allowed",
+  "@settingsProviderStackFlutterCallsAllowed": {
+    "description": "Semantics value when Flutter direct provider calls are allowed"
+  },
+  "settingsProviderStackFlutterCallsBlocked": "Blocked",
+  "@settingsProviderStackFlutterCallsBlocked": {
+    "description": "Semantics value when Flutter direct provider calls are blocked"
+  },
+  "settingsProviderStackFailClosedBadge": "fail-closed",
+  "@settingsProviderStackFailClosedBadge": {
+    "description": "Provider status badge for fail-closed behavior"
+  },
+  "settingsProviderStackReadOnlyBadge": "read-only",
+  "@settingsProviderStackReadOnlyBadge": {
+    "description": "Provider status badge for read-only behavior"
+  },
+  "settingsProviderStackPaidFeaturesRequiredBadge": "paid features required",
+  "@settingsProviderStackPaidFeaturesRequiredBadge": {
+    "description": "Provider status badge for paid feature requirements"
+  },
+  "settingsProviderModuleIdentityRealm": "Identity realm",
+  "@settingsProviderModuleIdentityRealm": {
+    "description": "Provider module label for identity realm"
+  },
+  "settingsProviderModuleSourceControl": "Source control",
+  "@settingsProviderModuleSourceControl": {
+    "description": "Provider module label for source control"
+  },
+  "settingsProviderModuleIssueTracker": "Issue tracker",
+  "@settingsProviderModuleIssueTracker": {
+    "description": "Provider module label for issue tracker"
+  },
+  "settingsProviderModuleCi": "CI",
+  "@settingsProviderModuleCi": {
+    "description": "Provider module label for CI"
+  },
+  "settingsProviderModuleRelease": "Release",
+  "@settingsProviderModuleRelease": {
+    "description": "Provider module label for releases"
+  },
+  "settingsProviderModuleOffice": "Office",
+  "@settingsProviderModuleOffice": {
+    "description": "Provider module label for Office"
+  },
+  "settingsProviderModuleFiles": "Files",
+  "@settingsProviderModuleFiles": {
+    "description": "Provider module label for files"
+  },
+  "settingsProviderModuleCalendar": "Calendar",
+  "@settingsProviderModuleCalendar": {
+    "description": "Provider module label for calendar"
+  },
+  "settingsProviderModuleContacts": "Contacts",
+  "@settingsProviderModuleContacts": {
+    "description": "Provider module label for contacts"
+  },
+  "settingsProviderModuleForms": "Forms",
+  "@settingsProviderModuleForms": {
+    "description": "Provider module label for forms"
+  },
+  "settingsProviderModuleBoards": "Boards",
+  "@settingsProviderModuleBoards": {
+    "description": "Provider module label for boards"
+  },
+  "settingsProviderModuleProvider": "Provider",
+  "@settingsProviderModuleProvider": {
+    "description": "Fallback provider module label"
+  },
+  "settingsProviderStateDisabled": "disabled",
+  "@settingsProviderStateDisabled": {
+    "description": "Provider state label for disabled providers"
+  },
+  "settingsProviderStateNotConfigured": "unconfigured",
+  "@settingsProviderStateNotConfigured": {
+    "description": "Provider state label for unconfigured providers"
+  },
+  "settingsProviderStateConfigured": "configured",
+  "@settingsProviderStateConfigured": {
+    "description": "Provider state label for configured providers"
+  },
+  "settingsProviderStateReady": "ready",
+  "@settingsProviderStateReady": {
+    "description": "Provider state label for ready providers"
+  },
+  "settingsProviderStateDegraded": "degraded",
+  "@settingsProviderStateDegraded": {
+    "description": "Provider state label for degraded providers"
+  },
+  "settingsProviderStateUnsupported": "unsupported",
+  "@settingsProviderStateUnsupported": {
+    "description": "Provider state label for unsupported providers"
+  },
+  "settingsProviderStateUnknown": "unknown",
+  "@settingsProviderStateUnknown": {
+    "description": "Provider state label for unknown provider state"
+  },
+  "settingsOfficeReadinessTitle": "Office readiness",
+  "@settingsOfficeReadinessTitle": {
+    "description": "Title for Office provider readiness summary"
+  },
+  "settingsOfficeReadinessSemanticLabel": "Office readiness. Launch is {launchState}. Provider is {providerState}.",
+  "@settingsOfficeReadinessSemanticLabel": {
+    "description": "Accessibility label for Office readiness summary",
+    "placeholders": {
+      "launchState": {
+        "type": "String"
+      },
+      "providerState": {
+        "type": "String"
+      }
+    }
+  },
+  "settingsOfficeReadinessFailClosedDescription": "Office launch is fail-closed until a backend-owned provider adapter, session tokens, callbacks, and permissions are configured.",
+  "@settingsOfficeReadinessFailClosedDescription": {
+    "description": "Office readiness description when launch is fail-closed"
+  },
+  "settingsOfficeReadinessAvailableDescription": "Office launch is available through the backend facade.",
+  "@settingsOfficeReadinessAvailableDescription": {
+    "description": "Office readiness description when launch is available"
+  },
+  "settingsOfficeReadinessAvailable": "available",
+  "@settingsOfficeReadinessAvailable": {
+    "description": "Office launch availability value"
+  },
+  "settingsOfficeReadinessEnabled": "enabled",
+  "@settingsOfficeReadinessEnabled": {
+    "description": "Office provider enabled value"
+  },
+  "settingsOfficeReadinessNoLaunchModes": "no launch modes",
+  "@settingsOfficeReadinessNoLaunchModes": {
+    "description": "Office readiness value when no launch modes are available"
+  },
+  "settingsOfficeReadinessModes": "modes: {modes}",
+  "@settingsOfficeReadinessModes": {
+    "description": "Enabled Office launch modes",
+    "placeholders": {
+      "modes": {
+        "type": "String"
+      }
+    }
+  },
   "settingsServerConfigurationDescription": "Update the provider and service URLs Weave should use for your self-hosted environment.",
-  "@settingsServerConfigurationDescription": { "description": "Description for the settings server configuration section" },
-
+  "@settingsServerConfigurationDescription": {
+    "description": "Description for the settings server configuration section"
+  },
   "settingsSaveButton": "Save Changes",
-  "@settingsSaveButton": { "description": "Label for the settings save button" },
-
+  "@settingsSaveButton": {
+    "description": "Label for the settings save button"
+  },
   "settingsSaveInProgress": "Saving…",
-  "@settingsSaveInProgress": { "description": "Label used while the settings form is saving" },
-
+  "@settingsSaveInProgress": {
+    "description": "Label used while the settings form is saving"
+  },
   "settingsSignOutTitle": "Session",
-  "@settingsSignOutTitle": { "description": "Section title for session management in settings" },
-
+  "@settingsSignOutTitle": {
+    "description": "Section title for session management in settings"
+  },
   "settingsSignOutDescription": "Sign out of the current server session and return to the sign-in gate.",
-  "@settingsSignOutDescription": { "description": "Description for the sign-out section in settings" },
-
+  "@settingsSignOutDescription": {
+    "description": "Description for the sign-out section in settings"
+  },
   "settingsSignOutButton": "Sign Out",
-  "@settingsSignOutButton": { "description": "Label for the settings sign-out button" },
-
+  "@settingsSignOutButton": {
+    "description": "Label for the settings sign-out button"
+  },
   "settingsSignOutInProgress": "Signing out…",
-  "@settingsSignOutInProgress": { "description": "Label shown while sign-out is in progress" },
-
+  "@settingsSignOutInProgress": {
+    "description": "Label shown while sign-out is in progress"
+  },
   "chatEmptyMessage": "No conversations yet",
-  "@chatEmptyMessage": { "description": "Empty state message for the chat screen" },
+  "@chatEmptyMessage": {
+    "description": "Empty state message for the chat screen"
+  },
   "chatEmptyGuidance": "Workspace rooms and direct messages will appear here when chat is ready.",
-  "@chatEmptyGuidance": { "description": "Guidance shown below the chat empty-state title" },
-
+  "@chatEmptyGuidance": {
+    "description": "Guidance shown below the chat empty-state title"
+  },
   "chatErrorTitle": "Chat is not available right now",
-  "@chatErrorTitle": { "description": "Friendly error-state title shown when the chat list cannot load" },
-
+  "@chatErrorTitle": {
+    "description": "Friendly error-state title shown when the chat list cannot load"
+  },
   "chatConversationNoPreview": "No recent messages",
-  "@chatConversationNoPreview": { "description": "Fallback preview text for a conversation without a recent event" },
-
+  "@chatConversationNoPreview": {
+    "description": "Fallback preview text for a conversation without a recent event"
+  },
   "chatConversationEncryptedPreview": "Encrypted message",
-  "@chatConversationEncryptedPreview": { "description": "Fallback preview label for encrypted Matrix events" },
-
+  "@chatConversationEncryptedPreview": {
+    "description": "Fallback preview label for encrypted Matrix events"
+  },
   "chatConversationUnsupportedPreview": "Unsupported message",
-  "@chatConversationUnsupportedPreview": { "description": "Fallback preview label for Matrix events that cannot be rendered yet" },
-
+  "@chatConversationUnsupportedPreview": {
+    "description": "Fallback preview label for Matrix events that cannot be rendered yet"
+  },
   "chatConversationInviteLabel": "Invitation",
-  "@chatConversationInviteLabel": { "description": "Accessibility label for invited chat rooms" },
-
+  "@chatConversationInviteLabel": {
+    "description": "Accessibility label for invited chat rooms"
+  },
   "chatConversationDirectMessageLabel": "Direct conversation",
-  "@chatConversationDirectMessageLabel": { "description": "Accessibility label for direct conversations" },
+  "@chatConversationDirectMessageLabel": {
+    "description": "Accessibility label for direct conversations"
+  },
   "chatConversationOpensChannelWorkspaceLabel": "Opens channel workspace",
-  "@chatConversationOpensChannelWorkspaceLabel": { "description": "Accessibility hint for channel conversation tiles that open the channel workspace" },
-
+  "@chatConversationOpensChannelWorkspaceLabel": {
+    "description": "Accessibility hint for channel conversation tiles that open the channel workspace"
+  },
   "chatConversationRecentNow": "Active now",
-  "@chatConversationRecentNow": { "description": "Recency badge for a chat conversation with activity in the last hour" },
-
+  "@chatConversationRecentNow": {
+    "description": "Recency badge for a chat conversation with activity in the last hour"
+  },
   "chatConversationRecentToday": "Today",
-  "@chatConversationRecentToday": { "description": "Recency badge for a chat conversation with activity earlier today" },
-
+  "@chatConversationRecentToday": {
+    "description": "Recency badge for a chat conversation with activity earlier today"
+  },
   "chatConversationRecentYesterday": "Yesterday",
-  "@chatConversationRecentYesterday": { "description": "Recency badge for a chat conversation with activity yesterday" },
-
+  "@chatConversationRecentYesterday": {
+    "description": "Recency badge for a chat conversation with activity yesterday"
+  },
   "chatConversationRecentThisWeek": "This week",
-  "@chatConversationRecentThisWeek": { "description": "Recency badge for a chat conversation with activity in the last week" },
-
+  "@chatConversationRecentThisWeek": {
+    "description": "Recency badge for a chat conversation with activity in the last week"
+  },
   "chatConversationUnreadCount": "{count, plural, =0 {No unread messages} =1 {1 unread message} other {{count} unread messages}}",
   "@chatConversationUnreadCount": {
     "description": "Accessibility label describing how many unread messages a conversation has",
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
-
   "chatRoomLoadingLabel": "Loading conversation…",
-  "@chatRoomLoadingLabel": { "description": "Message shown while a room timeline is loading" },
-
+  "@chatRoomLoadingLabel": {
+    "description": "Message shown while a room timeline is loading"
+  },
   "chatRoomEmptyMessage": "No messages yet",
-  "@chatRoomEmptyMessage": { "description": "Empty state message for a room without timeline events" },
-
+  "@chatRoomEmptyMessage": {
+    "description": "Empty state message for a room without timeline events"
+  },
   "chatRoomDraftRestoredMessage": "Draft restored from this device.",
-  "@chatRoomDraftRestoredMessage": { "description": "Banner shown when a local unsent chat draft is restored" },
-
+  "@chatRoomDraftRestoredMessage": {
+    "description": "Banner shown when a local unsent chat draft is restored"
+  },
   "chatRoomComposerHint": "Write a message",
-  "@chatRoomComposerHint": { "description": "Hint text for the room composer when sending is allowed" },
-
+  "@chatRoomComposerHint": {
+    "description": "Hint text for the room composer when sending is allowed"
+  },
   "chatRoomComposerDisabledHint": "Messages are unavailable in this room right now",
-  "@chatRoomComposerDisabledHint": { "description": "Hint text for the room composer when sending is disabled" },
-
+  "@chatRoomComposerDisabledHint": {
+    "description": "Hint text for the room composer when sending is disabled"
+  },
   "chatRoomSendButton": "Send",
-  "@chatRoomSendButton": { "description": "Primary button label for sending a room message" },
-
+  "@chatRoomSendButton": {
+    "description": "Primary button label for sending a room message"
+  },
   "chatRoomSendingButton": "Sending…",
-  "@chatRoomSendingButton": { "description": "Button label shown while a room message is sending" },
+  "@chatRoomSendingButton": {
+    "description": "Button label shown while a room message is sending"
+  },
   "chatRoomRetrySendAction": "Retry send",
-  "@chatRoomRetrySendAction": { "description": "Action label for retrying a failed room message send" },
+  "@chatRoomRetrySendAction": {
+    "description": "Action label for retrying a failed room message send"
+  },
   "chatRoomYouLabel": "You",
-  "@chatRoomYouLabel": { "description": "Sender label used for locally pending outgoing messages" },
+  "@chatRoomYouLabel": {
+    "description": "Sender label used for locally pending outgoing messages"
+  },
   "chatRoomMessageSendingStatus": "Sending…",
-  "@chatRoomMessageSendingStatus": { "description": "Status label shown on a message bubble while the message is sending" },
+  "@chatRoomMessageSendingStatus": {
+    "description": "Status label shown on a message bubble while the message is sending"
+  },
   "chatRoomMessageFailedStatus": "Not sent",
-  "@chatRoomMessageFailedStatus": { "description": "Friendly status label shown on a message bubble when sending failed" },
+  "@chatRoomMessageFailedStatus": {
+    "description": "Friendly status label shown on a message bubble when sending failed"
+  },
   "chatRoomEncryptedMessageLabel": "Encrypted message",
-  "@chatRoomEncryptedMessageLabel": { "description": "Fallback label for encrypted messages in the room timeline" },
+  "@chatRoomEncryptedMessageLabel": {
+    "description": "Fallback label for encrypted messages in the room timeline"
+  },
   "chatRoomUnsupportedMessageLabel": "Unsupported message",
-  "@chatRoomUnsupportedMessageLabel": { "description": "Fallback label for unsupported messages in the room timeline" },
+  "@chatRoomUnsupportedMessageLabel": {
+    "description": "Fallback label for unsupported messages in the room timeline"
+  },
   "chatRoomMessageActionsLabel": "Message actions",
-  "@chatRoomMessageActionsLabel": { "description": "Tooltip for the message actions menu" },
+  "@chatRoomMessageActionsLabel": {
+    "description": "Tooltip for the message actions menu"
+  },
   "chatRoomArchiveAction": "Archive",
-  "@chatRoomArchiveAction": { "description": "Action label for archiving a message from the room timeline" },
+  "@chatRoomArchiveAction": {
+    "description": "Action label for archiving a message from the room timeline"
+  },
   "chatRoomArchiveDialogTitle": "Archive message?",
-  "@chatRoomArchiveDialogTitle": { "description": "Dialog title shown before a chat message is archived" },
+  "@chatRoomArchiveDialogTitle": {
+    "description": "Dialog title shown before a chat message is archived"
+  },
   "chatRoomArchiveDialogMessage": "This hides the message from your main timeline on this device. You can review or restore it from Archived messages.",
-  "@chatRoomArchiveDialogMessage": { "description": "Dialog body shown before a chat message is archived" },
+  "@chatRoomArchiveDialogMessage": {
+    "description": "Dialog body shown before a chat message is archived"
+  },
   "chatRoomArchivedMessagesAction": "Review archived messages",
-  "@chatRoomArchivedMessagesAction": { "description": "App bar action that opens the archived messages review view" },
+  "@chatRoomArchivedMessagesAction": {
+    "description": "App bar action that opens the archived messages review view"
+  },
   "chatRoomActiveTimelineAction": "Back to active timeline",
-  "@chatRoomActiveTimelineAction": { "description": "Action that returns from archived messages to the active room timeline" },
+  "@chatRoomActiveTimelineAction": {
+    "description": "Action that returns from archived messages to the active room timeline"
+  },
   "chatRoomArchivedReviewTitle": "Archived messages",
-  "@chatRoomArchivedReviewTitle": { "description": "Heading shown above the archived messages review view" },
+  "@chatRoomArchivedReviewTitle": {
+    "description": "Heading shown above the archived messages review view"
+  },
   "chatRoomArchivedReviewDescription": "{count, plural, =0 {Archived messages from this room appear here, separate from the active timeline.} =1 {1 archived message is shown separately from the active timeline.} other {{count} archived messages are shown separately from the active timeline.}}",
   "@chatRoomArchivedReviewDescription": {
     "description": "Description shown above the archived messages review view",
     "placeholders": {
-      "count": { "type": "int" }
+      "count": {
+        "type": "int"
+      }
     }
   },
   "chatRoomArchivedReviewEmptyMessage": "No archived messages yet.",
-  "@chatRoomArchivedReviewEmptyMessage": { "description": "Empty state shown when the archived messages review view has no messages" },
+  "@chatRoomArchivedReviewEmptyMessage": {
+    "description": "Empty state shown when the archived messages review view has no messages"
+  },
   "chatRoomArchivedMessageLabel": "Archived",
-  "@chatRoomArchivedMessageLabel": { "description": "Label shown on messages in the archived messages review view" },
+  "@chatRoomArchivedMessageLabel": {
+    "description": "Label shown on messages in the archived messages review view"
+  },
   "chatRoomRestoreAction": "Restore to timeline",
-  "@chatRoomRestoreAction": { "description": "Action label for restoring an archived message to the active room timeline" },
+  "@chatRoomRestoreAction": {
+    "description": "Action label for restoring an archived message to the active room timeline"
+  },
   "chatRoomRestoreSuccessMessage": "Message restored to the active timeline.",
-  "@chatRoomRestoreSuccessMessage": { "description": "Snackbar confirmation after restoring an archived message" },
+  "@chatRoomRestoreSuccessMessage": {
+    "description": "Snackbar confirmation after restoring an archived message"
+  },
   "chatRoomRestoreFailureMessage": "This message could not be restored right now.",
-  "@chatRoomRestoreFailureMessage": { "description": "Snackbar error shown when restoring an archived message fails" },
+  "@chatRoomRestoreFailureMessage": {
+    "description": "Snackbar error shown when restoring an archived message fails"
+  },
   "chatRoomArchiveSuccessMessage": "Message archived.",
-  "@chatRoomArchiveSuccessMessage": { "description": "Snackbar confirmation after archiving a message" },
+  "@chatRoomArchiveSuccessMessage": {
+    "description": "Snackbar confirmation after archiving a message"
+  },
   "chatRoomArchiveFailureMessage": "This message could not be archived right now.",
-  "@chatRoomArchiveFailureMessage": { "description": "Snackbar error shown when archiving a message fails" },
+  "@chatRoomArchiveFailureMessage": {
+    "description": "Snackbar error shown when archiving a message fails"
+  },
   "chatRoomArchivedEmptyMessage": "Archived messages are hidden from this timeline.",
-  "@chatRoomArchivedEmptyMessage": { "description": "Empty state shown when all loaded messages have been archived from the main timeline" },
-
+  "@chatRoomArchivedEmptyMessage": {
+    "description": "Empty state shown when all loaded messages have been archived from the main timeline"
+  },
   "chatRoomContextPackTitle": "Context for this room",
-  "@chatRoomContextPackTitle": { "description": "Heading for the explicit context preview shown in a chat room" },
+  "@chatRoomContextPackTitle": {
+    "description": "Heading for the explicit context preview shown in a chat room"
+  },
   "chatRoomContextPackDescription": "Weave will only include scoped context that you can see here, such as this room, selected files, linked tasks, and recent decisions.",
-  "@chatRoomContextPackDescription": { "description": "Description for the explicit context preview shown in a chat room" },
+  "@chatRoomContextPackDescription": {
+    "description": "Description for the explicit context preview shown in a chat room"
+  },
   "chatRoomContextPackCounts": "{includedCount, plural, =0 {No sources included} =1 {1 source included} other {{includedCount} sources included}}. {availableCount, plural, =0 {No optional sources available} =1 {1 optional source available} other {{availableCount} optional sources available}}.",
   "@chatRoomContextPackCounts": {
     "description": "Accessibility summary of included and available context sources in a room",
     "placeholders": {
-      "includedCount": { "type": "int" },
-      "availableCount": { "type": "int" }
+      "includedCount": {
+        "type": "int"
+      },
+      "availableCount": {
+        "type": "int"
+      }
     }
   },
   "chatRoomContextPackNoBackgroundReading": "No agent is reading this room in the background.",
-  "@chatRoomContextPackNoBackgroundReading": { "description": "Safety note for the explicit context preview in a chat room" },
+  "@chatRoomContextPackNoBackgroundReading": {
+    "description": "Safety note for the explicit context preview in a chat room"
+  },
   "chatRoomContextCurrentRoomLabel": "Current room",
-  "@chatRoomContextCurrentRoomLabel": { "description": "Context chip label for the currently opened chat room" },
+  "@chatRoomContextCurrentRoomLabel": {
+    "description": "Context chip label for the currently opened chat room"
+  },
   "chatRoomContextSelectedFilesLabel": "Selected files",
-  "@chatRoomContextSelectedFilesLabel": { "description": "Context chip label for files explicitly selected by the user" },
+  "@chatRoomContextSelectedFilesLabel": {
+    "description": "Context chip label for files explicitly selected by the user"
+  },
   "chatRoomContextLinkedTasksLabel": "Linked tasks",
-  "@chatRoomContextLinkedTasksLabel": { "description": "Context chip label for tasks linked to a room" },
+  "@chatRoomContextLinkedTasksLabel": {
+    "description": "Context chip label for tasks linked to a room"
+  },
   "chatRoomContextRecentDecisionsLabel": "Recent decisions",
-  "@chatRoomContextRecentDecisionsLabel": { "description": "Context chip label for recent decisions linked to a room" },
+  "@chatRoomContextRecentDecisionsLabel": {
+    "description": "Context chip label for recent decisions linked to a room"
+  },
   "chatRoomContextIncludedStatus": "Included",
-  "@chatRoomContextIncludedStatus": { "description": "Accessibility status for context that is included in the preview" },
+  "@chatRoomContextIncludedStatus": {
+    "description": "Accessibility status for context that is included in the preview"
+  },
   "chatRoomContextAvailableStatus": "Available when selected",
-  "@chatRoomContextAvailableStatus": { "description": "Accessibility status for optional context that is not included yet" },
-
+  "@chatRoomContextAvailableStatus": {
+    "description": "Accessibility status for optional context that is not included yet"
+  },
   "chatDecisionEvidencePanelTitle": "Decisions, risks, questions, and evidence",
-  "@chatDecisionEvidencePanelTitle": { "description": "Heading for the room decision and evidence snapshot panel" },
+  "@chatDecisionEvidencePanelTitle": {
+    "description": "Heading for the room decision and evidence snapshot panel"
+  },
   "chatDecisionEvidencePanelDescription": "Capture important messages explicitly so the room keeps the reason behind the work. Nothing here is created by hidden room scanning.",
-  "@chatDecisionEvidencePanelDescription": { "description": "Description for the explicit decision and evidence capture panel" },
+  "@chatDecisionEvidencePanelDescription": {
+    "description": "Description for the explicit decision and evidence capture panel"
+  },
   "chatDecisionEvidenceNoBackgroundReading": "Records come from message actions you choose; no automatic continuous room reading is running.",
-  "@chatDecisionEvidenceNoBackgroundReading": { "description": "Safety note for explicit decision and evidence records" },
+  "@chatDecisionEvidenceNoBackgroundReading": {
+    "description": "Safety note for explicit decision and evidence records"
+  },
   "chatDecisionEvidenceEmptyState": "No records captured yet. Use a message action to capture a decision, risk, open question, or evidence with its source.",
-  "@chatDecisionEvidenceEmptyState": { "description": "Empty state for a room with no captured decision or evidence records" },
+  "@chatDecisionEvidenceEmptyState": {
+    "description": "Empty state for a room with no captured decision or evidence records"
+  },
   "chatDecisionEvidenceCountLabel": "{label}: {count}",
   "@chatDecisionEvidenceCountLabel": {
     "description": "Count label for a decision/evidence kind",
     "placeholders": {
-      "label": { "type": "String" },
-      "count": { "type": "int" }
+      "label": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
     }
   },
   "chatDecisionEvidenceDecisionLabel": "Decision",
-  "@chatDecisionEvidenceDecisionLabel": { "description": "Singular label for a captured decision" },
+  "@chatDecisionEvidenceDecisionLabel": {
+    "description": "Singular label for a captured decision"
+  },
   "chatDecisionEvidenceDecisionsLabel": "Decisions",
-  "@chatDecisionEvidenceDecisionsLabel": { "description": "Plural label for captured decisions" },
+  "@chatDecisionEvidenceDecisionsLabel": {
+    "description": "Plural label for captured decisions"
+  },
   "chatDecisionEvidenceRiskLabel": "Risk",
-  "@chatDecisionEvidenceRiskLabel": { "description": "Singular label for a captured risk" },
+  "@chatDecisionEvidenceRiskLabel": {
+    "description": "Singular label for a captured risk"
+  },
   "chatDecisionEvidenceRisksLabel": "Risks",
-  "@chatDecisionEvidenceRisksLabel": { "description": "Plural label for captured risks" },
+  "@chatDecisionEvidenceRisksLabel": {
+    "description": "Plural label for captured risks"
+  },
   "chatDecisionEvidenceOpenQuestionLabel": "Open question",
-  "@chatDecisionEvidenceOpenQuestionLabel": { "description": "Singular label for a captured open question" },
+  "@chatDecisionEvidenceOpenQuestionLabel": {
+    "description": "Singular label for a captured open question"
+  },
   "chatDecisionEvidenceOpenQuestionsLabel": "Open questions",
-  "@chatDecisionEvidenceOpenQuestionsLabel": { "description": "Plural label for captured open questions" },
+  "@chatDecisionEvidenceOpenQuestionsLabel": {
+    "description": "Plural label for captured open questions"
+  },
   "chatDecisionEvidenceEvidenceLabel": "Evidence",
-  "@chatDecisionEvidenceEvidenceLabel": { "description": "Singular label for captured evidence" },
+  "@chatDecisionEvidenceEvidenceLabel": {
+    "description": "Singular label for captured evidence"
+  },
   "chatDecisionEvidenceEvidencePluralLabel": "Evidence",
-  "@chatDecisionEvidenceEvidencePluralLabel": { "description": "Plural label for captured evidence" },
+  "@chatDecisionEvidenceEvidencePluralLabel": {
+    "description": "Plural label for captured evidence"
+  },
   "chatDecisionEvidenceOwnerYou": "You",
-  "@chatDecisionEvidenceOwnerYou": { "description": "Owner label for records captured by the current user" },
+  "@chatDecisionEvidenceOwnerYou": {
+    "description": "Owner label for records captured by the current user"
+  },
   "chatDecisionEvidenceStatusActive": "Active",
-  "@chatDecisionEvidenceStatusActive": { "description": "Lifecycle status for active decision/evidence records" },
+  "@chatDecisionEvidenceStatusActive": {
+    "description": "Lifecycle status for active decision/evidence records"
+  },
   "chatDecisionEvidenceStatusResolved": "Resolved",
-  "@chatDecisionEvidenceStatusResolved": { "description": "Lifecycle status for resolved decision/evidence records" },
+  "@chatDecisionEvidenceStatusResolved": {
+    "description": "Lifecycle status for resolved decision/evidence records"
+  },
   "chatDecisionEvidenceStatusArchived": "Archived",
-  "@chatDecisionEvidenceStatusArchived": { "description": "Lifecycle status for archived decision/evidence records" },
+  "@chatDecisionEvidenceStatusArchived": {
+    "description": "Lifecycle status for archived decision/evidence records"
+  },
   "chatDecisionEvidenceRecordMeta": "{status}. Captured by {owner}. Source: message from {sender}.",
   "@chatDecisionEvidenceRecordMeta": {
     "description": "Metadata shown for a captured decision/evidence record",
     "placeholders": {
-      "status": { "type": "String" },
-      "owner": { "type": "String" },
-      "sender": { "type": "String" }
+      "status": {
+        "type": "String"
+      },
+      "owner": {
+        "type": "String"
+      },
+      "sender": {
+        "type": "String"
+      }
     }
   },
   "chatDecisionEvidenceSourceLabel": "Source: message from {sender}",
   "@chatDecisionEvidenceSourceLabel": {
     "description": "Short source label for a captured decision/evidence record",
-    "placeholders": { "sender": { "type": "String" } }
+    "placeholders": {
+      "sender": {
+        "type": "String"
+      }
+    }
   },
   "chatDecisionEvidenceCapturedMessage": "Captured as {kind}. Source linked to this message.",
   "@chatDecisionEvidenceCapturedMessage": {
     "description": "Snackbar shown after a message is captured as a decision/evidence record",
-    "placeholders": { "kind": { "type": "String" } }
+    "placeholders": {
+      "kind": {
+        "type": "String"
+      }
+    }
   },
   "chatDecisionEvidenceMoreRecords": "{count, plural, =1 {1 more record} other {{count} more records}}",
   "@chatDecisionEvidenceMoreRecords": {
     "description": "Summary shown when the panel hides additional records",
-    "placeholders": { "count": { "type": "int" } }
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "chatDecisionEvidenceCaptureDecisionAction": "Capture as decision",
-  "@chatDecisionEvidenceCaptureDecisionAction": { "description": "Message menu action to capture a message as a decision" },
+  "@chatDecisionEvidenceCaptureDecisionAction": {
+    "description": "Message menu action to capture a message as a decision"
+  },
   "chatDecisionEvidenceCaptureRiskAction": "Capture as risk",
-  "@chatDecisionEvidenceCaptureRiskAction": { "description": "Message menu action to capture a message as a risk" },
+  "@chatDecisionEvidenceCaptureRiskAction": {
+    "description": "Message menu action to capture a message as a risk"
+  },
   "chatDecisionEvidenceCaptureQuestionAction": "Capture as open question",
-  "@chatDecisionEvidenceCaptureQuestionAction": { "description": "Message menu action to capture a message as an open question" },
+  "@chatDecisionEvidenceCaptureQuestionAction": {
+    "description": "Message menu action to capture a message as an open question"
+  },
   "chatDecisionEvidenceCaptureEvidenceAction": "Capture as evidence",
-  "@chatDecisionEvidenceCaptureEvidenceAction": { "description": "Message menu action to capture a message as evidence" },
-
+  "@chatDecisionEvidenceCaptureEvidenceAction": {
+    "description": "Message menu action to capture a message as evidence"
+  },
   "filesEmptyMessage": "No files yet",
-  "@filesEmptyMessage": { "description": "Empty state message for the files screen" },
+  "@filesEmptyMessage": {
+    "description": "Empty state message for the files screen"
+  },
   "filesEmptyGuidance": "Upload a file or create a folder when you are ready to add workspace files.",
-  "@filesEmptyGuidance": { "description": "Guidance shown below the files empty-state title" },
+  "@filesEmptyGuidance": {
+    "description": "Guidance shown below the files empty-state title"
+  },
   "filesDisconnectedTitle": "Files are not connected",
-  "@filesDisconnectedTitle": { "description": "Friendly empty-state title shown when files require a connection" },
+  "@filesDisconnectedTitle": {
+    "description": "Friendly empty-state title shown when files require a connection"
+  },
   "filesSetupNeededTitle": "Files need setup",
-  "@filesSetupNeededTitle": { "description": "Friendly empty-state title shown when files are misconfigured" },
+  "@filesSetupNeededTitle": {
+    "description": "Friendly empty-state title shown when files are misconfigured"
+  },
   "filesSessionExpiredTitle": "Files need to reconnect",
-  "@filesSessionExpiredTitle": { "description": "Friendly error-state title shown when the files session is invalid" },
+  "@filesSessionExpiredTitle": {
+    "description": "Friendly error-state title shown when the files session is invalid"
+  },
   "filesLoadErrorTitle": "Files could not be loaded",
-  "@filesLoadErrorTitle": { "description": "Friendly error-state title shown when files fail to load" },
+  "@filesLoadErrorTitle": {
+    "description": "Friendly error-state title shown when files fail to load"
+  },
   "filesErrorGuidance": "Try again. If this keeps happening, check the workspace files status in setup or diagnostics.",
-  "@filesErrorGuidance": { "description": "Friendly recovery guidance shown when files fail before detailed state is available" },
-
+  "@filesErrorGuidance": {
+    "description": "Friendly recovery guidance shown when files fail before detailed state is available"
+  },
   "calendarEmptyMessage": "No events yet",
-  "@calendarEmptyMessage": { "description": "Empty state message for the calendar screen" },
-
+  "@calendarEmptyMessage": {
+    "description": "Empty state message for the calendar screen"
+  },
   "deckEmptyMessage": "No boards in this active preview yet",
-  "@deckEmptyMessage": { "description": "Legacy hidden Deck empty state message retained for compatibility" },
-
+  "@deckEmptyMessage": {
+    "description": "Legacy hidden Deck empty state message retained for compatibility"
+  },
   "deviceLanguageLabel": "Device Language",
-  "@deviceLanguageLabel": { "description": "Label for the detected device language display" },
-
+  "@deviceLanguageLabel": {
+    "description": "Label for the detected device language display"
+  },
   "serverConfigurationProviderLabel": "OIDC Provider",
-  "@serverConfigurationProviderLabel": { "description": "Section title for choosing an OIDC provider" },
-
+  "@serverConfigurationProviderLabel": {
+    "description": "Section title for choosing an OIDC provider"
+  },
   "serverConfigurationProviderFieldLabel": "Provider type",
-  "@serverConfigurationProviderFieldLabel": { "description": "Label for the provider selection field" },
-
+  "@serverConfigurationProviderFieldLabel": {
+    "description": "Label for the provider selection field"
+  },
   "oidcProviderAuthentik": "Authentik",
-  "@oidcProviderAuthentik": { "description": "Label for the Authentik provider option" },
-
+  "@oidcProviderAuthentik": {
+    "description": "Label for the Authentik provider option"
+  },
   "oidcProviderKeycloak": "Keycloak",
-  "@oidcProviderKeycloak": { "description": "Label for the Keycloak provider option" },
-
+  "@oidcProviderKeycloak": {
+    "description": "Label for the Keycloak provider option"
+  },
   "serverConfigurationIssuerLabel": "OIDC Issuer URL",
-  "@serverConfigurationIssuerLabel": { "description": "Label for the issuer URL field" },
-
+  "@serverConfigurationIssuerLabel": {
+    "description": "Label for the issuer URL field"
+  },
   "serverConfigurationIssuerHelper": "This must be the absolute issuer URL for your OIDC provider.",
-  "@serverConfigurationIssuerHelper": { "description": "Helper text for the issuer URL field" },
-
+  "@serverConfigurationIssuerHelper": {
+    "description": "Helper text for the issuer URL field"
+  },
   "serverConfigurationClientIdLabel": "OIDC Client ID",
-  "@serverConfigurationClientIdLabel": { "description": "Label for the OIDC client ID field" },
-
+  "@serverConfigurationClientIdLabel": {
+    "description": "Label for the OIDC client ID field"
+  },
   "serverConfigurationClientIdHelper": "Enter the public/native client ID registered for Weave on this issuer.",
-  "@serverConfigurationClientIdHelper": { "description": "Helper text for the OIDC client ID field" },
-
+  "@serverConfigurationClientIdHelper": {
+    "description": "Helper text for the OIDC client ID field"
+  },
   "serverConfigurationServicesLabel": "Service Endpoints",
-  "@serverConfigurationServicesLabel": { "description": "Section title for derived service endpoints" },
-
+  "@serverConfigurationServicesLabel": {
+    "description": "Section title for derived service endpoints"
+  },
   "serverConfigurationServicesHelper": "Defaults for Matrix, Nextcloud, and the backend API are derived from the issuer host. Edit them if your services live elsewhere.",
-  "@serverConfigurationServicesHelper": { "description": "Helper text for the service endpoints section" },
-
+  "@serverConfigurationServicesHelper": {
+    "description": "Helper text for the service endpoints section"
+  },
   "serverConfigurationMatrixLabel": "Matrix Homeserver URL",
-  "@serverConfigurationMatrixLabel": { "description": "Label for the Matrix homeserver URL field" },
-
+  "@serverConfigurationMatrixLabel": {
+    "description": "Label for the Matrix homeserver URL field"
+  },
   "serverConfigurationNextcloudLabel": "Nextcloud Base URL",
-  "@serverConfigurationNextcloudLabel": { "description": "Label for the Nextcloud base URL field" },
-
+  "@serverConfigurationNextcloudLabel": {
+    "description": "Label for the Nextcloud base URL field"
+  },
   "serverConfigurationBackendApiLabel": "Backend API Base URL",
-  "@serverConfigurationBackendApiLabel": { "description": "Label for the backend API base URL field" },
-
+  "@serverConfigurationBackendApiLabel": {
+    "description": "Label for the backend API base URL field"
+  },
   "serverConfigurationDerivedHint": "Derived default: {value}",
   "@serverConfigurationDerivedHint": {
     "description": "Helper text showing the derived default for a service endpoint",
     "placeholders": {
-      "value": { "type": "String" }
+      "value": {
+        "type": "String"
+      }
     }
   },
-
   "oidcRegistrationHelpTitle": "Register Weave as a native/public client",
-  "@oidcRegistrationHelpTitle": { "description": "Title for the OIDC client registration help card" },
-
+  "@oidcRegistrationHelpTitle": {
+    "description": "Title for the OIDC client registration help card"
+  },
   "oidcRegistrationHelpDescription": "Use Authorization Code + PKCE with the system browser, and allow the Weave redirect URIs below on the provider-side client registration.",
-  "@oidcRegistrationHelpDescription": { "description": "General description for the OIDC client registration help card" },
-
+  "@oidcRegistrationHelpDescription": {
+    "description": "General description for the OIDC client registration help card"
+  },
   "oidcRegistrationHelpNoSecret": "Do not create or paste a client secret here. Weave uses a public native-client flow.",
-  "@oidcRegistrationHelpNoSecret": { "description": "Warning that Weave should not use a client secret" },
-
+  "@oidcRegistrationHelpNoSecret": {
+    "description": "Warning that Weave should not use a client secret"
+  },
   "oidcRegistrationHelpAuthentikSteps": "In Authentik, create an OAuth2/OpenID Connect provider for Weave, add these redirect URIs to the provider, and ensure the client is configured for Authorization Code flow with `offline_access` available if you want refresh tokens.",
-  "@oidcRegistrationHelpAuthentikSteps": { "description": "Provider-specific OIDC registration guidance for Authentik" },
-
+  "@oidcRegistrationHelpAuthentikSteps": {
+    "description": "Provider-specific OIDC registration guidance for Authentik"
+  },
   "oidcRegistrationHelpKeycloakSteps": "In Keycloak, create a public OpenID Connect client for Weave, add these redirect URIs and post-logout redirect URIs, and enable Standard Flow with PKCE (S256) so Weave can sign in without a client secret.",
-  "@oidcRegistrationHelpKeycloakSteps": { "description": "Provider-specific OIDC registration guidance for Keycloak" },
-
+  "@oidcRegistrationHelpKeycloakSteps": {
+    "description": "Provider-specific OIDC registration guidance for Keycloak"
+  },
   "oidcRegistrationHelpRedirectsTitle": "Register these redirect URIs",
-  "@oidcRegistrationHelpRedirectsTitle": { "description": "Title shown above the redirect URI values" },
-
+  "@oidcRegistrationHelpRedirectsTitle": {
+    "description": "Title shown above the redirect URI values"
+  },
   "oidcRegistrationHelpRedirectValue": "Sign-in redirect: {value}",
   "@oidcRegistrationHelpRedirectValue": {
     "description": "Text showing the sign-in redirect URI",
     "placeholders": {
-      "value": { "type": "String" }
+      "value": {
+        "type": "String"
+      }
     }
   },
-
   "oidcRegistrationHelpPostLogoutRedirectValue": "Post-logout redirect: {value}",
   "@oidcRegistrationHelpPostLogoutRedirectValue": {
     "description": "Text showing the post-logout redirect URI",
     "placeholders": {
-      "value": { "type": "String" }
+      "value": {
+        "type": "String"
+      }
     }
   },
-
   "signInScreenTitle": "Sign In",
-  "@signInScreenTitle": { "description": "App bar title for the sign-in screen" },
-
+  "@signInScreenTitle": {
+    "description": "App bar title for the sign-in screen"
+  },
   "signInTitle": "Sign in to continue",
-  "@signInTitle": { "description": "Main heading on the sign-in screen" },
-
+  "@signInTitle": {
+    "description": "Main heading on the sign-in screen"
+  },
   "signInDescription": "Weave is configured. Use your provider account in the system browser to open the authenticated app shell.",
-  "@signInDescription": { "description": "Description text on the sign-in screen" },
-
+  "@signInDescription": {
+    "description": "Description text on the sign-in screen"
+  },
   "signInConfigurationTitle": "Current sign-in configuration",
-  "@signInConfigurationTitle": { "description": "Title for the sign-in configuration summary card" },
-
+  "@signInConfigurationTitle": {
+    "description": "Title for the sign-in configuration summary card"
+  },
   "signInConfigurationProvider": "Provider: {value}",
   "@signInConfigurationProvider": {
     "description": "Summary line showing the provider label on the sign-in screen",
     "placeholders": {
-      "value": { "type": "String" }
+      "value": {
+        "type": "String"
+      }
     }
   },
-
   "signInConfigurationIssuer": "Issuer: {value}",
   "@signInConfigurationIssuer": {
     "description": "Summary line showing the issuer URL on the sign-in screen",
     "placeholders": {
-      "value": { "type": "String" }
+      "value": {
+        "type": "String"
+      }
     }
   },
-
   "signInConfigurationClientId": "Client ID: {value}",
   "@signInConfigurationClientId": {
     "description": "Summary line showing the client ID on the sign-in screen",
     "placeholders": {
-      "value": { "type": "String" }
+      "value": {
+        "type": "String"
+      }
     }
   },
-
   "signInButton": "Sign In",
-  "@signInButton": { "description": "Primary sign-in button label" },
-
+  "@signInButton": {
+    "description": "Primary sign-in button label"
+  },
   "signInInProgress": "Signing in…",
-  "@signInInProgress": { "description": "Label shown while sign-in is in progress" },
-
+  "@signInInProgress": {
+    "description": "Label shown while sign-in is in progress"
+  },
   "signInBackToSetupButton": "Back to Setup",
-  "@signInBackToSetupButton": { "description": "Secondary action label to return to setup from the sign-in screen" },
-
+  "@signInBackToSetupButton": {
+    "description": "Secondary action label to return to setup from the sign-in screen"
+  },
   "signInMissingConfigurationTitle": "Finish setup to sign in",
-  "@signInMissingConfigurationTitle": { "description": "Heading shown when auth configuration is incomplete" },
-
+  "@signInMissingConfigurationTitle": {
+    "description": "Heading shown when auth configuration is incomplete"
+  },
   "signInMissingConfigurationDescription": "Weave still needs a valid issuer URL and client ID before it can open the browser sign-in flow.",
-  "@signInMissingConfigurationDescription": { "description": "Description shown when auth configuration is incomplete" }
-,
+  "@signInMissingConfigurationDescription": {
+    "description": "Description shown when auth configuration is incomplete"
+  },
   "profileSectionTitle": "Weave profile",
-  "@profileSectionTitle": {"description": "Settings section title for the authenticated Weave profile"},
+  "@profileSectionTitle": {
+    "description": "Settings section title for the authenticated Weave profile"
+  },
   "profileSectionDescription": "This profile comes from the Weave backend identity facade and is shared by product modules.",
-  "@profileSectionDescription": {"description": "Settings description for the profile card"},
+  "@profileSectionDescription": {
+    "description": "Settings description for the profile card"
+  },
   "profileLoadFailure": "The Weave profile could not be loaded right now.",
-  "@profileLoadFailure": {"description": "Profile card error message"},
+  "@profileLoadFailure": {
+    "description": "Profile card error message"
+  },
   "profileSignedOutMessage": "Sign in to view your Weave profile.",
-  "@profileSignedOutMessage": {"description": "Profile card message when there is no authenticated session"},
+  "@profileSignedOutMessage": {
+    "description": "Profile card message when there is no authenticated session"
+  },
   "profileDisplayNameLabel": "Display name",
-  "@profileDisplayNameLabel": {"description": "Profile display name field label"},
+  "@profileDisplayNameLabel": {
+    "description": "Profile display name field label"
+  },
   "profileUsernameLabel": "Username",
-  "@profileUsernameLabel": {"description": "Profile username field label"},
+  "@profileUsernameLabel": {
+    "description": "Profile username field label"
+  },
   "profileEmailLabel": "Email",
-  "@profileEmailLabel": {"description": "Profile email field label"},
+  "@profileEmailLabel": {
+    "description": "Profile email field label"
+  },
   "profileEmailVerifiedLabel": "Email verified",
-  "@profileEmailVerifiedLabel": {"description": "Profile email verification field label"},
+  "@profileEmailVerifiedLabel": {
+    "description": "Profile email verification field label"
+  },
   "profileEmailVerifiedYes": "Yes",
-  "@profileEmailVerifiedYes": {"description": "Yes value for verified email"},
+  "@profileEmailVerifiedYes": {
+    "description": "Yes value for verified email"
+  },
   "profileEmailVerifiedNo": "No",
-  "@profileEmailVerifiedNo": {"description": "No value for unverified email"},
+  "@profileEmailVerifiedNo": {
+    "description": "No value for unverified email"
+  },
   "profileLocaleLabel": "Locale",
-  "@profileLocaleLabel": {"description": "Profile locale field label"},
+  "@profileLocaleLabel": {
+    "description": "Profile locale field label"
+  },
   "profileTimezoneLabel": "Timezone",
-  "@profileTimezoneLabel": {"description": "Profile timezone field label"},
+  "@profileTimezoneLabel": {
+    "description": "Profile timezone field label"
+  },
   "profileRolesLabel": "Roles",
-  "@profileRolesLabel": {"description": "Profile roles field label"},
+  "@profileRolesLabel": {
+    "description": "Profile roles field label"
+  },
   "profileGroupsLabel": "Groups",
-  "@profileGroupsLabel": {"description": "Profile groups field label"},
+  "@profileGroupsLabel": {
+    "description": "Profile groups field label"
+  },
   "profileEditingBlockedMessage": "Profile editing is prepared in the app, but saving changes is blocked until the backend exposes PATCH /api/profile.",
-  "@profileEditingBlockedMessage": {"description": "Deprecated message explaining why profile editing was not yet enabled"},
+  "@profileEditingBlockedMessage": {
+    "description": "Deprecated message explaining why profile editing was not yet enabled"
+  },
   "profileEditSectionTitle": "Edit profile",
-  "@profileEditSectionTitle": {"description": "Title for the editable profile form"},
+  "@profileEditSectionTitle": {
+    "description": "Title for the editable profile form"
+  },
   "profileEditSectionDescription": "Save changes through the Weave backend profile facade so every product module sees the same profile.",
-  "@profileEditSectionDescription": {"description": "Description for the editable profile form"},
+  "@profileEditSectionDescription": {
+    "description": "Description for the editable profile form"
+  },
   "profileDisplayNameHelper": "Shown to workspace members in Weave surfaces.",
-  "@profileDisplayNameHelper": {"description": "Helper text for the profile display name field"},
+  "@profileDisplayNameHelper": {
+    "description": "Helper text for the profile display name field"
+  },
   "profileLocaleHelper": "Use a locale code such as en or de.",
-  "@profileLocaleHelper": {"description": "Helper text for the profile locale field"},
+  "@profileLocaleHelper": {
+    "description": "Helper text for the profile locale field"
+  },
   "profileTimezoneHelper": "Use an IANA timezone such as Europe/Berlin.",
-  "@profileTimezoneHelper": {"description": "Helper text for the profile timezone field"},
+  "@profileTimezoneHelper": {
+    "description": "Helper text for the profile timezone field"
+  },
   "profileEditRequiredFieldError": "This field is required.",
-  "@profileEditRequiredFieldError": {"description": "Validation error for empty editable profile fields"},
+  "@profileEditRequiredFieldError": {
+    "description": "Validation error for empty editable profile fields"
+  },
   "profileEditSaveButton": "Save profile",
-  "@profileEditSaveButton": {"description": "Button label for saving profile edits"},
+  "@profileEditSaveButton": {
+    "description": "Button label for saving profile edits"
+  },
   "profileEditSavingButton": "Saving profile…",
-  "@profileEditSavingButton": {"description": "Busy button label while saving profile edits"},
+  "@profileEditSavingButton": {
+    "description": "Busy button label while saving profile edits"
+  },
   "profileEditSavedMessage": "Profile saved.",
-  "@profileEditSavedMessage": {"description": "Live-region success message after saving profile edits"},
+  "@profileEditSavedMessage": {
+    "description": "Live-region success message after saving profile edits"
+  },
   "settingsWorkspaceCalendarLabel": "Calendar",
-  "@settingsWorkspaceCalendarLabel": {"description": "Row label for calendar readiness in the workspace readiness summary"},
+  "@settingsWorkspaceCalendarLabel": {
+    "description": "Row label for calendar readiness in the workspace readiness summary"
+  },
   "settingsWorkspaceBoardsLabel": "Boards",
-  "@settingsWorkspaceBoardsLabel": {"description": "Row label for boards readiness in the workspace readiness summary"},
+  "@settingsWorkspaceBoardsLabel": {
+    "description": "Row label for boards readiness in the workspace readiness summary"
+  },
   "calendarWorkspaceScopeTitle": "Workspace calendar",
-  "@calendarWorkspaceScopeTitle": {"description": "Title for the workspace-scoped calendar banner"},
+  "@calendarWorkspaceScopeTitle": {
+    "description": "Title for the workspace-scoped calendar banner"
+  },
   "calendarWorkspaceScopeDescription": "This first Calendar slice is the workspace scope of Weave shared scheduling. Team and channel calendars are the next product scopes; private personal calendars are out of scope.",
-  "@calendarWorkspaceScopeDescription": {"description": "Description explaining that the current calendar surface is workspace-scoped rather than private-personal scoped"},
+  "@calendarWorkspaceScopeDescription": {
+    "description": "Description explaining that the current calendar surface is workspace-scoped rather than private-personal scoped"
+  },
   "calendarGenericScopeDescription": "Events are shown from {scopeLabel}.",
-  "@calendarGenericScopeDescription": {"description": "Description for non-workspace calendar scope metadata returned by the backend", "placeholders": {"scopeLabel": {"type": "String"}}},
+  "@calendarGenericScopeDescription": {
+    "description": "Description for non-workspace calendar scope metadata returned by the backend",
+    "placeholders": {
+      "scopeLabel": {
+        "type": "String"
+      }
+    }
+  },
   "calendarClientSetupTitle": "Use Calendar in other apps",
-  "@calendarClientSetupTitle": {"description": "Title for the external calendar client setup card"},
+  "@calendarClientSetupTitle": {
+    "description": "Title for the external calendar client setup card"
+  },
   "calendarClientSetupDescription": "Weave can hand native clients secret-free setup details. Weave still owns the product calendar UI.",
-  "@calendarClientSetupDescription": {"description": "Description for the external calendar client setup card"},
+  "@calendarClientSetupDescription": {
+    "description": "Description for the external calendar client setup card"
+  },
   "calendarClientSetupIconSemantic": "External calendar setup",
-  "@calendarClientSetupIconSemantic": {"description": "Semantic label for the external calendar setup icon"},
+  "@calendarClientSetupIconSemantic": {
+    "description": "Semantic label for the external calendar setup icon"
+  },
   "calendarClientSetupLoading": "Loading setup options…",
-  "@calendarClientSetupLoading": {"description": "Loading message for external calendar setup options"},
+  "@calendarClientSetupLoading": {
+    "description": "Loading message for external calendar setup options"
+  },
   "calendarClientSetupUnavailable": "Calendar setup options are unavailable right now.",
-  "@calendarClientSetupUnavailable": {"description": "Error message when external calendar setup options cannot be loaded"},
+  "@calendarClientSetupUnavailable": {
+    "description": "Error message when external calendar setup options cannot be loaded"
+  },
   "calendarCapabilityLoading": "Checking Calendar availability…",
-  "@calendarCapabilityLoading": {"description": "Loading message while checking whether the backend reports Calendar as available"},
+  "@calendarCapabilityLoading": {
+    "description": "Loading message while checking whether the backend reports Calendar as available"
+  },
   "calendarCapabilityError": "Calendar availability could not be checked right now.",
-  "@calendarCapabilityError": {"description": "Error shown when Calendar capability status cannot be loaded"},
+  "@calendarCapabilityError": {
+    "description": "Error shown when Calendar capability status cannot be loaded"
+  },
   "calendarUnavailableTitle": "Calendar is unavailable",
-  "@calendarUnavailableTitle": {"description": "Title for the Calendar module unavailable state"},
+  "@calendarUnavailableTitle": {
+    "description": "Title for the Calendar module unavailable state"
+  },
   "calendarUnavailableDescription": "Backend readiness is {readiness}. Event changes stay disabled until the Weave backend reports Calendar ready.",
-  "@calendarUnavailableDescription": {"description": "Description for the Calendar module unavailable state", "placeholders": {"readiness": {"type": "String"}}},
+  "@calendarUnavailableDescription": {
+    "description": "Description for the Calendar module unavailable state",
+    "placeholders": {
+      "readiness": {
+        "type": "String"
+      }
+    }
+  },
   "calendarClientSetupUsernameLabel": "Username",
-  "@calendarClientSetupUsernameLabel": {"description": "Label for the external CalDAV username"},
+  "@calendarClientSetupUsernameLabel": {
+    "description": "Label for the external CalDAV username"
+  },
   "calendarClientSetupDiscoveryUrlLabel": "CalDAV discovery URL",
-  "@calendarClientSetupDiscoveryUrlLabel": {"description": "Label for the CalDAV discovery URL"},
+  "@calendarClientSetupDiscoveryUrlLabel": {
+    "description": "Label for the CalDAV discovery URL"
+  },
   "calendarClientSetupPrincipalUrlLabel": "Principal URL",
-  "@calendarClientSetupPrincipalUrlLabel": {"description": "Label for the CalDAV principal URL"},
+  "@calendarClientSetupPrincipalUrlLabel": {
+    "description": "Label for the CalDAV principal URL"
+  },
   "calendarClientSetupCredentialPolicyTitle": "Credential safety",
-  "@calendarClientSetupCredentialPolicyTitle": {"description": "Heading for the external calendar credential safety policy"},
+  "@calendarClientSetupCredentialPolicyTitle": {
+    "description": "Heading for the external calendar credential safety policy"
+  },
   "calendarClientSetupAccessModelTitle": "Access model",
-  "@calendarClientSetupAccessModelTitle": {"description": "Heading for the calendar external client access model"},
+  "@calendarClientSetupAccessModelTitle": {
+    "description": "Heading for the calendar external client access model"
+  },
   "calendarClientSetupPrivateCalendarsAvailable": "Private personal calendars out of scope",
-  "@calendarClientSetupPrivateCalendarsAvailable": {"description": "Status text when private personal calendars are available"},
+  "@calendarClientSetupPrivateCalendarsAvailable": {
+    "description": "Status text when private personal calendars are available"
+  },
   "calendarClientSetupPrivateCalendarsBlocked": "Private personal calendars out of scope",
-  "@calendarClientSetupPrivateCalendarsBlocked": {"description": "Status text when private personal calendars are blocked"},
+  "@calendarClientSetupPrivateCalendarsBlocked": {
+    "description": "Status text when private personal calendars are blocked"
+  },
   "calendarClientSetupExternalCredentialModel": "External credential model: {model}",
-  "@calendarClientSetupExternalCredentialModel": {"description": "Calendar external credential model label", "placeholders": {"model": {"type": "String"}}},
+  "@calendarClientSetupExternalCredentialModel": {
+    "description": "Calendar external credential model label",
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  },
   "calendarClientSetupCredentialReadinessTitle": "Credential readiness",
-  "@calendarClientSetupCredentialReadinessTitle": {"description": "Heading for calendar credential readiness details"},
+  "@calendarClientSetupCredentialReadinessTitle": {
+    "description": "Heading for calendar credential readiness details"
+  },
   "calendarClientSetupCredentialReadinessStatus": "Status: {status}",
-  "@calendarClientSetupCredentialReadinessStatus": {"description": "Calendar credential readiness status", "placeholders": {"status": {"type": "String"}}},
+  "@calendarClientSetupCredentialReadinessStatus": {
+    "description": "Calendar credential readiness status",
+    "placeholders": {
+      "status": {
+        "type": "String"
+      }
+    }
+  },
   "calendarClientSetupAppleProfileBlocked": "Apple profiles stay disabled until profiles are signed and safe credentials exist.",
-  "@calendarClientSetupAppleProfileBlocked": {"description": "Blocked state explanation for Apple calendar profiles"},
+  "@calendarClientSetupAppleProfileBlocked": {
+    "description": "Blocked state explanation for Apple calendar profiles"
+  },
   "calendarClientSetupSubscriptionsBlocked": "Webcal/ICS subscriptions stay disabled until revocable read-only tokens exist.",
-  "@calendarClientSetupSubscriptionsBlocked": {"description": "Blocked state explanation for calendar subscriptions"},
+  "@calendarClientSetupSubscriptionsBlocked": {
+    "description": "Blocked state explanation for calendar subscriptions"
+  },
   "calendarClientSetupCredentialsSafe": "Backend actor credentials are not exposed to client setup artifacts.",
-  "@calendarClientSetupCredentialsSafe": {"description": "Safe credential boundary statement for calendar client setup"},
+  "@calendarClientSetupCredentialsSafe": {
+    "description": "Safe credential boundary statement for calendar client setup"
+  },
   "calendarClientSetupCredentialsUnsafe": "Setup is blocked because backend actor credentials would be exposed.",
-  "@calendarClientSetupCredentialsUnsafe": {"description": "Unsafe credential boundary warning for calendar client setup"},
+  "@calendarClientSetupCredentialsUnsafe": {
+    "description": "Unsafe credential boundary warning for calendar client setup"
+  },
   "calendarClientSetupPlatformsTitle": "Platform setup",
-  "@calendarClientSetupPlatformsTitle": {"description": "Heading for external calendar platform setup options"},
+  "@calendarClientSetupPlatformsTitle": {
+    "description": "Heading for external calendar platform setup options"
+  },
   "calendarClientSetupAvailableStatus": "available",
-  "@calendarClientSetupAvailableStatus": {"description": "Status label for an available external calendar setup option"},
+  "@calendarClientSetupAvailableStatus": {
+    "description": "Status label for an available external calendar setup option"
+  },
   "calendarClientSetupPlannedStatus": "planned",
-  "@calendarClientSetupPlannedStatus": {"description": "Status label for a planned external calendar setup option"},
+  "@calendarClientSetupPlannedStatus": {
+    "description": "Status label for a planned external calendar setup option"
+  },
   "calendarClientSetupPlannedFallback": "This setup path is feature-gated until revocation, provisioning, and platform profile tests are complete.",
-  "@calendarClientSetupPlannedFallback": {"description": "Fallback explanation for a planned external calendar setup option"},
+  "@calendarClientSetupPlannedFallback": {
+    "description": "Fallback explanation for a planned external calendar setup option"
+  },
   "calendarClientSetupOptionTitle": "{platform} via {method}: {status}",
-  "@calendarClientSetupOptionTitle": {"description": "External calendar setup option summary", "placeholders": {"platform": {"type": "String"}, "method": {"type": "String"}, "status": {"type": "String"}}},
+  "@calendarClientSetupOptionTitle": {
+    "description": "External calendar setup option summary",
+    "placeholders": {
+      "platform": {
+        "type": "String"
+      },
+      "method": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      }
+    }
+  },
   "calendarClientSetupCopyTooltip": "Copy {label}",
-  "@calendarClientSetupCopyTooltip": {"description": "Tooltip for copying an external calendar setup value", "placeholders": {"label": {"type": "String"}}},
+  "@calendarClientSetupCopyTooltip": {
+    "description": "Tooltip for copying an external calendar setup value",
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
   "calendarClientSetupCopied": "Calendar setup value copied.",
-  "@calendarClientSetupCopied": {"description": "Snackbar after copying an external calendar setup value"},
+  "@calendarClientSetupCopied": {
+    "description": "Snackbar after copying an external calendar setup value"
+  },
   "calendarCreateButton": "Create event",
-  "@calendarCreateButton": {"description": "Button label for opening the create calendar event form"},
+  "@calendarCreateButton": {
+    "description": "Button label for opening the create calendar event form"
+  },
   "calendarCreateDialogTitle": "Create calendar event",
-  "@calendarCreateDialogTitle": {"description": "Dialog title for creating a calendar event"},
+  "@calendarCreateDialogTitle": {
+    "description": "Dialog title for creating a calendar event"
+  },
   "calendarEditDialogTitle": "Edit calendar event",
-  "@calendarEditDialogTitle": {"description": "Dialog title for editing a calendar event"},
+  "@calendarEditDialogTitle": {
+    "description": "Dialog title for editing a calendar event"
+  },
   "calendarTitleFieldLabel": "Title",
-  "@calendarTitleFieldLabel": {"description": "Calendar event title field label"},
+  "@calendarTitleFieldLabel": {
+    "description": "Calendar event title field label"
+  },
   "calendarDescriptionFieldLabel": "Description",
-  "@calendarDescriptionFieldLabel": {"description": "Calendar event description field label"},
+  "@calendarDescriptionFieldLabel": {
+    "description": "Calendar event description field label"
+  },
   "calendarLocationFieldLabel": "Location",
-  "@calendarLocationFieldLabel": {"description": "Calendar event location field label"},
+  "@calendarLocationFieldLabel": {
+    "description": "Calendar event location field label"
+  },
   "calendarTitleRequired": "Enter an event title.",
-  "@calendarTitleRequired": {"description": "Validation message when a calendar event title is missing"},
+  "@calendarTitleRequired": {
+    "description": "Validation message when a calendar event title is missing"
+  },
   "calendarCancelButton": "Cancel",
-  "@calendarCancelButton": {"description": "Button label for closing the calendar create dialog"},
+  "@calendarCancelButton": {
+    "description": "Button label for closing the calendar create dialog"
+  },
   "calendarSaveButton": "Save event",
-  "@calendarSaveButton": {"description": "Button label for saving a calendar event"},
+  "@calendarSaveButton": {
+    "description": "Button label for saving a calendar event"
+  },
   "calendarDeleteEventTooltip": "Delete {title}",
-  "@calendarDeleteEventTooltip": {"description": "Tooltip for deleting a calendar event", "placeholders": {"title": {"type": "String"}}},
+  "@calendarDeleteEventTooltip": {
+    "description": "Tooltip for deleting a calendar event",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "calendarEditEventTooltip": "Edit {title}",
-  "@calendarEditEventTooltip": {"description": "Tooltip for editing a calendar event", "placeholders": {"title": {"type": "String"}}},
+  "@calendarEditEventTooltip": {
+    "description": "Tooltip for editing a calendar event",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "calendarViewEventTooltip": "View {title}",
-  "@calendarViewEventTooltip": {"description": "Tooltip for opening a calendar event detail view", "placeholders": {"title": {"type": "String"}}},
+  "@calendarViewEventTooltip": {
+    "description": "Tooltip for opening a calendar event detail view",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
   "calendarEventSemantic": "{title}, starts {startsAt}, ends {endsAt}",
-  "@calendarEventSemantic": {"description": "Semantic label for a calendar event row", "placeholders": {"title": {"type": "String"}, "startsAt": {"type": "String"}, "endsAt": {"type": "String"}}},
+  "@calendarEventSemantic": {
+    "description": "Semantic label for a calendar event row",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      },
+      "startsAt": {
+        "type": "String"
+      },
+      "endsAt": {
+        "type": "String"
+      }
+    }
+  },
   "calendarDetailsDialogTitle": "Calendar event details",
-  "@calendarDetailsDialogTitle": {"description": "Title for the calendar event details dialog"},
+  "@calendarDetailsDialogTitle": {
+    "description": "Title for the calendar event details dialog"
+  },
   "calendarDetailsLoading": "Loading event details…",
-  "@calendarDetailsLoading": {"description": "Loading message while a calendar event is read from the backend"},
+  "@calendarDetailsLoading": {
+    "description": "Loading message while a calendar event is read from the backend"
+  },
   "calendarDetailsError": "Calendar event details are unavailable right now.",
-  "@calendarDetailsError": {"description": "Error shown when reading a calendar event from the backend fails"},
+  "@calendarDetailsError": {
+    "description": "Error shown when reading a calendar event from the backend fails"
+  },
   "calendarDetailsTimeLabel": "Time",
-  "@calendarDetailsTimeLabel": {"description": "Label for the calendar event time range in the details dialog"},
+  "@calendarDetailsTimeLabel": {
+    "description": "Label for the calendar event time range in the details dialog"
+  },
   "calendarDetailsScopeLabel": "Calendar scope",
-  "@calendarDetailsScopeLabel": {"description": "Label for the calendar scope in the event details dialog"},
+  "@calendarDetailsScopeLabel": {
+    "description": "Label for the calendar scope in the event details dialog"
+  },
   "calendarDetailsContextLabel": "Context",
-  "@calendarDetailsContextLabel": {"description": "Label for the Weave Context/Space id in the event details dialog"},
+  "@calendarDetailsContextLabel": {
+    "description": "Label for the Weave Context/Space id in the event details dialog"
+  },
   "calendarDetailsMeetingThreadLabel": "Meeting thread",
-  "@calendarDetailsMeetingThreadLabel": {"description": "Label for meeting thread metadata in the event details dialog"},
+  "@calendarDetailsMeetingThreadLabel": {
+    "description": "Label for meeting thread metadata in the event details dialog"
+  },
   "calendarDetailsMeetingThreadPending": "Safe context metadata is available; chat thread linkage is not configured yet.",
-  "@calendarDetailsMeetingThreadPending": {"description": "Calendar details text when the backend exposes safe context metadata but not a Matrix thread id"},
+  "@calendarDetailsMeetingThreadPending": {
+    "description": "Calendar details text when the backend exposes safe context metadata but not a Matrix thread id"
+  },
   "calendarDetailsAttendeesLabel": "Attendees",
-  "@calendarDetailsAttendeesLabel": {"description": "Label for safe attendee metadata in the calendar event details dialog"},
+  "@calendarDetailsAttendeesLabel": {
+    "description": "Label for safe attendee metadata in the calendar event details dialog"
+  },
   "calendarDetailsProviderLabel": "Provider reference",
-  "@calendarDetailsProviderLabel": {"description": "Label for safe provider metadata in the calendar event details dialog"},
+  "@calendarDetailsProviderLabel": {
+    "description": "Label for safe provider metadata in the calendar event details dialog"
+  },
   "calendarDetailsProviderPathHidden": "raw provider path hidden",
-  "@calendarDetailsProviderPathHidden": {"description": "Calendar details text explaining that raw provider paths are not exposed"},
+  "@calendarDetailsProviderPathHidden": {
+    "description": "Calendar details text explaining that raw provider paths are not exposed"
+  },
   "calendarDetailsUpdatedLabel": "Updated",
-  "@calendarDetailsUpdatedLabel": {"description": "Label for the last known calendar event update timestamp in the details dialog"},
+  "@calendarDetailsUpdatedLabel": {
+    "description": "Label for the last known calendar event update timestamp in the details dialog"
+  },
   "calendarDetailsLocationLabel": "Location",
-  "@calendarDetailsLocationLabel": {"description": "Label for the calendar event location in the details dialog"},
+  "@calendarDetailsLocationLabel": {
+    "description": "Label for the calendar event location in the details dialog"
+  },
   "calendarDetailsDescriptionLabel": "Description",
-  "@calendarDetailsDescriptionLabel": {"description": "Label for the calendar event description in the details dialog"},
+  "@calendarDetailsDescriptionLabel": {
+    "description": "Label for the calendar event description in the details dialog"
+  },
   "calendarCloseButton": "Close",
-  "@calendarCloseButton": {"description": "Button label for closing the calendar details dialog"},
+  "@calendarCloseButton": {
+    "description": "Button label for closing the calendar details dialog"
+  },
   "calendarCreateSuccess": "Calendar event created.",
-  "@calendarCreateSuccess": {"description": "Snackbar message after a calendar event is created"},
+  "@calendarCreateSuccess": {
+    "description": "Snackbar message after a calendar event is created"
+  },
   "calendarUpdateSuccess": "Calendar event updated.",
-  "@calendarUpdateSuccess": {"description": "Snackbar message after a calendar event is updated"},
+  "@calendarUpdateSuccess": {
+    "description": "Snackbar message after a calendar event is updated"
+  },
   "calendarDeleteSuccess": "Calendar event deleted.",
-  "@calendarDeleteSuccess": {"description": "Snackbar message after a calendar event is deleted"},
+  "@calendarDeleteSuccess": {
+    "description": "Snackbar message after a calendar event is deleted"
+  },
   "calendarOperationFailure": "The calendar could not save that change right now.",
-  "@calendarOperationFailure": {"description": "Snackbar message when a calendar operation fails"}
-,
+  "@calendarOperationFailure": {
+    "description": "Snackbar message when a calendar operation fails"
+  },
   "boardsPreviewScreenTitle": "Boards preview",
-  "@boardsPreviewScreenTitle": {"description": "Title for the feature-gated boards/tasks preview screen"},
+  "@boardsPreviewScreenTitle": {
+    "description": "Title for the feature-gated boards/tasks preview screen"
+  },
   "boardsPreviewIconSemantic": "Boards preview",
-  "@boardsPreviewIconSemantic": {"description": "Semantic label for the boards preview icon"},
+  "@boardsPreviewIconSemantic": {
+    "description": "Semantic label for the boards preview icon"
+  },
   "boardsPreviewBoundaryTitle": "Active boards/tasks preview",
-  "@boardsPreviewBoundaryTitle": {"description": "Title for the banner that marks boards/tasks as active gated scope"},
+  "@boardsPreviewBoundaryTitle": {
+    "description": "Title for the banner that marks boards/tasks as active gated scope"
+  },
   "boardsPreviewBoundaryDescription": "This active preview shows the intended Weave-owned board model and accessible task movement alternatives. It remains feature-gated and is not connected to Vikunja, Deck, or another provider yet.",
-  "@boardsPreviewBoundaryDescription": {"description": "Description explaining that boards/tasks are active scope but not provider-connected"},
+  "@boardsPreviewBoundaryDescription": {
+    "description": "Description explaining that boards/tasks are active scope but not provider-connected"
+  },
   "boardsPreviewBoundarySemantic": "Active boards/tasks preview. Feature-gated provider-neutral Weave model with keyboard and screen-reader alternatives; no live provider is connected yet.",
-  "@boardsPreviewBoundarySemantic": {"description": "Semantic summary for the active-preview boundary banner"},
+  "@boardsPreviewBoundarySemantic": {
+    "description": "Semantic summary for the active-preview boundary banner"
+  },
   "boardsPreviewActivePreviewChip": "Active preview",
-  "@boardsPreviewActivePreviewChip": {"description": "Chip label stating boards/tasks are active preview scope"},
+  "@boardsPreviewActivePreviewChip": {
+    "description": "Chip label stating boards/tasks are active preview scope"
+  },
   "boardsPreviewProviderNeutralChip": "Provider-neutral model",
-  "@boardsPreviewProviderNeutralChip": {"description": "Chip label stating the boards model is provider-neutral"},
+  "@boardsPreviewProviderNeutralChip": {
+    "description": "Chip label stating the boards model is provider-neutral"
+  },
   "boardsPreviewKeyboardChip": "No drag required",
-  "@boardsPreviewKeyboardChip": {"description": "Chip label stating board operations have non-drag alternatives"},
+  "@boardsPreviewKeyboardChip": {
+    "description": "Chip label stating board operations have non-drag alternatives"
+  },
   "boardsPreviewColumnCount": "{count, plural, =0{No columns} one{1 column} other{{count} columns}}",
-  "@boardsPreviewColumnCount": {"description": "Number of preview board columns", "placeholders": {"count": {"type": "int"}}},
+  "@boardsPreviewColumnCount": {
+    "description": "Number of preview board columns",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "boardsPreviewTaskCount": "{count, plural, =0{No tasks} one{1 task} other{{count} tasks}}",
-  "@boardsPreviewTaskCount": {"description": "Number of preview tasks", "placeholders": {"count": {"type": "int"}}},
+  "@boardsPreviewTaskCount": {
+    "description": "Number of preview tasks",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "boardsPreviewNonDragMovement": "Move menu instead of drag-only",
-  "@boardsPreviewNonDragMovement": {"description": "Summary chip for accessible non-drag movement"},
+  "@boardsPreviewNonDragMovement": {
+    "description": "Summary chip for accessible non-drag movement"
+  },
   "boardsPreviewBoardSemantic": "Board {boardName}, {columnCount, plural, one{1 column} other{{columnCount} columns}}, {taskCount, plural, one{1 task} other{{taskCount} tasks}}.",
-  "@boardsPreviewBoardSemantic": {"description": "Semantic label for the board preview summary", "placeholders": {"boardName": {"type": "String"}, "columnCount": {"type": "int"}, "taskCount": {"type": "int"}}},
+  "@boardsPreviewBoardSemantic": {
+    "description": "Semantic label for the board preview summary",
+    "placeholders": {
+      "boardName": {
+        "type": "String"
+      },
+      "columnCount": {
+        "type": "int"
+      },
+      "taskCount": {
+        "type": "int"
+      }
+    }
+  },
   "boardsPreviewColumnSemantic": "Column {columnName}, status {status}, {taskCount, plural, one{1 task} other{{taskCount} tasks}}.",
-  "@boardsPreviewColumnSemantic": {"description": "Semantic label for a board column", "placeholders": {"columnName": {"type": "String"}, "status": {"type": "String"}, "taskCount": {"type": "int"}}},
+  "@boardsPreviewColumnSemantic": {
+    "description": "Semantic label for a board column",
+    "placeholders": {
+      "columnName": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      },
+      "taskCount": {
+        "type": "int"
+      }
+    }
+  },
   "boardsPreviewColumnTaskSummary": "{count, plural, =0{No tasks in this column} one{1 task in this column} other{{count} tasks in this column}}",
-  "@boardsPreviewColumnTaskSummary": {"description": "Visible task count summary for a column", "placeholders": {"count": {"type": "int"}}},
+  "@boardsPreviewColumnTaskSummary": {
+    "description": "Visible task count summary for a column",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "boardsPreviewColumnWipSummary": "{count, plural, =0{No tasks} one{1 task} other{{count} tasks}} · WIP limit {limit}",
-  "@boardsPreviewColumnWipSummary": {"description": "Visible task count and WIP limit summary for a column", "placeholders": {"count": {"type": "int"}, "limit": {"type": "int"}}},
+  "@boardsPreviewColumnWipSummary": {
+    "description": "Visible task count and WIP limit summary for a column",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
   "boardsPreviewTaskSemantic": "Task {taskTitle}. Column {columnName}. Status {status}. Assignee {assignee}. Due {due}. Priority {priority}.",
-  "@boardsPreviewTaskSemantic": {"description": "Semantic label for a board task card", "placeholders": {"taskTitle": {"type": "String"}, "columnName": {"type": "String"}, "status": {"type": "String"}, "assignee": {"type": "String"}, "due": {"type": "String"}, "priority": {"type": "String"}}},
+  "@boardsPreviewTaskSemantic": {
+    "description": "Semantic label for a board task card",
+    "placeholders": {
+      "taskTitle": {
+        "type": "String"
+      },
+      "columnName": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      },
+      "assignee": {
+        "type": "String"
+      },
+      "due": {
+        "type": "String"
+      },
+      "priority": {
+        "type": "String"
+      }
+    }
+  },
   "boardsPreviewTaskActionsTooltip": "Task actions for {taskTitle}",
-  "@boardsPreviewTaskActionsTooltip": {"description": "Tooltip for the task action menu", "placeholders": {"taskTitle": {"type": "String"}}},
+  "@boardsPreviewTaskActionsTooltip": {
+    "description": "Tooltip for the task action menu",
+    "placeholders": {
+      "taskTitle": {
+        "type": "String"
+      }
+    }
+  },
   "boardsPreviewMoveTaskAction": "Move to another column",
-  "@boardsPreviewMoveTaskAction": {"description": "Preview task action for non-drag column movement"},
+  "@boardsPreviewMoveTaskAction": {
+    "description": "Preview task action for non-drag column movement"
+  },
   "boardsPreviewMarkDoneAction": "Mark done",
-  "@boardsPreviewMarkDoneAction": {"description": "Preview task action for marking a task done"},
+  "@boardsPreviewMarkDoneAction": {
+    "description": "Preview task action for marking a task done"
+  },
   "boardsPreviewBlockTaskAction": "Mark blocked",
-  "@boardsPreviewBlockTaskAction": {"description": "Preview task action for marking a task blocked"},
+  "@boardsPreviewBlockTaskAction": {
+    "description": "Preview task action for marking a task blocked"
+  },
   "boardsPreviewActionPreviewOnly": "Preview only — no task was changed.",
-  "@boardsPreviewActionPreviewOnly": {"description": "Snackbar shown when a preview task action is selected"},
+  "@boardsPreviewActionPreviewOnly": {
+    "description": "Snackbar shown when a preview task action is selected"
+  },
   "boardsPreviewStatusNotStarted": "Not started",
-  "@boardsPreviewStatusNotStarted": {"description": "Board task status label"},
+  "@boardsPreviewStatusNotStarted": {
+    "description": "Board task status label"
+  },
   "boardsPreviewStatusInProgress": "In progress",
-  "@boardsPreviewStatusInProgress": {"description": "Board task status label"},
+  "@boardsPreviewStatusInProgress": {
+    "description": "Board task status label"
+  },
   "boardsPreviewStatusBlocked": "Blocked",
-  "@boardsPreviewStatusBlocked": {"description": "Board task status label"},
+  "@boardsPreviewStatusBlocked": {
+    "description": "Board task status label"
+  },
   "boardsPreviewStatusDone": "Done",
-  "@boardsPreviewStatusDone": {"description": "Board task status label"},
+  "@boardsPreviewStatusDone": {
+    "description": "Board task status label"
+  },
   "boardsPreviewStatusSemantic": "Status: {status}",
-  "@boardsPreviewStatusSemantic": {"description": "Semantic label for task/column status pills", "placeholders": {"status": {"type": "String"}}},
+  "@boardsPreviewStatusSemantic": {
+    "description": "Semantic label for task/column status pills",
+    "placeholders": {
+      "status": {
+        "type": "String"
+      }
+    }
+  },
   "boardsPreviewBackendFedChip": "Backend facade fed",
-  "@boardsPreviewBackendFedChip": {"description": "Chip label indicating the preview snapshot came from the backend facade"},
+  "@boardsPreviewBackendFedChip": {
+    "description": "Chip label indicating the preview snapshot came from the backend facade"
+  },
   "boardsPreviewProviderBlockedChip": "Provider runtime blocked",
-  "@boardsPreviewProviderBlockedChip": {"description": "Chip label indicating the backend provider runtime is blocked/unavailable"},
+  "@boardsPreviewProviderBlockedChip": {
+    "description": "Chip label indicating the backend provider runtime is blocked/unavailable"
+  },
   "boardsPreviewStaticFixtureChip": "Static fixture preview",
-  "@boardsPreviewStaticFixtureChip": {"description": "Chip label indicating the preview is still using local fixtures"},
+  "@boardsPreviewStaticFixtureChip": {
+    "description": "Chip label indicating the preview is still using local fixtures"
+  },
   "boardsPreviewProviderCapabilitySummary": "Provider: {provider}",
-  "@boardsPreviewProviderCapabilitySummary": {"description": "Visible provider capability summary", "placeholders": {"provider": {"type": "String"}}},
+  "@boardsPreviewProviderCapabilitySummary": {
+    "description": "Visible provider capability summary",
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
   "boardsPreviewCapabilityNonDragReady": "Backend non-drag actions ready",
-  "@boardsPreviewCapabilityNonDragReady": {"description": "Capability label when accessible non-drag backend actions are available"},
+  "@boardsPreviewCapabilityNonDragReady": {
+    "description": "Capability label when accessible non-drag backend actions are available"
+  },
   "boardsPreviewCapabilityNonDragBlocked": "Backend non-drag actions blocked",
-  "@boardsPreviewCapabilityNonDragBlocked": {"description": "Capability label when accessible non-drag backend actions are unavailable"},
+  "@boardsPreviewCapabilityNonDragBlocked": {
+    "description": "Capability label when accessible non-drag backend actions are unavailable"
+  },
   "boardsPreviewProviderInMemory": "in-memory backend facade",
-  "@boardsPreviewProviderInMemory": {"description": "Provider label for the hidden local backend facade"},
+  "@boardsPreviewProviderInMemory": {
+    "description": "Provider label for the hidden local backend facade"
+  },
   "boardsPreviewProviderVikunja": "Vikunja adapter",
-  "@boardsPreviewProviderVikunja": {"description": "Provider label for Vikunja"},
+  "@boardsPreviewProviderVikunja": {
+    "description": "Provider label for Vikunja"
+  },
   "boardsPreviewProviderOpenProject": "OpenProject adapter",
-  "@boardsPreviewProviderOpenProject": {"description": "Provider label for OpenProject"},
+  "@boardsPreviewProviderOpenProject": {
+    "description": "Provider label for OpenProject"
+  },
   "boardsPreviewProviderNextcloudDeck": "Nextcloud Deck adapter",
-  "@boardsPreviewProviderNextcloudDeck": {"description": "Provider label for Nextcloud Deck"},
+  "@boardsPreviewProviderNextcloudDeck": {
+    "description": "Provider label for Nextcloud Deck"
+  },
   "boardsPreviewProviderNone": "no backend provider",
-  "@boardsPreviewProviderNone": {"description": "Provider label when only static fixtures are available"},
+  "@boardsPreviewProviderNone": {
+    "description": "Provider label when only static fixtures are available"
+  },
   "boardsPreviewProviderUnavailable": "backend unavailable",
-  "@boardsPreviewProviderUnavailable": {"description": "Provider label when the backend facade is unavailable"},
+  "@boardsPreviewProviderUnavailable": {
+    "description": "Provider label when the backend facade is unavailable"
+  },
   "boardsPreviewProviderUnknown": "unknown provider",
-  "@boardsPreviewProviderUnknown": {"description": "Provider label for an unrecognized backend provider"},
+  "@boardsPreviewProviderUnknown": {
+    "description": "Provider label for an unrecognized backend provider"
+  },
   "boardsPreviewActionMoved": "Task moved through the backend facade.",
-  "@boardsPreviewActionMoved": {"description": "Snackbar after a backend move task action succeeds"},
+  "@boardsPreviewActionMoved": {
+    "description": "Snackbar after a backend move task action succeeds"
+  },
   "boardsPreviewActionCompleted": "Task marked done through the backend facade.",
-  "@boardsPreviewActionCompleted": {"description": "Snackbar after a backend complete task action succeeds"},
+  "@boardsPreviewActionCompleted": {
+    "description": "Snackbar after a backend complete task action succeeds"
+  },
   "boardsPreviewActionFailed": "The backend facade could not save that Boards preview action.",
-  "@boardsPreviewActionFailed": {"description": "Snackbar after a backend Boards action fails"},
+  "@boardsPreviewActionFailed": {
+    "description": "Snackbar after a backend Boards action fails"
+  },
   "boardsPreviewActionNoNextColumn": "This task is already in the last preview column.",
-  "@boardsPreviewActionNoNextColumn": {"description": "Snackbar when moving to the next preview column is not possible"},
-
+  "@boardsPreviewActionNoNextColumn": {
+    "description": "Snackbar when moving to the next preview column is not possible"
+  },
   "settingsAdminSetupTitle": "Owner and admin setup",
-  "@settingsAdminSetupTitle": {"description": "Title for the owner/admin setup card in settings"},
+  "@settingsAdminSetupTitle": {
+    "description": "Title for the owner/admin setup card in settings"
+  },
   "settingsAdminSetupDescription": "Workspace owners and admins manage OIDC, realm, organization, and service endpoints here. Members and guests only see sign-in and product settings.",
-  "@settingsAdminSetupDescription": {"description": "Description for owner/admin setup responsibilities"},
+  "@settingsAdminSetupDescription": {
+    "description": "Description for owner/admin setup responsibilities"
+  },
   "settingsAdminPermissionTitle": "Admin controls unlocked",
-  "@settingsAdminPermissionTitle": {"description": "Title confirming admin controls are visible"},
+  "@settingsAdminPermissionTitle": {
+    "description": "Title confirming admin controls are visible"
+  },
   "settingsAdminPermissionDescription": "Visible because your Weave roles are: {roles}. Backend APIs remain the authority for every write.",
-  "@settingsAdminPermissionDescription": {"description": "Admin permission explanation with role list", "placeholders": {"roles": {"type": "String"}}},
+  "@settingsAdminPermissionDescription": {
+    "description": "Admin permission explanation with role list",
+    "placeholders": {
+      "roles": {
+        "type": "String"
+      }
+    }
+  },
   "settingsAdminPermissionSemantic": "Admin controls unlocked. Visible because your Weave roles are: {roles}. Backend APIs remain the authority for every write.",
-  "@settingsAdminPermissionSemantic": {"description": "Screen-reader label for admin permission summary", "placeholders": {"roles": {"type": "String"}}},
+  "@settingsAdminPermissionSemantic": {
+    "description": "Screen-reader label for admin permission summary",
+    "placeholders": {
+      "roles": {
+        "type": "String"
+      }
+    }
+  },
   "settingsAdminBoundaryTitle": "Workspace setup is admin-only",
-  "@settingsAdminBoundaryTitle": {"description": "Title for hidden admin setup boundary card"},
+  "@settingsAdminBoundaryTitle": {
+    "description": "Title for hidden admin setup boundary card"
+  },
   "settingsAdminBoundaryDescription": "OIDC, realm, organization, and service endpoint setup is handled by workspace owners or admins. Normal users can keep using Weave without Matrix, Nextcloud, or realm details.",
-  "@settingsAdminBoundaryDescription": {"description": "Explanation shown to non-admin users instead of server configuration controls"},
+  "@settingsAdminBoundaryDescription": {
+    "description": "Explanation shown to non-admin users instead of server configuration controls"
+  },
   "settingsAdminPermissionLoading": "Checking admin permissions…",
-  "@settingsAdminPermissionLoading": {"description": "Loading label while profile roles are being resolved"},
+  "@settingsAdminPermissionLoading": {
+    "description": "Loading label while profile roles are being resolved"
+  },
   "chatContextCardTitle": "Context for this workspace",
-  "@chatContextCardTitle": {"description": "Title for the implicit context card on Weave Home"},
+  "@chatContextCardTitle": {
+    "description": "Title for the implicit context card on Weave Home"
+  },
   "chatContextCardDescription": "Weave can prepare focused context from channels, decisions, and shared work when you ask for help. It does not show a database diagram or continuously read everything.",
-  "@chatContextCardDescription": {"description": "Explanation for context-aware chat UX"},
+  "@chatContextCardDescription": {
+    "description": "Explanation for context-aware chat UX"
+  },
   "chatContextCardPolicy": "Agents use scoped context on demand, show what context was used, and stay inside admin-defined boundaries.",
-  "@chatContextCardPolicy": {"description": "Agent context privacy policy copy"},
+  "@chatContextCardPolicy": {
+    "description": "Agent context privacy policy copy"
+  },
   "chatContextChannelHintTitle": "Channel context",
-  "@chatContextChannelHintTitle": {"description": "Context hint title for channel history"},
+  "@chatContextChannelHintTitle": {
+    "description": "Context hint title for channel history"
+  },
   "chatContextChannelHintDescription": "Recent room signals can become a small context card for the current task.",
-  "@chatContextChannelHintDescription": {"description": "Context hint body for channel history"},
+  "@chatContextChannelHintDescription": {
+    "description": "Context hint body for channel history"
+  },
   "chatContextEvidenceHintTitle": "Decisions and evidence",
-  "@chatContextEvidenceHintTitle": {"description": "Context hint title for decisions/evidence"},
+  "@chatContextEvidenceHintTitle": {
+    "description": "Context hint title for decisions/evidence"
+  },
   "chatContextEvidenceHintDescription": "Decision notes and supporting links can be cited without exposing graph internals.",
-  "@chatContextEvidenceHintDescription": {"description": "Context hint body for decision/evidence layer"},
+  "@chatContextEvidenceHintDescription": {
+    "description": "Context hint body for decision/evidence layer"
+  },
   "chatContextAgentHintTitle": "Agent context packs",
-  "@chatContextAgentHintTitle": {"description": "Context hint title for agent context packs"},
+  "@chatContextAgentHintTitle": {
+    "description": "Context hint title for agent context packs"
+  },
   "chatContextAgentHintDescription": "Assistants receive only the scoped pack for the request, mention, or schedule.",
-  "@chatContextAgentHintDescription": {"description": "Context hint body for scoped agent context packs"},
+  "@chatContextAgentHintDescription": {
+    "description": "Context hint body for scoped agent context packs"
+  },
   "firstRunAdminSetupTitle": "Owner/admin setup responsibilities",
-  "@firstRunAdminSetupTitle": {"description": "Title for first-run admin setup guidance"},
+  "@firstRunAdminSetupTitle": {
+    "description": "Title for first-run admin setup guidance"
+  },
   "firstRunAdminSetupDescription": "Your role can administer workspace setup. Keep OIDC, realm, organization, invite, and service endpoint changes here or in Settings; normal users should only need one Weave sign-in.",
-  "@firstRunAdminSetupDescription": {"description": "First-run guidance for owner/admin users"}
-,
+  "@firstRunAdminSetupDescription": {
+    "description": "First-run guidance for owner/admin users"
+  },
   "agentCapabilityPolicyTitle": "AI agent capability governance",
-  "@agentCapabilityPolicyTitle": { "description": "Settings card title for AI agent capability governance" },
+  "@agentCapabilityPolicyTitle": {
+    "description": "Settings card title for AI agent capability governance"
+  },
   "agentCapabilityPolicyAdminDescription": "Owners and admins decide which agent packages and connectors can be used. This preview stays off until permission, consent, and audit controls are connected.",
-  "@agentCapabilityPolicyAdminDescription": { "description": "Admin-facing description for AI agent capability governance" },
+  "@agentCapabilityPolicyAdminDescription": {
+    "description": "Admin-facing description for AI agent capability governance"
+  },
   "agentCapabilityPolicyUserDescription": "AI agent chats are not enabled for this workspace yet. You can keep using Weave normally; an owner or admin must turn this on first.",
-  "@agentCapabilityPolicyUserDescription": { "description": "Member-facing description for AI agent capability governance" },
+  "@agentCapabilityPolicyUserDescription": {
+    "description": "Member-facing description for AI agent capability governance"
+  },
   "agentCapabilityPolicyFailClosedNotice": "Agent capabilities are blocked until Weave can confirm your role and the workspace policy.",
-  "@agentCapabilityPolicyFailClosedNotice": { "description": "Fail-closed notice when policy cannot be trusted" },
+  "@agentCapabilityPolicyFailClosedNotice": {
+    "description": "Fail-closed notice when policy cannot be trusted"
+  },
   "agentCapabilityPolicyManageDisabledButton": "Management unavailable in this preview",
-  "@agentCapabilityPolicyManageDisabledButton": { "description": "Disabled button label for future agent capability management" },
+  "@agentCapabilityPolicyManageDisabledButton": {
+    "description": "Disabled button label for future agent capability management"
+  },
   "agentCapabilityPolicyAskAdminHint": "Need an agent for your team? Ask a workspace owner or admin to review agent capabilities when they are available.",
-  "@agentCapabilityPolicyAskAdminHint": { "description": "Hint for non-admin users" },
+  "@agentCapabilityPolicyAskAdminHint": {
+    "description": "Hint for non-admin users"
+  },
   "agentCapabilityPolicyAdminStateHint": "Current state: off by default. Future controls will require owner/admin review before users can start an agent.",
-  "@agentCapabilityPolicyAdminStateHint": { "description": "Admin state hint for disabled agent capabilities" },
+  "@agentCapabilityPolicyAdminStateHint": {
+    "description": "Admin state hint for disabled agent capabilities"
+  },
   "agentCapabilityPersonalAssistantTitle": "Personal assistant",
-  "@agentCapabilityPersonalAssistantTitle": { "description": "Agent capability title for personal assistant" },
+  "@agentCapabilityPersonalAssistantTitle": {
+    "description": "Agent capability title for personal assistant"
+  },
   "agentCapabilityPersonalAssistantDescription": "Will only use context you choose for a request, after your workspace enables the capability.",
-  "@agentCapabilityPersonalAssistantDescription": { "description": "Agent capability description for personal assistant" },
+  "@agentCapabilityPersonalAssistantDescription": {
+    "description": "Agent capability description for personal assistant"
+  },
   "agentCapabilityChannelAgentTitle": "Channel agent",
-  "@agentCapabilityChannelAgentTitle": { "description": "Agent capability title for channel agent" },
+  "@agentCapabilityChannelAgentTitle": {
+    "description": "Agent capability title for channel agent"
+  },
   "agentCapabilityChannelAgentDescription": "Requires an owner or admin to choose which channels, files, calendar items, or boards the agent may use.",
-  "@agentCapabilityChannelAgentDescription": { "description": "Agent capability description for channel agent" },
+  "@agentCapabilityChannelAgentDescription": {
+    "description": "Agent capability description for channel agent"
+  },
   "agentCapabilityAvailabilityPreviewOnly": "Preview only",
-  "@agentCapabilityAvailabilityPreviewOnly": { "description": "Agent capability availability label for preview-only state" },
+  "@agentCapabilityAvailabilityPreviewOnly": {
+    "description": "Agent capability availability label for preview-only state"
+  },
   "agentCapabilityAvailabilityAdminSetupRequired": "Admin setup required",
-  "@agentCapabilityAvailabilityAdminSetupRequired": { "description": "Agent capability availability label when admin setup is required" },
+  "@agentCapabilityAvailabilityAdminSetupRequired": {
+    "description": "Agent capability availability label when admin setup is required"
+  },
   "agentCapabilityAvailabilityBlocked": "Blocked",
-  "@agentCapabilityAvailabilityBlocked": { "description": "Agent capability availability label for blocked state" },
+  "@agentCapabilityAvailabilityBlocked": {
+    "description": "Agent capability availability label for blocked state"
+  },
   "agentCapabilityPolicyErrorTitle": "Agent capability policy is unavailable.",
-  "@agentCapabilityPolicyErrorTitle": { "description": "Error message for AI agent capability policy settings section" },
+  "@agentCapabilityPolicyErrorTitle": {
+    "description": "Error message for AI agent capability policy settings section"
+  },
   "agentCapabilityPolicyLoading": "Checking agent capability policy…",
-  "@agentCapabilityPolicyLoading": { "description": "Loading message for AI agent capability policy settings section" }
-,
+  "@agentCapabilityPolicyLoading": {
+    "description": "Loading message for AI agent capability policy settings section"
+  },
   "workflowPreviewTitle": "Active workflows",
-  "@workflowPreviewTitle": {"description": "Title for the context-driven workflow preview panel"},
+  "@workflowPreviewTitle": {
+    "description": "Title for the context-driven workflow preview panel"
+  },
   "workflowPreviewDescription": "A linear view of current steps, owners, blockers, and evidence. Diagrams can come later; this view must work with keyboard and screen readers first.",
-  "@workflowPreviewDescription": {"description": "Description for accessible workflow preview panel"},
+  "@workflowPreviewDescription": {
+    "description": "Description for accessible workflow preview panel"
+  },
   "workflowPreviewLinearViewChip": "Linear view first",
-  "@workflowPreviewLinearViewChip": {"description": "Chip saying workflows are shown linearly first"},
+  "@workflowPreviewLinearViewChip": {
+    "description": "Chip saying workflows are shown linearly first"
+  },
   "workflowPreviewExplicitContextChip": "Explicit context only",
-  "@workflowPreviewExplicitContextChip": {"description": "Chip saying workflow context is explicit"},
+  "@workflowPreviewExplicitContextChip": {
+    "description": "Chip saying workflow context is explicit"
+  },
   "workflowPreviewGovernedActionsChip": "Governed actions",
-  "@workflowPreviewGovernedActionsChip": {"description": "Chip saying workflow actions are governed"},
+  "@workflowPreviewGovernedActionsChip": {
+    "description": "Chip saying workflow actions are governed"
+  },
   "workflowPreviewNoBackgroundReading": "Workflow context is attached deliberately; Weave does not continuously read rooms in the background.",
-  "@workflowPreviewNoBackgroundReading": {"description": "Safety note for workflow context collection"},
+  "@workflowPreviewNoBackgroundReading": {
+    "description": "Safety note for workflow context collection"
+  },
   "workflowPreviewSemanticSummary": "{workflowCount, plural, =0{No active workflows} one{1 active workflow} other{{workflowCount} active workflows}}. {activeStepCount, plural, =0{No active steps} one{1 active step} other{{activeStepCount} active steps}}. {blockerCount, plural, =0{No blockers} one{1 blocker} other{{blockerCount} blockers}}.",
-  "@workflowPreviewSemanticSummary": {"description": "Screen-reader summary for workflow preview panel", "placeholders": {"workflowCount": {"type": "int"}, "activeStepCount": {"type": "int"}, "blockerCount": {"type": "int"}}},
+  "@workflowPreviewSemanticSummary": {
+    "description": "Screen-reader summary for workflow preview panel",
+    "placeholders": {
+      "workflowCount": {
+        "type": "int"
+      },
+      "activeStepCount": {
+        "type": "int"
+      },
+      "blockerCount": {
+        "type": "int"
+      }
+    }
+  },
   "workflowPreviewRunSemantic": "Workflow {title}. Context {context}. {stepCount, plural, one{1 step} other{{stepCount} steps}}. {blockerCount, plural, =0{No blockers} one{1 blocker} other{{blockerCount} blockers}}.",
-  "@workflowPreviewRunSemantic": {"description": "Screen-reader summary for one workflow run", "placeholders": {"title": {"type": "String"}, "context": {"type": "String"}, "stepCount": {"type": "int"}, "blockerCount": {"type": "int"}}},
+  "@workflowPreviewRunSemantic": {
+    "description": "Screen-reader summary for one workflow run",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      },
+      "context": {
+        "type": "String"
+      },
+      "stepCount": {
+        "type": "int"
+      },
+      "blockerCount": {
+        "type": "int"
+      }
+    }
+  },
   "workflowPreviewContextLabel": "Context: {context}",
-  "@workflowPreviewContextLabel": {"description": "Workflow context label", "placeholders": {"context": {"type": "String"}}},
+  "@workflowPreviewContextLabel": {
+    "description": "Workflow context label",
+    "placeholders": {
+      "context": {
+        "type": "String"
+      }
+    }
+  },
   "workflowPreviewNextAction": "Next action: {stepTitle} — {action}",
-  "@workflowPreviewNextAction": {"description": "Workflow next action text", "placeholders": {"stepTitle": {"type": "String"}, "action": {"type": "String"}}},
+  "@workflowPreviewNextAction": {
+    "description": "Workflow next action text",
+    "placeholders": {
+      "stepTitle": {
+        "type": "String"
+      },
+      "action": {
+        "type": "String"
+      }
+    }
+  },
   "workflowPreviewStepSemantic": "Step {title}. Type {kind}. Status {status}. Owner {owner}. Due {due}. Next action {nextAction}. Blocked: {blockers}. Evidence: {evidence}.",
-  "@workflowPreviewStepSemantic": {"description": "Screen-reader label for a workflow step", "placeholders": {"title": {"type": "String"}, "kind": {"type": "String"}, "status": {"type": "String"}, "owner": {"type": "String"}, "due": {"type": "String"}, "nextAction": {"type": "String"}, "blockers": {"type": "String"}, "evidence": {"type": "String"}}},
+  "@workflowPreviewStepSemantic": {
+    "description": "Screen-reader label for a workflow step",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      },
+      "kind": {
+        "type": "String"
+      },
+      "status": {
+        "type": "String"
+      },
+      "owner": {
+        "type": "String"
+      },
+      "due": {
+        "type": "String"
+      },
+      "nextAction": {
+        "type": "String"
+      },
+      "blockers": {
+        "type": "String"
+      },
+      "evidence": {
+        "type": "String"
+      }
+    }
+  },
   "workflowPreviewKindStep": "Step",
-  "@workflowPreviewKindStep": {"description": "Workflow step kind label"},
+  "@workflowPreviewKindStep": {
+    "description": "Workflow step kind label"
+  },
   "workflowPreviewKindGate": "Gate",
-  "@workflowPreviewKindGate": {"description": "Workflow gate kind label"},
+  "@workflowPreviewKindGate": {
+    "description": "Workflow gate kind label"
+  },
   "workflowPreviewKindApproval": "Approval",
-  "@workflowPreviewKindApproval": {"description": "Workflow approval kind label"},
+  "@workflowPreviewKindApproval": {
+    "description": "Workflow approval kind label"
+  },
   "workflowPreviewStatusReady": "Ready",
-  "@workflowPreviewStatusReady": {"description": "Workflow ready status"},
+  "@workflowPreviewStatusReady": {
+    "description": "Workflow ready status"
+  },
   "workflowPreviewStatusInProgress": "In progress",
-  "@workflowPreviewStatusInProgress": {"description": "Workflow in-progress status"},
+  "@workflowPreviewStatusInProgress": {
+    "description": "Workflow in-progress status"
+  },
   "workflowPreviewStatusBlocked": "Blocked",
-  "@workflowPreviewStatusBlocked": {"description": "Workflow blocked status"},
+  "@workflowPreviewStatusBlocked": {
+    "description": "Workflow blocked status"
+  },
   "workflowPreviewStatusWaiting": "Waiting for approval",
-  "@workflowPreviewStatusWaiting": {"description": "Workflow waiting-for-approval status"},
+  "@workflowPreviewStatusWaiting": {
+    "description": "Workflow waiting-for-approval status"
+  },
   "workflowPreviewStatusDone": "Done",
-  "@workflowPreviewStatusDone": {"description": "Workflow done status"},
+  "@workflowPreviewStatusDone": {
+    "description": "Workflow done status"
+  },
   "workflowPreviewOwner": "Owner: {owner}",
-  "@workflowPreviewOwner": {"description": "Workflow owner fact", "placeholders": {"owner": {"type": "String"}}},
+  "@workflowPreviewOwner": {
+    "description": "Workflow owner fact",
+    "placeholders": {
+      "owner": {
+        "type": "String"
+      }
+    }
+  },
   "workflowPreviewDue": "Due: {due}",
-  "@workflowPreviewDue": {"description": "Workflow due/next timing fact", "placeholders": {"due": {"type": "String"}}},
+  "@workflowPreviewDue": {
+    "description": "Workflow due/next timing fact",
+    "placeholders": {
+      "due": {
+        "type": "String"
+      }
+    }
+  },
   "workflowPreviewStepNextAction": "Next action: {action}",
-  "@workflowPreviewStepNextAction": {"description": "Workflow step next action fact", "placeholders": {"action": {"type": "String"}}},
+  "@workflowPreviewStepNextAction": {
+    "description": "Workflow step next action fact",
+    "placeholders": {
+      "action": {
+        "type": "String"
+      }
+    }
+  },
   "workflowPreviewNoBlockers": "No blockers",
-  "@workflowPreviewNoBlockers": {"description": "Workflow no-blockers label"},
+  "@workflowPreviewNoBlockers": {
+    "description": "Workflow no-blockers label"
+  },
   "workflowPreviewBlockers": "Blocked: {blockers}",
-  "@workflowPreviewBlockers": {"description": "Workflow blocker fact", "placeholders": {"blockers": {"type": "String"}}},
+  "@workflowPreviewBlockers": {
+    "description": "Workflow blocker fact",
+    "placeholders": {
+      "blockers": {
+        "type": "String"
+      }
+    }
+  },
   "workflowPreviewEvidence": "Evidence: {evidence}",
-  "@workflowPreviewEvidence": {"description": "Workflow evidence fact", "placeholders": {"evidence": {"type": "String"}}},
+  "@workflowPreviewEvidence": {
+    "description": "Workflow evidence fact",
+    "placeholders": {
+      "evidence": {
+        "type": "String"
+      }
+    }
+  },
   "workflowPreviewApprovalRequired": "Owner approval is required before this action can run.",
-  "@workflowPreviewApprovalRequired": {"description": "Workflow approval-required note"},
+  "@workflowPreviewApprovalRequired": {
+    "description": "Workflow approval-required note"
+  },
   "workflowPreviewAgentDryRunOnly": "Agent help is dry-run only until admin policy and approval are connected.",
-  "@workflowPreviewAgentDryRunOnly": {"description": "Workflow governed-agent note"},
+  "@workflowPreviewAgentDryRunOnly": {
+    "description": "Workflow governed-agent note"
+  },
   "workflowPreviewOpenStepButton": "Open step",
-  "@workflowPreviewOpenStepButton": {"description": "Disabled placeholder action for opening a workflow step"},
+  "@workflowPreviewOpenStepButton": {
+    "description": "Disabled placeholder action for opening a workflow step"
+  },
   "workflowPreviewReviewEvidenceButton": "Review evidence",
-  "@workflowPreviewReviewEvidenceButton": {"description": "Disabled placeholder action for reviewing workflow evidence"}
-
-
+  "@workflowPreviewReviewEvidenceButton": {
+    "description": "Disabled placeholder action for reviewing workflow evidence"
+  }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2705,6 +2705,288 @@ abstract class AppLocalizations {
   /// **'Backend API URL changed'**
   String get settingsWorkspaceInvalidationBackendApiBaseUrlChanged;
 
+  /// Title for provider stack readiness summary in settings
+  ///
+  /// In en, this message translates to:
+  /// **'Provider stack readiness'**
+  String get settingsProviderStackTitle;
+
+  /// Accessibility label for provider readiness summary
+  ///
+  /// In en, this message translates to:
+  /// **'Provider stack readiness. Backend-owned facades: {backendOwnedFacades}. Flutter provider calls: {flutterCalls}.'**
+  String settingsProviderStackSemanticLabel(
+    String backendOwnedFacades,
+    String flutterCalls,
+  );
+
+  /// Provider stack description when backend facade and fail-closed rules are satisfied
+  ///
+  /// In en, this message translates to:
+  /// **'Provider integrations stay fail-closed behind backend-owned facades. Flutter does not call GitLab, Office, or other provider APIs directly.'**
+  String get settingsProviderStackFailClosedDescription;
+
+  /// Provider stack description when readiness needs review
+  ///
+  /// In en, this message translates to:
+  /// **'Provider readiness needs review before enabling direct launch or workspace actions.'**
+  String get settingsProviderStackNeedsReviewDescription;
+
+  /// Pill label for backend-owned provider facades
+  ///
+  /// In en, this message translates to:
+  /// **'Backend facades'**
+  String get settingsProviderStackBackendFacadesLabel;
+
+  /// Pill label for whether Flutter calls provider APIs directly
+  ///
+  /// In en, this message translates to:
+  /// **'Flutter provider calls'**
+  String get settingsProviderStackFlutterCallsLabel;
+
+  /// Pill label for support-safe provider diagnostics
+  ///
+  /// In en, this message translates to:
+  /// **'Support safety'**
+  String get settingsProviderStackSupportSafetyLabel;
+
+  /// Value when provider facades are backend-owned
+  ///
+  /// In en, this message translates to:
+  /// **'Owned by backend'**
+  String get settingsProviderStackOwned;
+
+  /// Value when provider facades are missing
+  ///
+  /// In en, this message translates to:
+  /// **'Missing'**
+  String get settingsProviderStackMissing;
+
+  /// Value when provider stack needs review
+  ///
+  /// In en, this message translates to:
+  /// **'Needs review'**
+  String get settingsProviderStackNeedsReview;
+
+  /// Value when direct provider calls are blocked
+  ///
+  /// In en, this message translates to:
+  /// **'Blocked'**
+  String get settingsProviderStackBlocked;
+
+  /// Value when provider diagnostics are support-safe/redacted
+  ///
+  /// In en, this message translates to:
+  /// **'Redacted'**
+  String get settingsProviderStackRedacted;
+
+  /// Short yes value in provider stack semantics
+  ///
+  /// In en, this message translates to:
+  /// **'Yes'**
+  String get settingsProviderStackYes;
+
+  /// Short no value in provider stack semantics
+  ///
+  /// In en, this message translates to:
+  /// **'No'**
+  String get settingsProviderStackNo;
+
+  /// Semantics value when Flutter direct provider calls are allowed
+  ///
+  /// In en, this message translates to:
+  /// **'Allowed'**
+  String get settingsProviderStackFlutterCallsAllowed;
+
+  /// Semantics value when Flutter direct provider calls are blocked
+  ///
+  /// In en, this message translates to:
+  /// **'Blocked'**
+  String get settingsProviderStackFlutterCallsBlocked;
+
+  /// Provider status badge for fail-closed behavior
+  ///
+  /// In en, this message translates to:
+  /// **'fail-closed'**
+  String get settingsProviderStackFailClosedBadge;
+
+  /// Provider status badge for read-only behavior
+  ///
+  /// In en, this message translates to:
+  /// **'read-only'**
+  String get settingsProviderStackReadOnlyBadge;
+
+  /// Provider status badge for paid feature requirements
+  ///
+  /// In en, this message translates to:
+  /// **'paid features required'**
+  String get settingsProviderStackPaidFeaturesRequiredBadge;
+
+  /// Provider module label for identity realm
+  ///
+  /// In en, this message translates to:
+  /// **'Identity realm'**
+  String get settingsProviderModuleIdentityRealm;
+
+  /// Provider module label for source control
+  ///
+  /// In en, this message translates to:
+  /// **'Source control'**
+  String get settingsProviderModuleSourceControl;
+
+  /// Provider module label for issue tracker
+  ///
+  /// In en, this message translates to:
+  /// **'Issue tracker'**
+  String get settingsProviderModuleIssueTracker;
+
+  /// Provider module label for CI
+  ///
+  /// In en, this message translates to:
+  /// **'CI'**
+  String get settingsProviderModuleCi;
+
+  /// Provider module label for releases
+  ///
+  /// In en, this message translates to:
+  /// **'Release'**
+  String get settingsProviderModuleRelease;
+
+  /// Provider module label for Office
+  ///
+  /// In en, this message translates to:
+  /// **'Office'**
+  String get settingsProviderModuleOffice;
+
+  /// Provider module label for files
+  ///
+  /// In en, this message translates to:
+  /// **'Files'**
+  String get settingsProviderModuleFiles;
+
+  /// Provider module label for calendar
+  ///
+  /// In en, this message translates to:
+  /// **'Calendar'**
+  String get settingsProviderModuleCalendar;
+
+  /// Provider module label for contacts
+  ///
+  /// In en, this message translates to:
+  /// **'Contacts'**
+  String get settingsProviderModuleContacts;
+
+  /// Provider module label for forms
+  ///
+  /// In en, this message translates to:
+  /// **'Forms'**
+  String get settingsProviderModuleForms;
+
+  /// Provider module label for boards
+  ///
+  /// In en, this message translates to:
+  /// **'Boards'**
+  String get settingsProviderModuleBoards;
+
+  /// Fallback provider module label
+  ///
+  /// In en, this message translates to:
+  /// **'Provider'**
+  String get settingsProviderModuleProvider;
+
+  /// Provider state label for disabled providers
+  ///
+  /// In en, this message translates to:
+  /// **'disabled'**
+  String get settingsProviderStateDisabled;
+
+  /// Provider state label for unconfigured providers
+  ///
+  /// In en, this message translates to:
+  /// **'unconfigured'**
+  String get settingsProviderStateNotConfigured;
+
+  /// Provider state label for configured providers
+  ///
+  /// In en, this message translates to:
+  /// **'configured'**
+  String get settingsProviderStateConfigured;
+
+  /// Provider state label for ready providers
+  ///
+  /// In en, this message translates to:
+  /// **'ready'**
+  String get settingsProviderStateReady;
+
+  /// Provider state label for degraded providers
+  ///
+  /// In en, this message translates to:
+  /// **'degraded'**
+  String get settingsProviderStateDegraded;
+
+  /// Provider state label for unsupported providers
+  ///
+  /// In en, this message translates to:
+  /// **'unsupported'**
+  String get settingsProviderStateUnsupported;
+
+  /// Provider state label for unknown provider state
+  ///
+  /// In en, this message translates to:
+  /// **'unknown'**
+  String get settingsProviderStateUnknown;
+
+  /// Title for Office provider readiness summary
+  ///
+  /// In en, this message translates to:
+  /// **'Office readiness'**
+  String get settingsOfficeReadinessTitle;
+
+  /// Accessibility label for Office readiness summary
+  ///
+  /// In en, this message translates to:
+  /// **'Office readiness. Launch is {launchState}. Provider is {providerState}.'**
+  String settingsOfficeReadinessSemanticLabel(
+    String launchState,
+    String providerState,
+  );
+
+  /// Office readiness description when launch is fail-closed
+  ///
+  /// In en, this message translates to:
+  /// **'Office launch is fail-closed until a backend-owned provider adapter, session tokens, callbacks, and permissions are configured.'**
+  String get settingsOfficeReadinessFailClosedDescription;
+
+  /// Office readiness description when launch is available
+  ///
+  /// In en, this message translates to:
+  /// **'Office launch is available through the backend facade.'**
+  String get settingsOfficeReadinessAvailableDescription;
+
+  /// Office launch availability value
+  ///
+  /// In en, this message translates to:
+  /// **'available'**
+  String get settingsOfficeReadinessAvailable;
+
+  /// Office provider enabled value
+  ///
+  /// In en, this message translates to:
+  /// **'enabled'**
+  String get settingsOfficeReadinessEnabled;
+
+  /// Office readiness value when no launch modes are available
+  ///
+  /// In en, this message translates to:
+  /// **'no launch modes'**
+  String get settingsOfficeReadinessNoLaunchModes;
+
+  /// Enabled Office launch modes
+  ///
+  /// In en, this message translates to:
+  /// **'modes: {modes}'**
+  String settingsOfficeReadinessModes(String modes);
+
   /// Description for the settings server configuration section
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -1583,6 +1583,162 @@ class AppLocalizationsDe extends AppLocalizations {
       'Backend-API-URL geändert';
 
   @override
+  String get settingsProviderStackTitle => 'Provider-Stack-Bereitschaft';
+
+  @override
+  String settingsProviderStackSemanticLabel(
+    String backendOwnedFacades,
+    String flutterCalls,
+  ) {
+    return 'Bereitschaft des Provider-Stacks. Backend-Fassaden: $backendOwnedFacades. Flutter-Provider-Aufrufe: $flutterCalls.';
+  }
+
+  @override
+  String get settingsProviderStackFailClosedDescription =>
+      'Provider-Integrationen bleiben fail-closed hinter Backend-eigenen Fassaden. Flutter ruft GitLab, Office oder andere Provider-APIs nicht direkt auf.';
+
+  @override
+  String get settingsProviderStackNeedsReviewDescription =>
+      'Die Provider-Bereitschaft muss geprüft werden, bevor direkte Starts oder Workspace-Aktionen aktiviert werden.';
+
+  @override
+  String get settingsProviderStackBackendFacadesLabel => 'Backend-Fassaden';
+
+  @override
+  String get settingsProviderStackFlutterCallsLabel =>
+      'Flutter-Provider-Aufrufe';
+
+  @override
+  String get settingsProviderStackSupportSafetyLabel => 'Support-Sicherheit';
+
+  @override
+  String get settingsProviderStackOwned => 'Backend-eigen';
+
+  @override
+  String get settingsProviderStackMissing => 'Fehlt';
+
+  @override
+  String get settingsProviderStackNeedsReview => 'Prüfung nötig';
+
+  @override
+  String get settingsProviderStackBlocked => 'Blockiert';
+
+  @override
+  String get settingsProviderStackRedacted => 'Redigiert';
+
+  @override
+  String get settingsProviderStackYes => 'Ja';
+
+  @override
+  String get settingsProviderStackNo => 'Nein';
+
+  @override
+  String get settingsProviderStackFlutterCallsAllowed => 'Erlaubt';
+
+  @override
+  String get settingsProviderStackFlutterCallsBlocked => 'Blockiert';
+
+  @override
+  String get settingsProviderStackFailClosedBadge => 'fail-closed';
+
+  @override
+  String get settingsProviderStackReadOnlyBadge => 'nur lesend';
+
+  @override
+  String get settingsProviderStackPaidFeaturesRequiredBadge =>
+      'kostenpflichtige Features nötig';
+
+  @override
+  String get settingsProviderModuleIdentityRealm => 'Identity-Realm';
+
+  @override
+  String get settingsProviderModuleSourceControl => 'Quellcodeverwaltung';
+
+  @override
+  String get settingsProviderModuleIssueTracker => 'Issue-Tracker';
+
+  @override
+  String get settingsProviderModuleCi => 'CI';
+
+  @override
+  String get settingsProviderModuleRelease => 'Release';
+
+  @override
+  String get settingsProviderModuleOffice => 'Office';
+
+  @override
+  String get settingsProviderModuleFiles => 'Dateien';
+
+  @override
+  String get settingsProviderModuleCalendar => 'Kalender';
+
+  @override
+  String get settingsProviderModuleContacts => 'Kontakte';
+
+  @override
+  String get settingsProviderModuleForms => 'Formulare';
+
+  @override
+  String get settingsProviderModuleBoards => 'Boards';
+
+  @override
+  String get settingsProviderModuleProvider => 'Provider';
+
+  @override
+  String get settingsProviderStateDisabled => 'deaktiviert';
+
+  @override
+  String get settingsProviderStateNotConfigured => 'unkonfiguriert';
+
+  @override
+  String get settingsProviderStateConfigured => 'konfiguriert';
+
+  @override
+  String get settingsProviderStateReady => 'bereit';
+
+  @override
+  String get settingsProviderStateDegraded => 'eingeschränkt';
+
+  @override
+  String get settingsProviderStateUnsupported => 'nicht unterstützt';
+
+  @override
+  String get settingsProviderStateUnknown => 'unbekannt';
+
+  @override
+  String get settingsOfficeReadinessTitle => 'Office-Bereitschaft';
+
+  @override
+  String settingsOfficeReadinessSemanticLabel(
+    String launchState,
+    String providerState,
+  ) {
+    return 'Office-Bereitschaft. Start ist $launchState. Provider ist $providerState.';
+  }
+
+  @override
+  String get settingsOfficeReadinessFailClosedDescription =>
+      'Office-Start bleibt fail-closed, bis ein Backend-eigener Provider-Adapter, Session-Tokens, Callbacks und Berechtigungen konfiguriert sind.';
+
+  @override
+  String get settingsOfficeReadinessAvailableDescription =>
+      'Office-Start ist über die Backend-Fassade verfügbar.';
+
+  @override
+  String get settingsOfficeReadinessAvailable => 'verfügbar';
+
+  @override
+  String get settingsOfficeReadinessEnabled => 'aktiviert';
+
+  @override
+  String get settingsOfficeReadinessNoLaunchModes => 'keine Startmodi';
+
+  @override
+  String settingsOfficeReadinessModes(String modes) {
+    return 'Modi: $modes';
+  }
+
+  @override
   String get settingsServerConfigurationDescription =>
       'Aktualisiere den Anbieter und die Dienst-URLs, die Weave für deine selbst gehostete Umgebung verwenden soll.';
 

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1562,6 +1562,161 @@ class AppLocalizationsEn extends AppLocalizations {
       'Backend API URL changed';
 
   @override
+  String get settingsProviderStackTitle => 'Provider stack readiness';
+
+  @override
+  String settingsProviderStackSemanticLabel(
+    String backendOwnedFacades,
+    String flutterCalls,
+  ) {
+    return 'Provider stack readiness. Backend-owned facades: $backendOwnedFacades. Flutter provider calls: $flutterCalls.';
+  }
+
+  @override
+  String get settingsProviderStackFailClosedDescription =>
+      'Provider integrations stay fail-closed behind backend-owned facades. Flutter does not call GitLab, Office, or other provider APIs directly.';
+
+  @override
+  String get settingsProviderStackNeedsReviewDescription =>
+      'Provider readiness needs review before enabling direct launch or workspace actions.';
+
+  @override
+  String get settingsProviderStackBackendFacadesLabel => 'Backend facades';
+
+  @override
+  String get settingsProviderStackFlutterCallsLabel => 'Flutter provider calls';
+
+  @override
+  String get settingsProviderStackSupportSafetyLabel => 'Support safety';
+
+  @override
+  String get settingsProviderStackOwned => 'Owned by backend';
+
+  @override
+  String get settingsProviderStackMissing => 'Missing';
+
+  @override
+  String get settingsProviderStackNeedsReview => 'Needs review';
+
+  @override
+  String get settingsProviderStackBlocked => 'Blocked';
+
+  @override
+  String get settingsProviderStackRedacted => 'Redacted';
+
+  @override
+  String get settingsProviderStackYes => 'Yes';
+
+  @override
+  String get settingsProviderStackNo => 'No';
+
+  @override
+  String get settingsProviderStackFlutterCallsAllowed => 'Allowed';
+
+  @override
+  String get settingsProviderStackFlutterCallsBlocked => 'Blocked';
+
+  @override
+  String get settingsProviderStackFailClosedBadge => 'fail-closed';
+
+  @override
+  String get settingsProviderStackReadOnlyBadge => 'read-only';
+
+  @override
+  String get settingsProviderStackPaidFeaturesRequiredBadge =>
+      'paid features required';
+
+  @override
+  String get settingsProviderModuleIdentityRealm => 'Identity realm';
+
+  @override
+  String get settingsProviderModuleSourceControl => 'Source control';
+
+  @override
+  String get settingsProviderModuleIssueTracker => 'Issue tracker';
+
+  @override
+  String get settingsProviderModuleCi => 'CI';
+
+  @override
+  String get settingsProviderModuleRelease => 'Release';
+
+  @override
+  String get settingsProviderModuleOffice => 'Office';
+
+  @override
+  String get settingsProviderModuleFiles => 'Files';
+
+  @override
+  String get settingsProviderModuleCalendar => 'Calendar';
+
+  @override
+  String get settingsProviderModuleContacts => 'Contacts';
+
+  @override
+  String get settingsProviderModuleForms => 'Forms';
+
+  @override
+  String get settingsProviderModuleBoards => 'Boards';
+
+  @override
+  String get settingsProviderModuleProvider => 'Provider';
+
+  @override
+  String get settingsProviderStateDisabled => 'disabled';
+
+  @override
+  String get settingsProviderStateNotConfigured => 'unconfigured';
+
+  @override
+  String get settingsProviderStateConfigured => 'configured';
+
+  @override
+  String get settingsProviderStateReady => 'ready';
+
+  @override
+  String get settingsProviderStateDegraded => 'degraded';
+
+  @override
+  String get settingsProviderStateUnsupported => 'unsupported';
+
+  @override
+  String get settingsProviderStateUnknown => 'unknown';
+
+  @override
+  String get settingsOfficeReadinessTitle => 'Office readiness';
+
+  @override
+  String settingsOfficeReadinessSemanticLabel(
+    String launchState,
+    String providerState,
+  ) {
+    return 'Office readiness. Launch is $launchState. Provider is $providerState.';
+  }
+
+  @override
+  String get settingsOfficeReadinessFailClosedDescription =>
+      'Office launch is fail-closed until a backend-owned provider adapter, session tokens, callbacks, and permissions are configured.';
+
+  @override
+  String get settingsOfficeReadinessAvailableDescription =>
+      'Office launch is available through the backend facade.';
+
+  @override
+  String get settingsOfficeReadinessAvailable => 'available';
+
+  @override
+  String get settingsOfficeReadinessEnabled => 'enabled';
+
+  @override
+  String get settingsOfficeReadinessNoLaunchModes => 'no launch modes';
+
+  @override
+  String settingsOfficeReadinessModes(String modes) {
+    return 'modes: $modes';
+  }
+
+  @override
   String get settingsServerConfigurationDescription =>
       'Update the provider and service URLs Weave should use for your self-hosted environment.';
 

--- a/test/features/app/release_golden_paths_test.dart
+++ b/test/features/app/release_golden_paths_test.dart
@@ -6,6 +6,7 @@ import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provid
 import 'package:weave/core/persistence/flutter_secure_store.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
 import 'package:weave/features/app/presentation/providers/workspace_connection_provider.dart';
@@ -230,6 +231,64 @@ class _StaticWeaveApiClient implements WeaveApiClient {
       connectorWritePolicy:
           'fail_closed_until_audit_consent_and_matrix_e2ee_client_identity_are_implemented',
     );
+  }
+
+  @override
+  Future<ProviderStackSnapshot> fetchProviderStackStatus({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return const ProviderStackSnapshot(
+      releaseStatus: 'test',
+      backendOwnedFacades: true,
+      flutterDirectProviderCallsAllowed: false,
+      supportSafe: true,
+      providers: [],
+    );
+  }
+
+  @override
+  Future<DevopsProviderSummarySnapshot> fetchDevopsSummary({
+    required Uri baseUrl,
+    required String accessToken,
+    required String workspaceId,
+    required String channelId,
+  }) async {
+    return DevopsProviderSummarySnapshot(
+      workspaceId: workspaceId,
+      channelId: channelId,
+      releaseStatus: 'test',
+      readOnly: true,
+      paidFeaturesRequired: false,
+      supportSafe: true,
+      providerReadiness: const [],
+    );
+  }
+
+  @override
+  Future<OfficeCapabilitiesSnapshot> fetchOfficeCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return const OfficeCapabilitiesSnapshot(
+      releaseStatus: 'test',
+      enabled: false,
+      configured: false,
+      supportSafe: true,
+      launchMode: 'disabled',
+      defaultProvider: 'none',
+      providerReadiness: [],
+      supportedFileTypes: [],
+    );
+  }
+
+  @override
+  Future<OfficeLaunchSnapshot> launchOfficeSession({
+    required Uri baseUrl,
+    required String accessToken,
+    required String documentId,
+  }) async {
+    throw UnimplementedError('Office launch is not used by this test fake.');
   }
 }
 

--- a/test/features/app/release_golden_paths_test.dart
+++ b/test/features/app/release_golden_paths_test.dart
@@ -279,6 +279,28 @@ class _StaticWeaveApiClient implements WeaveApiClient {
       defaultProvider: 'none',
       providerReadiness: [],
       supportedFileTypes: [],
+      candidates: [],
+      capabilities: OfficeCapabilityFlagsSnapshot(
+        view: false,
+        edit: false,
+        comment: false,
+        review: false,
+        formFill: false,
+      ),
+      permissions: OfficePermissionModelSnapshot(
+        canView: false,
+        canEdit: false,
+        canComment: false,
+        canReview: false,
+        canFillForms: false,
+        reason: 'not-used',
+      ),
+      lockSessionReadiness: OfficeLockSessionReadinessSnapshot(
+        documentLocks: 'disabled',
+        sessionTokens: 'disabled',
+        callbackVerification: 'disabled',
+        supportSafe: true,
+      ),
     );
   }
 
@@ -286,7 +308,8 @@ class _StaticWeaveApiClient implements WeaveApiClient {
   Future<OfficeLaunchSnapshot> launchOfficeSession({
     required Uri baseUrl,
     required String accessToken,
-    required String documentId,
+    required String fileId,
+    required String requestedMode,
   }) async {
     throw UnimplementedError('Office launch is not used by this test fake.');
   }

--- a/test/features/app/weave_app_backend_capability_flow_test.dart
+++ b/test/features/app/weave_app_backend_capability_flow_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/core/persistence/flutter_secure_store.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/auth/data/dtos/auth_session_dto.dart';
 import 'package:weave/features/auth/data/repositories/oidc_auth_session_repository.dart';
@@ -132,6 +133,64 @@ class _RecordingWeaveApiClient implements WeaveApiClient {
       connectorWritePolicy:
           'fail_closed_until_audit_consent_and_matrix_e2ee_client_identity_are_implemented',
     );
+  }
+
+  @override
+  Future<ProviderStackSnapshot> fetchProviderStackStatus({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return const ProviderStackSnapshot(
+      releaseStatus: 'test',
+      backendOwnedFacades: true,
+      flutterDirectProviderCallsAllowed: false,
+      supportSafe: true,
+      providers: [],
+    );
+  }
+
+  @override
+  Future<DevopsProviderSummarySnapshot> fetchDevopsSummary({
+    required Uri baseUrl,
+    required String accessToken,
+    required String workspaceId,
+    required String channelId,
+  }) async {
+    return DevopsProviderSummarySnapshot(
+      workspaceId: workspaceId,
+      channelId: channelId,
+      releaseStatus: 'test',
+      readOnly: true,
+      paidFeaturesRequired: false,
+      supportSafe: true,
+      providerReadiness: const [],
+    );
+  }
+
+  @override
+  Future<OfficeCapabilitiesSnapshot> fetchOfficeCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return const OfficeCapabilitiesSnapshot(
+      releaseStatus: 'test',
+      enabled: false,
+      configured: false,
+      supportSafe: true,
+      launchMode: 'disabled',
+      defaultProvider: 'none',
+      providerReadiness: [],
+      supportedFileTypes: [],
+    );
+  }
+
+  @override
+  Future<OfficeLaunchSnapshot> launchOfficeSession({
+    required Uri baseUrl,
+    required String accessToken,
+    required String documentId,
+  }) async {
+    throw UnimplementedError('Office launch is not used by this test fake.');
   }
 }
 

--- a/test/features/app/weave_app_backend_capability_flow_test.dart
+++ b/test/features/app/weave_app_backend_capability_flow_test.dart
@@ -181,6 +181,28 @@ class _RecordingWeaveApiClient implements WeaveApiClient {
       defaultProvider: 'none',
       providerReadiness: [],
       supportedFileTypes: [],
+      candidates: [],
+      capabilities: OfficeCapabilityFlagsSnapshot(
+        view: false,
+        edit: false,
+        comment: false,
+        review: false,
+        formFill: false,
+      ),
+      permissions: OfficePermissionModelSnapshot(
+        canView: false,
+        canEdit: false,
+        canComment: false,
+        canReview: false,
+        canFillForms: false,
+        reason: 'not-used',
+      ),
+      lockSessionReadiness: OfficeLockSessionReadinessSnapshot(
+        documentLocks: 'disabled',
+        sessionTokens: 'disabled',
+        callbackVerification: 'disabled',
+        supportSafe: true,
+      ),
     );
   }
 
@@ -188,7 +210,8 @@ class _RecordingWeaveApiClient implements WeaveApiClient {
   Future<OfficeLaunchSnapshot> launchOfficeSession({
     required Uri baseUrl,
     required String accessToken,
-    required String documentId,
+    required String fileId,
+    required String requestedMode,
   }) async {
     throw UnimplementedError('Office launch is not used by this test fake.');
   }

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -536,6 +536,40 @@ void main() {
               ],
             ),
           ),
+          weaveApiOfficeCapabilitiesSnapshotProvider.overrideWith(
+            (ref) async => const OfficeCapabilitiesSnapshot(
+              releaseStatus: 'contract-preview',
+              enabled: false,
+              configured: false,
+              supportSafe: true,
+              launchMode: 'disabled',
+              defaultProvider: 'onlyoffice-community',
+              providerReadiness: [],
+              supportedFileTypes: [],
+              candidates: [],
+              capabilities: OfficeCapabilityFlagsSnapshot(
+                view: false,
+                edit: false,
+                comment: false,
+                review: false,
+                formFill: false,
+              ),
+              permissions: OfficePermissionModelSnapshot(
+                canView: false,
+                canEdit: false,
+                canComment: false,
+                canReview: false,
+                canFillForms: false,
+                reason: 'token leaked from https://office.example.test',
+              ),
+              lockSessionReadiness: OfficeLockSessionReadinessSnapshot(
+                documentLocks: 'unavailable',
+                sessionTokens: 'unavailable',
+                callbackVerification: 'unavailable',
+                supportSafe: true,
+              ),
+            ),
+          ),
           userProfileProvider.overrideWith((ref) async => _ownerProfile),
         ],
       );
@@ -559,8 +593,16 @@ void main() {
         findsOneWidget,
       );
       expect(find.textContaining('Flutter never calls GitLab'), findsOneWidget);
+      expect(find.text('Office readiness'), findsOneWidget);
+      expect(find.text('not configured'), findsWidgets);
+      expect(find.text('fail-closed'), findsWidgets);
+      expect(
+        find.textContaining('Office launch is fail-closed'),
+        findsOneWidget,
+      );
       expect(find.textContaining('provider-token-123'), findsNothing);
       expect(find.textContaining('https://gitlab.example.test'), findsNothing);
+      expect(find.textContaining('https://office.example.test'), findsNothing);
     });
 
     testWidgets(

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:weave/core/theme/shared_preferences_app_theme_preference_reposit
 import 'package:weave/core/widgets/weave_logo.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
 import 'package:weave/features/app/presentation/providers/workspace_connection_provider.dart';
@@ -482,6 +483,84 @@ void main() {
         store.rawString(shellModulePreferencesStorageKey),
         '{"hiddenModules":["workspaceStatus"],"moduleOrder":["recentActivity","workspaceStatus"]}',
       );
+    });
+
+    testWidgets('surfaces provider stack fail-closed readiness safely', (
+      tester,
+    ) async {
+      final container = ProviderContainer.test(
+        overrides: [
+          preferencesStoreProvider.overrideWith(
+            (ref) => InMemoryPreferencesStore(buildStoredConfiguration()),
+          ),
+          chatSecurityRepositoryProvider.overrideWithValue(
+            FakeChatSecurityRepository(),
+          ),
+          workspaceConnectionStateProvider.overrideWithValue(
+            _workspaceConnectionState(),
+          ),
+          workspaceCapabilitySnapshotProvider.overrideWithValue(
+            _workspaceCapabilitySnapshot(),
+          ),
+          weaveBackendConnectionStateProvider.overrideWithValue(
+            WeaveBackendConnectionState.connected,
+          ),
+          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
+            (ref) async => _matrixDiagnostic,
+          ),
+          weaveApiProviderStackSnapshotProvider.overrideWith(
+            (ref) async => const ProviderStackSnapshot(
+              releaseStatus: 'contract-preview',
+              backendOwnedFacades: true,
+              flutterDirectProviderCallsAllowed: false,
+              supportSafe: true,
+              providers: [
+                ProviderStatusSnapshot(
+                  module: 'office',
+                  providerKey: 'onlyoffice-community',
+                  state: ProviderState.disabled,
+                  readiness: 'fail-closed',
+                  enabled: false,
+                  configured: false,
+                  readOnly: true,
+                  failClosed: true,
+                  supportSafe: true,
+                  paidFeaturesRequired: false,
+                  summary: 'Disabled until configured behind backend facade.',
+                  supportedCapabilities: [],
+                  unsupportedOperations: ['launch'],
+                  supportSafeErrorCodes: ['PROVIDER_DISABLED'],
+                  redactionPolicy: 'support-safe',
+                  candidates: ['ONLYOFFICE Docs Community'],
+                ),
+              ],
+            ),
+          ),
+          userProfileProvider.overrideWith((ref) async => _ownerProfile),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: SettingsScreen()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Provider stack readiness'), findsOneWidget);
+      expect(
+        find.text('Flutter provider calls: Blocked', findRichText: true),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Flutter never calls GitLab'), findsOneWidget);
+      expect(find.textContaining('provider-token-123'), findsNothing);
+      expect(find.textContaining('https://gitlab.example.test'), findsNothing);
     });
 
     testWidgets(

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -592,7 +592,10 @@ void main() {
         find.text('Flutter provider calls: Blocked', findRichText: true),
         findsOneWidget,
       );
-      expect(find.textContaining('Flutter never calls GitLab'), findsOneWidget);
+      expect(
+        find.textContaining('Flutter does not call GitLab'),
+        findsOneWidget,
+      );
       expect(find.text('Office readiness'), findsOneWidget);
       expect(find.text('not configured'), findsWidgets);
       expect(find.text('fail-closed'), findsWidgets);

--- a/test/features/settings/settings_screen_test.dart
+++ b/test/features/settings/settings_screen_test.dart
@@ -597,7 +597,7 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('Office readiness'), findsOneWidget);
-      expect(find.text('not configured'), findsWidgets);
+      expect(find.text('unconfigured'), findsWidgets);
       expect(find.text('fail-closed'), findsWidgets);
       expect(
         find.textContaining('Office launch is fail-closed'),

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -261,6 +261,13 @@ void main() {
                 'paidFeaturesRequired': false,
                 'summary': 'token leaked from https://gitlab.example.test',
                 'redactionPolicy': 'secret should not be visible',
+                'diagnostics': {
+                  'safeFlag': true,
+                  'nested': {
+                    'details': ['ok', 'https://gitlab.example.test/token'],
+                  },
+                  'tokenHeader': 'Bearer provider-token-123',
+                },
               },
             ],
           });
@@ -277,6 +284,16 @@ void main() {
       expect(
         snapshot.providers.single.redactionPolicy,
         isNot(contains('secret')),
+      );
+      expect(snapshot.providers.single.diagnostics['safeFlag'], isTrue);
+      expect(snapshot.providers.single.diagnostics.toString(), contains('ok'));
+      expect(
+        snapshot.providers.single.diagnostics.toString(),
+        isNot(contains('provider-token-123')),
+      );
+      expect(
+        snapshot.providers.single.diagnostics.toString(),
+        isNot(contains('https://gitlab.example.test')),
       );
     });
 
@@ -365,6 +382,29 @@ void main() {
       expect(launch.errorCode, 'office-provider-not-configured');
       expect(launch.message, isNot(contains('token-123')));
     });
+
+    test(
+      'maps non-JSON Office launch 503 errors to fail-closed results',
+      () async {
+        final client = HttpWeaveApiClient(
+          httpClient: _RecordingHttpClient((request) async {
+            return http.StreamedResponse(Stream.value(const <int>[]), 503);
+          }),
+        );
+
+        final launch = await client.launchOfficeSession(
+          baseUrl: Uri.parse('https://api.weave.local/api'),
+          accessToken: 'token-123',
+          fileId: 'file-1',
+          requestedMode: 'view',
+        );
+
+        expect(launch.launched, isFalse);
+        expect(launch.failClosed, isTrue);
+        expect(launch.errorCode, 'office-launch-fail-closed');
+        expect(launch.message, isNot(contains('token-123')));
+      },
+    );
 
     test('maps successful Office launch sessions', () async {
       final client = HttpWeaveApiClient(

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -334,6 +334,64 @@ void main() {
       );
     });
 
+    test('maps Office launch 503 errors to fail-closed results', () async {
+      late http.BaseRequest capturedRequest;
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          capturedRequest = request;
+          return _jsonResponse({
+            'code': 'office-provider-not-configured',
+            'message':
+                'Office launch is fail-closed until the backend provider is configured.',
+            'requestId': 'request-123',
+          }, statusCode: 503);
+        }),
+      );
+
+      final launch = await client.launchOfficeSession(
+        baseUrl: Uri.parse('https://api.weave.local/api'),
+        accessToken: 'token-123',
+        fileId: 'file-1',
+        requestedMode: 'view',
+      );
+
+      expect(capturedRequest.method, 'POST');
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.weave.local/api/office/launch',
+      );
+      expect(launch.launched, isFalse);
+      expect(launch.failClosed, isTrue);
+      expect(launch.errorCode, 'office-provider-not-configured');
+      expect(launch.message, isNot(contains('token-123')));
+    });
+
+    test('maps successful Office launch sessions', () async {
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          return _jsonResponse({
+            'sessionId': 'session-1',
+            'launchMode': 'view',
+            'providerKey': 'onlyoffice-community',
+            'expiresAt': '2026-05-22T20:00:00Z',
+            'grantedPermissions': ['view'],
+          });
+        }),
+      );
+
+      final launch = await client.launchOfficeSession(
+        baseUrl: Uri.parse('https://api.weave.local/api'),
+        accessToken: 'token-123',
+        fileId: 'file-1',
+        requestedMode: 'view',
+      );
+
+      expect(launch.launched, isTrue);
+      expect(launch.providerKey, 'onlyoffice-community');
+      expect(launch.expiresAt, DateTime.parse('2026-05-22T20:00:00Z'));
+      expect(launch.grantedPermissions, ['view']);
+    });
+
     test(
       'rejects unauthorized backend sessions with a dedicated failure',
       () async {

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -188,6 +188,153 @@ void main() {
     });
 
     test(
+      'fetches provider stack readiness without direct provider URLs',
+      () async {
+        late http.BaseRequest capturedRequest;
+        final client = HttpWeaveApiClient(
+          httpClient: _RecordingHttpClient((request) async {
+            capturedRequest = request;
+            return _jsonResponse({
+              'releaseStatus': 'contract-preview',
+              'backendOwnedFacades': true,
+              'flutterDirectProviderCallsAllowed': false,
+              'supportSafe': true,
+              'providers': [
+                {
+                  'module': 'office',
+                  'providerKey': 'onlyoffice-community',
+                  'state': 'disabled',
+                  'readiness': 'fail-closed',
+                  'enabled': false,
+                  'configured': false,
+                  'readOnly': true,
+                  'failClosed': true,
+                  'supportSafe': true,
+                  'paidFeaturesRequired': false,
+                  'summary': 'Disabled until configured behind backend facade.',
+                  'supportedCapabilities': ['documents'],
+                  'unsupportedOperations': ['launch'],
+                  'supportSafeErrorCodes': ['PROVIDER_DISABLED'],
+                  'redactionPolicy': 'no raw provider errors',
+                  'candidates': ['ONLYOFFICE Docs Community'],
+                },
+              ],
+            });
+          }),
+        );
+
+        final snapshot = await client.fetchProviderStackStatus(
+          baseUrl: Uri.parse('https://api.weave.local/api'),
+          accessToken: 'token-123',
+        );
+
+        expect(
+          capturedRequest.url.toString(),
+          'https://api.weave.local/api/providers/status',
+        );
+        expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
+        expect(snapshot.failClosed, isTrue);
+        expect(snapshot.providers.single.module, 'office');
+        expect(snapshot.providers.single.failClosed, isTrue);
+      },
+    );
+
+    test('redacts sensitive provider summary text from DTOs', () async {
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          return _jsonResponse({
+            'releaseStatus': 'contract-preview',
+            'backendOwnedFacades': true,
+            'flutterDirectProviderCallsAllowed': false,
+            'supportSafe': true,
+            'providers': [
+              {
+                'module': 'source-control',
+                'providerKey': 'gitlab-ce-foss',
+                'state': 'not_configured',
+                'readiness': 'fail-closed',
+                'enabled': false,
+                'configured': false,
+                'readOnly': true,
+                'failClosed': true,
+                'supportSafe': true,
+                'paidFeaturesRequired': false,
+                'summary': 'token leaked from https://gitlab.example.test',
+                'redactionPolicy': 'secret should not be visible',
+              },
+            ],
+          });
+        }),
+      );
+
+      final snapshot = await client.fetchProviderStackStatus(
+        baseUrl: Uri.parse('https://api.weave.local/api'),
+        accessToken: 'token-123',
+      );
+
+      expect(snapshot.providers.single.summary, isNot(contains('token')));
+      expect(snapshot.providers.single.summary, isNot(contains('https://')));
+      expect(
+        snapshot.providers.single.redactionPolicy,
+        isNot(contains('secret')),
+      );
+    });
+
+    test('fetches DevOps and Office readiness through backend facades', () async {
+      final requests = <String>[];
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          requests.add(request.url.toString());
+          if (request.url.path.endsWith('/devops/summary')) {
+            return _jsonResponse({
+              'workspaceId': 'workspace-1',
+              'channelId': 'channel-1',
+              'releaseStatus': 'contract-preview',
+              'readOnly': true,
+              'paidFeaturesRequired': false,
+              'supportSafe': true,
+              'providerReadiness': [],
+            });
+          }
+          return _jsonResponse({
+            'releaseStatus': 'contract-preview',
+            'enabled': false,
+            'configured': false,
+            'supportSafe': true,
+            'launchMode': 'disabled',
+            'defaultProvider': 'onlyoffice-community',
+            'providerReadiness': [],
+            'supportedFileTypes': [],
+          });
+        }),
+      );
+
+      final devops = await client.fetchDevopsSummary(
+        baseUrl: Uri.parse('https://api.weave.local/api'),
+        accessToken: 'token-123',
+        workspaceId: 'workspace-1',
+        channelId: 'channel-1',
+      );
+      final office = await client.fetchOfficeCapabilities(
+        baseUrl: Uri.parse('https://api.weave.local/api'),
+        accessToken: 'token-123',
+      );
+
+      expect(devops.supportSafe, isTrue);
+      expect(office.launchAvailable, isFalse);
+      expect(
+        requests,
+        contains(
+          'https://api.weave.local/api/workspaces/workspace-1/channels/channel-1/devops/summary',
+        ),
+      );
+      expect(
+        requests,
+        contains('https://api.weave.local/api/office/capabilities'),
+      );
+    });
+
+    test(
       'rejects unauthorized backend sessions with a dedicated failure',
       () async {
         for (final statusCode in [401, 403]) {


### PR DESCRIPTION
## Summary
- adds Weave backend facade models/client calls for provider registry, DevOps summary, Office capabilities, and Office launch/fail-closed results
- surfaces provider stack and Office readiness in Settings with accessible, support-safe disabled/unconfigured/fail-closed states
- keeps Flutter behind weave-backend only; no direct GitLab/Forgejo/Nextcloud/ONLYOFFICE/Keycloak/provider API calls and no raw provider errors/secrets/URLs in UI summaries

## DevOps / Office workspace wiring
- DevOps and Office readiness are wired through the app-side `WeaveApiClient`/Riverpod facade so channel/workspace surfaces can consume the backend endpoints.
- This PR only renders the readiness summaries in Settings/admin capability UI because the current channel workspace screens do not have a safe, stable DevOps/Office readiness slot yet; adding a decorative channel badge would not be deterministic acceptance evidence.

## Validation
- `flutter test test/integrations/weave_api/data/services/weave_api_client_test.dart test/features/settings/settings_screen_test.dart`
- `flutter analyze`
- `flutter test` (339 passed, 6 skipped)

## Stack
Depends on masssi164/weave-backend#108 for the provider endpoints.
