### PR TITLE
feat: wire provider stack readiness in app e2e

### DIFF
--- a/acceptance/live_stack_app.feature
+++ b/acceptance/live_stack_app.feature
@@ -36,6 +36,15 @@ Feature: Live Stack product acceptance journey
     And downloading the file returns the original content
     And the test removes the file it created
 
+  @weave-live-provider-stack-readiness
+  Scenario: Provider stack readiness is visible and fail-closed through Weave
+    Given the signed-in person has the Weave backend facade available
+    When the app reads provider stack readiness
+    Then the registry is visible through the Weave API
+    And DevOps Office Forms and Contacts providers are fail-closed by default
+    And profile readiness uses CEFACADE at /profile/readiness
+    And no provider secrets or direct Flutter provider calls are exposed
+
   @weave-live-calendar-threadrefs
   Scenario: Channel calendar events keep their meeting thread reference
     Given workspace, team, and channel calendar scopes are available in Weave

--- a/acceptance/scenario_mappings.json
+++ b/acceptance/scenario_mappings.json
@@ -31,6 +31,22 @@
       "evidenceMarkers": ["FILES_RESULT"]
     },
     {
+      "tag": "@weave-live-provider-stack-readiness",
+      "scenario": "Provider stack readiness is visible and fail-closed through Weave",
+      "feature": "acceptance/live_stack_app.feature",
+      "executableTest": "integration_test/live_stack_app_e2e_test.dart",
+      "evidenceMarkers": ["PROVIDER_STACK_RESULT"],
+      "additionalEvidence": [
+        {
+          "path": "test/live_stack_contract_test.dart",
+          "fragments": [
+            "provider stack readiness stays behind the Weave backend facade",
+            "direct Flutter provider calls remain blocked for optional provider stack modules"
+          ]
+        }
+      ]
+    },
+    {
       "tag": "@weave-live-calendar-threadrefs",
       "scenario": "Channel calendar events keep their meeting thread reference",
       "feature": "acceptance/live_stack_app.feature",

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -192,6 +192,94 @@ void main() {
         'accessTokenPresent=${restoredSession?.accessToken.isNotEmpty ?? false}',
       );
 
+      final providerHttpClient = createTrustedTestHttpClient();
+      addTearDown(providerHttpClient.close);
+      final providerStatus = _decodeHttpJson(
+        await providerHttpClient.get(
+          config.apiUri('/api/providers/status'),
+          headers: <String, String>{
+            'Accept': 'application/json',
+            'Authorization': 'Bearer ${appSession.accessToken}',
+          },
+        ),
+        operation: 'read provider stack readiness',
+      );
+      final providerReadiness = _jsonListOfMaps(providerStatus['providers']);
+      final providerModules = providerReadiness
+          .map((provider) => _jsonString(provider['module']))
+          .toSet();
+      const failClosedModules = <String>{
+        'office',
+        'contacts',
+        'forms',
+        'source-control',
+        'issue-tracker',
+        'ci',
+        'release',
+      };
+      final providerRegistryVisible =
+          providerStatus['backendOwnedFacades'] == true &&
+          providerStatus['flutterDirectProviderCallsAllowed'] == false &&
+          providerStatus['supportSafe'] == true &&
+          providerModules.containsAll(<String>{
+            'files',
+            'calendar',
+            'boards',
+            'office',
+            'contacts',
+            'forms',
+            'source-control',
+            'issue-tracker',
+            'ci',
+            'release',
+            'identity-realm',
+          });
+      final optionalProvidersFailClosed = providerReadiness
+          .where(
+            (provider) =>
+                failClosedModules.contains(_jsonString(provider['module'])),
+          )
+          .every(
+            (provider) =>
+                provider['enabled'] == false &&
+                provider['configured'] == false &&
+                provider['failClosed'] == true &&
+                provider['supportSafe'] == true,
+          );
+      final providerSecretsExposed = RegExp(
+        r'(Authorization|api[_-]?token|/api/v3/|/work_packages/|/projects/)',
+        caseSensitive: false,
+      ).hasMatch(jsonEncode(providerStatus));
+      final profileReadiness = _decodeHttpJson(
+        await providerHttpClient.get(
+          config.apiUri('/api/profile/readiness'),
+          headers: <String, String>{
+            'Accept': 'application/json',
+            'Authorization': 'Bearer ${appSession.accessToken}',
+          },
+        ),
+        operation: 'read profile readiness',
+      );
+      final profileReadinessOk =
+          profileReadiness['contractId'] == 'CEFACADE' &&
+          profileReadiness['endpoint'] == '/profile/readiness' &&
+          profileReadiness['backendOwnedFacade'] == true &&
+          profileReadiness['directProviderCallsAllowed'] == false &&
+          profileReadiness['supportSafe'] == true;
+      // ignore: avoid_print
+      print(
+        'PROVIDER_STACK_RESULT releaseStatus=${providerStatus['releaseStatus']} '
+        'providers=${providerReadiness.length} '
+        'modules=${providerModules.join(',')} '
+        'registryVisible=$providerRegistryVisible '
+        'optionalProvidersFailClosed=$optionalProvidersFailClosed '
+        'directFlutterProviderCallsAllowed=${providerStatus['flutterDirectProviderCallsAllowed']} '
+        'providerSecretsExposed=$providerSecretsExposed '
+        'profileReadinessContract=${profileReadiness['contractId']} '
+        'profileReadinessEndpoint=${profileReadiness['endpoint']} '
+        'profileReadinessOk=$profileReadinessOk',
+      );
+
       final profileRepository = container.read(userProfileRepositoryProvider);
       final originalProfile = await profileRepository.loadProfile();
       if (originalProfile == null) {
@@ -762,6 +850,10 @@ void main() {
           !calendarUpdatedThreadRefReady ||
           !calendarMeetingThreadStable ||
           !calendarDeleted ||
+          !providerRegistryVisible ||
+          !optionalProvidersFailClosed ||
+          providerSecretsExposed ||
+          !profileReadinessOk ||
           !boardsProviderNeutral ||
           !boardsNonDragMutationWorked) {
         fail(
@@ -801,6 +893,10 @@ void main() {
           'calendarMeetingThreadId=${readCreatedEvent.threadRef.meetingThreadId} '
           'calendarDeleted=$calendarDeleted '
           'calendarEventId=${createdEvent.id} '
+          'providerRegistryVisible=$providerRegistryVisible '
+          'optionalProvidersFailClosed=$optionalProvidersFailClosed '
+          'providerSecretsExposed=$providerSecretsExposed '
+          'profileReadinessOk=$profileReadinessOk '
           'boardsProviderNeutral=$boardsProviderNeutral '
           'boardsNonDragMutationWorked=$boardsNonDragMutationWorked '
           'boardsTaskId=$taskId',
@@ -826,6 +922,10 @@ void main() {
       expect(calendarUpdatedThreadRefReady, isTrue);
       expect(calendarMeetingThreadStable, isTrue);
       expect(calendarDeleted, isTrue);
+      expect(providerRegistryVisible, isTrue);
+      expect(optionalProvidersFailClosed, isTrue);
+      expect(providerSecretsExposed, isFalse);
+      expect(profileReadinessOk, isTrue);
       expect(boardsProviderNeutral, isTrue);
       expect(boardsNonDragMutationWorked, isTrue);
     },

--- a/lib/features/app/domain/entities/provider_stack_status.dart
+++ b/lib/features/app/domain/entities/provider_stack_status.dart
@@ -1,0 +1,175 @@
+class ProviderStackStatus {
+  const ProviderStackStatus({
+    required this.releaseStatus,
+    required this.backendOwnedFacades,
+    required this.flutterDirectProviderCallsAllowed,
+    required this.supportSafe,
+    required this.providers,
+  });
+
+  final String releaseStatus;
+  final bool backendOwnedFacades;
+  final bool flutterDirectProviderCallsAllowed;
+  final bool supportSafe;
+  final List<ProviderReadiness> providers;
+
+  Iterable<ProviderReadiness> byModule(String module) {
+    return providers.where((provider) => provider.module == module);
+  }
+
+  bool get allOptionalProvidersFailClosed {
+    const optionalModules = <String>{
+      'office',
+      'contacts',
+      'forms',
+      'source-control',
+      'issue-tracker',
+      'ci',
+      'release',
+    };
+    final optionalProviders = providers
+        .where((provider) => optionalModules.contains(provider.module))
+        .toList(growable: false);
+    return optionalProviders.isNotEmpty &&
+        optionalProviders.every((provider) => provider.isFailClosedUnavailable);
+  }
+
+  bool get satisfiesFrontendBoundary =>
+      backendOwnedFacades && !flutterDirectProviderCallsAllowed && supportSafe;
+
+  bool moduleFailsClosed(String module) {
+    final moduleProviders = byModule(module).toList(growable: false);
+    return moduleProviders.isNotEmpty &&
+        moduleProviders.every(
+          (provider) => provider.failClosed && provider.supportSafe,
+        );
+  }
+}
+
+class ProviderReadiness {
+  const ProviderReadiness({
+    required this.module,
+    required this.providerKey,
+    required this.state,
+    required this.readiness,
+    required this.enabled,
+    required this.configured,
+    required this.readOnly,
+    required this.failClosed,
+    required this.supportSafe,
+    required this.summary,
+    required this.supportedCapabilities,
+    required this.unsupportedOperations,
+    this.paidFeaturesRequired = false,
+    this.supportSafeErrorCodes = const <String>{},
+    this.redactionPolicy =
+        'support-safe: no tokens, passwords, credentials, authorization headers, or raw provider errors',
+    this.candidates = const <String>{},
+  });
+
+  final String module;
+  final String providerKey;
+  final String state;
+  final String readiness;
+  final bool enabled;
+  final bool configured;
+  final bool readOnly;
+  final bool failClosed;
+  final bool supportSafe;
+  final String summary;
+  final Set<String> supportedCapabilities;
+  final Set<String> unsupportedOperations;
+  final bool paidFeaturesRequired;
+  final Set<String> supportSafeErrorCodes;
+  final String redactionPolicy;
+  final Set<String> candidates;
+
+  bool get isReady => enabled && configured && readiness == 'ready';
+
+  bool get isFailClosedUnavailable =>
+      !enabled && !configured && failClosed && supportSafe;
+}
+
+class DevopsChannelSummary {
+  const DevopsChannelSummary({
+    required this.workspaceId,
+    required this.channelId,
+    required this.releaseStatus,
+    required this.readOnly,
+    required this.paidFeaturesRequired,
+    required this.supportSafe,
+    required this.providerReadiness,
+  });
+
+  final String workspaceId;
+  final String channelId;
+  final String releaseStatus;
+  final bool readOnly;
+  final bool paidFeaturesRequired;
+  final bool supportSafe;
+  final List<ProviderReadiness> providerReadiness;
+
+  bool get isUnavailableFailClosed =>
+      supportSafe &&
+      readOnly &&
+      providerReadiness.isNotEmpty &&
+      providerReadiness.every(
+        (provider) => !provider.configured && provider.failClosed,
+      );
+}
+
+class OfficeCapabilities {
+  const OfficeCapabilities({
+    required this.releaseStatus,
+    required this.enabled,
+    required this.configured,
+    required this.supportSafe,
+    required this.launchMode,
+    required this.defaultProvider,
+    required this.providerReadiness,
+    required this.supportedFileTypes,
+    required this.permissions,
+  });
+
+  final String releaseStatus;
+  final bool enabled;
+  final bool configured;
+  final bool supportSafe;
+  final String launchMode;
+  final String defaultProvider;
+  final List<ProviderReadiness> providerReadiness;
+  final Set<String> supportedFileTypes;
+  final OfficePermissionModel permissions;
+
+  bool get canLaunch =>
+      enabled &&
+      configured &&
+      launchMode != 'unavailable' &&
+      permissions.canView;
+
+  bool get isUnavailableFailClosed =>
+      !enabled &&
+      !configured &&
+      supportSafe &&
+      launchMode == 'unavailable' &&
+      !permissions.canView &&
+      !permissions.canEdit;
+}
+
+class OfficePermissionModel {
+  const OfficePermissionModel({
+    required this.canView,
+    required this.canEdit,
+    required this.canComment,
+    required this.canReview,
+    required this.canFillForms,
+    required this.reason,
+  });
+
+  final bool canView;
+  final bool canEdit;
+  final bool canComment;
+  final bool canReview;
+  final bool canFillForms;
+  final String reason;
+}

--- a/lib/features/chat/domain/entities/channel_workspace.dart
+++ b/lib/features/chat/domain/entities/channel_workspace.dart
@@ -1,3 +1,4 @@
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
 import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 
 enum ChannelWorkspaceSurfaceKind { chat, files, boards, calendar, meetings }
@@ -10,12 +11,14 @@ class ChannelWorkspaceSurface {
     required this.availability,
     required this.providerContractId,
     required this.contextId,
+    required this.providerReadinessId,
   });
 
   final ChannelWorkspaceSurfaceKind kind;
   final ChannelWorkspaceSurfaceAvailability availability;
   final String providerContractId;
   final String contextId;
+  final String providerReadinessId;
 
   bool get isAvailable =>
       availability == ChannelWorkspaceSurfaceAvailability.available;
@@ -157,9 +160,20 @@ class ChannelWorkspacePreview {
   });
 
   factory ChannelWorkspacePreview.forConversation(
-    ChatConversation conversation,
-  ) {
+    ChatConversation conversation, {
+    ProviderStackStatus? providerStack,
+  }) {
     final contextId = 'channel:${conversation.id}';
+    final officeReadiness = _providerReadinessId(
+      providerStack,
+      modules: const {'office'},
+      prefix: 'office',
+    );
+    final devopsReadiness = _providerReadinessId(
+      providerStack,
+      modules: const {'source-control', 'issue-tracker', 'ci', 'release'},
+      prefix: 'devops',
+    );
     return ChannelWorkspacePreview(
       channelId: conversation.id,
       channelTitle: conversation.title,
@@ -170,30 +184,35 @@ class ChannelWorkspacePreview {
           availability: ChannelWorkspaceSurfaceAvailability.available,
           providerContractId: 'matrix-room',
           contextId: contextId,
+          providerReadinessId: 'matrix-client-ready',
         ),
         ChannelWorkspaceSurface(
           kind: ChannelWorkspaceSurfaceKind.files,
           availability: ChannelWorkspaceSurfaceAvailability.preview,
           providerContractId: 'weave-files-channel-link',
           contextId: contextId,
+          providerReadinessId: officeReadiness,
         ),
         ChannelWorkspaceSurface(
           kind: ChannelWorkspaceSurfaceKind.boards,
           availability: ChannelWorkspaceSurfaceAvailability.preview,
           providerContractId: 'weave-boards-channel-link',
           contextId: contextId,
+          providerReadinessId: devopsReadiness,
         ),
         ChannelWorkspaceSurface(
           kind: ChannelWorkspaceSurfaceKind.calendar,
           availability: ChannelWorkspaceSurfaceAvailability.gated,
           providerContractId: 'weave-calendar-channel-scope',
           contextId: contextId,
+          providerReadinessId: 'calendar-channel-scope-gated',
         ),
         ChannelWorkspaceSurface(
           kind: ChannelWorkspaceSurfaceKind.meetings,
           availability: ChannelWorkspaceSurfaceAvailability.gated,
           providerContractId: 'weave-meetings-channel-preview',
           contextId: contextId,
+          providerReadinessId: 'meetings-provider-fail-closed',
         ),
       ],
       meetingPreview: ChannelMeetingPreview.forConversation(
@@ -223,4 +242,31 @@ class ChannelWorkspacePreview {
   ChannelWorkspaceSurface surface(ChannelWorkspaceSurfaceKind kind) {
     return surfaces.singleWhere((surface) => surface.kind == kind);
   }
+}
+
+String _providerReadinessId(
+  ProviderStackStatus? providerStack, {
+  required Set<String> modules,
+  required String prefix,
+}) {
+  if (providerStack == null) {
+    return '$prefix-provider-registry-pending';
+  }
+
+  final providers = providerStack.providers
+      .where((provider) => modules.contains(provider.module))
+      .toList(growable: false);
+  if (providers.isEmpty) {
+    return '$prefix-provider-unavailable';
+  }
+
+  if (providers.any((provider) => provider.isReady)) {
+    return '$prefix-provider-ready';
+  }
+
+  if (providers.every((provider) => provider.isFailClosedUnavailable)) {
+    return '$prefix-provider-fail-closed';
+  }
+
+  return '$prefix-provider-review-required';
 }

--- a/lib/features/chat/presentation/chat_room_screen.dart
+++ b/lib/features/chat/presentation/chat_room_screen.dart
@@ -18,6 +18,7 @@ import 'package:weave/features/chat/presentation/providers/channel_workspace_pre
 import 'package:weave/features/chat/presentation/providers/chat_repository_provider.dart';
 import 'package:weave/features/chat/presentation/providers/context_pack_preview_provider.dart';
 import 'package:weave/features/chat/presentation/providers/decision_evidence_provider.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 import 'package:weave/l10n/generated/app_localizations.dart';
 
 class ChatRoomScreen extends ConsumerStatefulWidget {
@@ -589,8 +590,12 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
     }
 
     final workspaceFacade = ref.watch(channelWorkspacePreviewFacadeProvider);
+    final providerStack = ref.watch(weaveApiProviderStackStatusProvider);
     final workspace = workspaceFacade.supportsWorkspaceTabs(widget.conversation)
-        ? workspaceFacade.previewForChannel(widget.conversation)
+        ? workspaceFacade.previewForChannel(
+            widget.conversation,
+            providerStack: providerStack.asData?.value,
+          )
         : null;
     final scaffold = Scaffold(
       appBar: AppBar(
@@ -828,6 +833,7 @@ class _ChannelWorkspaceSurfacePanel extends StatelessWidget {
       status,
       body,
       l10n.channelWorkspaceProviderContract(surface.providerContractId),
+      l10n.channelWorkspaceProviderReadiness(surface.providerReadinessId),
       l10n.channelWorkspaceExplicitContextNote(workspace.channelTitle),
     ].join('. ');
 
@@ -888,6 +894,14 @@ class _ChannelWorkspaceSurfacePanel extends StatelessWidget {
                         label: Text(
                           l10n.channelWorkspaceProviderContract(
                             surface.providerContractId,
+                          ),
+                        ),
+                      ),
+                      Chip(
+                        avatar: const Icon(Icons.health_and_safety_outlined, size: 18),
+                        label: Text(
+                          l10n.channelWorkspaceProviderReadiness(
+                            surface.providerReadinessId,
                           ),
                         ),
                       ),

--- a/lib/features/chat/presentation/chat_room_screen.dart
+++ b/lib/features/chat/presentation/chat_room_screen.dart
@@ -590,11 +590,16 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
     }
 
     final workspaceFacade = ref.watch(channelWorkspacePreviewFacadeProvider);
-    final providerStack = ref.watch(weaveApiProviderStackStatusProvider);
-    final workspace = workspaceFacade.supportsWorkspaceTabs(widget.conversation)
+    final supportsTabs = workspaceFacade.supportsWorkspaceTabs(
+      widget.conversation,
+    );
+    final providerStack = supportsTabs
+        ? ref.watch(weaveApiProviderStackStatusProvider).asData?.value
+        : null;
+    final workspace = supportsTabs
         ? workspaceFacade.previewForChannel(
             widget.conversation,
-            providerStack: providerStack.asData?.value,
+            providerStack: providerStack,
           )
         : null;
     final scaffold = Scaffold(
@@ -898,7 +903,10 @@ class _ChannelWorkspaceSurfacePanel extends StatelessWidget {
                         ),
                       ),
                       Chip(
-                        avatar: const Icon(Icons.health_and_safety_outlined, size: 18),
+                        avatar: const Icon(
+                          Icons.health_and_safety_outlined,
+                          size: 18,
+                        ),
                         label: Text(
                           l10n.channelWorkspaceProviderReadiness(
                             surface.providerReadinessId,

--- a/lib/features/chat/presentation/providers/channel_workspace_preview_provider.dart
+++ b/lib/features/chat/presentation/providers/channel_workspace_preview_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
 import 'package:weave/features/chat/domain/entities/channel_workspace.dart';
 import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 
@@ -14,7 +15,13 @@ class ChannelWorkspacePreviewFacade {
     return !conversation.isDirectMessage && !conversation.isAiChat;
   }
 
-  ChannelWorkspacePreview previewForChannel(ChatConversation conversation) {
-    return ChannelWorkspacePreview.forConversation(conversation);
+  ChannelWorkspacePreview previewForChannel(
+    ChatConversation conversation, {
+    ProviderStackStatus? providerStack,
+  }) {
+    return ChannelWorkspacePreview.forConversation(
+      conversation,
+      providerStack: providerStack,
+    );
   }
 }

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -15,6 +15,7 @@ import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/core/widgets/weave_logo.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
 import 'package:weave/features/agents/presentation/providers/agent_capability_policy_provider.dart';
@@ -830,6 +831,7 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
     final capabilities = ref.watch(workspaceCapabilitySnapshotProvider);
     final backendState = ref.watch(weaveBackendConnectionStateProvider);
     final matrixDiagnostic = ref.watch(weaveApiMatrixE2eeDiagnosticProvider);
+    final providerStack = ref.watch(weaveApiProviderStackStatusProvider);
 
     return Card(
       elevation: 0,
@@ -902,6 +904,8 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                   capability: capabilitySnapshot.calendar,
                   connection: workspaceState.nextcloud,
                 ),
+                const Divider(height: 32),
+                _ProviderStackReadinessSection(providerStack: providerStack),
               ],
             ),
           (AsyncError(), _) || (_, AsyncError()) => ErrorState(
@@ -962,6 +966,196 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
       IntegrationConnectionStatus.connected =>
         l10n.settingsWorkspaceSummaryConnected,
     };
+  }
+}
+
+class _ProviderStackReadinessSection extends ConsumerWidget {
+  const _ProviderStackReadinessSection({required this.providerStack});
+
+  final AsyncValue<ProviderStackStatus?> providerStack;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Semantics(
+      container: true,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.settingsWorkspaceProviderStackTitle,
+            style: theme.textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            l10n.settingsWorkspaceProviderStackDescription,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 12),
+          switch (providerStack) {
+            AsyncData(value: final status?) => _ProviderStackStatusDetails(
+              status: status,
+            ),
+            AsyncData(value: null) => Text(
+              l10n.settingsWorkspaceProviderStackUnavailable,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            AsyncError() => ErrorState(
+              message: l10n.settingsWorkspaceProviderStackError,
+              retryLabel: l10n.retryButton,
+              onRetry: () =>
+                  ref.invalidate(weaveApiProviderStackStatusProvider),
+            ),
+            _ => LoadingState(message: l10n.loadingLabel),
+          },
+        ],
+      ),
+    );
+  }
+}
+
+class _ProviderStackStatusDetails extends StatelessWidget {
+  const _ProviderStackStatusDetails({required this.status});
+
+  final ProviderStackStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final trackedProviders = status.providers
+        .where(
+          (provider) => const {
+            'office',
+            'contacts',
+            'forms',
+            'source-control',
+            'issue-tracker',
+            'ci',
+            'release',
+          }.contains(provider.module),
+        )
+        .toList(growable: false);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: [
+            _StatusPill(
+              label: l10n.settingsWorkspaceProviderStackBackendFacadeLabel,
+              value: status.backendOwnedFacades
+                  ? l10n.settingsWorkspaceProviderStackBackendFacadeValue
+                  : l10n.settingsWorkspaceProviderStackReviewValue,
+            ),
+            _StatusPill(
+              label: l10n.settingsWorkspaceProviderStackFlutterBoundaryLabel,
+              value: status.flutterDirectProviderCallsAllowed
+                  ? l10n.settingsWorkspaceProviderStackReviewValue
+                  : l10n.settingsWorkspaceProviderStackFlutterBoundaryValue,
+            ),
+            _StatusPill(
+              label: l10n.settingsWorkspaceProviderStackSupportSafeLabel,
+              value: status.supportSafe
+                  ? l10n.settingsWorkspaceProviderStackSupportSafeValue
+                  : l10n.settingsWorkspaceProviderStackReviewValue,
+            ),
+            _StatusPill(
+              label: l10n.settingsWorkspaceProviderStackFailClosedLabel,
+              value: status.allOptionalProvidersFailClosed
+                  ? l10n.settingsWorkspaceProviderStackFailClosedValue
+                  : l10n.settingsWorkspaceProviderStackReviewValue,
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        if (trackedProviders.isEmpty)
+          Text(
+            l10n.settingsWorkspaceProviderStackUnavailable,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          )
+        else
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: trackedProviders
+                .map(
+                  (provider) => Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: _ProviderReadinessRow(provider: provider),
+                  ),
+                )
+                .toList(growable: false),
+          ),
+      ],
+    );
+  }
+}
+
+class _ProviderReadinessRow extends StatelessWidget {
+  const _ProviderReadinessRow({required this.provider});
+
+  final ProviderReadiness provider;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return MergeSemantics(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            provider.module,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _StatusPill(
+                label: l10n.settingsWorkspaceProviderStackProviderLabel,
+                value: provider.providerKey,
+              ),
+              _StatusPill(
+                label: l10n.settingsWorkspaceProviderStackStateLabel,
+                value: provider.state,
+              ),
+              _StatusPill(
+                label: l10n.settingsWorkspaceProviderStackReadinessLabel,
+                value: provider.readiness,
+              ),
+              _StatusPill(
+                label: l10n.settingsWorkspaceProviderStackFailClosedLabel,
+                value: provider.isFailClosedUnavailable
+                    ? l10n.settingsWorkspaceProviderStackFailClosedValue
+                    : l10n.settingsWorkspaceProviderStackReviewValue,
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            provider.summary,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/lib/features/settings/presentation/settings_screen.dart
+++ b/lib/features/settings/presentation/settings_screen.dart
@@ -1012,7 +1012,12 @@ class _ProviderStackReadinessSection extends ConsumerWidget {
               onRetry: () =>
                   ref.invalidate(weaveApiProviderStackStatusProvider),
             ),
-            _ => LoadingState(message: l10n.loadingLabel),
+            _ => Text(
+              l10n.settingsWorkspaceProviderStackUnavailable,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
           },
         ],
       ),

--- a/lib/integrations/weave_api/data/dtos/provider_stack_status_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/provider_stack_status_response_dto.dart
@@ -1,0 +1,320 @@
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
+
+class ProviderStackStatusResponseDto {
+  const ProviderStackStatusResponseDto({
+    required this.releaseStatus,
+    required this.backendOwnedFacades,
+    required this.flutterDirectProviderCallsAllowed,
+    required this.supportSafe,
+    required this.providers,
+  });
+
+  factory ProviderStackStatusResponseDto.fromJson(Map<String, dynamic> json) {
+    final providers = json['providers'];
+    if (providers is! List) {
+      throw const AppFailure.unknown(
+        'The backend returned an invalid provider readiness response.',
+      );
+    }
+
+    return ProviderStackStatusResponseDto(
+      releaseStatus: _string(json['releaseStatus']),
+      backendOwnedFacades: _bool(json['backendOwnedFacades']),
+      flutterDirectProviderCallsAllowed: _bool(
+        json['flutterDirectProviderCallsAllowed'],
+      ),
+      supportSafe: _bool(json['supportSafe']),
+      providers: providers
+          .map(
+            (provider) => ProviderReadinessDto.fromJson(
+              (provider as Map).cast<String, dynamic>(),
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+
+  final String releaseStatus;
+  final bool backendOwnedFacades;
+  final bool flutterDirectProviderCallsAllowed;
+  final bool supportSafe;
+  final List<ProviderReadinessDto> providers;
+
+  ProviderStackStatus toEntity() {
+    return ProviderStackStatus(
+      releaseStatus: releaseStatus,
+      backendOwnedFacades: backendOwnedFacades,
+      flutterDirectProviderCallsAllowed: flutterDirectProviderCallsAllowed,
+      supportSafe: supportSafe,
+      providers: providers.map((provider) => provider.toEntity()).toList(),
+    );
+  }
+}
+
+class ProviderReadinessDto {
+  const ProviderReadinessDto({
+    required this.module,
+    required this.providerKey,
+    required this.state,
+    required this.readiness,
+    required this.enabled,
+    required this.configured,
+    required this.readOnly,
+    required this.failClosed,
+    required this.supportSafe,
+    required this.summary,
+    required this.supportedCapabilities,
+    required this.unsupportedOperations,
+    required this.paidFeaturesRequired,
+    required this.supportSafeErrorCodes,
+    required this.redactionPolicy,
+    required this.candidates,
+  });
+
+  factory ProviderReadinessDto.fromJson(Map<String, dynamic> json) {
+    return ProviderReadinessDto(
+      module: _string(json['module']),
+      providerKey: _string(json['providerKey']),
+      state: _string(json['state']),
+      readiness: _string(json['readiness']),
+      enabled: _bool(json['enabled']),
+      configured: _bool(json['configured']),
+      readOnly: _bool(json['readOnly']),
+      failClosed: _bool(json['failClosed']),
+      supportSafe: _bool(json['supportSafe']),
+      summary: _string(json['summary']),
+      supportedCapabilities: _stringSet(json['supportedCapabilities']),
+      unsupportedOperations: _stringSet(json['unsupportedOperations']),
+      paidFeaturesRequired: _optionalBool(
+        json['paidFeaturesRequired'],
+        defaultValue: false,
+      ),
+      supportSafeErrorCodes: _optionalStringSet(json['supportSafeErrorCodes']),
+      redactionPolicy: _optionalString(
+        json['redactionPolicy'],
+        defaultValue:
+            'support-safe: no tokens, passwords, credentials, authorization headers, or raw provider errors',
+      ),
+      candidates: _optionalStringSet(json['candidates']),
+    );
+  }
+
+  final String module;
+  final String providerKey;
+  final String state;
+  final String readiness;
+  final bool enabled;
+  final bool configured;
+  final bool readOnly;
+  final bool failClosed;
+  final bool supportSafe;
+  final String summary;
+  final Set<String> supportedCapabilities;
+  final Set<String> unsupportedOperations;
+  final bool paidFeaturesRequired;
+  final Set<String> supportSafeErrorCodes;
+  final String redactionPolicy;
+  final Set<String> candidates;
+
+  ProviderReadiness toEntity() {
+    return ProviderReadiness(
+      module: module,
+      providerKey: providerKey,
+      state: state,
+      readiness: readiness,
+      enabled: enabled,
+      configured: configured,
+      readOnly: readOnly,
+      failClosed: failClosed,
+      supportSafe: supportSafe,
+      summary: summary,
+      supportedCapabilities: supportedCapabilities,
+      unsupportedOperations: unsupportedOperations,
+      paidFeaturesRequired: paidFeaturesRequired,
+      supportSafeErrorCodes: supportSafeErrorCodes,
+      redactionPolicy: redactionPolicy,
+      candidates: candidates,
+    );
+  }
+}
+
+class DevopsSummaryResponseDto {
+  const DevopsSummaryResponseDto({
+    required this.workspaceId,
+    required this.channelId,
+    required this.releaseStatus,
+    required this.readOnly,
+    required this.paidFeaturesRequired,
+    required this.supportSafe,
+    required this.providerReadiness,
+  });
+
+  factory DevopsSummaryResponseDto.fromJson(Map<String, dynamic> json) {
+    return DevopsSummaryResponseDto(
+      workspaceId: _string(json['workspaceId']),
+      channelId: _string(json['channelId']),
+      releaseStatus: _optionalString(
+        json['releaseStatus'],
+        defaultValue: 'provider-stack-contract-preview',
+      ),
+      readOnly: _bool(json['readOnly']),
+      paidFeaturesRequired: _bool(json['paidFeaturesRequired']),
+      supportSafe: _bool(json['supportSafe']),
+      providerReadiness: _providerReadinessList(json['providerReadiness']),
+    );
+  }
+
+  final String workspaceId;
+  final String channelId;
+  final String releaseStatus;
+  final bool readOnly;
+  final bool paidFeaturesRequired;
+  final bool supportSafe;
+  final List<ProviderReadiness> providerReadiness;
+
+  DevopsChannelSummary toEntity() {
+    return DevopsChannelSummary(
+      workspaceId: workspaceId,
+      channelId: channelId,
+      releaseStatus: releaseStatus,
+      readOnly: readOnly,
+      paidFeaturesRequired: paidFeaturesRequired,
+      supportSafe: supportSafe,
+      providerReadiness: providerReadiness,
+    );
+  }
+}
+
+class OfficeCapabilitiesResponseDto {
+  const OfficeCapabilitiesResponseDto({
+    required this.releaseStatus,
+    required this.enabled,
+    required this.configured,
+    required this.supportSafe,
+    required this.launchMode,
+    required this.defaultProvider,
+    required this.providerReadiness,
+    required this.supportedFileTypes,
+    required this.permissions,
+  });
+
+  factory OfficeCapabilitiesResponseDto.fromJson(Map<String, dynamic> json) {
+    final permissions = json['permissions'];
+    if (permissions is! Map) {
+      throw const AppFailure.unknown(
+        'The backend returned an invalid Office capabilities response.',
+      );
+    }
+    final permissionJson = permissions.cast<String, dynamic>();
+
+    return OfficeCapabilitiesResponseDto(
+      releaseStatus: _optionalString(
+        json['releaseStatus'],
+        defaultValue: 'provider-stack-contract-preview',
+      ),
+      enabled: _bool(json['enabled']),
+      configured: _bool(json['configured']),
+      supportSafe: _bool(json['supportSafe']),
+      launchMode: _string(json['launchMode']),
+      defaultProvider: _string(json['defaultProvider']),
+      providerReadiness: _providerReadinessList(json['providerReadiness']),
+      supportedFileTypes: _optionalStringSet(json['supportedFileTypes']),
+      permissions: OfficePermissionModel(
+        canView: _bool(permissionJson['canView']),
+        canEdit: _bool(permissionJson['canEdit']),
+        canComment: _bool(permissionJson['canComment']),
+        canReview: _bool(permissionJson['canReview']),
+        canFillForms: _bool(permissionJson['canFillForms']),
+        reason: _string(permissionJson['reason']),
+      ),
+    );
+  }
+
+  final String releaseStatus;
+  final bool enabled;
+  final bool configured;
+  final bool supportSafe;
+  final String launchMode;
+  final String defaultProvider;
+  final List<ProviderReadiness> providerReadiness;
+  final Set<String> supportedFileTypes;
+  final OfficePermissionModel permissions;
+
+  OfficeCapabilities toEntity() {
+    return OfficeCapabilities(
+      releaseStatus: releaseStatus,
+      enabled: enabled,
+      configured: configured,
+      supportSafe: supportSafe,
+      launchMode: launchMode,
+      defaultProvider: defaultProvider,
+      providerReadiness: providerReadiness,
+      supportedFileTypes: supportedFileTypes,
+      permissions: permissions,
+    );
+  }
+}
+
+String _string(Object? value) {
+  if (value is String && value.trim().isNotEmpty) {
+    return value.trim();
+  }
+  throw const AppFailure.unknown(
+    'The backend returned an invalid provider readiness response.',
+  );
+}
+
+String _optionalString(Object? value, {required String defaultValue}) {
+  if (value == null) {
+    return defaultValue;
+  }
+  return _string(value);
+}
+
+bool _bool(Object? value) {
+  if (value is bool) {
+    return value;
+  }
+  throw const AppFailure.unknown(
+    'The backend returned an invalid provider readiness response.',
+  );
+}
+
+bool _optionalBool(Object? value, {required bool defaultValue}) {
+  if (value == null) {
+    return defaultValue;
+  }
+  return _bool(value);
+}
+
+Set<String> _stringSet(Object? value) {
+  if (value is! List) {
+    throw const AppFailure.unknown(
+      'The backend returned an invalid provider readiness response.',
+    );
+  }
+  return value.map((item) => _string(item)).toSet();
+}
+
+Set<String> _optionalStringSet(Object? value) {
+  if (value == null) {
+    return const <String>{};
+  }
+  return _stringSet(value);
+}
+
+List<ProviderReadiness> _providerReadinessList(Object? value) {
+  if (value is! List) {
+    throw const AppFailure.unknown(
+      'The backend returned an invalid provider readiness response.',
+    );
+  }
+  return value
+      .map(
+        (provider) => ProviderReadinessDto.fromJson(
+          (provider as Map).cast<String, dynamic>(),
+        ).toEntity(),
+      )
+      .toList(growable: false);
+}

--- a/lib/integrations/weave_api/data/dtos/provider_stack_status_response_dto.dart
+++ b/lib/integrations/weave_api/data/dtos/provider_stack_status_response_dto.dart
@@ -25,13 +25,7 @@ class ProviderStackStatusResponseDto {
         json['flutterDirectProviderCallsAllowed'],
       ),
       supportSafe: _bool(json['supportSafe']),
-      providers: providers
-          .map(
-            (provider) => ProviderReadinessDto.fromJson(
-              (provider as Map).cast<String, dynamic>(),
-            ),
-          )
-          .toList(growable: false),
+      providers: providers.map(_providerReadinessDto).toList(growable: false),
     );
   }
 
@@ -311,10 +305,15 @@ List<ProviderReadiness> _providerReadinessList(Object? value) {
     );
   }
   return value
-      .map(
-        (provider) => ProviderReadinessDto.fromJson(
-          (provider as Map).cast<String, dynamic>(),
-        ).toEntity(),
-      )
+      .map((provider) => _providerReadinessDto(provider).toEntity())
       .toList(growable: false);
+}
+
+ProviderReadinessDto _providerReadinessDto(Object? provider) {
+  if (provider is! Map) {
+    throw const AppFailure.unknown(
+      'The backend returned an invalid provider readiness response.',
+    );
+  }
+  return ProviderReadinessDto.fromJson(provider.cast<String, dynamic>());
 }

--- a/lib/integrations/weave_api/data/services/weave_api_client.dart
+++ b/lib/integrations/weave_api/data/services/weave_api_client.dart
@@ -4,8 +4,10 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/integrations/weave_api/data/dtos/platform_status_response_dto.dart';
+import 'package:weave/integrations/weave_api/data/dtos/provider_stack_status_response_dto.dart';
 import 'package:weave/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart';
 
 abstract interface class WeaveApiClient {
@@ -17,6 +19,30 @@ abstract interface class WeaveApiClient {
   Future<MatrixE2eeDiagnostic> fetchMatrixE2eeDiagnostic({
     required Uri baseUrl,
     required String accessToken,
+  });
+
+  Future<ProviderStackStatus> fetchProviderStackStatus({
+    required Uri baseUrl,
+    required String accessToken,
+  });
+
+  Future<DevopsChannelSummary> fetchDevopsSummary({
+    required Uri baseUrl,
+    required String accessToken,
+    required String workspaceId,
+    required String channelId,
+  });
+
+  Future<OfficeCapabilities> fetchOfficeCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  });
+
+  Future<void> launchOfficeSession({
+    required Uri baseUrl,
+    required String accessToken,
+    required String fileId,
+    required String requestedMode,
   });
 }
 
@@ -61,6 +87,78 @@ class HttpWeaveApiClient implements WeaveApiClient {
     );
 
     return PlatformStatusResponseDto.fromJson(payload).toMatrixDiagnostic();
+  }
+
+  @override
+  Future<ProviderStackStatus> fetchProviderStackStatus({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    final payload = await _getJson(
+      requestUri: _providerStackStatusUri(baseUrl),
+      accessToken: accessToken,
+      failureMessage: 'The Weave backend failed to return provider readiness.',
+      invalidPayloadMessage:
+          'The backend returned an invalid provider readiness response.',
+      decodeFailureMessage:
+          'Unable to decode provider readiness from the Weave backend.',
+    );
+
+    return ProviderStackStatusResponseDto.fromJson(payload).toEntity();
+  }
+
+  @override
+  Future<DevopsChannelSummary> fetchDevopsSummary({
+    required Uri baseUrl,
+    required String accessToken,
+    required String workspaceId,
+    required String channelId,
+  }) async {
+    final payload = await _getJson(
+      requestUri: _devopsSummaryUri(baseUrl, workspaceId, channelId),
+      accessToken: accessToken,
+      failureMessage: 'The Weave backend failed to return DevOps readiness.',
+      invalidPayloadMessage:
+          'The backend returned an invalid DevOps readiness response.',
+      decodeFailureMessage:
+          'Unable to decode DevOps readiness from the Weave backend.',
+    );
+
+    return DevopsSummaryResponseDto.fromJson(payload).toEntity();
+  }
+
+  @override
+  Future<OfficeCapabilities> fetchOfficeCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    final payload = await _getJson(
+      requestUri: _officeCapabilitiesUri(baseUrl),
+      accessToken: accessToken,
+      failureMessage: 'The Weave backend failed to return Office readiness.',
+      invalidPayloadMessage:
+          'The backend returned an invalid Office readiness response.',
+      decodeFailureMessage:
+          'Unable to decode Office readiness from the Weave backend.',
+    );
+
+    return OfficeCapabilitiesResponseDto.fromJson(payload).toEntity();
+  }
+
+  @override
+  Future<void> launchOfficeSession({
+    required Uri baseUrl,
+    required String accessToken,
+    required String fileId,
+    required String requestedMode,
+  }) async {
+    await _postJson(
+      requestUri: _officeLaunchUri(baseUrl),
+      accessToken: accessToken,
+      body: {'fileId': fileId, 'requestedMode': requestedMode},
+      failureMessage:
+          'The Weave backend refused to launch an Office session fail-closed.',
+    );
   }
 
   Future<Map<String, dynamic>> _getJson({
@@ -112,6 +210,60 @@ class HttpWeaveApiClient implements WeaveApiClient {
     }
   }
 
+  Future<Map<String, dynamic>> _postJson({
+    required Uri requestUri,
+    required String accessToken,
+    required Map<String, Object?> body,
+    required String failureMessage,
+  }) async {
+    late http.Response response;
+    try {
+      response = await _httpClient
+          .post(
+            requestUri,
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json',
+              'Authorization': 'Bearer $accessToken',
+            },
+            body: jsonEncode(body),
+          )
+          .timeout(const Duration(seconds: 5));
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to reach the Weave backend right now.',
+        cause: error,
+      );
+    }
+
+    if (response.statusCode == 401 || response.statusCode == 403) {
+      throw const AppFailure.unknown(
+        'The Weave backend rejected the current session.',
+      );
+    }
+
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw AppFailure.unknown(failureMessage, cause: response.statusCode);
+    }
+
+    try {
+      final payload = jsonDecode(response.body);
+      if (payload is! Map<String, dynamic>) {
+        throw const AppFailure.unknown(
+          'The Weave backend returned an invalid Office launch response.',
+        );
+      }
+      return payload;
+    } on AppFailure {
+      rethrow;
+    } catch (error) {
+      throw AppFailure.unknown(
+        'Unable to decode Office launch response from the Weave backend.',
+        cause: error,
+      );
+    }
+  }
+
   Uri _workspaceCapabilitiesUri(Uri baseUrl) {
     return baseUrl.replace(
       pathSegments: _apiPath(baseUrl, const [
@@ -126,6 +278,38 @@ class HttpWeaveApiClient implements WeaveApiClient {
   Uri _platformStatusUri(Uri baseUrl) {
     return baseUrl.replace(
       pathSegments: _apiPath(baseUrl, const ['api', 'platform', 'status']),
+    );
+  }
+
+  Uri _providerStackStatusUri(Uri baseUrl) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, const ['api', 'providers', 'status']),
+    );
+  }
+
+  Uri _devopsSummaryUri(Uri baseUrl, String workspaceId, String channelId) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, [
+        'api',
+        'workspaces',
+        workspaceId,
+        'channels',
+        channelId,
+        'devops',
+        'summary',
+      ]),
+    );
+  }
+
+  Uri _officeCapabilitiesUri(Uri baseUrl) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, const ['api', 'office', 'capabilities']),
+    );
+  }
+
+  Uri _officeLaunchUri(Uri baseUrl) {
+    return baseUrl.replace(
+      pathSegments: _apiPath(baseUrl, const ['api', 'office', 'launch']),
     );
   }
 

--- a/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
+++ b/lib/integrations/weave_api/presentation/providers/weave_api_provider.dart
@@ -5,6 +5,7 @@ import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provid
 import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/presentation/providers/workspace_invalidation_provider.dart';
 import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
@@ -68,6 +69,16 @@ final weaveApiMatrixE2eeDiagnosticProvider =
     FutureProvider<MatrixE2eeDiagnostic?>((ref) async {
       return _withWeaveApiSession(ref, (client, baseUrl, accessToken) {
         return client.fetchMatrixE2eeDiagnostic(
+          baseUrl: baseUrl,
+          accessToken: accessToken,
+        );
+      });
+    });
+
+final weaveApiProviderStackStatusProvider =
+    FutureProvider<ProviderStackStatus?>((ref) async {
+      return _withWeaveApiSession(ref, (client, baseUrl, accessToken) {
+        return client.fetchProviderStackStatus(
           baseUrl: baseUrl,
           accessToken: accessToken,
         );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -406,6 +406,55 @@
   "chatSecurityEmojiSummaryLabel": "Sicherheits-Emojis",
   "chatSecurityNumbersSummaryLabel": "Sicherheitszahlen {value}",
   "settingsServerConfigurationTitle": "Serverkonfiguration",
+
+  "settingsWorkspaceProviderStackTitle": "Provider-Stack-Status",
+  "@settingsWorkspaceProviderStackTitle": { "description": "Title for provider stack readiness details in settings" },
+
+  "settingsWorkspaceProviderStackDescription": "Optionale DevOps-, Office-, Forms- und Contacts-Provider werden nur über backend-eigene Fassaden sichtbar und bleiben fail-closed, wenn sie deaktiviert sind.",
+  "@settingsWorkspaceProviderStackDescription": { "description": "Description for provider stack readiness details in settings" },
+
+  "settingsWorkspaceProviderStackUnavailable": "Provider-Status ist erst verfügbar, wenn die Backend-Registry gelesen werden kann.",
+  "@settingsWorkspaceProviderStackUnavailable": { "description": "Message when provider readiness data is missing" },
+
+  "settingsWorkspaceProviderStackError": "Provider-Status konnte nicht aus dem Weave-Backend geladen werden.",
+  "@settingsWorkspaceProviderStackError": { "description": "Error when provider readiness loading fails" },
+
+  "settingsWorkspaceProviderStackBackendFacadeLabel": "Backend-Fassade",
+  "@settingsWorkspaceProviderStackBackendFacadeLabel": { "description": "Provider stack boundary pill label for backend-owned facades" },
+
+  "settingsWorkspaceProviderStackBackendFacadeValue": "Backend-eigen",
+  "@settingsWorkspaceProviderStackBackendFacadeValue": { "description": "Provider stack boundary pill value for backend-owned facades" },
+
+  "settingsWorkspaceProviderStackFlutterBoundaryLabel": "Flutter-Grenze",
+  "@settingsWorkspaceProviderStackFlutterBoundaryLabel": { "description": "Provider stack boundary pill label for Flutter provider calls" },
+
+  "settingsWorkspaceProviderStackFlutterBoundaryValue": "Direkte Provider-Aufrufe blockiert",
+  "@settingsWorkspaceProviderStackFlutterBoundaryValue": { "description": "Provider stack boundary pill value when Flutter cannot call providers directly" },
+
+  "settingsWorkspaceProviderStackSupportSafeLabel": "Support-Sicherheit",
+  "@settingsWorkspaceProviderStackSupportSafeLabel": { "description": "Provider stack boundary pill label for support-safe metadata" },
+
+  "settingsWorkspaceProviderStackSupportSafeValue": "Keine Secrets exponiert",
+  "@settingsWorkspaceProviderStackSupportSafeValue": { "description": "Provider stack boundary pill value when metadata is support safe" },
+
+  "settingsWorkspaceProviderStackFailClosedLabel": "Fail-closed",
+  "@settingsWorkspaceProviderStackFailClosedLabel": { "description": "Provider stack boundary pill label for fail-closed state" },
+
+  "settingsWorkspaceProviderStackFailClosedValue": "Sicher deaktiviert",
+  "@settingsWorkspaceProviderStackFailClosedValue": { "description": "Provider stack boundary pill value when providers are disabled safely" },
+
+  "settingsWorkspaceProviderStackReviewValue": "Prüfen",
+  "@settingsWorkspaceProviderStackReviewValue": { "description": "Provider stack boundary pill value when a state needs review" },
+
+  "settingsWorkspaceProviderStackProviderLabel": "Provider",
+  "@settingsWorkspaceProviderStackProviderLabel": { "description": "Provider stack readiness pill label for provider key" },
+
+  "settingsWorkspaceProviderStackStateLabel": "Status",
+  "@settingsWorkspaceProviderStackStateLabel": { "description": "Provider stack readiness pill label for provider state" },
+
+  "settingsWorkspaceProviderStackReadinessLabel": "Bereitschaft",
+  "@settingsWorkspaceProviderStackReadinessLabel": { "description": "Provider stack readiness pill label for provider readiness" },
+
   "settingsServerConfigurationDescription": "Aktualisiere den Anbieter und die Dienst-URLs, die Weave für deine selbst gehostete Umgebung verwenden soll.",
   "settingsSaveButton": "Änderungen speichern",
   "settingsSaveInProgress": "Wird gespeichert…",
@@ -465,6 +514,11 @@
   "channelWorkspaceStatusPreview": "Vorschau-Vertrag",
   "channelWorkspaceStatusGated": "Durch Fähigkeit gesperrt",
   "channelWorkspaceProviderContract": "Anbieter-Nahtstelle: {contractId}",
+  "channelWorkspaceProviderReadiness": "Provider-Status: {readinessId}",
+  "@channelWorkspaceProviderReadiness": {
+    "description": "Provider readiness label for a channel workspace surface",
+    "placeholders": { "readinessId": { "type": "String" } }
+  },
   "channelWorkspaceExplicitContextNote": "Hier wird nur ausdrücklicher Kontext aus {channelName} gezeigt; Weave liest den Raum nicht dauerhaft im Hintergrund mit.",
   "chatRoomLoadingLabel": "Konversation wird geladen…",
   "chatRoomEmptyMessage": "Noch keine Nachrichten",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -403,6 +403,11 @@
     "description": "Provider/domain seam label for a channel workspace surface",
     "placeholders": { "contractId": { "type": "String" } }
   },
+  "channelWorkspaceProviderReadiness": "Provider readiness: {readinessId}",
+  "@channelWorkspaceProviderReadiness": {
+    "description": "Provider readiness label for a channel workspace surface",
+    "placeholders": { "readinessId": { "type": "String" } }
+  },
   "channelWorkspaceExplicitContextNote": "Only explicit context from {channelName} is shown here; Weave does not continuously read the room in the background.",
   "@channelWorkspaceExplicitContextNote": {
     "description": "Privacy/context note for a channel workspace surface",
@@ -1272,6 +1277,55 @@
 
   "settingsWorkspaceInvalidationBackendApiBaseUrlChanged": "Backend API URL changed",
   "@settingsWorkspaceInvalidationBackendApiBaseUrlChanged": { "description": "Invalidation label for backend API base URL changes" },
+
+
+  "settingsWorkspaceProviderStackTitle": "Provider stack readiness",
+  "@settingsWorkspaceProviderStackTitle": { "description": "Title for provider stack readiness details in settings" },
+
+  "settingsWorkspaceProviderStackDescription": "Optional DevOps, Office, Forms, and Contacts providers are exposed only through backend-owned facades and stay fail-closed when disabled.",
+  "@settingsWorkspaceProviderStackDescription": { "description": "Description for provider stack readiness details in settings" },
+
+  "settingsWorkspaceProviderStackUnavailable": "Provider readiness is unavailable until the backend registry can be read.",
+  "@settingsWorkspaceProviderStackUnavailable": { "description": "Message when provider readiness data is missing" },
+
+  "settingsWorkspaceProviderStackError": "Provider readiness could not be loaded from the Weave backend.",
+  "@settingsWorkspaceProviderStackError": { "description": "Error when provider readiness loading fails" },
+
+  "settingsWorkspaceProviderStackBackendFacadeLabel": "Backend facade",
+  "@settingsWorkspaceProviderStackBackendFacadeLabel": { "description": "Provider stack boundary pill label for backend-owned facades" },
+
+  "settingsWorkspaceProviderStackBackendFacadeValue": "Backend-owned",
+  "@settingsWorkspaceProviderStackBackendFacadeValue": { "description": "Provider stack boundary pill value for backend-owned facades" },
+
+  "settingsWorkspaceProviderStackFlutterBoundaryLabel": "Flutter boundary",
+  "@settingsWorkspaceProviderStackFlutterBoundaryLabel": { "description": "Provider stack boundary pill label for Flutter provider calls" },
+
+  "settingsWorkspaceProviderStackFlutterBoundaryValue": "Direct provider calls blocked",
+  "@settingsWorkspaceProviderStackFlutterBoundaryValue": { "description": "Provider stack boundary pill value when Flutter cannot call providers directly" },
+
+  "settingsWorkspaceProviderStackSupportSafeLabel": "Support safety",
+  "@settingsWorkspaceProviderStackSupportSafeLabel": { "description": "Provider stack boundary pill label for support-safe metadata" },
+
+  "settingsWorkspaceProviderStackSupportSafeValue": "No secrets exposed",
+  "@settingsWorkspaceProviderStackSupportSafeValue": { "description": "Provider stack boundary pill value when metadata is support safe" },
+
+  "settingsWorkspaceProviderStackFailClosedLabel": "Fail-closed",
+  "@settingsWorkspaceProviderStackFailClosedLabel": { "description": "Provider stack boundary pill label for fail-closed state" },
+
+  "settingsWorkspaceProviderStackFailClosedValue": "Disabled safely",
+  "@settingsWorkspaceProviderStackFailClosedValue": { "description": "Provider stack boundary pill value when providers are disabled safely" },
+
+  "settingsWorkspaceProviderStackReviewValue": "Review",
+  "@settingsWorkspaceProviderStackReviewValue": { "description": "Provider stack boundary pill value when a state needs review" },
+
+  "settingsWorkspaceProviderStackProviderLabel": "Provider",
+  "@settingsWorkspaceProviderStackProviderLabel": { "description": "Provider stack readiness pill label for provider key" },
+
+  "settingsWorkspaceProviderStackStateLabel": "State",
+  "@settingsWorkspaceProviderStackStateLabel": { "description": "Provider stack readiness pill label for provider state" },
+
+  "settingsWorkspaceProviderStackReadinessLabel": "Readiness",
+  "@settingsWorkspaceProviderStackReadinessLabel": { "description": "Provider stack readiness pill label for provider readiness" },
 
   "settingsServerConfigurationDescription": "Update the provider and service URLs Weave should use for your self-hosted environment.",
   "@settingsServerConfigurationDescription": { "description": "Description for the settings server configuration section" },

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1163,6 +1163,12 @@ abstract class AppLocalizations {
   /// **'Provider seam: {contractId}'**
   String channelWorkspaceProviderContract(String contractId);
 
+  /// Provider readiness label for a channel workspace surface
+  ///
+  /// In en, this message translates to:
+  /// **'Provider readiness: {readinessId}'**
+  String channelWorkspaceProviderReadiness(String readinessId);
+
   /// Privacy/context note for a channel workspace surface
   ///
   /// In en, this message translates to:
@@ -2704,6 +2710,102 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Backend API URL changed'**
   String get settingsWorkspaceInvalidationBackendApiBaseUrlChanged;
+
+  /// Title for provider stack readiness details in settings
+  ///
+  /// In en, this message translates to:
+  /// **'Provider stack readiness'**
+  String get settingsWorkspaceProviderStackTitle;
+
+  /// Description for provider stack readiness details in settings
+  ///
+  /// In en, this message translates to:
+  /// **'Optional DevOps, Office, Forms, and Contacts providers are exposed only through backend-owned facades and stay fail-closed when disabled.'**
+  String get settingsWorkspaceProviderStackDescription;
+
+  /// Message when provider readiness data is missing
+  ///
+  /// In en, this message translates to:
+  /// **'Provider readiness is unavailable until the backend registry can be read.'**
+  String get settingsWorkspaceProviderStackUnavailable;
+
+  /// Error when provider readiness loading fails
+  ///
+  /// In en, this message translates to:
+  /// **'Provider readiness could not be loaded from the Weave backend.'**
+  String get settingsWorkspaceProviderStackError;
+
+  /// Provider stack boundary pill label for backend-owned facades
+  ///
+  /// In en, this message translates to:
+  /// **'Backend facade'**
+  String get settingsWorkspaceProviderStackBackendFacadeLabel;
+
+  /// Provider stack boundary pill value for backend-owned facades
+  ///
+  /// In en, this message translates to:
+  /// **'Backend-owned'**
+  String get settingsWorkspaceProviderStackBackendFacadeValue;
+
+  /// Provider stack boundary pill label for Flutter provider calls
+  ///
+  /// In en, this message translates to:
+  /// **'Flutter boundary'**
+  String get settingsWorkspaceProviderStackFlutterBoundaryLabel;
+
+  /// Provider stack boundary pill value when Flutter cannot call providers directly
+  ///
+  /// In en, this message translates to:
+  /// **'Direct provider calls blocked'**
+  String get settingsWorkspaceProviderStackFlutterBoundaryValue;
+
+  /// Provider stack boundary pill label for support-safe metadata
+  ///
+  /// In en, this message translates to:
+  /// **'Support safety'**
+  String get settingsWorkspaceProviderStackSupportSafeLabel;
+
+  /// Provider stack boundary pill value when metadata is support safe
+  ///
+  /// In en, this message translates to:
+  /// **'No secrets exposed'**
+  String get settingsWorkspaceProviderStackSupportSafeValue;
+
+  /// Provider stack boundary pill label for fail-closed state
+  ///
+  /// In en, this message translates to:
+  /// **'Fail-closed'**
+  String get settingsWorkspaceProviderStackFailClosedLabel;
+
+  /// Provider stack boundary pill value when providers are disabled safely
+  ///
+  /// In en, this message translates to:
+  /// **'Disabled safely'**
+  String get settingsWorkspaceProviderStackFailClosedValue;
+
+  /// Provider stack boundary pill value when a state needs review
+  ///
+  /// In en, this message translates to:
+  /// **'Review'**
+  String get settingsWorkspaceProviderStackReviewValue;
+
+  /// Provider stack readiness pill label for provider key
+  ///
+  /// In en, this message translates to:
+  /// **'Provider'**
+  String get settingsWorkspaceProviderStackProviderLabel;
+
+  /// Provider stack readiness pill label for provider state
+  ///
+  /// In en, this message translates to:
+  /// **'State'**
+  String get settingsWorkspaceProviderStackStateLabel;
+
+  /// Provider stack readiness pill label for provider readiness
+  ///
+  /// In en, this message translates to:
+  /// **'Readiness'**
+  String get settingsWorkspaceProviderStackReadinessLabel;
 
   /// Description for the settings server configuration section
   ///

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -624,6 +624,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String channelWorkspaceProviderReadiness(String readinessId) {
+    return 'Provider-Status: $readinessId';
+  }
+
+  @override
   String channelWorkspaceExplicitContextNote(String channelName) {
     return 'Hier wird nur ausdrücklicher Kontext aus $channelName gezeigt; Weave liest den Raum nicht dauerhaft im Hintergrund mit.';
   }
@@ -1581,6 +1586,64 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get settingsWorkspaceInvalidationBackendApiBaseUrlChanged =>
       'Backend-API-URL geändert';
+
+  @override
+  String get settingsWorkspaceProviderStackTitle => 'Provider-Stack-Status';
+
+  @override
+  String get settingsWorkspaceProviderStackDescription =>
+      'Optionale DevOps-, Office-, Forms- und Contacts-Provider werden nur über backend-eigene Fassaden sichtbar und bleiben fail-closed, wenn sie deaktiviert sind.';
+
+  @override
+  String get settingsWorkspaceProviderStackUnavailable =>
+      'Provider-Status ist erst verfügbar, wenn die Backend-Registry gelesen werden kann.';
+
+  @override
+  String get settingsWorkspaceProviderStackError =>
+      'Provider-Status konnte nicht aus dem Weave-Backend geladen werden.';
+
+  @override
+  String get settingsWorkspaceProviderStackBackendFacadeLabel =>
+      'Backend-Fassade';
+
+  @override
+  String get settingsWorkspaceProviderStackBackendFacadeValue =>
+      'Backend-eigen';
+
+  @override
+  String get settingsWorkspaceProviderStackFlutterBoundaryLabel =>
+      'Flutter-Grenze';
+
+  @override
+  String get settingsWorkspaceProviderStackFlutterBoundaryValue =>
+      'Direkte Provider-Aufrufe blockiert';
+
+  @override
+  String get settingsWorkspaceProviderStackSupportSafeLabel =>
+      'Support-Sicherheit';
+
+  @override
+  String get settingsWorkspaceProviderStackSupportSafeValue =>
+      'Keine Secrets exponiert';
+
+  @override
+  String get settingsWorkspaceProviderStackFailClosedLabel => 'Fail-closed';
+
+  @override
+  String get settingsWorkspaceProviderStackFailClosedValue =>
+      'Sicher deaktiviert';
+
+  @override
+  String get settingsWorkspaceProviderStackReviewValue => 'Prüfen';
+
+  @override
+  String get settingsWorkspaceProviderStackProviderLabel => 'Provider';
+
+  @override
+  String get settingsWorkspaceProviderStackStateLabel => 'Status';
+
+  @override
+  String get settingsWorkspaceProviderStackReadinessLabel => 'Bereitschaft';
 
   @override
   String get settingsServerConfigurationDescription =>

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -621,6 +621,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String channelWorkspaceProviderReadiness(String readinessId) {
+    return 'Provider readiness: $readinessId';
+  }
+
+  @override
   String channelWorkspaceExplicitContextNote(String channelName) {
     return 'Only explicit context from $channelName is shown here; Weave does not continuously read the room in the background.';
   }
@@ -1560,6 +1565,62 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get settingsWorkspaceInvalidationBackendApiBaseUrlChanged =>
       'Backend API URL changed';
+
+  @override
+  String get settingsWorkspaceProviderStackTitle => 'Provider stack readiness';
+
+  @override
+  String get settingsWorkspaceProviderStackDescription =>
+      'Optional DevOps, Office, Forms, and Contacts providers are exposed only through backend-owned facades and stay fail-closed when disabled.';
+
+  @override
+  String get settingsWorkspaceProviderStackUnavailable =>
+      'Provider readiness is unavailable until the backend registry can be read.';
+
+  @override
+  String get settingsWorkspaceProviderStackError =>
+      'Provider readiness could not be loaded from the Weave backend.';
+
+  @override
+  String get settingsWorkspaceProviderStackBackendFacadeLabel =>
+      'Backend facade';
+
+  @override
+  String get settingsWorkspaceProviderStackBackendFacadeValue =>
+      'Backend-owned';
+
+  @override
+  String get settingsWorkspaceProviderStackFlutterBoundaryLabel =>
+      'Flutter boundary';
+
+  @override
+  String get settingsWorkspaceProviderStackFlutterBoundaryValue =>
+      'Direct provider calls blocked';
+
+  @override
+  String get settingsWorkspaceProviderStackSupportSafeLabel => 'Support safety';
+
+  @override
+  String get settingsWorkspaceProviderStackSupportSafeValue =>
+      'No secrets exposed';
+
+  @override
+  String get settingsWorkspaceProviderStackFailClosedLabel => 'Fail-closed';
+
+  @override
+  String get settingsWorkspaceProviderStackFailClosedValue => 'Disabled safely';
+
+  @override
+  String get settingsWorkspaceProviderStackReviewValue => 'Review';
+
+  @override
+  String get settingsWorkspaceProviderStackProviderLabel => 'Provider';
+
+  @override
+  String get settingsWorkspaceProviderStackStateLabel => 'State';
+
+  @override
+  String get settingsWorkspaceProviderStackReadinessLabel => 'Readiness';
 
   @override
   String get settingsServerConfigurationDescription =>

--- a/test/features/app/release_golden_paths_test.dart
+++ b/test/features/app/release_golden_paths_test.dart
@@ -6,6 +6,7 @@ import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provid
 import 'package:weave/core/persistence/flutter_secure_store.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
 import 'package:weave/features/app/presentation/providers/workspace_connection_provider.dart';
@@ -231,6 +232,71 @@ class _StaticWeaveApiClient implements WeaveApiClient {
           'fail_closed_until_audit_consent_and_matrix_e2ee_client_identity_are_implemented',
     );
   }
+
+  @override
+  Future<ProviderStackStatus> fetchProviderStackStatus({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return const ProviderStackStatus(
+      releaseStatus: 'provider-stack-contract-preview',
+      backendOwnedFacades: true,
+      flutterDirectProviderCallsAllowed: false,
+      supportSafe: true,
+      providers: <ProviderReadiness>[],
+    );
+  }
+
+  @override
+  Future<DevopsChannelSummary> fetchDevopsSummary({
+    required Uri baseUrl,
+    required String accessToken,
+    required String workspaceId,
+    required String channelId,
+  }) async {
+    return const DevopsChannelSummary(
+      workspaceId: 'workspace-default',
+      channelId: 'general',
+      releaseStatus: 'provider-stack-contract-preview',
+      readOnly: true,
+      paidFeaturesRequired: false,
+      supportSafe: true,
+      providerReadiness: <ProviderReadiness>[],
+    );
+  }
+
+  @override
+  Future<OfficeCapabilities> fetchOfficeCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return const OfficeCapabilities(
+      releaseStatus: 'provider-stack-contract-preview',
+      enabled: false,
+      configured: false,
+      supportSafe: true,
+      launchMode: 'unavailable',
+      defaultProvider: 'onlyoffice',
+      providerReadiness: <ProviderReadiness>[],
+      supportedFileTypes: <String>{},
+      permissions: OfficePermissionModel(
+        canView: false,
+        canEdit: false,
+        canComment: false,
+        canReview: false,
+        canFillForms: false,
+        reason: 'office-provider-disabled',
+      ),
+    );
+  }
+
+  @override
+  Future<void> launchOfficeSession({
+    required Uri baseUrl,
+    required String accessToken,
+    required String fileId,
+    required String requestedMode,
+  }) async {}
 }
 
 void main() {

--- a/test/features/app/weave_app_backend_capability_flow_test.dart
+++ b/test/features/app/weave_app_backend_capability_flow_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/core/persistence/flutter_secure_store.dart';
 import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/auth/data/dtos/auth_session_dto.dart';
 import 'package:weave/features/auth/data/repositories/oidc_auth_session_repository.dart';
@@ -133,6 +134,100 @@ class _RecordingWeaveApiClient implements WeaveApiClient {
           'fail_closed_until_audit_consent_and_matrix_e2ee_client_identity_are_implemented',
     );
   }
+
+  @override
+  Future<ProviderStackStatus> fetchProviderStackStatus({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return const ProviderStackStatus(
+      releaseStatus: 'provider-stack-contract-preview',
+      backendOwnedFacades: true,
+      flutterDirectProviderCallsAllowed: false,
+      supportSafe: true,
+      providers: <ProviderReadiness>[
+        ProviderReadiness(
+          module: 'office',
+          providerKey: 'onlyoffice',
+          state: 'disabled',
+          readiness: 'unavailable',
+          enabled: false,
+          configured: false,
+          readOnly: true,
+          failClosed: true,
+          supportSafe: true,
+          summary: 'ONLYOFFICE is disabled by default and launch is blocked.',
+          supportedCapabilities: <String>{},
+          unsupportedOperations: <String>{'launch'},
+        ),
+        ProviderReadiness(
+          module: 'source-control',
+          providerKey: 'gitlab-ce',
+          state: 'disabled',
+          readiness: 'unavailable',
+          enabled: false,
+          configured: false,
+          readOnly: true,
+          failClosed: true,
+          supportSafe: true,
+          summary: 'GitLab CE is profiled out by default.',
+          supportedCapabilities: <String>{},
+          unsupportedOperations: <String>{'clone'},
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<DevopsChannelSummary> fetchDevopsSummary({
+    required Uri baseUrl,
+    required String accessToken,
+    required String workspaceId,
+    required String channelId,
+  }) async {
+    return const DevopsChannelSummary(
+      workspaceId: 'workspace-default',
+      channelId: 'general',
+      releaseStatus: 'provider-stack-contract-preview',
+      readOnly: true,
+      paidFeaturesRequired: false,
+      supportSafe: true,
+      providerReadiness: <ProviderReadiness>[],
+    );
+  }
+
+  @override
+  Future<OfficeCapabilities> fetchOfficeCapabilities({
+    required Uri baseUrl,
+    required String accessToken,
+  }) async {
+    return const OfficeCapabilities(
+      releaseStatus: 'provider-stack-contract-preview',
+      enabled: false,
+      configured: false,
+      supportSafe: true,
+      launchMode: 'unavailable',
+      defaultProvider: 'onlyoffice',
+      providerReadiness: <ProviderReadiness>[],
+      supportedFileTypes: <String>{},
+      permissions: OfficePermissionModel(
+        canView: false,
+        canEdit: false,
+        canComment: false,
+        canReview: false,
+        canFillForms: false,
+        reason: 'office-provider-disabled',
+      ),
+    );
+  }
+
+  @override
+  Future<void> launchOfficeSession({
+    required Uri baseUrl,
+    required String accessToken,
+    required String fileId,
+    required String requestedMode,
+  }) async {}
 }
 
 const _memberProfile = UserProfile(

--- a/test/features/chat/channel_workspace_test.dart
+++ b/test/features/chat/channel_workspace_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_status.dart';
 import 'package:weave/features/chat/domain/entities/channel_workspace.dart';
 import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 import 'package:weave/features/chat/presentation/providers/channel_workspace_preview_provider.dart';
@@ -34,8 +35,16 @@ void main() {
       'weave-files-channel-link',
     );
     expect(
+      preview.surface(ChannelWorkspaceSurfaceKind.files).providerReadinessId,
+      'office-provider-registry-pending',
+    );
+    expect(
       preview.surface(ChannelWorkspaceSurfaceKind.boards).providerContractId,
       'weave-boards-channel-link',
+    );
+    expect(
+      preview.surface(ChannelWorkspaceSurfaceKind.boards).providerReadinessId,
+      'devops-provider-registry-pending',
     );
     expect(
       preview.surface(ChannelWorkspaceSurfaceKind.calendar).availability,
@@ -59,6 +68,57 @@ void main() {
     expect(
       preview.meetingPreview.controls.every((control) => !control.enabled),
       isTrue,
+    );
+  });
+
+  test('projects provider fail-closed readiness into channel surfaces', () {
+    final preview = ChannelWorkspacePreview.forConversation(
+      channel,
+      providerStack: const ProviderStackStatus(
+        releaseStatus: 'provider-stack-contract-preview',
+        backendOwnedFacades: true,
+        flutterDirectProviderCallsAllowed: false,
+        supportSafe: true,
+        providers: <ProviderReadiness>[
+          ProviderReadiness(
+            module: 'office',
+            providerKey: 'onlyoffice-community',
+            state: 'disabled',
+            readiness: 'unavailable',
+            enabled: false,
+            configured: false,
+            readOnly: true,
+            failClosed: true,
+            supportSafe: true,
+            summary: 'Office launch is disabled safely.',
+            supportedCapabilities: <String>{},
+            unsupportedOperations: <String>{'launch'},
+          ),
+          ProviderReadiness(
+            module: 'source-control',
+            providerKey: 'gitlab-ce',
+            state: 'disabled',
+            readiness: 'unavailable',
+            enabled: false,
+            configured: false,
+            readOnly: true,
+            failClosed: true,
+            supportSafe: true,
+            summary: 'GitLab CE is profiled out by default.',
+            supportedCapabilities: <String>{},
+            unsupportedOperations: <String>{'clone'},
+          ),
+        ],
+      ),
+    );
+
+    expect(
+      preview.surface(ChannelWorkspaceSurfaceKind.files).providerReadinessId,
+      'office-provider-fail-closed',
+    );
+    expect(
+      preview.surface(ChannelWorkspaceSurfaceKind.boards).providerReadinessId,
+      'devops-provider-fail-closed',
     );
   });
 

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -247,6 +247,28 @@ void main() {
       },
     );
 
+    test('rejects malformed provider stack readiness entries', () async {
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((_) async {
+          return _jsonResponse({
+            'releaseStatus': 'provider-stack-contract-preview',
+            'backendOwnedFacades': true,
+            'flutterDirectProviderCallsAllowed': false,
+            'supportSafe': true,
+            'providers': ['not-a-provider-object'],
+          });
+        }),
+      );
+
+      await expectLater(
+        client.fetchProviderStackStatus(
+          baseUrl: Uri.parse('https://api.weave.local/api'),
+          accessToken: 'token-123',
+        ),
+        throwsA(isA<AppFailure>()),
+      );
+    });
+
     test('fetches DevOps summary through the backend facade', () async {
       late http.BaseRequest capturedRequest;
       final client = HttpWeaveApiClient(
@@ -293,6 +315,32 @@ void main() {
       expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
       expect(summary.isUnavailableFailClosed, isTrue);
       expect(summary.providerReadiness.single.providerKey, 'gitlab-ce');
+    });
+
+    test('rejects malformed DevOps provider readiness entries', () async {
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((_) async {
+          return _jsonResponse({
+            'workspaceId': 'workspace-default',
+            'channelId': 'general',
+            'releaseStatus': 'provider-stack-contract-preview',
+            'readOnly': true,
+            'paidFeaturesRequired': false,
+            'supportSafe': true,
+            'providerReadiness': ['not-a-provider-object'],
+          });
+        }),
+      );
+
+      await expectLater(
+        client.fetchDevopsSummary(
+          baseUrl: Uri.parse('https://api.weave.local/api'),
+          accessToken: 'token-123',
+          workspaceId: 'workspace-default',
+          channelId: 'general',
+        ),
+        throwsA(isA<AppFailure>()),
+      );
     });
 
     test(

--- a/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -188,6 +188,188 @@ void main() {
     });
 
     test(
+      'fetches provider stack readiness through the backend facade',
+      () async {
+        late http.BaseRequest capturedRequest;
+        final client = HttpWeaveApiClient(
+          httpClient: _RecordingHttpClient((request) async {
+            capturedRequest = request;
+            return _jsonResponse({
+              'releaseStatus': 'provider-stack-contract-preview',
+              'backendOwnedFacades': true,
+              'flutterDirectProviderCallsAllowed': false,
+              'supportSafe': true,
+              'generatedAt': '2026-05-22T18:47:00Z',
+              'providers': [
+                {
+                  'module': 'office',
+                  'providerKey': 'onlyoffice-community',
+                  'state': 'not_configured',
+                  'readiness': 'not_configured',
+                  'enabled': false,
+                  'configured': false,
+                  'readOnly': true,
+                  'failClosed': true,
+                  'supportSafe': true,
+                  'paidFeaturesRequired': false,
+                  'summary': 'Office provider is not configured.',
+                  'supportedCapabilities': ['view', 'edit'],
+                  'unsupportedOperations': [
+                    'credential-bearing-url',
+                    'raw-provider-errors',
+                  ],
+                  'supportSafeErrorCodes': ['office-provider-not-configured'],
+                  'redactionPolicy': 'support-safe',
+                  'candidates': ['onlyoffice-community'],
+                  'diagnostics': {'defaultProvider': 'onlyoffice-community'},
+                },
+              ],
+            });
+          }),
+        );
+
+        final status = await client.fetchProviderStackStatus(
+          baseUrl: Uri.parse('https://api.weave.local/api'),
+          accessToken: 'token-123',
+        );
+
+        expect(
+          capturedRequest.url.toString(),
+          'https://api.weave.local/api/providers/status',
+        );
+        expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
+        expect(status.backendOwnedFacades, isTrue);
+        expect(status.flutterDirectProviderCallsAllowed, isFalse);
+        expect(status.supportSafe, isTrue);
+        expect(status.allOptionalProvidersFailClosed, isTrue);
+        expect(status.providers.single.module, 'office');
+        expect(status.providers.single.failClosed, isTrue);
+      },
+    );
+
+    test('fetches DevOps summary through the backend facade', () async {
+      late http.BaseRequest capturedRequest;
+      final client = HttpWeaveApiClient(
+        httpClient: _RecordingHttpClient((request) async {
+          capturedRequest = request;
+          return _jsonResponse({
+            'workspaceId': 'workspace-default',
+            'channelId': 'general',
+            'releaseStatus': 'provider-stack-contract-preview',
+            'readOnly': true,
+            'paidFeaturesRequired': false,
+            'supportSafe': true,
+            'providerReadiness': [
+              {
+                'module': 'source-control',
+                'providerKey': 'gitlab-ce',
+                'state': 'disabled',
+                'readiness': 'unavailable',
+                'enabled': false,
+                'configured': false,
+                'readOnly': true,
+                'failClosed': true,
+                'supportSafe': true,
+                'summary': 'GitLab CE is profiled out by default.',
+                'supportedCapabilities': [],
+                'unsupportedOperations': ['clone'],
+              },
+            ],
+          });
+        }),
+      );
+
+      final summary = await client.fetchDevopsSummary(
+        baseUrl: Uri.parse('https://api.weave.local/api'),
+        accessToken: 'token-123',
+        workspaceId: 'workspace-default',
+        channelId: 'general',
+      );
+
+      expect(
+        capturedRequest.url.toString(),
+        'https://api.weave.local/api/workspaces/workspace-default/channels/general/devops/summary',
+      );
+      expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
+      expect(summary.isUnavailableFailClosed, isTrue);
+      expect(summary.providerReadiness.single.providerKey, 'gitlab-ce');
+    });
+
+    test(
+      'fetches Office capabilities and refuses launch fail-closed',
+      () async {
+        final requests = <http.BaseRequest>[];
+        final client = HttpWeaveApiClient(
+          httpClient: _RecordingHttpClient((request) async {
+            requests.add(request);
+            if (request.method == 'POST') {
+              return _jsonResponse({'status': 'blocked'}, statusCode: 409);
+            }
+            return _jsonResponse({
+              'releaseStatus': 'provider-stack-contract-preview',
+              'enabled': false,
+              'configured': false,
+              'supportSafe': true,
+              'launchMode': 'unavailable',
+              'defaultProvider': 'onlyoffice-community',
+              'providerReadiness': [
+                {
+                  'module': 'office',
+                  'providerKey': 'onlyoffice-community',
+                  'state': 'disabled',
+                  'readiness': 'unavailable',
+                  'enabled': false,
+                  'configured': false,
+                  'readOnly': true,
+                  'failClosed': true,
+                  'supportSafe': true,
+                  'summary': 'Office provider is disabled.',
+                  'supportedCapabilities': [],
+                  'unsupportedOperations': ['launch'],
+                },
+              ],
+              'supportedFileTypes': [],
+              'permissions': {
+                'canView': false,
+                'canEdit': false,
+                'canComment': false,
+                'canReview': false,
+                'canFillForms': false,
+                'reason': 'office-provider-disabled',
+              },
+            });
+          }),
+        );
+
+        final capabilities = await client.fetchOfficeCapabilities(
+          baseUrl: Uri.parse('https://api.weave.local/api'),
+          accessToken: 'token-123',
+        );
+
+        expect(
+          requests.single.url.toString(),
+          'https://api.weave.local/api/office/capabilities',
+        );
+        expect(capabilities.isUnavailableFailClosed, isTrue);
+
+        await expectLater(
+          client.launchOfficeSession(
+            baseUrl: Uri.parse('https://api.weave.local/api'),
+            accessToken: 'token-123',
+            fileId: 'file-1',
+            requestedMode: 'edit',
+          ),
+          throwsA(isA<AppFailure>()),
+        );
+        expect(
+          requests.last.url.toString(),
+          'https://api.weave.local/api/office/launch',
+        );
+        expect(requests.last.headers['Authorization'], 'Bearer token-123');
+      },
+    );
+
+    test(
       'rejects unauthorized backend sessions with a dedicated failure',
       () async {
         for (final statusCode in [401, 403]) {

--- a/test/live_stack_contract_test.dart
+++ b/test/live_stack_contract_test.dart
@@ -90,6 +90,52 @@ void main() {
       );
     });
 
+    test('provider stack readiness stays behind the Weave backend facade', () {
+      expect(
+        liveConfig.apiUri('/api/providers/status').toString(),
+        'https://api.weave.local/api/providers/status',
+      );
+      expect(
+        liveConfig.apiUri('/api/profile/readiness').toString(),
+        'https://api.weave.local/api/profile/readiness',
+      );
+    });
+
+    test(
+      'direct Flutter provider calls remain blocked for optional provider stack modules',
+      () async {
+        final forbiddenFragments = <String>[
+          '/api/v3/',
+          '/work_packages',
+          'openproject.example',
+          'openproject.weave.local',
+          'gitlab.com/api',
+          'forgejo/api',
+          'onlyoffice',
+          'collabora-code',
+          'nextcloud/forms',
+          'carddav',
+        ];
+
+        final offenders = <String>[];
+        for (final file in _productionDartFiles()) {
+          final content = await file.readAsString();
+          for (final fragment in forbiddenFragments) {
+            if (content.toLowerCase().contains(fragment.toLowerCase())) {
+              offenders.add('${file.path}: $fragment');
+            }
+          }
+        }
+
+        expect(
+          offenders,
+          isEmpty,
+          reason:
+              'Flutter must call backend facades such as /api/providers/status and /profile/readiness, not provider APIs directly.',
+        );
+      },
+    );
+
     test(
       'shell readiness contract can be exercised without live auth',
       () async {
@@ -236,6 +282,89 @@ void main() {
     }
   }, skip: liveSkipReason);
 
+  test('authenticated GET /api/providers/status returns fail-closed provider '
+      'readiness', () async {
+    final accessToken = await authHelper.signIn(config);
+
+    final response = await httpClient.get(
+      config.apiUri('/api/providers/status'),
+      headers: <String, String>{
+        'Accept': 'application/json',
+        'Authorization': 'Bearer $accessToken',
+      },
+    );
+
+    expect(response.statusCode, 200, reason: response.body);
+    final payload = _decodeObject(response.body);
+    expect(payload['backendOwnedFacades'], isTrue);
+    expect(payload['flutterDirectProviderCallsAllowed'], isFalse);
+    expect(payload['supportSafe'], isTrue);
+
+    final providers = (payload['providers'] as List).cast<Map>();
+    final modules = providers.map((provider) => provider['module']).toSet();
+    expect(
+      modules,
+      containsAll(<String>[
+        'office',
+        'contacts',
+        'forms',
+        'source-control',
+        'issue-tracker',
+        'ci',
+        'release',
+      ]),
+    );
+    for (final provider in providers.where(
+      (provider) => <String>{
+        'office',
+        'contacts',
+        'forms',
+        'source-control',
+        'issue-tracker',
+        'ci',
+        'release',
+      }.contains(provider['module']),
+    )) {
+      expect(provider['enabled'], isFalse, reason: '$provider');
+      expect(provider['configured'], isFalse, reason: '$provider');
+      expect(provider['failClosed'], isTrue, reason: '$provider');
+      expect(provider['supportSafe'], isTrue, reason: '$provider');
+    }
+
+    expect(
+      response.body,
+      isNot(
+        matches(
+          RegExp(r'Authorization|api[_-]?token|/api/v3/', caseSensitive: false),
+        ),
+      ),
+    );
+  }, skip: liveSkipReason);
+
+  test(
+    'authenticated GET /api/profile/readiness returns CEFACADE readiness',
+    () async {
+      final accessToken = await authHelper.signIn(config);
+
+      final response = await httpClient.get(
+        config.apiUri('/api/profile/readiness'),
+        headers: <String, String>{
+          'Accept': 'application/json',
+          'Authorization': 'Bearer $accessToken',
+        },
+      );
+
+      expect(response.statusCode, 200, reason: response.body);
+      final payload = _decodeObject(response.body);
+      expect(payload['contractId'], 'CEFACADE');
+      expect(payload['endpoint'], '/profile/readiness');
+      expect(payload['backendOwnedFacade'], isTrue);
+      expect(payload['directProviderCallsAllowed'], isFalse);
+      expect(payload['supportSafe'], isTrue);
+    },
+    skip: liveSkipReason,
+  );
+
   test(
     'backend unavailable -> backend client surfaces unreachable failure',
     () async {
@@ -308,6 +437,20 @@ Map<String, dynamic> _decodeObject(String body) {
   }
 
   return decoded;
+}
+
+List<File> _productionDartFiles() {
+  final lib = Directory('lib');
+  if (!lib.existsSync()) {
+    return const <File>[];
+  }
+
+  return lib
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((file) => file.path.endsWith('.dart'))
+      .where((file) => !file.path.contains('/l10n/generated/'))
+      .toList(growable: false);
 }
 
 class _MemoryServerConfigurationRepository

--- a/test/live_stack_feature_mapping_test.dart
+++ b/test/live_stack_feature_mapping_test.dart
@@ -32,6 +32,7 @@ void main() {
           'Matrix chat sends and reads a workspace message',
           'Matrix encryption status is proved honestly',
           'Files are uploaded, shown, downloaded, and cleaned up in Weave',
+          'Provider stack readiness is visible and fail-closed through Weave',
           'Channel calendar events keep their meeting thread reference',
           'Boards preview supports accessible non-drag task work',
         ]),


### PR DESCRIPTION
## Summary
- wire `/api/providers/status` into the Flutter backend facade client and settings/channel readiness surfaces
- add deterministic Gherkin mapping plus live E2E `PROVIDER_STACK_RESULT` evidence for provider-stack readiness
- add offline/live contract gates proving optional provider readiness stays backend-owned, fail-closed, support-safe, and free of direct Flutter provider calls

## E2E / Gherkin / runner evidence
- `acceptance/live_stack_app.feature` adds `@weave-live-provider-stack-readiness`
- `acceptance/scenario_mappings.json` maps the scenario to `integration_test/live_stack_app_e2e_test.dart` with `PROVIDER_STACK_RESULT`
- `.github/workflows/live-stack-e2e.yml` already runs `make integration-test`, so the new marker is collected by the existing live-stack runner

## Validation
- `flutter analyze`
- `make offline-contract-test`
- `flutter test test/live_stack_feature_mapping_test.dart test/live_stack_contract_test.dart test/features/app/weave_app_backend_capability_flow_test.dart test/features/app/release_golden_paths_test.dart test/integrations/weave_api/data/services/weave_api_client_test.dart`

## Contract impact
- Flutter reads provider readiness only via the Weave backend facade (`/api/providers/status`, `/api/profile/readiness`).
- Direct provider API calls remain blocked in production Dart code by contract tests.
- Live provider runtimes remain optional/profiled; this PR adds fail-closed readiness proof rather than enabling heavyweight providers by default.

## Dependencies / blockers
- Requires backend provider registry/profile readiness contracts from weave-backend PR #109.
- Full live-stack E2E still requires the self-hosted runner prerequisites and real `WEAVE_TEST_USERNAME`/`WEAVE_TEST_PASSWORD` secrets.
