### PR TITLE
docs: refresh Weave product positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,46 @@
   <a href="https://github.com/masssi164/weave/actions/workflows/live-stack-e2e.yml"><img src="https://github.com/masssi164/weave/actions/workflows/live-stack-e2e.yml/badge.svg" alt="Live Stack E2E workflow status"></a>
 </p>
 
-Weave is an accessibility-first collaboration client for teams that want modern work tools without giving up data sovereignty. It brings setup, sign-in, chat, files, and workspace settings into one Flutter app backed by self-hosted services such as Matrix, Nextcloud, Keycloak, and the Weave backend.
+**Accessible collaboration, under your control.**
 
-The goal is simple: give teams and organizations a humane migration path away from closed team suites while keeping the product experience cohesive, professional, and understandable for admins and end users.
+Weave is a self-hosted collaboration workspace for teams that need modern daily work tools without handing their data, identity, or accessibility standards to a closed suite. The Flutter app turns Matrix, Nextcloud, Keycloak, and the Weave backend into one coherent product experience for setup, sign-in, chat, files, readiness, and workspace settings.
 
-## Why Weave
+Weave is not a raw bundle of provider UIs and it is not claiming to be a finished Slack or Microsoft Teams clone. It is an active product-maturity build with honest feature gates: usable surfaces are shown as usable, guarded previews are labelled as guarded, and unsafe provider paths fail closed.
 
-- **Accessibility built into the core** — critical flows are designed around large touch targets, semantic labels, keyboard/screen-reader behavior, and clear error states. Formal accessibility claims should stay tied to documented audits and evidence.
-- **Data-sovereign collaboration** — Matrix and Nextcloud provide open protocol/data foundations behind a Weave-owned user experience.
-- **One product, not separate islands** — sign-in, profile, navigation, diagnostics, chat, files, and settings are designed to feel like one workspace.
-- **Migration-friendly** — Slack and Microsoft Teams interop are planned as controlled backend-owned migration and bridge paths, not as client-side shortcuts.
-- **Built for later personal agents** — the long-term direction includes Weaver PA: an OpenClaw-style per-user agent runtime with organization-governed skills, connectors, and group-chat agents. This is later scope, not part of the current active product track.
+## What Weave is for
 
-## Current status
+- Privacy-sensitive teams, clubs, small organizations, public-sector/NGO/health/education groups, and self-hosters who want one polished front door over open collaboration services.
+- Operators who need repeatable deployment, health checks, readiness states, backups, and support diagnostics without exposing secrets.
+- Users who need an accessible workspace shell with clear recovery states instead of scattered admin/protocol screens.
 
-Weave is on an active product-maturity track. The showcased client surfaces are the parts that contributors can evaluate directly today: guided setup, service endpoint review, custom chat, basic files, and workspace settings. Calendar, Matrix E2EE completion, boards/tasks, production bridges, public connector SDKs, and Weaver PA remain behind explicit contracts, feature gates, or later roadmap boundaries until their evidence is complete.
+## Product pillars
 
-The live-stack contract now proves selected end-to-end behavior through CI artifacts, while the default pull-request path stays offline and inexpensive. See [Quality and acceptance evidence](docs/quality-and-evidence.md) for what each gate proves and how to interpret failures.
+- **Accessible workspace shell:** setup, sign-in, navigation, settings, recovery states, semantic labels, keyboard/screen-reader-friendly flows, and non-color-only status.
+- **Sovereign collaboration:** Matrix-backed chat and Nextcloud-backed files/calendar foundations, presented through Weave-owned UX instead of raw provider screens.
+- **Backend-owned provider boundary:** Flutter talks to `weave-backend` product APIs. It does not call GitLab, Forgejo, OpenProject, ONLYOFFICE, Collabora, Nextcloud admin APIs, or other provider runtimes directly.
+- **Honest readiness:** provider status, capability snapshots, degraded states, and fail-closed errors are visible without leaking backend actor tokens, provider URLs, raw errors, or secrets.
+- **Operator-grade validation:** offline checks stay cheap for normal PRs; live-stack E2E runs only when the full stack and runner budget are explicitly available.
 
-Current focus areas:
+## Available now
 
-- **Dependable Chat + Matrix E2EE architecture** — a custom Weave Matrix client surface with accessible message states, explicit retry/recovery affordances, and native Matrix E2EE as active architecture scope. E2EE claims stay tied to real device, verification, key backup/recovery, and metadata-boundary validation.
-- **Explorer-grade Files** — a Weave files experience backed by the product backend and Nextcloud/WebDAV/OCS contracts, with clearer metadata, actions, and recovery states.
-- **Consistent recovery UX** — shared loading, empty, error, success, and retry patterns so setup, chat, files, settings, and gated surfaces do not end in cryptic dead states.
-- **Teams-like shared Calendar** — Calendar follows the collaboration hierarchy: workspace/org calendar, team calendars, and channel events/meeting threads. The guarded live-stack path now validates shared scope metadata and channel event CRUD through the backend facade; private personal calendar ingestion is not a product goal.
-- **Settings, OIDC sign-in, and in-app Help** — setup, authentication, stored server configuration, account/session controls, and the localized Help/user handbook remain part of the daily product shell.
+The current app lets contributors evaluate these product surfaces directly:
 
-Weave still does **not** claim a complete Teams/Slack replacement, public connector SDK, production Slack/Teams bridge, private personal calendar provisioning, or Weaver PA. Matrix E2EE and Boards are active scope behind explicit contracts and feature flags; claims must remain tied to validated implementation state.
+- guided workspace setup and service endpoint review;
+- OIDC sign-in and persisted server configuration;
+- custom Matrix chat shell with explicit recovery/retry states;
+- backend-facade files browsing and actions;
+- settings/profile/session controls;
+- workspace, Matrix E2EE, and provider-stack readiness views that stay support-safe.
+
+## Guarded previews and non-goals
+
+These areas are active product scope but deliberately gated:
+
+- **Shared calendars:** workspace, team, and channel scheduling through backend facades. Private personal calendar ingestion is not a product goal.
+- **Boards/tasks:** provider-neutral Weave UX and backend contracts first. OpenProject is the preferred read-only provider validation path; Vikunja and Deck stay comparison/fallback research until a later contract promotes them.
+- **Matrix E2EE:** active architecture path, not a completed claim. Weave must validate encrypted rooms, device verification, key backup/recovery, multi-device behavior, metadata boundaries, and accessibility before claiming production readiness.
+- **Interop/connectors:** Slack/Teams/connector routes default off and remain backend-owned. No client-side provider shortcuts.
+- **Personal agents/automation:** later roadmap, not README hero scope.
 
 ## Product screenshots
 
@@ -57,144 +70,41 @@ A first look at the active product-maturity experience: guided setup, service re
 
 [<img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screenshot showing OIDC issuer, client ID, Nextcloud URL, and account session controls." width="560">](docs/assets/marketing/05-settings.svg)
 
-Regenerate screenshots with `make marketing-screenshots` and review the SVG diff before committing. Additional gated surfaces are documented separately in [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md) so the main showcase does not overclaim unfinished product areas.
+Regenerate screenshots with `make marketing-screenshots` and review the SVG diff before committing. Additional gated surfaces are documented in [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md) so the main showcase does not overclaim unfinished product areas.
 
-## Quick start for contributors
+## Cross-repo architecture
 
-Start with the [Developer handbook](docs/developer-handbook.md) for the complete workflow. The minimal offline path is:
+Weave is developed across three repositories:
 
-```sh
-flutter pub get
-flutter gen-l10n
-dart run build_runner build --delete-conflicting-outputs
-dart format --output=none --set-exit-if-changed .
-flutter analyze --fatal-infos
-flutter test
-make offline-contract-test
-```
+- [`weave`](https://github.com/masssi164/weave): Flutter client, app shell, accessibility, chat/files/settings UX, provider-readiness presentation, and app tests.
+- [`weave-backend`](https://github.com/masssi164/weave-backend): Spring Boot product API/BFF, JWT validation, profile/files/calendar/provider facades, readiness, support-safe errors, and backend contracts.
+- [`weave-infra`](https://github.com/masssi164/weave-infra): Docker/Terraform stack, Caddy routing, Keycloak, Matrix/Synapse/MAS, Nextcloud, optional provider runtimes, backups, smoke checks, and live E2E environment.
 
-Use [`weave-infra`](https://github.com/masssi164/weave-infra) only when a change requires live-stack validation. The expensive live path and its acceptance artifacts are described in [Quality and acceptance evidence](docs/quality-and-evidence.md) and [Acceptance contracts](docs/acceptance-contracts.md).
+Responsibility split:
 
-## Roadmap honesty
+- Keycloak owns identity.
+- Matrix owns chat protocol and Matrix-native auth/E2EE foundations.
+- Nextcloud owns files/calendar storage foundations.
+- Weave backend owns product APIs, readiness, server-side facades, secret boundaries, error envelopes, audit/consent seams, and provider gating.
+- Weave Flutter owns the daily product experience and must stay on backend-owned product contracts.
+- Caddy and infrastructure own routing, TLS, deployment, smoke checks, backups, restore smoke, and support diagnostics.
 
-Weave does **not** claim a complete Teams/Slack replacement, public connector SDK, production Slack/Teams bridge, private personal calendar provisioning, completed Matrix E2EE UX, or Weaver PA. Current roadmap surfaces and gated evidence are kept in [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md) and [Product scope: calendar hierarchy, Matrix E2EE, and Boards](docs/product-calendar-e2ee-boards-scope.md).
+For details, see:
 
-## Product architecture
+- [Flutter architecture](docs/architecture.md)
+- [Developer handbook](docs/developer-handbook.md)
+- [Quality and acceptance evidence](docs/quality-and-evidence.md)
+- [Acceptance contracts](docs/acceptance-contracts.md)
+- [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md)
 
-Weave is the Flutter client in a three-repository product system:
-
-| Repository | Owns |
-| --- | --- |
-| [`weave`](https://github.com/masssi164/weave) | Flutter mobile/desktop client, app shell, custom chat/files/settings UX, accessibility, and client-side tests. |
-| [`weave-backend`](https://github.com/masssi164/weave-backend) | Spring Boot product API/BFF, auth validation, profile facade, files/calendar facades, readiness, and backend contracts. |
-| [`weave-infra`](https://github.com/masssi164/weave-infra) | Local/dev stack, Caddy routing, Keycloak, Matrix/Synapse/MAS, Nextcloud, Terraform, Docker orchestration, smoke/E2E environment. |
-| `specs/` (workspace sibling) | Binding cross-repo product and architecture contracts when this repository is checked out in the full workspace. |
-
-The Weave product should feel like one collaboration platform even though sovereign modules sit behind it:
-
-- **Keycloak** is the identity authority.
-- **Weave backend** is the product-facing API/BFF after sign-in.
-- **Matrix** provides chat protocol and storage.
-- **Nextcloud** provides files and calendar data foundations behind product-owned Weave surfaces.
-- **Caddy** exposes the local/dev HTTPS gateway.
-
-For the detailed Flutter architecture, see [docs/architecture.md](docs/architecture.md). The binding active product scope for Teams-like Calendar, Matrix E2EE, and Boards is [docs/product-calendar-e2ee-boards-scope.md](docs/product-calendar-e2ee-boards-scope.md). For the later interop direction, see [docs/interop-gateway-and-external-collaboration.md](docs/interop-gateway-and-external-collaboration.md). For boards/tasks provider research, see [docs/research/boards-task-module-provider-strategy.md](docs/research/boards-task-module-provider-strategy.md) and [docs/research/boards-task-domain-contract.md](docs/research/boards-task-domain-contract.md).
-
-## Current client foundation
-
-The app starts through an explicit bootstrap phase before the router is built. Startup resolves into one of:
-
-- `loading`
-- `needsSetup`
-- `needsSignIn`
-- `ready`
-- `error`
-
-Setup and Settings share one persisted server configuration model:
-
-- OIDC provider type
-- OIDC issuer URL
-- infra-managed OIDC app client ID, defaulting to `weave-app`
-- Matrix homeserver URL
-- Nextcloud/files base URL
-- backend API base URL
-
-App OIDC redirect handling is aligned to the infrastructure contract:
-
-- sign-in redirect URI: `com.massimotter.weave:/oauthredirect`
-- logout redirect URI: `com.massimotter.weave:/logout`
-
-For local development stacks, Weave accepts `http://` issuer and service URLs in addition to `https://`.
-
-Default local/dev surfaces are:
-
-| Surface | URL |
-| --- | --- |
-| Product shell/admin entry | `https://weave.local` |
-| Backend API/BFF | `https://api.weave.local/api` |
-| Auth | `https://auth.weave.local` |
-| Matrix | `https://matrix.weave.local` |
-| Raw Nextcloud/admin/protocol fallback | `https://files.weave.local` |
-
-## Code layout
-
-Weave follows a feature-first clean architecture layout:
-
-```text
-lib/
-├── core/
-│   ├── bootstrap/    # App start resolution before routing
-│   ├── failures/     # Shared app-level error model
-│   ├── persistence/  # Secure/non-secure storage boundaries
-│   ├── router/       # go_router setup and route constants
-│   ├── theme/
-│   └── widgets/
-├── integrations/     # Shared external-service/platform boundaries
-└── features/
-    ├── auth/
-    ├── chat/
-    ├── files/
-    ├── calendar/
-    ├── onboarding/
-    ├── server_config/
-    └── settings/
-```
-
-Inside each feature:
-
-- `presentation/` contains screens, widgets, and Riverpod UI state.
-- `domain/` contains entities and repository contracts.
-- `data/` contains repository implementations, persistence adapters, DTOs, and protocol/service clients.
-
-Shared integrations use the same layering under `lib/integrations/<integration>/` when multiple features need the same protocol or platform boundary.
-
-## Accessibility baseline
-
-Accessibility is a release requirement, not polish:
-
-- interactive targets must be at least `48x48` logical pixels;
-- icon-only actions must expose semantics labels;
-- complex layouts must keep a predictable reading order;
-- setup, sign-in, shell navigation, chat, files, settings, and error states must remain screen-reader friendly;
-- user-facing failures should be plain-language and actionable.
-
-## Development
-
-For the full contributor workflow, read the [Developer handbook](docs/developer-handbook.md). It covers local setup, generated code, l10n, clean architecture conventions, accessibility, acceptance evidence, screenshot generation, and cross-repo boundaries.
-
-### Prerequisites
-
-- [Flutter SDK](https://docs.flutter.dev/get-started/install)
-- A local Weave stack from [`weave-infra`](https://github.com/masssi164/weave-infra) for live integration and E2E tests
-
-### Run locally
+## Local development
 
 ```sh
 flutter pub get
 flutter run
 ```
 
-### Lightweight validation
+Full lightweight validation:
 
 ```sh
 flutter pub get
@@ -206,25 +116,11 @@ flutter test
 make offline-contract-test
 ```
 
-### Marketing screenshots
+## Live stack and E2E
 
-Marketing/README screenshots are deterministic SVG assets generated from a small checked-in script, not pixel-perfect goldens. This keeps normal PR validation focused on behavior while still making docs imagery reproducible and reviewable.
+Use [`weave-infra`](https://github.com/masssi164/weave-infra) when a change needs real Keycloak, Matrix, Nextcloud, backend, or provider-stack evidence.
 
-```sh
-make marketing-screenshots
-```
-
-The command regenerates the product-maturity setup, endpoint review, chat, files, and settings images in `docs/assets/marketing/`, plus guarded roadmap visuals in `docs/assets/roadmap/`. CI runs the generator and fails if the checked-in assets drift. In GitHub Actions, run the `CI` workflow manually with `capture_marketing_screenshots=true` to also download the `weave-marketing-screenshots` artifact.
-
-When adding selected images to the README or docs, keep nearby prose and descriptive `alt` text so the documentation is not image-only.
-
-## Live stack and integration tests
-
-Integration tests require a live local Weave stack, including the backend API and Keycloak OIDC provider. Start the stack from the `weave-infra` setup first, with local hostnames resolving to the stack and the local CA trusted by the machine or simulator running the tests.
-
-The local stack writes reusable test settings to `weave-infra/weave-workspace/.generated/bootstrap.env`. The Make targets source that repo-local file by default. Use `WEAVE_BOOTSTRAP_ENV` when your infra checkout lives elsewhere; there is no implicit global `/tmp` fallback.
-
-Run against the default local stack:
+Default local stack flow:
 
 ```sh
 cd ../weave-infra/weave-workspace
@@ -233,35 +129,45 @@ cd ../../weave
 make integration-test
 ```
 
-Run against a different infra checkout:
+The local stack writes reusable test settings to `weave-infra/weave-workspace/.generated/bootstrap.env`. Override the path when using another checkout:
 
 ```sh
 WEAVE_BOOTSTRAP_ENV=../weave-infra/weave-workspace/.generated/bootstrap.env make integration-test
 ```
 
-The GitHub Actions live-stack path runs on a dedicated `self-hosted`, `macOS`, `ARM64`, `weave-live` runner and is manual-only through `workflow_dispatch` or explicit workflow reuse. Dispatch requires confirmation that the runner has enough power, storage, and maintenance budget.
+Useful targets:
 
-Useful test targets:
+- `make offline-contract-test`: automatic no-network contract gate.
+- `make integration-contract-test`: live-stack contract check requiring real test credentials.
+- `make integration-app-e2e` / `make integration-test`: expensive app-level live E2E targets for manual runs.
+- `make marketing-screenshots`: regenerate README/roadmap SVG assets.
 
-- `make offline-contract-test` — lightweight automatic/no-network contract gate.
-- `make integration-contract-test` — live-stack contract check requiring real test credentials.
-- `make integration-app-e2e` / `make integration-test` — expensive app-level live E2E targets for manual runs.
+The GitHub Actions live-stack path runs on a dedicated self-hosted macOS ARM64 runner and is manual-only. Dispatch requires confirmation that the runner has enough power, storage, and maintenance budget.
 
-Gherkin scenarios are product acceptance contracts, not decorative BDD. See
-[docs/acceptance-contracts.md](docs/acceptance-contracts.md) for the ATDD workflow,
-scenario-to-test mapping guard, and live-stack acceptance artifact contract.
+## Accessibility baseline
 
-Supported overrides:
+Accessibility is a release gate, not polish:
 
-- `WEAVE_API_BASE_URL`: canonical base URL for the Weave backend API, defaulting to `https://api.weave.local/api`
-- `WEAVE_BASE_URL`: legacy-compatible alias for `WEAVE_API_BASE_URL`
-- `WEAVE_OIDC_ISSUER_URL`: OIDC issuer URL, defaulting to `https://auth.weave.local/realms/weave`
-- `WEAVE_OIDC_CLIENT_ID`: app OIDC client ID, defaulting to `weave-app`
-- `WEAVE_NEXTCLOUD_BASE_URL`: canonical Nextcloud URL, defaulting to `files.<workspace-host>`; legacy `WEAVE_NEXTCLOUD_URL` is also accepted
-- `WEAVE_MATRIX_HOMESERVER_URL`: Matrix homeserver URL, defaulting to `matrix.<workspace-host>`; legacy `WEAVE_MATRIX_URL` is also accepted
-- `WEAVE_TEST_USERNAME`: username for the test account
-- `WEAVE_TEST_PASSWORD`: password for the test account
+- interactive targets are at least `48x48` logical pixels;
+- icon-only actions expose semantic labels;
+- complex layouts keep predictable reading order;
+- setup, sign-in, shell navigation, chat, files, settings, readiness, and error states remain screen-reader friendly;
+- status is never conveyed by color alone;
+- user-facing failures are plain-language and actionable.
 
-## Status and roadmap honesty
+## Code layout
 
-Weave is under active development. The active product track focuses on making the core client shell, chat, files, recovery states, Teams-like calendar, Matrix E2EE architecture, and boards/tasks honest and product-ready behind clear gates before broadening the surface. The roadmap is ambitious, but README claims should stay tied to implemented or explicitly future-scoped capabilities.
+```text
+lib/
+├── core/             # bootstrap, failure model, persistence, router, theme, shared widgets
+├── integrations/     # reusable backend/platform boundaries
+└── features/         # auth, chat, files, calendar, onboarding, settings, app shell
+```
+
+Inside each feature:
+
+- `presentation/`: screens, widgets, and Riverpod UI state.
+- `domain/`: entities and repository contracts.
+- `data/`: repositories, persistence adapters, DTOs, and service clients.
+
+Shared integrations follow the same layering under `lib/integrations/<integration>/` when multiple features need one protocol or platform boundary.

--- a/docs/accessibility-release-gate.md
+++ b/docs/accessibility-release-gate.md
@@ -1,14 +1,14 @@
-# Release 1 Accessibility Gate
+# Accessibility Release Gate
 
 Status: Release-1 gate checklist  
 Owner: `weave` frontend, with admin/recovery evidence from `weave-infra`  
 Baseline: WCAG 2.1 AA for critical user and admin flows
 
-This checklist is the release evidence index for issue #112. It does not replace live assistive-technology testing; it makes the automated and manual evidence required before Release 1 explicit and auditable.
+This checklist is the release evidence index for issue #112. It does not replace live assistive-technology testing; it makes the automated and manual evidence required before current release explicit and auditable.
 
 ## Automated CI evidence
 
-Run these before requesting Release 1 approval:
+Run these before requesting release approval:
 
 ```bash
 flutter gen-l10n
@@ -33,7 +33,7 @@ The automated suite must include widget or contract coverage for these accessibi
 | Shared controls | minimum target sizing and explicit semantic labels for reusable buttons | `test/core/a11y/semantic_button_test.dart`, `test/core/widgets/core_widgets_test.dart` |
 | Release-1 journey | setup, sign-in, chat, files, settings recovery remain coherent in one flow | `test/release_1/release_golden_paths_test.dart` |
 
-## Manual assistive-technology evidence required before Release 1 sign-off
+## Manual assistive-technology evidence required before release sign-off
 
 Record the tester, date, platform, assistive technology, result, and evidence link in the release issue or runbook. Manual-only checks are a gate; they may not be inferred from green widget tests.
 
@@ -61,6 +61,6 @@ Record the tester, date, platform, assistive technology, result, and evidence li
 ## Release accounting
 
 - Automated evidence is attached by CI run URL and local command output.
-- Manual evidence is attached to the Release 1 gate issue with platform/device notes.
-- Any failed row creates or links a blocking issue and prevents Release 1 sign-off until fixed or explicitly deferred by product decision.
-- Calendar and admin/recovery rows may remain marked `blocked` only when the corresponding backend/infra live-stack gate is also explicitly blocked; do not call Release 1 accessibility complete while those flows lack evidence.
+- Manual evidence is attached to the release gate issue with platform/device notes.
+- Any failed row creates or links a blocking issue and prevents release sign-off until fixed or explicitly deferred by product decision.
+- Calendar and admin/recovery rows may remain marked `blocked` only when the corresponding backend/infra live-stack gate is also explicitly blocked; do not call current release accessibility complete while those flows lack evidence.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,7 @@ Shell destinations:
 
 - Chat
 - Files
-- Calendar (feature-gated active scope; Teams-like workspace/team/channel calendar hierarchy)
+- Calendar (feature-gated active scope; shared workspace/team/channel calendar hierarchy)
 - Tasks/Boards (feature-gated active scope; provider-neutral Weave model, not a Nextcloud Deck product dependency)
 - Settings
 
@@ -174,7 +174,7 @@ This keeps the current Files UX intact while making the same Nextcloud platform 
 
 ## Calendar backend facade scope
 
-Calendar is active shared-scheduling scope and remains wired through the Weave backend product facade rather than direct CalDAV. The product model is Teams-like: workspace/org calendar, team calendars, and channel calendars/events/meeting threads. The backend currently exposes the first safe slice as `scope.type = "workspace"`: a shared Weave workspace calendar owned/provisioned through the backend actor. The frontend parses that scope metadata and labels the surface as the first shared workspace scope, not as a private-personal calendar.
+Calendar is active shared-scheduling scope and remains wired through the Weave backend product facade rather than direct CalDAV. The product model is shared scheduling: workspace calendar, team calendars, and channel calendars/events/meeting threads. The backend currently exposes the first safe slice as `scope.type = "workspace"`: a shared Weave workspace calendar owned/provisioned through the backend actor. The frontend parses that scope metadata and labels the surface as the first shared workspace scope, not as a private-personal calendar.
 
 Private personal calendars are out of scope for the current product path. Frontend code must continue to fail through the backend facade and must not add a direct private-personal CalDAV fallback or secret-bearing client setup path.
 

--- a/docs/assets/roadmap/06-calendar-roadmap-readiness.svg
+++ b/docs/assets/roadmap/06-calendar-roadmap-readiness.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
   <title id="title">Weave calendar roadmap readiness screen</title>
-  <desc id="desc">The guarded Calendar roadmap shows active workspace/team/channel readiness copy for the Teams-like shared scheduling path.</desc>
+  <desc id="desc">The guarded Calendar roadmap shows active workspace/team/channel readiness copy for the shared scheduling path.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#eff6ff"/>
@@ -35,9 +35,9 @@
 
   <rect x="104" y="212" width="1096" height="150" rx="34" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
   <text x="144" y="270" font-size="42" font-weight="900" fill="#0f172a">Calendar channel schedule readiness</text>
-  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">The shared Calendar path is Teams-like: workspace, team, and</text>
-<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">channel scopes are visible; channel event CRUD is validated through</text>
-<text x="144" y="384" font-size="26" font-weight="400" fill="#475569">the backend Calendar facade.</text>
+  <text x="144" y="316" font-size="26" font-weight="400" fill="#475569">The shared Calendar path uses workspace, team, and channel scopes;</text>
+<text x="144" y="350" font-size="26" font-weight="400" fill="#475569">channel event CRUD is validated through the backend Calendar</text>
+<text x="144" y="384" font-size="26" font-weight="400" fill="#475569">facade.</text>
 
     <rect x="104" y="402" width="346" height="116" rx="28" fill="#ffffff" stroke="#dbeafe" stroke-width="2"/>
     <text x="132" y="444" font-size="21" font-weight="700" fill="#0369a1">Scope</text>

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -89,7 +89,7 @@ Accessibility is release scope, not polish:
 - Do not communicate state by color alone.
 - Keep keyboard and screen-reader paths in mind for setup, sign-in, chat, files, settings, and live-stack error states.
 
-See [Release 1 Accessibility Gate](release-1-accessibility-gate.md) for the current automated and manual evidence model.
+See [Accessibility Release Gate](accessibility-release-gate.md) for the current automated and manual evidence model.
 
 ## Acceptance contract workflow
 

--- a/docs/product-calendar-e2ee-boards-scope.md
+++ b/docs/product-calendar-e2ee-boards-scope.md
@@ -1,10 +1,10 @@
 # Product scope: calendar hierarchy, Matrix E2EE, and Boards
 
-Weave is past the old Release 1-only framing. The active product track is a self-hosted, accessibility-first collaboration workspace with chat, files, Teams-like shared calendars, Matrix E2EE, and Boards/Tasks behind clear product gates.
+Weave is past the old current release gate-only framing. The active product track is a self-hosted, accessibility-first collaboration workspace with chat, files, shared workspace shared calendars, Matrix E2EE, and Boards/Tasks behind clear product gates.
 
 This document is binding product direction for the Flutter client. Backend and infra work should keep their own contracts aligned with these scopes.
 
-## Teams-like calendar hierarchy
+## shared calendar hierarchy
 
 Calendar is not a private personal-calendar ingestion feature. The product model follows Weave collaboration structure:
 

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -7,7 +7,7 @@ Weave uses layered evidence so contributors can move quickly while release claim
 | Layer | What it proves | Where to find it |
 | --- | --- | --- |
 | Offline Flutter checks | Formatting, static analysis, unit/widget behavior, generated code consistency, and no-network contract checks. | `.github/workflows/ci.yml`, local `flutter` commands, `make offline-contract-test`. |
-| Accessibility gate | Automated checks and the manual assistive-technology evidence required before release sign-off. | [Release 1 Accessibility Gate](release-1-accessibility-gate.md). |
+| Accessibility gate | Automated checks and the manual assistive-technology evidence required before release sign-off. | [Accessibility Release Gate](accessibility-release-gate.md). |
 | Deterministic screenshots | README and roadmap SVG assets match the checked-in generator and do not drift silently. | `make marketing-screenshots`, `docs/assets/marketing/`, `docs/assets/roadmap/`, CI screenshot drift step. |
 | Acceptance contract guard | Gherkin acceptance scenarios stay mapped to executable frontend/live-stack tests. | [Acceptance contracts](acceptance-contracts.md), [Product acceptance flows](product-acceptance-flows.md), `test/live_stack_feature_mapping_test.dart`. |
 | Live Stack E2E | A prepared self-hosted stack can boot the app-level journey and upload acceptance evidence artifacts. | `.github/workflows/live-stack-e2e.yml` workflow runs and their uploaded artifacts. |
@@ -61,5 +61,5 @@ The workflow prepares an acceptance evidence directory, runs the app-level live-
 - [Developer handbook](developer-handbook.md)
 - [Acceptance contracts](acceptance-contracts.md)
 - [Product acceptance flows](product-acceptance-flows.md)
-- [Release 1 Accessibility Gate](release-1-accessibility-gate.md)
+- [Accessibility Release Gate](accessibility-release-gate.md)
 - [Roadmap and guarded surfaces](roadmap-and-guarded-surfaces.md)

--- a/docs/roadmap-and-guarded-surfaces.md
+++ b/docs/roadmap-and-guarded-surfaces.md
@@ -1,10 +1,10 @@
 # Roadmap and guarded surfaces
 
-The README showcase is limited to product surfaces that contributors can evaluate directly today: setup, service review, chat, files, and settings. This page keeps in-progress product areas visible without marketing them as fully shipped.
+The README showcase is limited to product surfaces that contributors can evaluate directly today: setup, service review, chat, files, readiness, and settings. This page keeps in-progress product areas visible without marketing them as fully shipped.
 
-## Teams-like calendar
+## Shared calendars
 
-Calendar is active product scope, but it is not promoted as a normal finished surface in the README showcase. The target product model is workspace/org, team, and channel scheduling backed by the Weave backend calendar facade and Nextcloud/CalDAV. Private personal calendar ingestion is not a product goal for the current MVP path.
+Calendar is active product scope, but it is not promoted as a finished everyday surface in the README showcase. The target product model is shared workspace, team, and channel scheduling backed by the Weave backend calendar facade and Nextcloud/CalDAV storage foundations. Private personal calendar ingestion is not a product goal for the current path.
 
 [<img src="assets/roadmap/06-calendar-roadmap-readiness.svg" alt="Weave calendar roadmap visual showing workspace, team, and channel scheduling scopes with channel event CRUD validated through the backend facade." width="560">](assets/roadmap/06-calendar-roadmap-readiness.svg)
 
@@ -13,7 +13,7 @@ Current evidence and boundaries:
 - Shared scope metadata and channel event create/read/update/delete are live-stack contract scope.
 - Meeting-thread attachment is follow-up work.
 - Raw Nextcloud Calendar is not the normal product UX.
-- Backend actor credentials must not leak into generated setup artifacts.
+- Backend actor credentials must not leak into generated setup artifacts, app config, logs, or support bundles.
 
 ## Boards/tasks
 
@@ -24,12 +24,24 @@ Boards/tasks are active Weave scope behind feature gates and provider-neutral ba
 Current evidence and boundaries:
 
 - Flutter may render provider-neutral board/task DTOs and accessible non-drag actions.
+- OpenProject is the preferred read-only provider validation path, not the visible product UX.
+- Vikunja and Deck remain comparison/fallback research unless a later contract promotes them.
 - Provider auth, pagination, sync, webhook validation, export/import, and error translation belong behind backend or connector adapters.
 - Any provider-specific claim must be tied to a validated runtime and documented capability boundary.
 
 ## Matrix E2EE
 
-Matrix E2EE is active chat architecture scope, not a completed product claim. Weave must not claim chat is end-to-end encrypted until encrypted-room behavior, device verification, key backup/recovery, lost-device handling, multi-device behavior, and accessible verification/recovery UX are implemented and validated.
+Matrix E2EE is active chat architecture scope, not a completed product claim. Weave must not claim chat is end-to-end encrypted until encrypted-room behavior, device verification, key backup/recovery, lost-device handling, multi-device behavior, metadata boundaries, and accessible verification/recovery UX are implemented and validated.
+
+## Provider stack readiness
+
+Provider stack readiness is visible in Settings so users and operators can understand whether files, calendar, office, DevOps, boards, identity, and other modules are ready, disabled, degraded, or intentionally unsupported. The app must keep this support-safe:
+
+- no raw provider URLs;
+- no bearer tokens, API tokens, app passwords, cookies, or secrets;
+- no raw downstream error bodies;
+- no direct Flutter provider calls;
+- retry paths must rebuild backend readiness through Weave APIs.
 
 ## Related contracts
 

--- a/integration_test/live_stack_app_e2e_test.dart
+++ b/integration_test/live_stack_app_e2e_test.dart
@@ -528,7 +528,7 @@ void main() {
       final calendarDraft = CalendarEventDraft(
         title: calendarTitle,
         description:
-            'Created by the live-stack Teams-like channel calendar E2E gate.',
+            'Created by the live-stack shared channel calendar E2E gate.',
         startTime: calendarStart,
         endTime: calendarStart.add(const Duration(minutes: 30)),
         timezone: 'UTC',

--- a/test/architecture/readme_release_scope_contract_test.dart
+++ b/test/architecture/readme_release_scope_contract_test.dart
@@ -27,14 +27,14 @@ void main() {
     final roadmap = await File(
       'docs/roadmap-and-guarded-surfaces.md',
     ).readAsString();
-    final calendarRoadmap = _section(roadmap, '## Teams-like calendar');
+    final calendarRoadmap = _section(roadmap, '## Shared calendars');
     final boardsRoadmap = _section(roadmap, '## Boards/tasks');
 
     expect(calendarRoadmap, contains('06-calendar-roadmap-readiness.svg'));
     expect(calendarRoadmap.toLowerCase(), isNot(contains('preview')));
     expect(
       calendarRoadmap,
-      contains('workspace/org, team, and channel scheduling'),
+      contains('shared workspace, team, and channel scheduling'),
     );
     expect(
       calendarRoadmap,

--- a/test/release_1/accessibility_gate_contract_test.dart
+++ b/test/release_1/accessibility_gate_contract_test.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('Release 1 accessibility gate', () {
-    final checklist = File('docs/release-1-accessibility-gate.md');
+  group('accessibility release gate', () {
+    final checklist = File('docs/accessibility-release-gate.md');
 
     test('documents automated and manual evidence for every critical flow', () {
       expect(checklist.existsSync(), isTrue);
@@ -13,7 +13,7 @@ void main() {
 
       for (final requiredSection in <String>[
         'Automated CI evidence',
-        'Manual assistive-technology evidence required before Release 1 sign-off',
+        'Manual assistive-technology evidence required before release sign-off',
         'Non-negotiable pass criteria',
         'Release accounting',
       ]) {
@@ -36,7 +36,7 @@ void main() {
         expect(
           markdown,
           contains(flow),
-          reason: 'Missing Release 1 accessibility flow: $flow',
+          reason: 'Missing current release accessibility flow: $flow',
         );
       }
 
@@ -69,7 +69,7 @@ void main() {
           markdown,
           contains(command),
           reason:
-              'Missing Release 1 accessibility validation command: $command',
+              'Missing current release accessibility validation command: $command',
         );
       }
     });

--- a/test/release_1/release_golden_paths_test.dart
+++ b/test/release_1/release_golden_paths_test.dart
@@ -45,7 +45,7 @@ import 'package:weave/main.dart';
 import '../helpers/in_memory_stores.dart';
 
 void main() {
-  group('Release 1 auth/files golden paths', () {
+  group('current release auth/files golden paths', () {
     testWidgets(
       'setup, sign-in, ready shell, files browsing, chat room open plus send, sign-out/re-auth, and changed-server recovery',
       (tester) async {

--- a/tool/generate_marketing_screenshots.py
+++ b/tool/generate_marketing_screenshots.py
@@ -148,10 +148,10 @@ SCREENS: tuple[Screen, ...] = (
         output_dir=ROADMAP_OUTPUT_DIR,
         file_name="06-calendar-roadmap-readiness.svg",
         title="Weave calendar roadmap readiness screen",
-        description="The guarded Calendar roadmap shows active workspace/team/channel readiness copy for the Teams-like shared scheduling path.",
+        description="The guarded Calendar roadmap shows active workspace/team/channel readiness copy for the shared scheduling path.",
         active_nav="Calendar",
         hero="Calendar channel schedule readiness",
-        subhero="The shared Calendar path is Teams-like: workspace, team, and channel scopes are visible; channel event CRUD is validated through the backend Calendar facade.",
+        subhero="The shared Calendar path uses workspace, team, and channel scopes; channel event CRUD is validated through the backend Calendar facade.",
         metrics=(
             Metric("Scope", "Workspace · team · channel"),
             Metric("Access", "Private calendars blocked"),


### PR DESCRIPTION
## Summary

- Rewrites the app README around the professional positioning “Accessible collaboration, under your control.”
- Clarifies current available surfaces vs guarded previews and removes stale Release 1 / Teams-like / Weaver-first hero language.
- Adds provider-stack readiness posture to roadmap docs and keeps Flutter behind backend-owned provider facades.
- Renames the accessibility gate doc to a non-Release-1 name and updates tests/references.

## Validation

- `make marketing-screenshots`
- `flutter test test/architecture/readme_release_scope_contract_test.dart test/release_1/accessibility_gate_contract_test.dart`
- `make offline-contract-test`
