### PR TITLE
test: map provider readiness live evidence

### DIFF
--- a/client/integration_test/live_stack_app_e2e_test.dart
+++ b/client/integration_test/live_stack_app_e2e_test.dart
@@ -192,6 +192,98 @@ void main() {
         'accessTokenPresent=${restoredSession?.accessToken.isNotEmpty ?? false}',
       );
 
+      final providerHttpClient = createTrustedTestHttpClient();
+      addTearDown(providerHttpClient.close);
+      final providerStatus = _decodeHttpJson(
+        await providerHttpClient.get(
+          config.apiUri('/api/providers/status'),
+          headers: <String, String>{
+            'Accept': 'application/json',
+            'Authorization': 'Bearer ${appSession.accessToken}',
+          },
+        ),
+        operation: 'read provider stack readiness',
+      );
+      final providerReadiness = _jsonListOfMaps(providerStatus['providers']);
+      final providerModules = providerReadiness
+          .map((provider) => _jsonString(provider['module']))
+          .toSet();
+      const requiredProviderModules = <String>{
+        'identity-realm',
+        'matrix',
+        'matrix-auth',
+        'files',
+        'office',
+        'calendar',
+        'contacts',
+        'forms',
+        'boards',
+        'meetings',
+        'source-control',
+        'issue-tracker',
+        'ci',
+        'release',
+      };
+      const failClosedModules = <String>{
+        'office',
+        'contacts',
+        'forms',
+        'source-control',
+        'issue-tracker',
+        'ci',
+        'release',
+      };
+      final providerRegistryVisible =
+          providerStatus['backendOwnedFacades'] == true &&
+          providerStatus['flutterDirectProviderCallsAllowed'] == false &&
+          providerStatus['supportSafe'] == true &&
+          providerModules.containsAll(requiredProviderModules);
+      final optionalProvidersFailClosed = providerReadiness
+          .where(
+            (provider) =>
+                failClosedModules.contains(_jsonString(provider['module'])),
+          )
+          .every(
+            (provider) =>
+                provider['enabled'] == false &&
+                provider['configured'] == false &&
+                provider['failClosed'] == true &&
+                provider['supportSafe'] == true,
+          );
+      final providerSecretsExposed = RegExp(
+        r'(Authorization|api[_-]?token|/api/v3/|/work_packages/|/projects/)',
+        caseSensitive: false,
+      ).hasMatch(jsonEncode(providerStatus));
+      final profileReadiness = _decodeHttpJson(
+        await providerHttpClient.get(
+          config.apiUri('/api/profile/readiness'),
+          headers: <String, String>{
+            'Accept': 'application/json',
+            'Authorization': 'Bearer ${appSession.accessToken}',
+          },
+        ),
+        operation: 'read profile readiness',
+      );
+      final profileReadinessOk =
+          profileReadiness['contractId'] == 'CEFACADE' &&
+          profileReadiness['endpoint'] == '/profile/readiness' &&
+          profileReadiness['backendOwnedFacade'] == true &&
+          profileReadiness['directProviderCallsAllowed'] == false &&
+          profileReadiness['supportSafe'] == true;
+      // ignore: avoid_print
+      print(
+        'PROVIDER_STACK_RESULT releaseStatus=${providerStatus['releaseStatus']} '
+        'providers=${providerReadiness.length} '
+        'modules=${providerModules.join(',')} '
+        'registryVisible=$providerRegistryVisible '
+        'optionalProvidersFailClosed=$optionalProvidersFailClosed '
+        'directFlutterProviderCallsAllowed=${providerStatus['flutterDirectProviderCallsAllowed']} '
+        'providerSecretsExposed=$providerSecretsExposed '
+        'profileReadinessContract=${profileReadiness['contractId']} '
+        'profileReadinessEndpoint=${profileReadiness['endpoint']} '
+        'profileReadinessOk=$profileReadinessOk',
+      );
+
       final profileRepository = container.read(userProfileRepositoryProvider);
       final originalProfile = await profileRepository.loadProfile();
       if (originalProfile == null) {
@@ -762,6 +854,10 @@ void main() {
           !calendarUpdatedThreadRefReady ||
           !calendarMeetingThreadStable ||
           !calendarDeleted ||
+          !providerRegistryVisible ||
+          !optionalProvidersFailClosed ||
+          providerSecretsExposed ||
+          !profileReadinessOk ||
           !boardsProviderNeutral ||
           !boardsNonDragMutationWorked) {
         fail(
@@ -801,6 +897,10 @@ void main() {
           'calendarMeetingThreadId=${readCreatedEvent.threadRef.meetingThreadId} '
           'calendarDeleted=$calendarDeleted '
           'calendarEventId=${createdEvent.id} '
+          'providerRegistryVisible=$providerRegistryVisible '
+          'optionalProvidersFailClosed=$optionalProvidersFailClosed '
+          'providerSecretsExposed=$providerSecretsExposed '
+          'profileReadinessOk=$profileReadinessOk '
           'boardsProviderNeutral=$boardsProviderNeutral '
           'boardsNonDragMutationWorked=$boardsNonDragMutationWorked '
           'boardsTaskId=$taskId',
@@ -826,6 +926,10 @@ void main() {
       expect(calendarUpdatedThreadRefReady, isTrue);
       expect(calendarMeetingThreadStable, isTrue);
       expect(calendarDeleted, isTrue);
+      expect(providerRegistryVisible, isTrue);
+      expect(optionalProvidersFailClosed, isTrue);
+      expect(providerSecretsExposed, isFalse);
+      expect(profileReadinessOk, isTrue);
       expect(boardsProviderNeutral, isTrue);
       expect(boardsNonDragMutationWorked, isTrue);
     },

--- a/client/test/live_stack_contract_test.dart
+++ b/client/test/live_stack_contract_test.dart
@@ -90,6 +90,52 @@ void main() {
       );
     });
 
+    test('provider stack readiness stays behind the Weave backend facade', () {
+      expect(
+        liveConfig.apiUri('/api/providers/status').toString(),
+        'https://api.weave.local/api/providers/status',
+      );
+      expect(
+        liveConfig.apiUri('/api/profile/readiness').toString(),
+        'https://api.weave.local/api/profile/readiness',
+      );
+    });
+
+    test(
+      'direct Flutter provider calls remain blocked for optional provider stack modules',
+      () async {
+        final forbiddenFragments = <String>[
+          '/api/v3/',
+          '/work_packages',
+          'openproject.example',
+          'openproject.weave.local',
+          'gitlab.com/api',
+          'forgejo/api',
+          'onlyoffice',
+          'collabora-code',
+          'nextcloud/forms',
+          'carddav',
+        ];
+
+        final offenders = <String>[];
+        for (final file in _productionDartFiles()) {
+          final content = await file.readAsString();
+          for (final fragment in forbiddenFragments) {
+            if (content.toLowerCase().contains(fragment.toLowerCase())) {
+              offenders.add('${file.path}: $fragment');
+            }
+          }
+        }
+
+        expect(
+          offenders,
+          isEmpty,
+          reason:
+              'Flutter must call backend facades such as /api/providers/status and /profile/readiness, not provider APIs directly.',
+        );
+      },
+    );
+
     test(
       'shell readiness contract can be exercised without live auth',
       () async {
@@ -308,6 +354,20 @@ Map<String, dynamic> _decodeObject(String body) {
   }
 
   return decoded;
+}
+
+List<File> _productionDartFiles() {
+  final lib = Directory('lib');
+  if (!lib.existsSync()) {
+    return const <File>[];
+  }
+
+  return lib
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((file) => file.path.endsWith('.dart'))
+      .where((file) => !file.path.contains('/l10n/generated/'))
+      .toList(growable: false);
 }
 
 class _MemoryServerConfigurationRepository

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -32,6 +32,7 @@ void main() {
           'Matrix chat sends and reads a workspace message',
           'Matrix encryption status is proved honestly',
           'Files are uploaded, shown, downloaded, and cleaned up in Weave',
+          'Provider stack readiness stays backend-owned and support-safe',
           'Channel calendar events keep their meeting thread reference',
           'Boards workspace supports accessible non-drag task work',
           'Weave Home starts the daily work loop',

--- a/e2e/features/live_stack_app.feature
+++ b/e2e/features/live_stack_app.feature
@@ -36,6 +36,14 @@ Feature: Live Stack product acceptance journey
     And downloading the file returns the original content
     And the test removes the file it created
 
+  @weave-live-provider-stack-readiness
+  Scenario: Provider stack readiness stays backend-owned and support-safe
+    Given the signed-in person has optional providers represented by Weave
+    When the app reads provider stack readiness
+    Then provider readiness is exposed only through backend-owned facades
+    And optional provider modules fail closed until configured
+    And no provider secrets or direct Flutter provider calls are exposed
+
   @weave-live-calendar-threadrefs
   Scenario: Channel calendar events keep their meeting thread reference
     Given workspace, team, and channel calendar scopes are available in Weave

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -41,6 +41,24 @@
       ]
     },
     {
+      "tag": "@weave-live-provider-stack-readiness",
+      "scenario": "Provider stack readiness stays backend-owned and support-safe",
+      "feature": "e2e/features/live_stack_app.feature",
+      "executableTest": "client/integration_test/live_stack_app_e2e_test.dart",
+      "evidenceMarkers": [
+        "PROVIDER_STACK_RESULT"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "client/test/live_stack_contract_test.dart",
+          "fragments": [
+            "provider stack readiness stays behind the Weave backend facade",
+            "direct Flutter provider calls remain blocked for optional provider stack modules"
+          ]
+        }
+      ]
+    },
+    {
       "tag": "@weave-live-calendar-threadrefs",
       "scenario": "Channel calendar events keep their meeting thread reference",
       "feature": "e2e/features/live_stack_app.feature",


### PR DESCRIPTION
## Summary
- ports the useful provider-readiness acceptance slice from the stale pre-monorepo PRs into the monorepo layout
- maps a new live-stack product scenario to executable `PROVIDER_STACK_RESULT` evidence
- proves provider readiness remains backend-owned/support-safe and Flutter does not call optional providers directly

## Validation
- `cd client && flutter test test/live_stack_feature_mapping_test.dart test/live_stack_contract_test.dart --dart-define=WEAVE_OFFLINE_CONTRACT_ONLY=true`
- `make acceptance-contract`
- `make -C client offline-contract-test`
- `cd client && flutter analyze --fatal-infos`

## Replaces stale PRs
- Replaces/supersedes the acceptance-evidence portion of #243 and #244 after the monorepo merge.
- The broader backend/provider contracts from old split-repo drafts should land separately under `server/` if still needed.
