### PR TITLE
docs: restore README logo and screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,46 @@
 # Weave Monorepo
 
+<p align="center">
+  <img src="client/assets/images/weave_logo.png" alt="Weave logo, an interlaced blue and teal knot" width="220">
+</p>
+
 Weave is an accessibility-first, self-hostable collaboration workspace for chat, files, shared calendars, boards/tasks, meetings, decisions, and operator health.
 
 This repository is the single source of truth for the product stack. Treat client, backend, infrastructure, acceptance evidence, and release metadata as one release unit.
+
+## Product screenshots
+
+These deterministic screenshots use checked-in Weave assets. They show Weave-owned surfaces that are suitable for the README showcase: admin-provisioned setup, service endpoint review, custom chat, files, and settings/readiness. They are not a promise that roadmap or guarded provider surfaces are shipped; those stay separated in [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md).
+
+### Admin-provisioned setup
+
+[<img src="docs/assets/marketing/01-setup-start.svg" alt="Weave setup start screen inviting an admin to configure a self-hosted workspace." width="680">](docs/assets/marketing/01-setup-start.svg)
+
+Setup starts from an admin/operator path so normal users are not asked to understand raw provider wiring.
+
+### Service endpoint review
+
+[<img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave setup review screen listing canonical local service endpoints before finishing configuration." width="680">](docs/assets/marketing/02-review-service-endpoints.svg)
+
+Endpoint review keeps canonical auth, API, Matrix, files, and calendar surfaces explicit before the workspace is used.
+
+### Custom Weave chat
+
+[<img src="docs/assets/marketing/03-chat-room.svg" alt="Custom Weave chat room showing a release room conversation and accessible message composer." width="680">](docs/assets/marketing/03-chat-room.svg)
+
+Chat is a Weave product experience backed by Matrix; raw Matrix administration is not the normal user path.
+
+### Weave files through the backend facade
+
+[<img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files screen listing folders and files through the backend files facade." width="680">](docs/assets/marketing/04-files-documents.svg)
+
+Files use Weave-owned product routes and backend facades instead of promoting raw Nextcloud as the everyday UX.
+
+### Settings and readiness
+
+[<img src="docs/assets/marketing/05-settings.svg" alt="Weave settings screen showing saved local service configuration and sign-out controls." width="680">](docs/assets/marketing/05-settings.svg)
+
+Settings and readiness surfaces should explain configured, disabled, degraded, or unsupported modules without exposing secrets or raw provider errors.
 
 ## Repository layout
 
@@ -15,7 +53,7 @@ This repository is the single source of truth for the product stack. Treat clien
 
 ## v0.1 product truth
 
-v0.1 is a dogfood-production release, not a preview showcase. A surface belongs in the release only when it is useful for daily project work and backed by executable evidence.
+v0.1 is a dogfood-production release, not a preview showcase. A surface belongs in the release only when it is useful for daily project work and backed by executable evidence. Preview-only or guarded surfaces stay fail-closed and out of the normal user UX until their product contract is promoted.
 
 Required v0.1 surfaces:
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@ This repository is the single source of truth for the product stack. Treat clien
 
 These deterministic screenshots use checked-in Weave assets. They show Weave-owned surfaces that are suitable for the README showcase: admin-provisioned setup, service endpoint review, custom chat, files, and settings/readiness. They are not a promise that roadmap or guarded provider surfaces are shipped; those stay separated in [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md).
 
+Future README showcase updates should keep this acceptance checklist:
+
+- Keep project naming in text (`# Weave Monorepo` and body copy), not image-only branding.
+- Use existing deterministic screenshot assets with descriptive alt text that states the user task.
+- Keep showcase surfaces limited to current dogfood-ready product paths (setup, endpoint review, chat, files, settings/readiness).
+- Keep preview-only, guarded, or admin-only provider surfaces explicitly out of the normal user path and linked from roadmap docs instead.
+
 ### Admin-provisioned setup
 
 [<img src="docs/assets/marketing/01-setup-start.svg" alt="Weave setup start screen inviting an admin to configure a self-hosted workspace." width="680">](docs/assets/marketing/01-setup-start.svg)
 
-Setup starts from an admin/operator path so normal users are not asked to understand raw provider wiring.
+Setup is admin-provisioned; normal users join after provisioning and are not asked to configure raw providers.
 
 ### Service endpoint review
 


### PR DESCRIPTION
## Summary
- Restore the Weave logo near the README heading with descriptive alt text and surrounding text that still names the project.
- Add the existing deterministic marketing screenshots for setup, endpoint review, chat, files, and settings/readiness.
- Keep README product language aligned with dogfood-production scope, admin-provisioned setup, backend/provider facades, and fail-closed guarded surfaces.

## Acceptance criteria
- README does not rely on the logo image as the only project name or meaning.
- README screenshots use existing checked-in assets and descriptive alt text.
- README showcase stays limited to ready/dogfood surfaces and links roadmap/guarded surfaces separately.
- README continues to state that raw providers are not the normal product UX and preview-only surfaces are not exposed to normal users.

## Validation
- `python3` README image-path/claim inspection script
- `cd client && make marketing-screenshots && git diff --exit-code -- ../docs/assets/marketing ../docs/assets/roadmap`
- `make acceptance-contract`
- `git diff --check`

## Contract impact
Docs-only README showcase update. No spec, API, runtime, or asset-generation contract changes.
