### PR TITLE
feat: add dogfood UX no-preview gates

### DIFF
--- a/client/lib/features/agents/domain/entities/agent_capability_policy.dart
+++ b/client/lib/features/agents/domain/entities/agent_capability_policy.dart
@@ -2,7 +2,11 @@ enum AgentCapability { personalAssistant, channelAgent }
 
 enum AgentCapabilityEnablement { disabled, enabled }
 
-enum AgentCapabilityAvailability { previewOnly, adminSetupRequired, blocked }
+enum AgentCapabilityAvailability {
+  adminSetupRequired,
+  disabledByPolicy,
+  blocked,
+}
 
 class AgentCapabilityPolicy {
   const AgentCapabilityPolicy({
@@ -11,14 +15,16 @@ class AgentCapabilityPolicy {
     this.isFailClosed = false,
   });
 
-  factory AgentCapabilityPolicy.preview({required bool canManageCapabilities}) {
+  factory AgentCapabilityPolicy.disabled({
+    required bool canManageCapabilities,
+  }) {
     return AgentCapabilityPolicy(
       canManageCapabilities: canManageCapabilities,
       capabilities: const <AgentCapabilityState>[
         AgentCapabilityState(
           capability: AgentCapability.personalAssistant,
           enablement: AgentCapabilityEnablement.disabled,
-          availability: AgentCapabilityAvailability.previewOnly,
+          availability: AgentCapabilityAvailability.disabledByPolicy,
         ),
         AgentCapabilityState(
           capability: AgentCapability.channelAgent,

--- a/client/lib/features/agents/presentation/providers/agent_capability_policy_provider.dart
+++ b/client/lib/features/agents/presentation/providers/agent_capability_policy_provider.dart
@@ -9,7 +9,7 @@ final agentCapabilityPolicyProvider =
 
       return switch (profile) {
         AsyncData(value: final user) => AsyncData(
-          AgentCapabilityPolicy.preview(
+          AgentCapabilityPolicy.disabled(
             canManageCapabilities: user?.canAdministerWorkspace ?? false,
           ),
         ),

--- a/client/lib/features/agents/presentation/widgets/agent_capability_policy_card.dart
+++ b/client/lib/features/agents/presentation/widgets/agent_capability_policy_card.dart
@@ -225,10 +225,10 @@ String _availabilityLabel(
   AgentCapabilityAvailability availability,
 ) {
   return switch (availability) {
-    AgentCapabilityAvailability.previewOnly =>
-      l10n.agentCapabilityAvailabilityPreviewOnly,
     AgentCapabilityAvailability.adminSetupRequired =>
       l10n.agentCapabilityAvailabilityAdminSetupRequired,
+    AgentCapabilityAvailability.disabledByPolicy =>
+      l10n.agentCapabilityAvailabilityDisabledByPolicy,
     AgentCapabilityAvailability.blocked =>
       l10n.agentCapabilityAvailabilityBlocked,
   };
@@ -243,9 +243,9 @@ IconData _capabilityIcon(AgentCapability capability) {
 
 IconData _availabilityIcon(AgentCapabilityAvailability availability) {
   return switch (availability) {
-    AgentCapabilityAvailability.previewOnly => Icons.visibility_outlined,
     AgentCapabilityAvailability.adminSetupRequired =>
       Icons.admin_panel_settings,
+    AgentCapabilityAvailability.disabledByPolicy => Icons.policy_outlined,
     AgentCapabilityAvailability.blocked => Icons.block,
   };
 }

--- a/client/lib/features/chat/domain/entities/agent_chat_preview.dart
+++ b/client/lib/features/chat/domain/entities/agent_chat_preview.dart
@@ -1,4 +1,4 @@
-enum AgentChatAvailability { previewOnly, adminSetupRequired, blocked }
+enum AgentChatAvailability { disabledByPolicy, adminSetupRequired, blocked }
 
 enum AgentChatPreviewKind { personalAssistant, channelAgent }
 

--- a/client/lib/features/chat/domain/entities/channel_workspace.dart
+++ b/client/lib/features/chat/domain/entities/channel_workspace.dart
@@ -2,7 +2,13 @@ import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 
 enum ChannelWorkspaceSurfaceKind { chat, files, boards, calendar, meetings }
 
-enum ChannelWorkspaceSurfaceAvailability { available, preview, gated }
+enum ChannelWorkspaceSurfaceAvailability {
+  available,
+  adminSetupRequired,
+  disabledByPolicy,
+  degraded,
+  gated,
+}
 
 class ChannelWorkspaceSurface {
   const ChannelWorkspaceSurface({
@@ -20,7 +26,13 @@ class ChannelWorkspaceSurface {
   bool get isAvailable =>
       availability == ChannelWorkspaceSurfaceAvailability.available;
 
-  bool get isGated => availability == ChannelWorkspaceSurfaceAvailability.gated;
+  bool get isUnavailable => !isAvailable;
+
+  bool get isGated =>
+      availability == ChannelWorkspaceSurfaceAvailability.gated ||
+      availability == ChannelWorkspaceSurfaceAvailability.adminSetupRequired ||
+      availability == ChannelWorkspaceSurfaceAvailability.disabledByPolicy ||
+      availability == ChannelWorkspaceSurfaceAvailability.degraded;
 }
 
 enum ChannelMeetingContextItemKind {
@@ -80,7 +92,7 @@ class ChannelMeetingPreview {
       channelId: conversation.id,
       channelTitle: conversation.title,
       contextId: contextId,
-      providerContractId: 'livekit-meetings-channel-preview',
+      providerContractId: 'livekit-meetings-channel-gate',
       contextItems: const [
         ChannelMeetingContextItem(
           kind: ChannelMeetingContextItemKind.agenda,
@@ -173,13 +185,13 @@ class ChannelWorkspacePreview {
         ),
         ChannelWorkspaceSurface(
           kind: ChannelWorkspaceSurfaceKind.files,
-          availability: ChannelWorkspaceSurfaceAvailability.preview,
+          availability: ChannelWorkspaceSurfaceAvailability.available,
           providerContractId: 'weave-files-channel-link',
           contextId: contextId,
         ),
         ChannelWorkspaceSurface(
           kind: ChannelWorkspaceSurfaceKind.boards,
-          availability: ChannelWorkspaceSurfaceAvailability.preview,
+          availability: ChannelWorkspaceSurfaceAvailability.adminSetupRequired,
           providerContractId: 'weave-boards-channel-link',
           contextId: contextId,
         ),
@@ -192,7 +204,7 @@ class ChannelWorkspacePreview {
         ChannelWorkspaceSurface(
           kind: ChannelWorkspaceSurfaceKind.meetings,
           availability: ChannelWorkspaceSurfaceAvailability.gated,
-          providerContractId: 'livekit-meetings-channel-preview',
+          providerContractId: 'livekit-meetings-channel-gate',
           contextId: contextId,
         ),
       ],

--- a/client/lib/features/chat/presentation/chat_room_screen.dart
+++ b/client/lib/features/chat/presentation/chat_room_screen.dart
@@ -987,8 +987,12 @@ String _channelSurfaceStatusLabel(
   return switch (availability) {
     ChannelWorkspaceSurfaceAvailability.available =>
       l10n.channelWorkspaceStatusAvailable,
-    ChannelWorkspaceSurfaceAvailability.preview =>
-      l10n.channelWorkspaceStatusPreview,
+    ChannelWorkspaceSurfaceAvailability.adminSetupRequired =>
+      l10n.channelWorkspaceStatusAdminSetupRequired,
+    ChannelWorkspaceSurfaceAvailability.disabledByPolicy =>
+      l10n.channelWorkspaceStatusDisabledByPolicy,
+    ChannelWorkspaceSurfaceAvailability.degraded =>
+      l10n.channelWorkspaceStatusDegraded,
     ChannelWorkspaceSurfaceAvailability.gated =>
       l10n.channelWorkspaceStatusGated,
   };

--- a/client/lib/features/chat/presentation/chat_room_screen.dart
+++ b/client/lib/features/chat/presentation/chat_room_screen.dart
@@ -827,7 +827,6 @@ class _ChannelWorkspaceSurfacePanel extends StatelessWidget {
       title,
       status,
       body,
-      l10n.channelWorkspaceProviderContract(surface.providerContractId),
       l10n.channelWorkspaceExplicitContextNote(workspace.channelTitle),
     ].join('. ');
 
@@ -882,14 +881,6 @@ class _ChannelWorkspaceSurfacePanel extends StatelessWidget {
                           size: 18,
                         ),
                         label: Text(status),
-                      ),
-                      Chip(
-                        avatar: const Icon(Icons.hub_outlined, size: 18),
-                        label: Text(
-                          l10n.channelWorkspaceProviderContract(
-                            surface.providerContractId,
-                          ),
-                        ),
                       ),
                     ],
                   ),
@@ -1015,7 +1006,6 @@ class _ChannelMeetingsPreviewPanel extends StatelessWidget {
       l10n.channelWorkspaceMeetingsCapabilityBody,
       l10n.channelWorkspaceMeetingsPrivacyBody(workspace.channelTitle),
       l10n.channelWorkspaceMeetingsRecordingOff,
-      l10n.channelWorkspaceProviderContract(meeting.providerContractId),
     ].join('. ');
 
     return Semantics(
@@ -1073,14 +1063,6 @@ class _ChannelMeetingsPreviewPanel extends StatelessWidget {
                           Chip(
                             avatar: const Icon(Icons.lock_outline, size: 18),
                             label: Text(l10n.channelWorkspaceStatusGated),
-                          ),
-                          Chip(
-                            avatar: const Icon(Icons.hub_outlined, size: 18),
-                            label: Text(
-                              l10n.channelWorkspaceProviderContract(
-                                meeting.providerContractId,
-                              ),
-                            ),
                           ),
                           Chip(
                             avatar: const Icon(

--- a/client/lib/features/chat/presentation/chat_screen.dart
+++ b/client/lib/features/chat/presentation/chat_screen.dart
@@ -710,7 +710,7 @@ String _agentAvailabilityLabel(
   AgentChatAvailability availability,
 ) {
   return switch (availability) {
-    AgentChatAvailability.previewOnly => l10n.chatAgentAvailabilityPreview,
+    AgentChatAvailability.disabledByPolicy => l10n.chatAgentAvailabilityPreview,
     AgentChatAvailability.adminSetupRequired =>
       l10n.chatAgentAvailabilityAdminSetup,
     AgentChatAvailability.blocked => l10n.chatAgentAvailabilityBlocked,
@@ -719,7 +719,7 @@ String _agentAvailabilityLabel(
 
 IconData _agentAvailabilityIcon(AgentChatAvailability availability) {
   return switch (availability) {
-    AgentChatAvailability.previewOnly => Icons.visibility_outlined,
+    AgentChatAvailability.disabledByPolicy => Icons.policy_outlined,
     AgentChatAvailability.adminSetupRequired => Icons.admin_panel_settings,
     AgentChatAvailability.blocked => Icons.block,
   };

--- a/client/lib/features/chat/presentation/providers/agent_chat_preview_provider.dart
+++ b/client/lib/features/chat/presentation/providers/agent_chat_preview_provider.dart
@@ -34,10 +34,10 @@ AgentChatPreviewCapability _previewFor(AgentCapabilityState state) {
       AgentCapability.channelAgent => AgentChatPreviewKind.channelAgent,
     },
     availability: switch (state.availability) {
-      AgentCapabilityAvailability.previewOnly =>
-        AgentChatAvailability.previewOnly,
       AgentCapabilityAvailability.adminSetupRequired =>
         AgentChatAvailability.adminSetupRequired,
+      AgentCapabilityAvailability.disabledByPolicy =>
+        AgentChatAvailability.disabledByPolicy,
       AgentCapabilityAvailability.blocked => AgentChatAvailability.blocked,
     },
     canStart: state.canStart,

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -835,6 +835,9 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
     final officeCapabilities = ref.watch(
       weaveApiOfficeCapabilitiesSnapshotProvider,
     );
+    final profile = ref.watch(userProfileProvider);
+    final canSeeOperatorDiagnostics =
+        profile.asData?.value?.canAdministerWorkspace ?? false;
 
     return Card(
       elevation: 0,
@@ -887,13 +890,14 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                   _workspaceSummary(l10n, workspaceState),
                   style: theme.textTheme.bodyMedium,
                 ),
-                if (providerStack.asData?.value case final stack?) ...[
-                  const SizedBox(height: 20),
-                  _ProviderStackReadinessSummary(
-                    stack: stack,
-                    officeCapabilities: officeCapabilities.asData?.value,
-                  ),
-                ],
+                if (canSeeOperatorDiagnostics)
+                  if (providerStack.asData?.value case final stack?) ...[
+                    const SizedBox(height: 20),
+                    _ProviderStackReadinessSummary(
+                      stack: stack,
+                      officeCapabilities: officeCapabilities.asData?.value,
+                    ),
+                  ],
                 const SizedBox(height: 20),
                 _WorkspaceReadinessRow(
                   label: l10n.settingsWorkspaceShellAccessLabel,

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -106,7 +106,7 @@
   "chatChannelsSectionEmpty": "Noch keine Kanäle verfügbar.",
   "chatAiChatsSectionTitle": "KI-Chats",
   "chatAiChatsSectionDescription": "Spezialisierte Assistenten- und Agentenchats haben ihren eigenen Bereich.",
-  "chatAiChatsSectionEmpty": "Noch keine KI-Chats verbunden. Künftige spezialisierte Agenten erscheinen hier, statt zwischen persönlichen Nachrichten zu verschwinden.",
+  "chatAiChatsSectionEmpty": "KI-Chats sind für diesen Arbeitsbereich nicht aktiviert. Owner oder Admins können gesteuerte Assistenten aktivieren, sobald Policy-, Einwilligungs- und Audit-Kontrollen bereit sind.",
   "chatAgentGovernanceTitle": "Agentenchats werden von deinem Workspace gesteuert",
   "chatAgentGovernanceDescription": "Agenten können in Weave erst helfen, wenn Owner oder Admins ein Paket aktivieren, Bereiche auswählen und Einwilligung sowie Audit sichtbar bleiben.",
   "chatAgentContextPackTitle": "Kontextpaket vor der Aktion",
@@ -114,14 +114,14 @@
   "chatAgentContextPackScopedBullet": "Kontext ist auf ausgewählte Chats, Dateien, Kalendertermine, Boards oder ausdrücklich gewählte Workspace-Quellen begrenzt.",
   "chatAgentContextPackConsentBullet": "Vor dem Start oder der Freigabe einer Agentenaktion siehst du Hinweise zu Berechtigungen.",
   "chatAgentContextPackNoSurveillanceBullet": "Agenten lesen Räume nicht dauerhaft im Hintergrund mit.",
-  "chatAgentGovernanceAuditNote": "Audit-Platzhalter gehören zu dieser Vorschau: Agentenerstellung, Kontextzugriff, Tool-/Aktionsausführung, Freigabe und Widerruf müssen vor einer Laufzeitfreigabe protokollierbar sein.",
-  "chatAgentAvailabilityPreview": "Nur Vorschau",
+  "chatAgentGovernanceAuditNote": "Agentenerstellung, Kontextzugriff, Tool-/Aktionsausführung, Freigabe und Widerruf müssen vor einer Laufzeitfreigabe auditierbar sein.",
+  "chatAgentAvailabilityPreview": "Durch Policy deaktiviert",
   "chatAgentAvailabilityAdminSetup": "Admin-Einrichtung nötig",
   "chatAgentAvailabilityBlocked": "Durch Policy blockiert",
   "chatAgentPersonalAssistantTitle": "Persönlicher Assistent",
-  "chatAgentPersonalAssistantDescription": "Ein künftiger privater Assistentenchat für Entwürfe, Zusammenfassungen und Erinnerungen in Weave.",
+  "chatAgentPersonalAssistantDescription": "Ein privater Assistentenchat für Entwürfe, Zusammenfassungen und Erinnerungen kann erst aktiviert werden, wenn Workspace-Policy, Einwilligung und Audit-Kontrollen bereit sind.",
   "chatAgentChannelAgentTitle": "Kanal-Agent",
-  "chatAgentChannelAgentDescription": "Ein künftiger Helfer für einen Kanal oder Projektraum, gesteuert durch ein von Admins freigegebenes Paket.",
+  "chatAgentChannelAgentDescription": "Ein Helfer für einen Kanal oder Projektraum kann nur über ein von Admins freigegebenes Paket aktiviert werden.",
   "chatAgentPersonalScope": "Nutzt nur Kontext, den du für die aktuelle Anfrage auswählst; Workspace-Policies entscheiden, welche Fähigkeiten verfügbar sind.",
   "chatAgentPersonalBoundary": "Kein dauerhaftes Mitlesen von Räumen; ein Kontextpaket wird erst nach deinem Start oder deiner Freigabe zusammengestellt.",
   "chatAgentPersonalAudit": "Erstellung, Kontextzugriff, Tool-Nutzung und Berechtigungsänderungen werden vor Laufzeitnutzung auditierbar.",
@@ -236,7 +236,7 @@
   "helpHandbookTitle": "Benutzerhandbuch",
   "helpHandbookDescription": "Dieses Handbuch erklärt die tägliche Weave-App in klarer Sprache. Es ist offline mit der App verfügbar und wächst, wenn weitere Bereiche bereit werden.",
   "helpWhatIsWeaveTitle": "Was Weave ist",
-  "helpWhatIsWeaveBody": "Weave ist eine Zusammenarbeits-App für Teams, die einen barrierearmen Workspace nutzen möchten, ohne Datensouveränität aufzugeben. Chat, Dateien, Kontoeinstellungen und künftige Zusammenarbeitsmodule erscheinen in Weave, während offene Dienste wie Matrix, Nextcloud, Keycloak und das Weave-Backend im Hintergrund arbeiten.",
+  "helpWhatIsWeaveBody": "Weave ist eine Zusammenarbeits-App für Teams, die einen barrierearmen Workspace nutzen möchten, ohne Datensouveränität aufzugeben. Chat, Dateien, Kontoeinstellungen und weitere Zusammenarbeitsmodule erscheinen in Weave, während offene Dienste wie Matrix, Nextcloud, Keycloak und das Weave-Backend im Hintergrund arbeiten.",
   "helpSignInTitle": "Anmelden: Grundlagen",
   "helpSignInBody": "Nutze die Workspace-Adresse deines Admins und melde dich dann einmal mit Weave-SSO an. Für die normale Nutzung solltest du keine separaten Matrix- oder Nextcloud-Passwörter brauchen. Wenn die Anmeldung scheitert oder in einer Schleife hängt, prüfe deine Verbindung, bestätige die Serveradresse in den Einstellungen und frage einen Admin, ob deine Einladung oder dein Konto aktiv ist.",
   "helpChatTitle": "Chat",
@@ -486,14 +486,14 @@
   "channelWorkspaceFilesTitle": "Channel-Dateien",
   "channelWorkspaceBoardsTitle": "Channel-Boards und Aufgaben",
   "channelWorkspaceCalendarTitle": "Channel-Kalender",
-  "channelWorkspaceMeetingsTitle": "Channel-Meeting-Vorschau",
+  "channelWorkspaceMeetingsTitle": "Channel-Meetings",
   "channelWorkspaceChatDescription": "Nachrichten bleiben der standardmäßige Live-Kontext für diesen Channel.",
-  "channelWorkspaceFilesDescription": "Channel-Dateiverknüpfung ist eine Vorschau-Nahtstelle. Dateien werden über die Weave-Datei-Fassade statt über rohe Anbieterpfade angebunden, sobald der Backend-Vertrag bereit ist.",
-  "channelWorkspaceBoardsDescription": "Verknüpfte Boards und Aufgaben erscheinen als ehrliche Vorschau, bis anbieterneutraler Board-Status mit diesem Channel-Kontext verbunden ist.",
+  "channelWorkspaceFilesDescription": "Channel-Dateien nutzen die Weave-Datei-Fassade, damit Nutzer Arbeitsbereichsdateien ohne rohe Anbieterpfade durchsuchen und anhängen können.",
+  "channelWorkspaceBoardsDescription": "Channel-Boards brauchen Admin-Einrichtung für Board-Fassade, Autorisierung und Audit, bevor Aufgabenänderungen für Mitglieder aktiviert werden.",
   "channelWorkspaceCalendarDescription": "Channel-Termine bleiben gesperrt, bis die Kalender-Scope-Fähigkeit für diesen Arbeitsbereich verfügbar ist.",
   "channelWorkspaceMeetingsDescription": "Meetings werden mit Kalender, Agenda, Entscheidungen, Aufgaben, Dateien und Folge-Nachweisen dieses Channels verknüpft. LiveKit ist der Medien-Provider-Kontrakt; Beitreten und Starten bleiben gesperrt, bis Backend-Tokens, Medienverschlüsselungsnachweise und Barrierefreiheitsnachweise konfiguriert sind.",
   "channelWorkspaceMeetingsCapabilityTitle": "LiveKit-Bereitschaft ist fail-closed",
-  "channelWorkspaceMeetingsCapabilityBody": "LiveKit-Räume und Join-Tokens bleiben hinter der Backend-Fassade. Beitreten und Starten bleiben deaktiviert, bis Provider-Status, Signaling/Medienpfade, Untertitel, Aufzeichnungen, Medienverschlüsselung und Metadatengrenzen belegt sind. Matrix bleibt Chat- und E2EE-Substrat; Matrix-Chat-Verschlüsselung deckt LiveKit-Medienanrufe nicht automatisch ab. Diese Vorschau behauptet nicht, dass verschlüsselte LiveKit-Anrufe verfügbar sind.",
+  "channelWorkspaceMeetingsCapabilityBody": "LiveKit-Räume und Join-Tokens bleiben hinter der Backend-Fassade. Beitreten und Starten bleiben deaktiviert, bis Provider-Status, Signaling/Medienpfade, Untertitel, Aufzeichnungen, Medienverschlüsselung und Metadatengrenzen belegt sind. Matrix bleibt Chat- und E2EE-Substrat; Matrix-Chat-Verschlüsselung deckt LiveKit-Medienanrufe nicht automatisch ab.",
   "channelWorkspaceMeetingsPrivacyTitle": "Nur ausdrücklicher Meeting-Kontext",
   "channelWorkspaceMeetingsPrivacyBody": "Nur ausdrücklich aus {channelName} ausgewählter Kontext wird für ein Meeting vorbereitet. Weave liest, zeichnet oder transkribiert den Raum nicht dauerhaft im Hintergrund.",
   "channelWorkspaceMeetingsRecordingOff": "Aufzeichnung und Transkription aus",
@@ -508,7 +508,7 @@
   "channelWorkspaceMeetingsStartButton": "Meeting starten",
   "channelWorkspaceMeetingsBackendUnavailableReason": "Meeting-Anbieterfähigkeit ist noch nicht verfügbar.",
   "channelWorkspaceStatusAvailable": "Verfügbar",
-  "channelWorkspaceStatusPreview": "Vorschau-Vertrag",
+  "channelWorkspaceStatusPreview": "Admin-Einrichtung nötig",
   "channelWorkspaceStatusGated": "Durch Fähigkeit gesperrt",
   "channelWorkspaceProviderContract": "Anbieter-Nahtstelle: {contractId}",
   "channelWorkspaceExplicitContextNote": "Hier wird nur ausdrücklicher Kontext aus {channelName} gezeigt; Weave liest den Raum nicht dauerhaft im Hintergrund mit.",
@@ -584,7 +584,7 @@
   "filesLoadErrorTitle": "Dateien konnten nicht geladen werden",
   "filesErrorGuidance": "Versuche es erneut. Wenn das weiterhin passiert, prüfe den Dateien-Status in Einrichtung oder Diagnose.",
   "calendarEmptyMessage": "Noch keine Termine",
-  "deckEmptyMessage": "Noch keine Boards in dieser Zukunftsvorschau",
+  "deckEmptyMessage": "Noch keine Boards verfügbar",
   "deviceLanguageLabel": "Gerätesprache",
   "serverConfigurationProviderLabel": "OIDC-Anbieter",
   "serverConfigurationProviderFieldLabel": "Anbietertyp",
@@ -818,7 +818,7 @@
   "@agentCapabilityPolicyTitle": {
     "description": "Settings card title for AI agent capability governance"
   },
-  "agentCapabilityPolicyAdminDescription": "Owner und Admins entscheiden, welche Agentenpakete und Verbindungen genutzt werden dürfen. Diese Vorschau bleibt aus, bis Berechtigungen, Einwilligung und Audit-Kontrollen verbunden sind.",
+  "agentCapabilityPolicyAdminDescription": "Owner und Admins entscheiden, welche Agentenpakete und Verbindungen genutzt werden dürfen. Diese Oberfläche bleibt deaktiviert, bis Berechtigungen, Einwilligung und Audit-Kontrollen verbunden sind.",
   "@agentCapabilityPolicyAdminDescription": {
     "description": "Admin-facing description for AI agent capability governance"
   },
@@ -830,7 +830,7 @@
   "@agentCapabilityPolicyFailClosedNotice": {
     "description": "Fail-closed notice when policy cannot be trusted"
   },
-  "agentCapabilityPolicyManageDisabledButton": "Verwaltung in dieser Vorschau nicht verfügbar",
+  "agentCapabilityPolicyManageDisabledButton": "Verwaltung nicht verfügbar, bis Kontrollen bereit sind",
   "@agentCapabilityPolicyManageDisabledButton": {
     "description": "Disabled button label for future agent capability management"
   },
@@ -838,7 +838,7 @@
   "@agentCapabilityPolicyAskAdminHint": {
     "description": "Hint for non-admin users"
   },
-  "agentCapabilityPolicyAdminStateHint": "Aktueller Zustand: standardmäßig aus. Künftige Kontrollen brauchen eine Owner-/Admin-Prüfung, bevor Nutzer einen Agenten starten können.",
+  "agentCapabilityPolicyAdminStateHint": "Aktueller Zustand: standardmäßig aus. Kontrollen brauchen eine Owner-/Admin-Prüfung, bevor Nutzer einen Agenten starten können.",
   "@agentCapabilityPolicyAdminStateHint": {
     "description": "Admin state hint for disabled agent capabilities"
   },
@@ -858,7 +858,7 @@
   "@agentCapabilityChannelAgentDescription": {
     "description": "Agent capability description for channel agent"
   },
-  "agentCapabilityAvailabilityPreviewOnly": "Nur Vorschau",
+  "agentCapabilityAvailabilityPreviewOnly": "Durch Policy deaktiviert",
   "@agentCapabilityAvailabilityPreviewOnly": {
     "description": "Agent capability availability label for gated state"
   },
@@ -936,5 +936,9 @@
         "type": "String"
       }
     }
-  }
+  },
+  "channelWorkspaceStatusAdminSetupRequired": "Admin-Einrichtung nötig",
+  "channelWorkspaceStatusDisabledByPolicy": "Durch Policy deaktiviert",
+  "channelWorkspaceStatusDegraded": "Eingeschränkt",
+  "agentCapabilityAvailabilityDisabledByPolicy": "Durch Policy deaktiviert"
 }

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -363,7 +363,7 @@
   "@chatAiChatsSectionDescription": {
     "description": "Description for the AI chats section in the chat overview"
   },
-  "chatAiChatsSectionEmpty": "No AI chats are connected yet. Future specialized agents will appear here instead of being mixed into personal messages.",
+  "chatAiChatsSectionEmpty": "AI chats are not enabled for this workspace. A workspace owner or admin can enable governed assistants after policy, consent, and audit controls are ready.",
   "@chatAiChatsSectionEmpty": {
     "description": "Empty state for the AI chats section in the chat overview"
   },
@@ -395,11 +395,11 @@
   "@chatAgentContextPackNoSurveillanceBullet": {
     "description": "Bullet explaining that agents are not surveillance-aware"
   },
-  "chatAgentGovernanceAuditNote": "Audit placeholders are part of this preview: agent creation, context access, tool/action execution, approval, and revocation must be recorded before runtime promotion.",
+  "chatAgentGovernanceAuditNote": "Agent creation, context access, tool/action execution, approval, and revocation must be audit-ready before runtime enablement.",
   "@chatAgentGovernanceAuditNote": {
     "description": "Audit and approval note for the governed agent chat preview panel"
   },
-  "chatAgentAvailabilityPreview": "Preview only",
+  "chatAgentAvailabilityPreview": "Disabled by policy",
   "@chatAgentAvailabilityPreview": {
     "description": "Agent availability label for a gated agent"
   },
@@ -415,7 +415,7 @@
   "@chatAgentPersonalAssistantTitle": {
     "description": "Title for the personal assistant preview tile"
   },
-  "chatAgentPersonalAssistantDescription": "A future private assistant chat for drafting, summaries, and reminders inside Weave.",
+  "chatAgentPersonalAssistantDescription": "A private assistant chat for drafting, summaries, and reminders can be enabled only after workspace policy, consent, and audit controls are ready.",
   "@chatAgentPersonalAssistantDescription": {
     "description": "Description for the personal assistant preview tile"
   },
@@ -423,7 +423,7 @@
   "@chatAgentChannelAgentTitle": {
     "description": "Title for the channel agent preview tile"
   },
-  "chatAgentChannelAgentDescription": "A future helper for a channel or project space, governed by an admin-approved package.",
+  "chatAgentChannelAgentDescription": "A helper for a channel or project space can be enabled only through an admin-approved package.",
   "@chatAgentChannelAgentDescription": {
     "description": "Description for the channel agent preview tile"
   },
@@ -553,7 +553,7 @@
   "@channelWorkspaceCalendarTitle": {
     "description": "Title for the calendar surface in a channel workspace"
   },
-  "channelWorkspaceMeetingsTitle": "Channel meeting preview",
+  "channelWorkspaceMeetingsTitle": "Channel meetings",
   "@channelWorkspaceMeetingsTitle": {
     "description": "Title for the meetings preview surface in a channel workspace"
   },
@@ -561,11 +561,11 @@
   "@channelWorkspaceChatDescription": {
     "description": "Description for the channel chat surface"
   },
-  "channelWorkspaceFilesDescription": "Channel file linking is a preview seam. Files will attach through the Weave files facade instead of raw provider paths once the backend contract is ready.",
+  "channelWorkspaceFilesDescription": "Channel files use the Weave files facade so people can browse and attach workspace files without raw provider paths.",
   "@channelWorkspaceFilesDescription": {
     "description": "Description for the channel files preview placeholder"
   },
-  "channelWorkspaceBoardsDescription": "Linked boards and tasks are shown as an honest preview until provider-neutral board state is connected to this channel context.",
+  "channelWorkspaceBoardsDescription": "Channel boards require admin setup for the board facade, authorization, and audit before member task writes are enabled.",
   "@channelWorkspaceBoardsDescription": {
     "description": "Description for the channel boards/tasks preview placeholder"
   },
@@ -581,7 +581,7 @@
   "@channelWorkspaceMeetingsCapabilityTitle": {
     "description": "Title explaining that channel meetings are fail-closed until backend and encryption evidence exist"
   },
-  "channelWorkspaceMeetingsCapabilityBody": "LiveKit room creation and join tokens stay behind the backend facade. Join and start stay disabled until provider status, signaling/media paths, captions, recordings, media encryption, and metadata boundaries have evidence. Matrix remains the chat/E2EE substrate; Matrix chat encryption does not by itself cover LiveKit media calls. This preview does not claim that encrypted LiveKit calls are available.",
+  "channelWorkspaceMeetingsCapabilityBody": "LiveKit room creation and join tokens stay behind the backend facade. Join and start stay disabled until provider status, signaling/media paths, captions, recordings, media encryption, and metadata boundaries have evidence. Matrix remains the chat/E2EE substrate; Matrix chat encryption does not by itself cover LiveKit media calls.",
   "@channelWorkspaceMeetingsCapabilityBody": {
     "description": "Body explaining honest fail-closed channel meeting capability state"
   },
@@ -646,7 +646,7 @@
   "@channelWorkspaceStatusAvailable": {
     "description": "Status label for an available channel workspace surface"
   },
-  "channelWorkspaceStatusPreview": "Preview contract",
+  "channelWorkspaceStatusPreview": "Admin setup required",
   "@channelWorkspaceStatusPreview": {
     "description": "Status label for a gated channel workspace surface"
   },
@@ -1140,7 +1140,7 @@
   "@helpWhatIsWeaveTitle": {
     "description": "Help section title explaining the product"
   },
-  "helpWhatIsWeaveBody": "Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and future collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.",
+  "helpWhatIsWeaveBody": "Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and additional collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.",
   "@helpWhatIsWeaveBody": {
     "description": "Help copy explaining what Weave is"
   },
@@ -2464,7 +2464,7 @@
   "@calendarEmptyMessage": {
     "description": "Empty state message for the calendar screen"
   },
-  "deckEmptyMessage": "No boards in this dogfood production yet",
+  "deckEmptyMessage": "No boards are available yet",
   "@deckEmptyMessage": {
     "description": "Legacy hidden Deck empty state message retained for compatibility"
   },
@@ -3410,7 +3410,7 @@
   "@agentCapabilityPolicyTitle": {
     "description": "Settings card title for AI agent capability governance"
   },
-  "agentCapabilityPolicyAdminDescription": "Owners and admins decide which agent packages and connectors can be used. This preview stays off until permission, consent, and audit controls are connected.",
+  "agentCapabilityPolicyAdminDescription": "Owners and admins decide which agent packages and connectors can be used. This surface stays disabled until permission, consent, and audit controls are connected.",
   "@agentCapabilityPolicyAdminDescription": {
     "description": "Admin-facing description for AI agent capability governance"
   },
@@ -3422,7 +3422,7 @@
   "@agentCapabilityPolicyFailClosedNotice": {
     "description": "Fail-closed notice when policy cannot be trusted"
   },
-  "agentCapabilityPolicyManageDisabledButton": "Management unavailable in this preview",
+  "agentCapabilityPolicyManageDisabledButton": "Management unavailable until controls are ready",
   "@agentCapabilityPolicyManageDisabledButton": {
     "description": "Disabled button label for future agent capability management"
   },
@@ -3430,7 +3430,7 @@
   "@agentCapabilityPolicyAskAdminHint": {
     "description": "Hint for non-admin users"
   },
-  "agentCapabilityPolicyAdminStateHint": "Current state: off by default. Future controls will require owner/admin review before users can start an agent.",
+  "agentCapabilityPolicyAdminStateHint": "Current state: off by default. Controls require owner/admin review before users can start an agent.",
   "@agentCapabilityPolicyAdminStateHint": {
     "description": "Admin state hint for disabled agent capabilities"
   },
@@ -3450,7 +3450,7 @@
   "@agentCapabilityChannelAgentDescription": {
     "description": "Agent capability description for channel agent"
   },
-  "agentCapabilityAvailabilityPreviewOnly": "Preview only",
+  "agentCapabilityAvailabilityPreviewOnly": "Disabled by policy",
   "@agentCapabilityAvailabilityPreviewOnly": {
     "description": "Agent capability availability label for gated state"
   },
@@ -3674,5 +3674,21 @@
   "workflowPreviewReviewEvidenceButton": "Review evidence",
   "@workflowPreviewReviewEvidenceButton": {
     "description": "Disabled placeholder action for reviewing workflow evidence"
+  },
+  "channelWorkspaceStatusAdminSetupRequired": "Admin setup required",
+  "@channelWorkspaceStatusAdminSetupRequired": {
+    "description": "Status chip for a channel workspace surface that requires admin setup"
+  },
+  "channelWorkspaceStatusDisabledByPolicy": "Disabled by policy",
+  "@channelWorkspaceStatusDisabledByPolicy": {
+    "description": "Status chip for a channel workspace surface disabled by policy"
+  },
+  "channelWorkspaceStatusDegraded": "Degraded",
+  "@channelWorkspaceStatusDegraded": {
+    "description": "Status chip for a degraded channel workspace surface"
+  },
+  "agentCapabilityAvailabilityDisabledByPolicy": "Disabled by policy",
+  "@agentCapabilityAvailabilityDisabledByPolicy": {
+    "description": "Availability chip for an agent capability disabled by workspace policy"
   }
 }

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -746,7 +746,7 @@ abstract class AppLocalizations {
   /// Empty state for the AI chats section in the chat overview
   ///
   /// In en, this message translates to:
-  /// **'No AI chats are connected yet. Future specialized agents will appear here instead of being mixed into personal messages.'**
+  /// **'AI chats are not enabled for this workspace. A workspace owner or admin can enable governed assistants after policy, consent, and audit controls are ready.'**
   String get chatAiChatsSectionEmpty;
 
   /// Title for the governed agent chat preview panel
@@ -794,13 +794,13 @@ abstract class AppLocalizations {
   /// Audit and approval note for the governed agent chat preview panel
   ///
   /// In en, this message translates to:
-  /// **'Audit placeholders are part of this preview: agent creation, context access, tool/action execution, approval, and revocation must be recorded before runtime promotion.'**
+  /// **'Agent creation, context access, tool/action execution, approval, and revocation must be audit-ready before runtime enablement.'**
   String get chatAgentGovernanceAuditNote;
 
   /// Agent availability label for a gated agent
   ///
   /// In en, this message translates to:
-  /// **'Preview only'**
+  /// **'Disabled by policy'**
   String get chatAgentAvailabilityPreview;
 
   /// Agent availability label when setup must be done by an admin
@@ -824,7 +824,7 @@ abstract class AppLocalizations {
   /// Description for the personal assistant preview tile
   ///
   /// In en, this message translates to:
-  /// **'A future private assistant chat for drafting, summaries, and reminders inside Weave.'**
+  /// **'A private assistant chat for drafting, summaries, and reminders can be enabled only after workspace policy, consent, and audit controls are ready.'**
   String get chatAgentPersonalAssistantDescription;
 
   /// Title for the channel agent preview tile
@@ -836,7 +836,7 @@ abstract class AppLocalizations {
   /// Description for the channel agent preview tile
   ///
   /// In en, this message translates to:
-  /// **'A future helper for a channel or project space, governed by an admin-approved package.'**
+  /// **'A helper for a channel or project space can be enabled only through an admin-approved package.'**
   String get chatAgentChannelAgentDescription;
 
   /// Scope explanation for personal assistant preview
@@ -1016,7 +1016,7 @@ abstract class AppLocalizations {
   /// Title for the meetings preview surface in a channel workspace
   ///
   /// In en, this message translates to:
-  /// **'Channel meeting preview'**
+  /// **'Channel meetings'**
   String get channelWorkspaceMeetingsTitle;
 
   /// Description for the channel chat surface
@@ -1028,13 +1028,13 @@ abstract class AppLocalizations {
   /// Description for the channel files preview placeholder
   ///
   /// In en, this message translates to:
-  /// **'Channel file linking is a preview seam. Files will attach through the Weave files facade instead of raw provider paths once the backend contract is ready.'**
+  /// **'Channel files use the Weave files facade so people can browse and attach workspace files without raw provider paths.'**
   String get channelWorkspaceFilesDescription;
 
   /// Description for the channel boards/tasks preview placeholder
   ///
   /// In en, this message translates to:
-  /// **'Linked boards and tasks are shown as an honest preview until provider-neutral board state is connected to this channel context.'**
+  /// **'Channel boards require admin setup for the board facade, authorization, and audit before member task writes are enabled.'**
   String get channelWorkspaceBoardsDescription;
 
   /// Description for the gated channel calendar placeholder
@@ -1058,7 +1058,7 @@ abstract class AppLocalizations {
   /// Body explaining honest fail-closed channel meeting capability state
   ///
   /// In en, this message translates to:
-  /// **'LiveKit room creation and join tokens stay behind the backend facade. Join and start stay disabled until provider status, signaling/media paths, captions, recordings, media encryption, and metadata boundaries have evidence. Matrix remains the chat/E2EE substrate; Matrix chat encryption does not by itself cover LiveKit media calls. This preview does not claim that encrypted LiveKit calls are available.'**
+  /// **'LiveKit room creation and join tokens stay behind the backend facade. Join and start stay disabled until provider status, signaling/media paths, captions, recordings, media encryption, and metadata boundaries have evidence. Matrix remains the chat/E2EE substrate; Matrix chat encryption does not by itself cover LiveKit media calls.'**
   String get channelWorkspaceMeetingsCapabilityBody;
 
   /// Title for the explicit context rule in the channel meetings preview
@@ -1148,7 +1148,7 @@ abstract class AppLocalizations {
   /// Status label for a gated channel workspace surface
   ///
   /// In en, this message translates to:
-  /// **'Preview contract'**
+  /// **'Admin setup required'**
   String get channelWorkspaceStatusPreview;
 
   /// Status label for a gated channel workspace surface
@@ -1706,7 +1706,7 @@ abstract class AppLocalizations {
   /// Help copy explaining what Weave is
   ///
   /// In en, this message translates to:
-  /// **'Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and future collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.'**
+  /// **'Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and additional collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.'**
   String get helpWhatIsWeaveBody;
 
   /// Help section title for sign-in basics
@@ -3570,7 +3570,7 @@ abstract class AppLocalizations {
   /// Legacy hidden Deck empty state message retained for compatibility
   ///
   /// In en, this message translates to:
-  /// **'No boards in this dogfood production yet'**
+  /// **'No boards are available yet'**
   String get deckEmptyMessage;
 
   /// Label for the detected device language display
@@ -4735,7 +4735,7 @@ abstract class AppLocalizations {
   /// Admin-facing description for AI agent capability governance
   ///
   /// In en, this message translates to:
-  /// **'Owners and admins decide which agent packages and connectors can be used. This preview stays off until permission, consent, and audit controls are connected.'**
+  /// **'Owners and admins decide which agent packages and connectors can be used. This surface stays disabled until permission, consent, and audit controls are connected.'**
   String get agentCapabilityPolicyAdminDescription;
 
   /// Member-facing description for AI agent capability governance
@@ -4753,7 +4753,7 @@ abstract class AppLocalizations {
   /// Disabled button label for future agent capability management
   ///
   /// In en, this message translates to:
-  /// **'Management unavailable in this preview'**
+  /// **'Management unavailable until controls are ready'**
   String get agentCapabilityPolicyManageDisabledButton;
 
   /// Hint for non-admin users
@@ -4765,7 +4765,7 @@ abstract class AppLocalizations {
   /// Admin state hint for disabled agent capabilities
   ///
   /// In en, this message translates to:
-  /// **'Current state: off by default. Future controls will require owner/admin review before users can start an agent.'**
+  /// **'Current state: off by default. Controls require owner/admin review before users can start an agent.'**
   String get agentCapabilityPolicyAdminStateHint;
 
   /// Agent capability title for personal assistant
@@ -4795,7 +4795,7 @@ abstract class AppLocalizations {
   /// Agent capability availability label for gated state
   ///
   /// In en, this message translates to:
-  /// **'Preview only'**
+  /// **'Disabled by policy'**
   String get agentCapabilityAvailabilityPreviewOnly;
 
   /// Agent capability availability label when admin setup is required
@@ -5013,6 +5013,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Review evidence'**
   String get workflowPreviewReviewEvidenceButton;
+
+  /// Status chip for a channel workspace surface that requires admin setup
+  ///
+  /// In en, this message translates to:
+  /// **'Admin setup required'**
+  String get channelWorkspaceStatusAdminSetupRequired;
+
+  /// Status chip for a channel workspace surface disabled by policy
+  ///
+  /// In en, this message translates to:
+  /// **'Disabled by policy'**
+  String get channelWorkspaceStatusDisabledByPolicy;
+
+  /// Status chip for a degraded channel workspace surface
+  ///
+  /// In en, this message translates to:
+  /// **'Degraded'**
+  String get channelWorkspaceStatusDegraded;
+
+  /// Availability chip for an agent capability disabled by workspace policy
+  ///
+  /// In en, this message translates to:
+  /// **'Disabled by policy'**
+  String get agentCapabilityAvailabilityDisabledByPolicy;
 }
 
 class _AppLocalizationsDelegate

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -374,7 +374,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chatAiChatsSectionEmpty =>
-      'Noch keine KI-Chats verbunden. Künftige spezialisierte Agenten erscheinen hier, statt zwischen persönlichen Nachrichten zu verschwinden.';
+      'KI-Chats sind für diesen Arbeitsbereich nicht aktiviert. Owner oder Admins können gesteuerte Assistenten aktivieren, sobald Policy-, Einwilligungs- und Audit-Kontrollen bereit sind.';
 
   @override
   String get chatAgentGovernanceTitle =>
@@ -405,10 +405,10 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chatAgentGovernanceAuditNote =>
-      'Audit-Platzhalter gehören zu dieser Vorschau: Agentenerstellung, Kontextzugriff, Tool-/Aktionsausführung, Freigabe und Widerruf müssen vor einer Laufzeitfreigabe protokollierbar sein.';
+      'Agentenerstellung, Kontextzugriff, Tool-/Aktionsausführung, Freigabe und Widerruf müssen vor einer Laufzeitfreigabe auditierbar sein.';
 
   @override
-  String get chatAgentAvailabilityPreview => 'Nur Vorschau';
+  String get chatAgentAvailabilityPreview => 'Durch Policy deaktiviert';
 
   @override
   String get chatAgentAvailabilityAdminSetup => 'Admin-Einrichtung nötig';
@@ -421,14 +421,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chatAgentPersonalAssistantDescription =>
-      'Ein künftiger privater Assistentenchat für Entwürfe, Zusammenfassungen und Erinnerungen in Weave.';
+      'Ein privater Assistentenchat für Entwürfe, Zusammenfassungen und Erinnerungen kann erst aktiviert werden, wenn Workspace-Policy, Einwilligung und Audit-Kontrollen bereit sind.';
 
   @override
   String get chatAgentChannelAgentTitle => 'Kanal-Agent';
 
   @override
   String get chatAgentChannelAgentDescription =>
-      'Ein künftiger Helfer für einen Kanal oder Projektraum, gesteuert durch ein von Admins freigegebenes Paket.';
+      'Ein Helfer für einen Kanal oder Projektraum kann nur über ein von Admins freigegebenes Paket aktiviert werden.';
 
   @override
   String get chatAgentPersonalScope =>
@@ -533,7 +533,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channelWorkspaceCalendarTitle => 'Channel-Kalender';
 
   @override
-  String get channelWorkspaceMeetingsTitle => 'Channel-Meeting-Vorschau';
+  String get channelWorkspaceMeetingsTitle => 'Channel-Meetings';
 
   @override
   String get channelWorkspaceChatDescription =>
@@ -541,11 +541,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get channelWorkspaceFilesDescription =>
-      'Channel-Dateiverknüpfung ist eine Vorschau-Nahtstelle. Dateien werden über die Weave-Datei-Fassade statt über rohe Anbieterpfade angebunden, sobald der Backend-Vertrag bereit ist.';
+      'Channel-Dateien nutzen die Weave-Datei-Fassade, damit Nutzer Arbeitsbereichsdateien ohne rohe Anbieterpfade durchsuchen und anhängen können.';
 
   @override
   String get channelWorkspaceBoardsDescription =>
-      'Verknüpfte Boards und Aufgaben erscheinen als ehrliche Vorschau, bis anbieterneutraler Board-Status mit diesem Channel-Kontext verbunden ist.';
+      'Channel-Boards brauchen Admin-Einrichtung für Board-Fassade, Autorisierung und Audit, bevor Aufgabenänderungen für Mitglieder aktiviert werden.';
 
   @override
   String get channelWorkspaceCalendarDescription =>
@@ -561,7 +561,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get channelWorkspaceMeetingsCapabilityBody =>
-      'LiveKit-Räume und Join-Tokens bleiben hinter der Backend-Fassade. Beitreten und Starten bleiben deaktiviert, bis Provider-Status, Signaling/Medienpfade, Untertitel, Aufzeichnungen, Medienverschlüsselung und Metadatengrenzen belegt sind. Matrix bleibt Chat- und E2EE-Substrat; Matrix-Chat-Verschlüsselung deckt LiveKit-Medienanrufe nicht automatisch ab. Diese Vorschau behauptet nicht, dass verschlüsselte LiveKit-Anrufe verfügbar sind.';
+      'LiveKit-Räume und Join-Tokens bleiben hinter der Backend-Fassade. Beitreten und Starten bleiben deaktiviert, bis Provider-Status, Signaling/Medienpfade, Untertitel, Aufzeichnungen, Medienverschlüsselung und Metadatengrenzen belegt sind. Matrix bleibt Chat- und E2EE-Substrat; Matrix-Chat-Verschlüsselung deckt LiveKit-Medienanrufe nicht automatisch ab.';
 
   @override
   String get channelWorkspaceMeetingsPrivacyTitle =>
@@ -613,7 +613,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get channelWorkspaceStatusAvailable => 'Verfügbar';
 
   @override
-  String get channelWorkspaceStatusPreview => 'Vorschau-Vertrag';
+  String get channelWorkspaceStatusPreview => 'Admin-Einrichtung nötig';
 
   @override
   String get channelWorkspaceStatusGated => 'Durch Fähigkeit gesperrt';
@@ -976,7 +976,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get helpWhatIsWeaveBody =>
-      'Weave ist eine Zusammenarbeits-App für Teams, die einen barrierearmen Workspace nutzen möchten, ohne Datensouveränität aufzugeben. Chat, Dateien, Kontoeinstellungen und künftige Zusammenarbeitsmodule erscheinen in Weave, während offene Dienste wie Matrix, Nextcloud, Keycloak und das Weave-Backend im Hintergrund arbeiten.';
+      'Weave ist eine Zusammenarbeits-App für Teams, die einen barrierearmen Workspace nutzen möchten, ohne Datensouveränität aufzugeben. Chat, Dateien, Kontoeinstellungen und weitere Zusammenarbeitsmodule erscheinen in Weave, während offene Dienste wie Matrix, Nextcloud, Keycloak und das Weave-Backend im Hintergrund arbeiten.';
 
   @override
   String get helpSignInTitle => 'Anmelden: Grundlagen';
@@ -2108,7 +2108,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get calendarEmptyMessage => 'Noch keine Termine';
 
   @override
-  String get deckEmptyMessage => 'Noch keine Boards in dieser Zukunftsvorschau';
+  String get deckEmptyMessage => 'Noch keine Boards verfügbar';
 
   @override
   String get deviceLanguageLabel => 'Gerätesprache';
@@ -2867,7 +2867,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get agentCapabilityPolicyAdminDescription =>
-      'Owner und Admins entscheiden, welche Agentenpakete und Verbindungen genutzt werden dürfen. Diese Vorschau bleibt aus, bis Berechtigungen, Einwilligung und Audit-Kontrollen verbunden sind.';
+      'Owner und Admins entscheiden, welche Agentenpakete und Verbindungen genutzt werden dürfen. Diese Oberfläche bleibt deaktiviert, bis Berechtigungen, Einwilligung und Audit-Kontrollen verbunden sind.';
 
   @override
   String get agentCapabilityPolicyUserDescription =>
@@ -2879,7 +2879,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get agentCapabilityPolicyManageDisabledButton =>
-      'Verwaltung in dieser Vorschau nicht verfügbar';
+      'Verwaltung nicht verfügbar, bis Kontrollen bereit sind';
 
   @override
   String get agentCapabilityPolicyAskAdminHint =>
@@ -2887,7 +2887,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get agentCapabilityPolicyAdminStateHint =>
-      'Aktueller Zustand: standardmäßig aus. Künftige Kontrollen brauchen eine Owner-/Admin-Prüfung, bevor Nutzer einen Agenten starten können.';
+      'Aktueller Zustand: standardmäßig aus. Kontrollen brauchen eine Owner-/Admin-Prüfung, bevor Nutzer einen Agenten starten können.';
 
   @override
   String get agentCapabilityPersonalAssistantTitle => 'Persönlicher Assistent';
@@ -2904,7 +2904,8 @@ class AppLocalizationsDe extends AppLocalizations {
       'Erfordert, dass Owner oder Admins auswählen, welche Kanäle, Dateien, Kalendertermine oder Boards der Agent nutzen darf.';
 
   @override
-  String get agentCapabilityAvailabilityPreviewOnly => 'Nur Vorschau';
+  String get agentCapabilityAvailabilityPreviewOnly =>
+      'Durch Policy deaktiviert';
 
   @override
   String get agentCapabilityAvailabilityAdminSetupRequired =>
@@ -3083,4 +3084,19 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get workflowPreviewReviewEvidenceButton => 'Evidenz prüfen';
+
+  @override
+  String get channelWorkspaceStatusAdminSetupRequired =>
+      'Admin-Einrichtung nötig';
+
+  @override
+  String get channelWorkspaceStatusDisabledByPolicy =>
+      'Durch Policy deaktiviert';
+
+  @override
+  String get channelWorkspaceStatusDegraded => 'Eingeschränkt';
+
+  @override
+  String get agentCapabilityAvailabilityDisabledByPolicy =>
+      'Durch Policy deaktiviert';
 }

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -371,7 +371,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get chatAiChatsSectionEmpty =>
-      'No AI chats are connected yet. Future specialized agents will appear here instead of being mixed into personal messages.';
+      'AI chats are not enabled for this workspace. A workspace owner or admin can enable governed assistants after policy, consent, and audit controls are ready.';
 
   @override
   String get chatAgentGovernanceTitle =>
@@ -402,10 +402,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get chatAgentGovernanceAuditNote =>
-      'Audit placeholders are part of this preview: agent creation, context access, tool/action execution, approval, and revocation must be recorded before runtime promotion.';
+      'Agent creation, context access, tool/action execution, approval, and revocation must be audit-ready before runtime enablement.';
 
   @override
-  String get chatAgentAvailabilityPreview => 'Preview only';
+  String get chatAgentAvailabilityPreview => 'Disabled by policy';
 
   @override
   String get chatAgentAvailabilityAdminSetup => 'Admin setup required';
@@ -418,14 +418,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get chatAgentPersonalAssistantDescription =>
-      'A future private assistant chat for drafting, summaries, and reminders inside Weave.';
+      'A private assistant chat for drafting, summaries, and reminders can be enabled only after workspace policy, consent, and audit controls are ready.';
 
   @override
   String get chatAgentChannelAgentTitle => 'Channel agent';
 
   @override
   String get chatAgentChannelAgentDescription =>
-      'A future helper for a channel or project space, governed by an admin-approved package.';
+      'A helper for a channel or project space can be enabled only through an admin-approved package.';
 
   @override
   String get chatAgentPersonalScope =>
@@ -530,7 +530,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get channelWorkspaceCalendarTitle => 'Channel calendar';
 
   @override
-  String get channelWorkspaceMeetingsTitle => 'Channel meeting preview';
+  String get channelWorkspaceMeetingsTitle => 'Channel meetings';
 
   @override
   String get channelWorkspaceChatDescription =>
@@ -538,11 +538,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get channelWorkspaceFilesDescription =>
-      'Channel file linking is a preview seam. Files will attach through the Weave files facade instead of raw provider paths once the backend contract is ready.';
+      'Channel files use the Weave files facade so people can browse and attach workspace files without raw provider paths.';
 
   @override
   String get channelWorkspaceBoardsDescription =>
-      'Linked boards and tasks are shown as an honest preview until provider-neutral board state is connected to this channel context.';
+      'Channel boards require admin setup for the board facade, authorization, and audit before member task writes are enabled.';
 
   @override
   String get channelWorkspaceCalendarDescription =>
@@ -558,7 +558,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get channelWorkspaceMeetingsCapabilityBody =>
-      'LiveKit room creation and join tokens stay behind the backend facade. Join and start stay disabled until provider status, signaling/media paths, captions, recordings, media encryption, and metadata boundaries have evidence. Matrix remains the chat/E2EE substrate; Matrix chat encryption does not by itself cover LiveKit media calls. This preview does not claim that encrypted LiveKit calls are available.';
+      'LiveKit room creation and join tokens stay behind the backend facade. Join and start stay disabled until provider status, signaling/media paths, captions, recordings, media encryption, and metadata boundaries have evidence. Matrix remains the chat/E2EE substrate; Matrix chat encryption does not by itself cover LiveKit media calls.';
 
   @override
   String get channelWorkspaceMeetingsPrivacyTitle =>
@@ -610,7 +610,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get channelWorkspaceStatusAvailable => 'Available';
 
   @override
-  String get channelWorkspaceStatusPreview => 'Preview contract';
+  String get channelWorkspaceStatusPreview => 'Admin setup required';
 
   @override
   String get channelWorkspaceStatusGated => 'Gated by capability';
@@ -970,7 +970,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get helpWhatIsWeaveBody =>
-      'Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and future collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.';
+      'Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and additional collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.';
 
   @override
   String get helpSignInTitle => 'Sign in basics';
@@ -2080,7 +2080,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get calendarEmptyMessage => 'No events yet';
 
   @override
-  String get deckEmptyMessage => 'No boards in this dogfood production yet';
+  String get deckEmptyMessage => 'No boards are available yet';
 
   @override
   String get deviceLanguageLabel => 'Device Language';
@@ -2825,7 +2825,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get agentCapabilityPolicyAdminDescription =>
-      'Owners and admins decide which agent packages and connectors can be used. This preview stays off until permission, consent, and audit controls are connected.';
+      'Owners and admins decide which agent packages and connectors can be used. This surface stays disabled until permission, consent, and audit controls are connected.';
 
   @override
   String get agentCapabilityPolicyUserDescription =>
@@ -2837,7 +2837,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get agentCapabilityPolicyManageDisabledButton =>
-      'Management unavailable in this preview';
+      'Management unavailable until controls are ready';
 
   @override
   String get agentCapabilityPolicyAskAdminHint =>
@@ -2845,7 +2845,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get agentCapabilityPolicyAdminStateHint =>
-      'Current state: off by default. Future controls will require owner/admin review before users can start an agent.';
+      'Current state: off by default. Controls require owner/admin review before users can start an agent.';
 
   @override
   String get agentCapabilityPersonalAssistantTitle => 'Personal assistant';
@@ -2862,7 +2862,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Requires an owner or admin to choose which channels, files, calendar items, or boards the agent may use.';
 
   @override
-  String get agentCapabilityAvailabilityPreviewOnly => 'Preview only';
+  String get agentCapabilityAvailabilityPreviewOnly => 'Disabled by policy';
 
   @override
   String get agentCapabilityAvailabilityAdminSetupRequired =>
@@ -3041,4 +3041,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get workflowPreviewReviewEvidenceButton => 'Review evidence';
+
+  @override
+  String get channelWorkspaceStatusAdminSetupRequired => 'Admin setup required';
+
+  @override
+  String get channelWorkspaceStatusDisabledByPolicy => 'Disabled by policy';
+
+  @override
+  String get channelWorkspaceStatusDegraded => 'Degraded';
+
+  @override
+  String get agentCapabilityAvailabilityDisabledByPolicy =>
+      'Disabled by policy';
 }

--- a/client/test/features/agents/domain/agent_capability_policy_test.dart
+++ b/client/test/features/agents/domain/agent_capability_policy_test.dart
@@ -3,15 +3,17 @@ import 'package:weave/features/agents/domain/entities/agent_capability_policy.da
 
 void main() {
   group('AgentCapabilityPolicy', () {
-    test('preview defaults are disabled and non-startable', () {
-      final policy = AgentCapabilityPolicy.preview(canManageCapabilities: true);
+    test('disabled defaults are non-startable and policy-owned', () {
+      final policy = AgentCapabilityPolicy.disabled(
+        canManageCapabilities: true,
+      );
 
       expect(policy.canManageCapabilities, isTrue);
       expect(policy.isFailClosed, isFalse);
       expect(policy.canStartAnyCapability, isFalse);
       expect(
         policy.stateFor(AgentCapability.personalAssistant).availability,
-        AgentCapabilityAvailability.previewOnly,
+        AgentCapabilityAvailability.disabledByPolicy,
       );
       expect(
         policy.stateFor(AgentCapability.channelAgent).availability,

--- a/client/test/features/chat/agent_chat_preview_provider_test.dart
+++ b/client/test/features/chat/agent_chat_preview_provider_test.dart
@@ -7,13 +7,13 @@ import 'package:weave/features/chat/presentation/providers/agent_chat_preview_pr
 
 void main() {
   test(
-    'agent chat previews remain gated before consent/audit runtime exists',
+    'agent chat entries remain disabled before consent/audit runtime exists',
     () {
       final container = ProviderContainer.test(
         overrides: [
           agentCapabilityPolicyProvider.overrideWithValue(
             AsyncData(
-              AgentCapabilityPolicy.preview(canManageCapabilities: true),
+              AgentCapabilityPolicy.disabled(canManageCapabilities: true),
             ),
           ),
         ],
@@ -34,12 +34,12 @@ void main() {
         previews.every((preview) => preview.canStart == false),
         isTrue,
         reason:
-            'The first agent surface is preview-only until backend policy, consent, and audit gates are connected.',
+            'The first agent surface is disabled until backend policy, consent, and audit gates are connected.',
       );
       expect(
         previews.map((preview) => preview.availability),
         containsAll(<AgentChatAvailability>{
-          AgentChatAvailability.previewOnly,
+          AgentChatAvailability.disabledByPolicy,
           AgentChatAvailability.adminSetupRequired,
         }),
       );

--- a/client/test/features/chat/channel_workspace_test.dart
+++ b/client/test/features/chat/channel_workspace_test.dart
@@ -34,8 +34,12 @@ void main() {
       'weave-files-channel-link',
     );
     expect(
-      preview.surface(ChannelWorkspaceSurfaceKind.boards).providerContractId,
-      'weave-boards-channel-link',
+      preview.surface(ChannelWorkspaceSurfaceKind.files).availability,
+      ChannelWorkspaceSurfaceAvailability.available,
+    );
+    expect(
+      preview.surface(ChannelWorkspaceSurfaceKind.boards).availability,
+      ChannelWorkspaceSurfaceAvailability.adminSetupRequired,
     );
     expect(
       preview.surface(ChannelWorkspaceSurfaceKind.calendar).availability,
@@ -43,7 +47,7 @@ void main() {
     );
     expect(
       preview.surface(ChannelWorkspaceSurfaceKind.meetings).providerContractId,
-      'livekit-meetings-channel-preview',
+      'livekit-meetings-channel-gate',
     );
     expect(preview.meetingPreview.contextId, preview.contextId);
     expect(preview.meetingPreview.isFailClosed, isTrue);

--- a/client/test/features/chat/chat_room_screen_test.dart
+++ b/client/test/features/chat/chat_room_screen_test.dart
@@ -131,7 +131,7 @@ void main() {
     await tester.tap(find.text('Files'));
     await tester.pumpAndSettle();
     expect(find.text('Channel files'), findsOneWidget);
-    expect(find.text('Preview contract'), findsOneWidget);
+    expect(find.text('Available'), findsOneWidget);
     expect(
       find.text('Provider seam: weave-files-channel-link'),
       findsOneWidget,
@@ -140,6 +140,7 @@ void main() {
     await tester.tap(find.text('Boards'));
     await tester.pumpAndSettle();
     expect(find.text('Channel boards and tasks'), findsOneWidget);
+    expect(find.text('Admin setup required'), findsOneWidget);
     expect(
       find.text('Provider seam: weave-boards-channel-link'),
       findsOneWidget,
@@ -156,11 +157,11 @@ void main() {
 
     await tester.tap(find.text('Meetings'));
     await tester.pumpAndSettle();
-    expect(find.text('Channel meeting preview'), findsOneWidget);
+    expect(find.text('Channel meetings'), findsOneWidget);
     expect(find.text('LiveKit readiness is fail-closed'), findsOneWidget);
     expect(
       find.textContaining(
-        'does not claim that encrypted LiveKit calls are available',
+        'Matrix chat encryption does not by itself cover LiveKit media calls',
       ),
       findsOneWidget,
     );
@@ -169,7 +170,7 @@ void main() {
     expect(find.text('Follow-up evidence'), findsOneWidget);
     expect(find.text('Recording and transcription off'), findsOneWidget);
     expect(
-      find.text('Provider seam: livekit-meetings-channel-preview'),
+      find.text('Provider seam: livekit-meetings-channel-gate'),
       findsOneWidget,
     );
     expect(

--- a/client/test/features/chat/chat_room_screen_test.dart
+++ b/client/test/features/chat/chat_room_screen_test.dart
@@ -132,28 +132,16 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Channel files'), findsOneWidget);
     expect(find.text('Available'), findsOneWidget);
-    expect(
-      find.text('Provider seam: weave-files-channel-link'),
-      findsOneWidget,
-    );
 
     await tester.tap(find.text('Boards'));
     await tester.pumpAndSettle();
     expect(find.text('Channel boards and tasks'), findsOneWidget);
     expect(find.text('Admin setup required'), findsOneWidget);
-    expect(
-      find.text('Provider seam: weave-boards-channel-link'),
-      findsOneWidget,
-    );
 
     await tester.tap(find.text('Calendar'));
     await tester.pumpAndSettle();
     expect(find.text('Channel calendar'), findsOneWidget);
     expect(find.text('Gated by capability'), findsOneWidget);
-    expect(
-      find.text('Provider seam: weave-calendar-channel-scope'),
-      findsOneWidget,
-    );
 
     await tester.tap(find.text('Meetings'));
     await tester.pumpAndSettle();
@@ -169,10 +157,7 @@ void main() {
     expect(find.text('Agenda'), findsOneWidget);
     expect(find.text('Follow-up evidence'), findsOneWidget);
     expect(find.text('Recording and transcription off'), findsOneWidget);
-    expect(
-      find.text('Provider seam: livekit-meetings-channel-gate'),
-      findsOneWidget,
-    );
+    expect(find.textContaining('Provider seam:'), findsNothing);
     expect(
       tester
           .widget<FilledButton>(

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -417,7 +417,7 @@ void main() {
               firstRunStatusProvider.overrideWith((ref) async => null),
               agentCapabilityPolicyProvider.overrideWithValue(
                 AsyncData(
-                  AgentCapabilityPolicy.preview(canManageCapabilities: true),
+                  AgentCapabilityPolicy.disabled(canManageCapabilities: true),
                 ),
               ),
             ],
@@ -448,7 +448,7 @@ void main() {
         );
         expect(find.text('Personal assistant'), findsOneWidget);
         expect(find.text('Channel agent'), findsOneWidget);
-        expect(find.text('Preview only'), findsOneWidget);
+        expect(find.text('Disabled by policy'), findsOneWidget);
         expect(find.text('Admin setup required'), findsOneWidget);
         expect(find.text('Unavailable until enabled'), findsNWidgets(2));
         expect(find.text('Favorites'), findsOneWidget);
@@ -520,7 +520,7 @@ void main() {
         expect(find.text('AI chats'), findsOneWidget);
         expect(
           find.text(
-            'No AI chats are connected yet. Future specialized agents will appear here instead of being mixed into personal messages.',
+            'AI chats are not enabled for this workspace. A workspace owner or admin can enable governed assistants after policy, consent, and audit controls are ready.',
           ),
           findsOneWidget,
         );

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -276,7 +276,7 @@ void main() {
       expect(find.text('Personal assistant'), findsOneWidget);
       expect(find.text('Channel agent'), findsOneWidget);
       expect(
-        find.text('Management unavailable in this preview'),
+        find.text('Management unavailable until controls are ready'),
         findsOneWidget,
       );
 
@@ -390,6 +390,82 @@ void main() {
       expect(find.text('Server Configuration'), findsNothing);
       expect(_textFieldWithLabel('OIDC Issuer URL'), findsNothing);
       expect(_textFieldWithLabel('Nextcloud Base URL'), findsNothing);
+      expect(find.text('Provider stack readiness'), findsNothing);
+      expect(find.textContaining('Flutter provider calls'), findsNothing);
+    });
+
+    testWidgets('keeps provider diagnostics admin-only for members', (
+      tester,
+    ) async {
+      final container = ProviderContainer.test(
+        overrides: [
+          preferencesStoreProvider.overrideWith(
+            (ref) => InMemoryPreferencesStore(buildStoredConfiguration()),
+          ),
+          chatSecurityRepositoryProvider.overrideWithValue(
+            FakeChatSecurityRepository(),
+          ),
+          workspaceConnectionStateProvider.overrideWithValue(
+            _workspaceConnectionState(),
+          ),
+          workspaceCapabilitySnapshotProvider.overrideWithValue(
+            _workspaceCapabilitySnapshot(),
+          ),
+          weaveBackendConnectionStateProvider.overrideWithValue(
+            WeaveBackendConnectionState.connected,
+          ),
+          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
+            (ref) async => _matrixDiagnostic,
+          ),
+          weaveApiProviderStackSnapshotProvider.overrideWith(
+            (ref) async => const ProviderStackSnapshot(
+              releaseStatus: 'provider-readiness',
+              backendOwnedFacades: true,
+              flutterDirectProviderCallsAllowed: false,
+              supportSafe: true,
+              providers: [
+                ProviderStatusSnapshot(
+                  module: 'files',
+                  providerKey: 'nextcloud-files',
+                  state: ProviderState.ready,
+                  readiness: 'ready',
+                  enabled: true,
+                  configured: true,
+                  readOnly: false,
+                  failClosed: false,
+                  supportSafe: true,
+                  paidFeaturesRequired: false,
+                  summary: 'Operator-only provider readiness.',
+                  supportedCapabilities: [],
+                  unsupportedOperations: [],
+                  supportSafeErrorCodes: [],
+                  redactionPolicy: 'support-safe',
+                  candidates: [],
+                ),
+              ],
+            ),
+          ),
+          userProfileProvider.overrideWith((ref) async => _memberProfile),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: SettingsScreen()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Workspace Readiness'), findsOneWidget);
+      expect(find.text('Provider stack readiness'), findsNothing);
+      expect(find.textContaining('nextcloud-files'), findsNothing);
+      expect(find.textContaining('Flutter provider calls'), findsNothing);
     });
 
     testWidgets('preserves overridden service URLs when the issuer changes', (

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -36,6 +36,7 @@ void main() {
           'Channel calendar events keep their meeting thread reference',
           'Boards workspace supports accessible non-drag task work',
           'Weave Home starts the daily work loop',
+          'A normal member sees a user-ready organization flow',
           'A channel is the primary workspace surface',
           'A user board write is authorized and audited',
           'A meeting capsule keeps work connected',

--- a/client/test/release_1/ux_release_copy_contract_test.dart
+++ b/client/test/release_1/ux_release_copy_contract_test.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ISO 9241-110 dogfood UX release gate', () {
+    final gate = File('../docs/iso-9241-110-dogfood-ux-gate.md');
+
+    test(
+      'documents precise planning states and first-use acceptance criteria',
+      () {
+        // V01_USER_READY_ORG_FLOW
+        expect(gate.existsSync(), isTrue);
+        final markdown = gate.readAsStringSync();
+
+        for (final required in <String>[
+          'Preview is not a release-scope state',
+          'Ready for users',
+          'Admin setup required',
+          'Disabled by policy',
+          'Broken/degraded',
+          'Not in this release',
+          'First-use acceptance criteria',
+          'Prompting checklist for future agent work',
+          'Provider diagnostics | Hidden from members',
+        ]) {
+          expect(markdown, contains(required));
+        }
+
+        for (final marker in <String>['V01_USER_READY_ORG_FLOW']) {
+          // ignore: avoid_print
+          print(marker);
+        }
+      },
+    );
+
+    test(
+      'release-scope localized copy does not leak preview/scaffold language',
+      () {
+        final banned = <Pattern>[
+          RegExp(r'\bpreview\b', caseSensitive: false),
+          RegExp(r'\bscaffold\b', caseSensitive: false),
+          RegExp(r'\bcoming soon\b', caseSensitive: false),
+          RegExp(r'\broadmap\b', caseSensitive: false),
+          RegExp(r'\bfuture\b', caseSensitive: false),
+          RegExp(r'\bvorschau\b', caseSensitive: false),
+          RegExp(r'\bgerüst\b', caseSensitive: false),
+          RegExp(r'\bdemnächst\b', caseSensitive: false),
+          RegExp(r'\bkünft\w*\b', caseSensitive: false),
+        ];
+
+        final findings = <String>[];
+        for (final path in <String>[
+          'lib/l10n/app_en.arb',
+          'lib/l10n/app_de.arb',
+        ]) {
+          final data =
+              jsonDecode(File(path).readAsStringSync()) as Map<String, dynamic>;
+          for (final entry in data.entries) {
+            final key = entry.key;
+            final value = entry.value;
+            if (key.startsWith('@') || value is! String) {
+              continue;
+            }
+            if (!_isReleaseScopeUserCopy(key)) {
+              continue;
+            }
+            final normalized = value
+                // Message snippets use the word "preview" as a variable name,
+                // not as product maturity copy.
+                .replaceAll('{preview}', '{latestActivity}')
+                .replaceAll('{Preview}', '{latestActivity}');
+            for (final pattern in banned) {
+              if (pattern.allMatches(normalized).isNotEmpty) {
+                findings.add('$path:$key -> $value');
+              }
+            }
+          }
+        }
+
+        expect(
+          findings,
+          isEmpty,
+          reason:
+              'Normal member/release-scope copy must use ready/admin setup/policy/degraded/hidden states, not preview or roadmap language.',
+        );
+      },
+    );
+
+    test(
+      'release-scope models do not classify visible surfaces as preview',
+      () {
+        final channelWorkspace = File(
+          'lib/features/chat/domain/entities/channel_workspace.dart',
+        ).readAsStringSync();
+        final agentPolicy = File(
+          'lib/features/agents/domain/entities/agent_capability_policy.dart',
+        ).readAsStringSync();
+
+        expect(
+          channelWorkspace,
+          isNot(contains('ChannelWorkspaceSurfaceAvailability.preview')),
+        );
+        expect(channelWorkspace, contains('adminSetupRequired'));
+        expect(channelWorkspace, contains('disabledByPolicy'));
+        expect(agentPolicy, isNot(contains('previewOnly')));
+        expect(agentPolicy, contains('disabledByPolicy'));
+      },
+    );
+  });
+}
+
+bool _isReleaseScopeUserCopy(String key) {
+  if (_featureGatedCopyPrefixes.any(key.startsWith)) {
+    return false;
+  }
+
+  return _releaseScopePrefixes.any(key.startsWith);
+}
+
+const _releaseScopePrefixes = <String>[
+  'welcome',
+  'setup',
+  'nav',
+  'shell',
+  'firstRun',
+  'chatOverview',
+  'chatFavorites',
+  'chatPersonal',
+  'chatChannels',
+  'chatAi',
+  'chatAgent',
+  'chatProvisioning',
+  'chatScreen',
+  'chatRoom',
+  'channelWorkspace',
+  'files',
+  'calendar',
+  'deck',
+  'settingsBrand',
+  'settingsTheme',
+  'settingsWorkspace',
+  'settingsAdmin',
+  'settingsHelp',
+  'settingsShell',
+  'agentCapability',
+  'helpWhatIsWeave',
+];
+
+const _featureGatedCopyPrefixes = <String>[
+  'settingsPreviewSurfaces',
+  'settingsGuestPortalPreview',
+  'settingsInteropAdminPreview',
+  'settingsMigrationDryRunPreview',
+];

--- a/client/test/release_1/v0_1_release_spine_contract_test.dart
+++ b/client/test/release_1/v0_1_release_spine_contract_test.dart
@@ -62,6 +62,7 @@ void main() {
 
       for (final tag in <String>[
         '@weave-v01-home-daily-loop',
+        '@weave-v01-user-ready-organization-flow',
         '@weave-v01-channel-workspace',
         '@weave-v01-board-write-audit',
         '@weave-v01-meeting-capsule',
@@ -75,6 +76,10 @@ void main() {
       expect(
         mappingText,
         contains('client/test/release_1/v0_1_release_spine_contract_test.dart'),
+      );
+      expect(
+        mappingText,
+        contains('client/test/release_1/ux_release_copy_contract_test.dart'),
       );
     });
   });

--- a/docs/iso-9241-110-dogfood-ux-gate.md
+++ b/docs/iso-9241-110-dogfood-ux-gate.md
@@ -1,0 +1,146 @@
+# ISO 9241-110 Dogfood UX Gate
+
+Status: v0.1 product UX contract
+Owner: `client/` product UX, with backend/infra evidence for readiness and operator actions
+Related issues: #258, #259
+
+## Purpose
+
+Weave v0.1 must open as a daily work product, not as a scaffold, roadmap gallery, or provider demo. This gate turns ISO 9241-110 dialogue principles into release-scope acceptance criteria and promptable planning rules for future agent work.
+
+## Dialogue principles as release checks
+
+- **Suitability for the task**: users can start real project work from Home, enter a channel, chat, use files, see calendar/board/meeting/decision availability, and recover from degraded state without raw provider fallbacks.
+- **Self-descriptiveness**: each screen explains current state, user impact, next user action, and admin/operator next action where relevant.
+- **Conformity with expectations**: visible labels use Weave product concepts first. Matrix, Nextcloud, OpenProject, LiveKit, and similar provider names appear only where they help admins/operators diagnose readiness.
+- **Suitability for learning**: first use teaches through short empty states and next actions, not walls of setup text.
+- **Controllability**: users can navigate, retry, cancel, confirm destructive work, and use non-drag alternatives for task movement.
+- **Error tolerance**: missing services fail closed with safe fallbacks, support-safe error copy, and no secrets, raw URLs, stack traces, or credential-bearing details.
+- **Suitability for individualization**: density, module visibility, theme, and notifications can evolve without making the core workspace unusable.
+
+## Release-scope capability states
+
+Every visible capability must use exactly one of these states. **Preview is not a release-scope state.**
+
+1. **Ready for users**
+   - Visible to normal members.
+   - Has Weave product UI, backend facade, support-safe errors, health/readiness state, and executable evidence.
+2. **Admin setup required**
+   - Visible to admins/operators with exact next setup action.
+   - Hidden from members unless they need a short impact-level unavailable state.
+3. **Disabled by policy**
+   - Members see a short policy reason.
+   - Admins see where the policy is controlled.
+4. **Broken/degraded**
+   - Members see impact and safe fallback.
+   - Admins/operators see the next diagnostic action and support-bundle/evidence path.
+5. **Not in this release**
+   - Not visible in normal member navigation.
+   - May appear in roadmap/docs/issues, not in product UI.
+
+## Shared vocabulary
+
+Use these labels consistently across Home, channel tabs, settings, Workspace Health, and acceptance evidence.
+
+### Status labels
+
+- Ready
+- Admin setup required
+- Disabled by policy
+- Degraded
+- Blocked
+- Unknown
+- Not in this release
+
+### User actions
+
+- Open
+- Create
+- Save
+- Upload
+- Download
+- Retry
+- Cancel
+- Delete
+- Restore
+- Ask an admin
+
+### Admin/operator actions
+
+- Configure
+- Enable by policy
+- Check readiness
+- Run smoke test
+- Generate support bundle
+- Review backup
+- Restore from backup
+- Open diagnostics
+
+### Banned release-scope copy
+
+Do not use these on normal member paths or release-scope screens:
+
+- preview
+- scaffold
+- coming soon
+- roadmap
+- future
+- raw provider setup instructions
+- provider stack traces, secrets, tokens, or credential-bearing URLs
+
+Exceptions must be narrow and explicit, for example message snippet variables named `preview` in code or roadmap documentation outside the product UI.
+
+## Surface classification for v0.1 planning
+
+| Surface | Member state | Admin/operator state | Evidence expectation |
+| --- | --- | --- | --- |
+| Home | Ready for users | Same plus health impact | Widget/contract test for hierarchy, empty state, and degraded state |
+| Channel chat | Ready for users | Same plus E2EE/readiness posture | Chat widget tests and live Matrix evidence |
+| Channel files | Ready for users when files facade is ready; otherwise degraded impact copy | Setup/readiness in Workspace Health | Files facade tests and live upload/download evidence |
+| Channel boards/tasks | Admin setup required until authenticated writes, authorization, audit, and rollback evidence are ready | Workspace Health shows next setup/diagnostic action | Non-drag task tests and backend facade/audit evidence |
+| Channel calendar | Admin setup required until channel event CRUD and readiness evidence are ready | Workspace Health shows calendar readiness | Calendar facade tests and live event/thread evidence |
+| Meetings/LiveKit | Admin setup required/fail-closed until token, media, E2EE boundary, accessibility, and support evidence are ready | Workspace Health shows exact readiness blocker | Backend token/readiness tests before member join/start is enabled |
+| Decision Ledger | Admin setup required until route, write/read flow, and links are implemented | Health/readiness only if persistence is degraded | Product route and acceptance mapping |
+| AI/Weaver | Disabled by policy / not in this release until approval receipts, consent, audit, and sandboxing ADR are accepted | Admin policy surface may explain disabled state | No runtime writes in v0.1 without accepted ADR |
+| Provider diagnostics | Hidden from members except impact-level status | Ready in Workspace Health | Role-based widget tests and support-safe DTO tests |
+
+## First-use acceptance criteria
+
+A newly invited member in an admin-provisioned workspace must be able to:
+
+1. Open Weave and understand that Home is the starting point for daily work.
+2. Open a channel workspace without learning provider names.
+3. Use chat as the reliable center of the channel.
+4. Use files through Weave or see a clear degraded impact state.
+5. See calendar, boards, meetings, decisions, and AI only when ready, admin-required, policy-disabled, or hidden according to the state table.
+6. Understand degraded state through plain-language impact and a safe next action.
+7. Avoid raw provider setup, raw provider failures, roadmap panels, or preview cards.
+
+An admin/operator must be able to:
+
+1. See Workspace Health as the place for setup/readiness/degraded provider state.
+2. Understand what members can currently do before inviting them.
+3. Get exact next setup or diagnostic actions without exposing secrets.
+4. Generate or find support-safe evidence for failures.
+
+## Prompting checklist for future agent work
+
+When asking an agent to implement or review a UX slice, include:
+
+- The target release-scope state from this document.
+- The affected role: member, admin, operator, or all.
+- The visible labels and banned copy expectations.
+- The backend facade/readiness/audit evidence that makes the surface user-ready.
+- The fallback state if evidence is missing.
+- The exact tests or acceptance mapping that must fail before the fix and pass after it.
+
+Example prompt shape:
+
+> Implement the Channel Boards member slice as `Admin setup required` until authenticated writes, authorization, audit, and rollback evidence are available. Do not show preview/coming-soon copy. Members see impact-level copy; admins see Workspace Health next action. Add widget/contract tests that fail on banned release-scope wording and prove member/provider-diagnostic role separation.
+
+## Required validation
+
+- `make acceptance-contract` when Gherkin or mappings change.
+- `make client-ci` for client/copy/widget changes.
+- Targeted widget tests for role separation and copy gates.
+- Manual release sign-off must still include the accessibility evidence listed in `docs/accessibility-release-gate.md`.

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -8,6 +8,7 @@ Weave uses layered evidence so contributors can move quickly while release claim
 | --- | --- | --- |
 | Offline Flutter checks | Formatting, static analysis, unit/widget behavior, generated code consistency, and no-network contract checks. | `.github/workflows/ci.yml`, local `flutter` commands, `make offline-contract-test`. |
 | Accessibility gate | Automated checks and the manual assistive-technology evidence required before release sign-off. | [Accessibility Release Gate](accessibility-release-gate.md). |
+| ISO 9241-110 dogfood UX gate | Product dialogue quality, release-scope capability states, banned preview/scaffold wording, and role separation for member vs admin/operator surfaces. | [ISO 9241-110 Dogfood UX Gate](iso-9241-110-dogfood-ux-gate.md), `test/release_1/ux_release_copy_contract_test.dart`. |
 | Deterministic screenshots | README and roadmap SVG assets match the checked-in generator and do not drift silently. | `make marketing-screenshots`, `docs/assets/marketing/`, `docs/assets/roadmap/`, CI screenshot drift step. |
 | Acceptance contract guard | Gherkin acceptance scenarios stay mapped to executable frontend/live-stack tests. | [Acceptance contracts](acceptance-contracts.md), [Product acceptance flows](product-acceptance-flows.md), `test/live_stack_feature_mapping_test.dart`. |
 | Live Stack E2E | A prepared self-hosted stack can boot the app-level journey and upload acceptance evidence artifacts. | `.github/workflows/live-stack-e2e.yml` workflow runs and their uploaded artifacts. |
@@ -62,4 +63,5 @@ The workflow prepares an acceptance evidence directory, runs the app-level live-
 - [Acceptance contracts](acceptance-contracts.md)
 - [Product acceptance flows](product-acceptance-flows.md)
 - [Accessibility Release Gate](accessibility-release-gate.md)
+- [ISO 9241-110 Dogfood UX Gate](iso-9241-110-dogfood-ux-gate.md)
 - [Roadmap and guarded surfaces](roadmap-and-guarded-surfaces.md)

--- a/docs/release-v0.1-dogfood-plan.md
+++ b/docs/release-v0.1-dogfood-plan.md
@@ -6,6 +6,8 @@ Status: implementation baseline for the monorepo refoundation.
 
 Ship Weave as a daily work tool for a real project, not as a demo stack.
 
+UX release quality is gated by [ISO 9241-110 Dogfood UX Gate](iso-9241-110-dogfood-ux-gate.md): visible release-scope surfaces use ready/admin-setup-required/disabled/degraded/hidden states, not preview or scaffold wording.
+
 v0.1 must support a complete project loop:
 
 1. Open Weave Home.

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -11,6 +11,14 @@ Feature: Weave v0.1 dogfood production release
     Then Weave shows recent channels, open tasks, upcoming meetings, recent decisions, and actionable health warnings
     And every home section has a keyboard and screen-reader path
 
+  @weave-v01-user-ready-organization-flow
+  Scenario: A normal member sees a user-ready organization flow
+    Given an admin has provisioned the organization and invited a member
+    When the member opens Weave and enters a channel workspace
+    Then release-scope surfaces use ready, admin-setup-required, policy-disabled, degraded, or hidden states
+    And the member does not see preview, scaffold, roadmap, or raw provider setup copy
+    And provider diagnostics stay in admin/operator health surfaces
+
   @weave-v01-channel-workspace
   Scenario: A channel is the primary workspace surface
     Given a workspace member enters a project channel

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -115,6 +115,32 @@
       ]
     },
     {
+      "tag": "@weave-v01-user-ready-organization-flow",
+      "scenario": "A normal member sees a user-ready organization flow",
+      "feature": "e2e/features/v0_1_dogfood_release.feature",
+      "executableTest": "client/test/release_1/ux_release_copy_contract_test.dart",
+      "evidenceMarkers": [
+        "V01_USER_READY_ORG_FLOW"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "docs/iso-9241-110-dogfood-ux-gate.md",
+          "fragments": [
+            "Preview is not a release-scope state",
+            "First-use acceptance criteria",
+            "Provider diagnostics | Hidden from members"
+          ]
+        },
+        {
+          "path": "client/test/features/settings/settings_screen_test.dart",
+          "fragments": [
+            "keeps provider diagnostics admin-only for members",
+            "Provider stack readiness"
+          ]
+        }
+      ]
+    },
+    {
       "tag": "@weave-v01-channel-workspace",
       "scenario": "A channel is the primary workspace surface",
       "feature": "e2e/features/v0_1_dogfood_release.feature",


### PR DESCRIPTION
## Problem

Fixes #258 and #259.

v0.1 is a dogfood-production release, not a preview showcase. Release-scope UX needed an explicit ISO 9241-110 usability gate plus executable copy/model guards so normal members see user-ready, setup-required, policy-disabled, degraded, or hidden states instead of preview/scaffold language.

## Target behavior

- Document ISO 9241-110 dogfood UX acceptance criteria and future agent prompting rules.
- Replace release-scope preview vocabulary in channel workspace, settings, and agent chat surfaces with readiness/policy/setup language.
- Keep provider stack diagnostics admin/operator-only; members see only impact-level readiness.
- Treat channel files as available, boards as admin setup required, meetings as fail-closed/gated, and AI agents as disabled by policy/admin setup until consent/audit/runtime evidence exists.
- Map the user-ready organization flow to executable evidence in the acceptance contract.

## Files changed

- `docs/iso-9241-110-dogfood-ux-gate.md`
- `docs/quality-and-evidence.md`
- `docs/release-v0.1-dogfood-plan.md`
- `e2e/features/v0_1_dogfood_release.feature`
- `e2e/scenario_mappings.json`
- `client/lib/features/chat/**`
- `client/lib/features/agents/**`
- `client/lib/features/settings/presentation/settings_screen.dart`
- `client/lib/l10n/**`
- `client/test/**`

## Validation

- [x] `flutter pub get && flutter gen-l10n`
- [x] `flutter test test/release_1/ux_release_copy_contract_test.dart test/release_1/v0_1_release_spine_contract_test.dart test/features/chat/channel_workspace_test.dart test/features/chat/chat_room_screen_test.dart test/features/chat/agent_chat_preview_provider_test.dart test/features/chat/chat_screen_test.dart test/features/agents/domain/agent_capability_policy_test.dart test/features/settings/settings_screen_test.dart`
- [x] `make acceptance-contract`
- [x] `make client-ci`
- [x] `git diff --check`

## Contract changes

- Adds `@weave-v01-user-ready-organization-flow` to the v0.1 dogfood release feature and maps it to `client/test/release_1/ux_release_copy_contract_test.dart`.
- Defines release-scope capability states: ready, admin setup required, disabled by policy, degraded/blocked, or not in release.
- Removes preview as a release-scope channel/agent availability model.

## Follow-up

- Full live E2E evidence is still collected by the existing live stack path; this PR adds/updates offline contract coverage and acceptance mapping.
