### PR TITLE
test: keep live E2E acceptance evidence mapped

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -11,7 +11,9 @@ acceptance-feature-mapping:
 	@flutter test test/live_stack_feature_mapping_test.dart
 
 release-spine-contract:
-	@flutter test test/release_1/v0_1_release_spine_contract_test.dart
+	@flutter test \
+	  test/release_1/v0_1_release_spine_contract_test.dart \
+	  test/release_1/ux_release_copy_contract_test.dart
 
 integration-contract-test:
 	@dart_defines_file=$$(mktemp); \

--- a/client/test/live_stack_contract_test.dart
+++ b/client/test/live_stack_contract_test.dart
@@ -91,14 +91,15 @@ void main() {
     });
 
     test('provider stack readiness stays behind the Weave backend facade', () {
-      expect(
-        liveConfig.apiUri('/api/providers/status').toString(),
-        'https://api.weave.local/api/providers/status',
-      );
-      expect(
-        liveConfig.apiUri('/api/profile/readiness').toString(),
-        'https://api.weave.local/api/profile/readiness',
-      );
+      final providerStatusUri = liveConfig.apiUri('/api/providers/status');
+      final profileReadinessUri = liveConfig.apiUri('/api/profile/readiness');
+
+      expect(providerStatusUri.host, liveConfig.backendApiBaseUrl.host);
+      expect(providerStatusUri.port, liveConfig.backendApiBaseUrl.port);
+      expect(providerStatusUri.path, '/api/providers/status');
+      expect(profileReadinessUri.host, liveConfig.backendApiBaseUrl.host);
+      expect(profileReadinessUri.port, liveConfig.backendApiBaseUrl.port);
+      expect(profileReadinessUri.path, '/api/profile/readiness');
     });
 
     test(


### PR DESCRIPTION
## Summary
- include the UX release-copy contract in the release-spine gate so `V01_USER_READY_ORG_FLOW` is present in live acceptance logs
- make backend facade URI contract assertions port-aware for the self-hosted live stack proxy

## Evidence
- `flutter gen-l10n`
- `dart format --output=none --set-exit-if-changed test/live_stack_contract_test.dart`
- `make release-spine-contract`
- `make offline-contract-test`
- `WEAVE_OFFLINE_CONTRACT_ONLY=true WEAVE_API_BASE_URL=https://api.weave.local:44443/api WEAVE_BOOTSTRAP_ENV=/dev/null WEAVE_TEST_USERNAME= WEAVE_TEST_PASSWORD= make integration-contract-test`

## Acceptance criteria
- Live Stack E2E does not fail on a missing `V01_USER_READY_ORG_FLOW` marker.
- Provider facade contract continues to reject path drift while allowing the configured live-stack HTTPS port.
- No user-facing preview/scaffold language is introduced.