### PR TITLE
fix(a11y): announce disabled agent start state

### DIFF
--- a/client/lib/features/chat/presentation/chat_screen.dart
+++ b/client/lib/features/chat/presentation/chat_screen.dart
@@ -635,9 +635,12 @@ class _AgentPreviewTile extends StatelessWidget {
     final scope = _agentScope(l10n, preview.kind);
     final boundary = _agentBoundary(l10n, preview.kind);
     final audit = _agentAudit(l10n, preview.kind);
+    final actionLabel = preview.canStart
+        ? ''
+        : '. ${l10n.chatAgentStartDisabledButton}';
     final semanticsLabel =
         '$title. $statusLabel. $description. $scope. '
-        '$boundary. $audit';
+        '$boundary. $audit$actionLabel';
 
     return Semantics(
       container: true,

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -451,6 +451,18 @@ void main() {
         expect(find.text('Disabled by policy'), findsOneWidget);
         expect(find.text('Admin setup required'), findsOneWidget);
         expect(find.text('Unavailable until enabled'), findsNWidgets(2));
+        expect(
+          find.bySemanticsLabel(
+            RegExp(r'Personal assistant\..*Unavailable until enabled'),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel(
+            RegExp(r'Channel agent\..*Unavailable until enabled'),
+          ),
+          findsOneWidget,
+        );
         expect(find.text('Favorites'), findsOneWidget);
         expect(find.text('Personal messages'), findsOneWidget);
         expect(find.text('Channels'), findsOneWidget);


### PR DESCRIPTION
## Summary\n- include the disabled agent start state in merged screen-reader labels\n- cover Personal assistant and Channel agent disabled semantics in ChatScreen tests\n\n## Validation\n- cd client && flutter test test/features/chat/chat_screen_test.dart test/release_1/ux_release_copy_contract_test.dart\n- make acceptance-contract\n\n🤖 Requested @copilot review for a focused accessibility patch.