### PR TITLE
docs: define provider-neutral product foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
   <img src="client/assets/images/weave_logo.png" alt="Weave logo, an interlaced blue and teal knot" width="220">
 </p>
 
-Weave is an accessibility-first, self-hostable collaboration workspace for chat, files, shared calendars, boards/tasks, meetings, decisions, and operator health.
+Weave is an accessibility-first, self-hostable organization suite and integration layer for chat, files, shared calendars, boards/tasks, meetings, decisions, and operator health.
 
-This repository is the single source of truth for the product stack. Treat client, backend, infrastructure, acceptance evidence, and release metadata as one release unit.
+Weave is provider-neutral by design: an organization should be able to keep its existing identity, chat, file, calendar, collaboration, and project systems while exposing them through coherent Weave product concepts. The default dogfood stack can use Keycloak, Matrix, Nextcloud, OpenProject, and LiveKit, but those are provider choices behind Weave-owned contracts, not the product boundary.
+
+This repository is the single source of truth for the product stack. Treat client, backend, infrastructure, acceptance evidence, and release metadata as one release unit. The active product-line reference is [Weave product line and Weaver integration plan](docs/product-line-and-weaver-plan.md).
 
 ## Product screenshots
 
-These deterministic screenshots use checked-in Weave assets. They show Weave-owned surfaces that are suitable for the README showcase: admin-provisioned setup, service endpoint review, custom chat, files, and settings/readiness. They are not a promise that roadmap or guarded provider surfaces are shipped; those stay separated in [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md).
+These deterministic screenshots use checked-in Weave assets. They show the active product-maturity track through Weave-owned surfaces that are suitable for the README showcase: admin-provisioned setup, service endpoint review, custom chat, files, and settings/readiness. They are not a promise that roadmap or guarded provider surfaces are shipped; those stay separated in [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md).
 
 Future README showcase updates should keep this acceptance checklist:
 
@@ -29,19 +31,19 @@ Setup is admin-provisioned; normal users join after provisioning and are not ask
 
 [<img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave setup review screen listing canonical local service endpoints before finishing configuration." width="680">](docs/assets/marketing/02-review-service-endpoints.svg)
 
-Endpoint review keeps canonical auth, API, Matrix, files, and calendar surfaces explicit before the workspace is used.
+Endpoint review keeps canonical identity, API, chat, files, and calendar surfaces explicit before the workspace is used. Concrete provider names belong in setup/readiness and operator docs, not as the member-facing product model.
 
 ### Custom Weave chat
 
 [<img src="docs/assets/marketing/03-chat-room.svg" alt="Custom Weave chat room showing a release room conversation and accessible message composer." width="680">](docs/assets/marketing/03-chat-room.svg)
 
-Chat is a Weave product experience backed by Matrix; raw Matrix administration is not the normal user path.
+Chat is a Weave product experience backed by the selected chat provider. Matrix is the current dogfood provider; raw provider administration is not the normal user path.
 
 ### Weave files through the backend facade
 
 [<img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files screen listing folders and files through the backend files facade." width="680">](docs/assets/marketing/04-files-documents.svg)
 
-Files use Weave-owned product routes and backend facades instead of promoting raw Nextcloud as the everyday UX.
+Files use Weave-owned product routes and backend facades instead of promoting raw provider UX such as Nextcloud or SharePoint as the everyday UX.
 
 ### Settings and readiness
 
@@ -64,6 +66,7 @@ v0.1 is a dogfood-production release, not a preview showcase. A surface belongs 
 
 Required v0.1 surfaces:
 
+- Admin-provisioned organization setup with provider categories for identity/IDM, chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver disabled by default until a later governed PA-runtime policy enables it.
 - Weave Home for recent work, next actions, and health warnings.
 - Channels as workspaces with accessible tabs for chat, files, boards/tasks, calendar, meetings, and decisions.
 - Files through Weave-owned backend/product routes, not raw provider UX as the normal path.
@@ -76,10 +79,11 @@ Required v0.1 surfaces:
 
 Out of v0.1:
 
-- Product agent runtime integration.
+- Product agent runtime integration. Weaver is a later governed per-user PA layer, not the foundation of the current product architecture.
 - Autonomous, group, or team-scoped agent writes.
 - Public connector SDK.
 - Teams/Slack migration tooling.
+- Full generic provider marketplace/admin console beyond the category seams needed for the current stack.
 - Broad SaaS administration beyond safe self-hosting boundaries.
 
 ## Boards and provider boundary
@@ -145,6 +149,7 @@ Live-stack E2E is intentionally opt-in. Run it only with explicit runner power/s
 
 - Keep user-facing documentation honest about what is shipped, gated, disabled, or future work.
 - Prefer accessible headings and bullets over dense tables.
+- Plan Weave product-first: organization setup, provider categories, admin policy, and readiness before Weaver/agent runtime work.
 - Do not promote raw provider screens as Weave product UX.
 - Do not expose provider secrets or service tokens to Flutter, support bundles, app config, or logs.
 - Treat `client/`, `server/`, `infra/`, `e2e/`, `docs/`, and `release/` changes as one coherent product story.

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -37,6 +37,7 @@ void main() {
           'Boards workspace supports accessible non-drag task work',
           'Weave Home starts the daily work loop',
           'A normal member sees a user-ready organization flow',
+          'Admin sees provider categories before member use',
           'A channel is the primary workspace surface',
           'A user board write is authorized and audited',
           'A meeting capsule keeps work connected',

--- a/client/test/release_1/v0_1_release_spine_contract_test.dart
+++ b/client/test/release_1/v0_1_release_spine_contract_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('v0.1 release spine', () {
     final plan = File('../docs/release-v0.1-dogfood-plan.md');
+    final productLine = File('../docs/product-line-and-weaver-plan.md');
+    final firstUse = File('../docs/admin-provisioned-first-use.md');
     final mapping = File('../e2e/scenario_mappings.json');
     final feature = File('../e2e/features/v0_1_dogfood_release.feature');
 
@@ -56,6 +58,60 @@ void main() {
       }
     });
 
+    test(
+      'documents provider-category admin foundation before Weaver runtime',
+      () {
+        // V01_ADMIN_PROVIDER_CATEGORIES
+        expect(productLine.existsSync(), isTrue);
+        expect(firstUse.existsSync(), isTrue);
+
+        final productLineText = productLine.readAsStringSync();
+        final firstUseText = firstUse.readAsStringSync();
+        final planText = plan.readAsStringSync();
+
+        for (final required in <String>[
+          'identity/IDM',
+          'chat',
+          'files',
+          'calendar',
+          'boards/tasks',
+          'meetings/calls',
+          'documents/collaboration',
+          'Weaver',
+          'disabled by default',
+          'Keycloak/Auth',
+          'Matrix/Chat',
+          'Nextcloud/Files and Calendar backing',
+          'OpenProject Boards validation',
+          'LiveKit Meetings readiness',
+        ]) {
+          expect(productLineText, contains(required));
+        }
+
+        for (final required in <String>[
+          'Provider-category admin boundary',
+          'Normal members never configure raw providers',
+          'service endpoints',
+          'provider secrets',
+          'provider diagnostics',
+          'support-safe readiness and next actions',
+        ]) {
+          expect(firstUseText, contains(required));
+        }
+
+        for (final required in <String>[
+          'Provider categories are first-class product/admin concepts',
+          'Weaver is represented only as a disabled-by-default category',
+          'never raw provider setup, service endpoints, provider secrets, or diagnostics',
+        ]) {
+          expect(planText, contains(required));
+        }
+
+        // ignore: avoid_print
+        print('V01_ADMIN_PROVIDER_CATEGORIES');
+      },
+    );
+
     test('keeps the Gherkin release spine mapped to executable evidence', () {
       final mappingText = mapping.readAsStringSync();
       final featureText = feature.readAsStringSync();
@@ -63,6 +119,7 @@ void main() {
       for (final tag in <String>[
         '@weave-v01-home-daily-loop',
         '@weave-v01-user-ready-organization-flow',
+        '@weave-v01-admin-provider-categories',
         '@weave-v01-channel-workspace',
         '@weave-v01-board-write-audit',
         '@weave-v01-meeting-capsule',

--- a/docs/admin-provisioned-first-use.md
+++ b/docs/admin-provisioned-first-use.md
@@ -10,6 +10,23 @@ Normal members must not configure OIDC, realms, provider URLs, service endpoints
 
 Admins and operators provision identity, domains, provider stack, policy, backup/restore, support bundles, and release readiness before inviting normal users. Workspace Health is the admin/operator control plane for setup, readiness, degraded services, and support-safe diagnostics.
 
+## Provider-category admin boundary
+
+Provider setup is category-first, not vendor-first. Workspace Health and admin setup must model these product/admin categories before member use:
+
+- identity/IDM;
+- chat;
+- files;
+- calendar;
+- boards/tasks;
+- meetings/calls;
+- documents/collaboration;
+- Weaver, disabled by default until a later admin policy enables the governed per-user PA runtime.
+
+The current dogfood defaults map into those categories as provider selections and readiness signals: Keycloak/Auth for identity/IDM, Matrix for chat, Nextcloud for files and calendar backing, OpenProject for boards/tasks validation, and LiveKit for meetings readiness. These names belong in admin/operator setup, readiness, support-safe diagnostics, and documentation. They must not become the normal member-facing product model.
+
+Normal members never configure raw providers, service endpoints, OIDC clients, provider secrets, backup/restore paths, or provider diagnostics. Members see ready Weave capabilities or short impact/fallback states. Admins/operators see support-safe readiness and next actions without secret values, bearer tokens, credential-bearing URLs, raw downstream error bodies, or provider internals that are not needed for remediation.
+
 ## Role boundary
 
 | Role | First-use experience | Setup and health scope |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,8 @@
 ## Overview
 Weave uses a feature-first clean architecture with deterministic bootstrap before routing. App-level OIDC bootstrap is resolved before navigation, while protocol-specific or platform-specific code lives either inside the owning feature or in `lib/integrations/<integration>/` when the boundary is shared across multiple features.
 
+Weave is product-first and provider-neutral. It models organization capabilities such as identity, chat, files, calendar, boards/tasks, meetings, documents/collaboration, and later Weaver. Concrete systems such as Keycloak, Entra ID, Matrix, Teams, Nextcloud, SharePoint, OpenProject, Jira, or LiveKit attach as provider adapters behind Weave contracts. See [Weave product line and Weaver integration plan](product-line-and-weaver-plan.md).
+
 ## App startup
 The app now resolves bootstrap before `MaterialApp.router` is built.
 

--- a/docs/product-line-and-weaver-plan.md
+++ b/docs/product-line-and-weaver-plan.md
@@ -1,0 +1,176 @@
+# Weave product line and Weaver integration plan
+
+Status: active product direction, 2026-05-24.
+
+## Decision lock
+
+Weave is planned product-first, not agent-first.
+
+Weave is a provider-neutral organization suite and integration layer. It lets an organization keep existing systems for identity, chat, files, calendar, boards/tasks, documents, meetings, and collaboration while presenting them through coherent Weave product concepts.
+
+Weaver is a later personal-assistant layer that plugs into this already-governed organization model. It must not define the product architecture by itself.
+
+## Product line
+
+### 1. Admin portal and organization setup
+
+The admin portal is the control center for organization setup and policy.
+
+It must let owners/admins choose and manage provider categories:
+
+- Identity/IDM: Keycloak, Entra ID, Authentik, or another OIDC/SAML source.
+- Chat: Matrix, Microsoft Teams, Slack, Nextcloud Talk, or another supported channel.
+- Files: Nextcloud Files, SharePoint/OneDrive, S3-compatible storage, SMB, or another provider.
+- Calendar: Weave-managed shared calendar facade backed by the selected provider stack.
+- Boards/tasks: Weave task/board model backed by OpenProject first, with other adapters possible.
+- Meetings/calls: LiveKit or another future provider through backend token facades.
+- Documents/collaboration: provider adapters, not direct product dependency on one vendor.
+- Weaver: disabled by default until the organization enables the PA runtime and tool policy.
+
+The admin portal owns:
+
+- provider selection and readiness;
+- role and group mapping;
+- policy profiles;
+- capability availability;
+- support-safe diagnostics;
+- backup/restore and operator evidence;
+- later: Weaver capability/tool allowlists.
+
+Normal members do not configure raw providers.
+
+### 2. Provider-neutral Weave suite
+
+Weave models collaboration categories, not vendor products.
+
+The product surfaces remain Weave-owned:
+
+- Home and activity overview;
+- personal messages;
+- channels as workspaces;
+- channel tabs for chat, files, boards/tasks, calendar/events, meetings, and decisions;
+- Workspace/Admin Health for readiness and support;
+- accessible settings and policy-visible capability states.
+
+Provider adapters sit behind Weave contracts. A Microsoft-heavy organization should be able to use Entra ID, Teams, SharePoint, and Planner/Jira-style integrations. A self-hosted organization should be able to use Keycloak, Matrix, Nextcloud, OpenProject, and LiveKit. Mixed setups must be valid.
+
+This means implementation work should add category contracts and adapter seams before adding vendor-specific UX. Provider names belong in admin/operator readiness and documentation, not as the main member-facing product model.
+
+### 3. Weaver as governed per-user PA runtime
+
+Weaver is optional and later.
+
+When enabled, each user receives a per-user Weaver runtime derived from OpenClaw and isolated in its own Docker container. The organization provides a baseline runtime and policy; the user may configure their personal workspace and agent defaults inside those boundaries.
+
+The central rule is:
+
+> user-rights, organization-whitelisted capabilities.
+
+The PA may act with the user's normal rights, but only through organization-approved capability channels. Routine operation must not depend on per-call confirmation. Step-up confirmation is reserved for exceptional high-risk actions.
+
+Admin policy controls:
+
+- which Weaver runtime profile a user/group receives;
+- which tools/capabilities are visible to that runtime;
+- which provider adapters can be used;
+- whether exec-like capabilities exist at all;
+- sandbox/workspace defaults;
+- connector/package approval, versioning, revocation, and audit.
+
+OpenClaw configuration remains an implementation target, not the product model. Weave should generate or constrain the Weaver/OpenClaw runtime from organization policy.
+
+## Implementation plan
+
+### Phase A: product foundation
+
+Goal: make the product line explicit before deeper agent work.
+
+- Add this document as the active product-line reference.
+- Update README positioning from one fixed self-hosted stack toward provider-neutral organization suite.
+- Keep v0.1 honest: existing dogfood stack stays real, but the architecture must not imply Nextcloud/Matrix/Keycloak are the only possible product shape.
+- Keep normal-member first use admin-provisioned.
+
+Evidence gate:
+
+- README and architecture docs state provider-neutral categories and admin-first setup.
+- No normal-member UX claims raw provider setup or future Weaver runtime as shipped v0.1.
+- Product acceptance includes an admin/provider-category scenario proving categories, dogfood-default mapping, member/admin boundaries, support-safe diagnostics, and Weaver-disabled-by-default ordering.
+
+### Phase B: admin/provider model
+
+Goal: implement category-based setup and readiness.
+
+- Define provider category entities in backend/domain docs: identity, chat, files, calendar, boards/tasks, meetings, docs/collaboration, Weaver.
+- Extend Workspace/Admin Health around category readiness and policy state.
+- Keep provider-specific diagnostics support-safe and admin/operator-only.
+- Map existing stack to categories: Keycloak/Auth, Matrix/Chat, Nextcloud/Files, backend calendar facade, OpenProject Boards validation, LiveKit Meetings.
+
+Evidence gate:
+
+- Admin/operator can inspect category readiness.
+- Member sees only ready capabilities or impact-level unavailable states.
+- Existing provider-specific routes remain behind Weave facades.
+
+Acceptance criteria for the initial #264 slice:
+
+- Workspace/Admin Health and setup language names identity/IDM, chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver as first-class categories.
+- Dogfood defaults are mapped as current provider choices only: Keycloak/Auth, Matrix/Chat, Nextcloud/Files and Calendar backing, OpenProject Boards validation, and LiveKit Meetings readiness.
+- Normal members do not configure raw providers, OIDC clients, service endpoints, secrets, backup/restore, or diagnostics.
+- Admin/operator diagnostics are support-safe and redact/avoid secrets, credential-bearing URLs, bearer tokens, raw downstream bodies, and unnecessary provider internals.
+- Weaver remains disabled by default and later than admin portal, IDM/RBAC, readiness, and whitelisting.
+- `make acceptance-contract` maps the product-level scenario to executable marker evidence before any runtime implementation work expands scope.
+
+### Phase C: RBAC and whitelisting
+
+Goal: make open-source policy realistic before Weaver.
+
+- Use OIDC/IDM as source of identity, groups, and roles.
+- Keep Keycloak as the self-hosted default but support Entra ID/Auth0/Authentik-style OIDC through adapter contracts.
+- Start with simple backend-owned RBAC/policy profiles; evaluate Casbin as the first embedded open-source policy engine if policy complexity grows.
+- Model capabilities as category-level permissions first, not low-level tool IDs.
+
+Examples:
+
+- `chat.read`, `chat.send`
+- `files.read`, `files.upload`
+- `calendar.read`, `calendar.manage_events`
+- `boards.read`, `boards.update_task`
+- `weaver.enabled`, `weaver.files_read`, `weaver.exec_disabled`
+
+Evidence gate:
+
+- Capabilities are deny-by-default.
+- Role/group changes affect Weave product surfaces before any agent runtime exists.
+- Policy state is visible to admins and support-safe for members.
+
+### Phase D: Weaver integration
+
+Goal: plug the PA into an already-governed product.
+
+- Add Weaver as a provider/category in the admin portal, initially disabled.
+- Create per-user Dockerized Weaver runtime profiles.
+- Generate baseline OpenClaw/Weaver config from Weave policy:
+  - per-user workspace;
+  - isolated agent directory;
+  - plugin allowlist matching selected chat/provider categories;
+  - tool/capability allowlist from admin policy;
+  - sandbox defaults;
+  - exec disabled or heavily restricted by default.
+- Add audit for Weaver capability usage.
+- Only fork OpenClaw where existing configuration/plugin hooks cannot enforce the required boundary.
+
+Evidence gate:
+
+- Weaver cannot see or call capabilities not enabled by admin policy.
+- User workspace customization cannot escape org baseline.
+- Exec/elevated surfaces are disabled by default and require explicit admin policy.
+
+## Cross-session tracking rule
+
+Future Weave planning should preserve this order:
+
+1. Product suite and provider categories.
+2. Admin portal, IDM/RBAC, readiness, and whitelisting.
+3. Weaver PA runtime as optional governed layer.
+
+Do not regress to agent-first planning. Do not assume one required provider stack. Do not expose raw provider setup to normal members.

--- a/docs/release-v0.1-dogfood-plan.md
+++ b/docs/release-v0.1-dogfood-plan.md
@@ -14,7 +14,7 @@ v0.1 must support a complete project loop after admins/operators provision the w
 2. Enter a workspace/channel.
 3. Chat, handle files, plan events, run meetings, move board tasks, and record decisions through Weave product concepts.
 4. See only complete capabilities or simple impact/fallback states as a member when something is broken.
-5. Inspect Workspace Health as an admin/operator control plane for setup, readiness, degraded provider state, backup/restore, support bundles, and release evidence.
+5. Inspect Workspace Health as an admin/operator control plane for category-based provider setup, readiness, degraded provider state, backup/restore, support bundles, and release evidence.
 6. Deploy, update, backup, restore, and roll back the stack with operator evidence.
 
 ## Non-goals for v0.1
@@ -141,8 +141,10 @@ Boards with user writes are release scope, not a demo-only demonstration.
 ### Workspace/Admin Health
 
 - Admin-provisioned first-use boundary from [Admin-provisioned first use boundary](admin-provisioned-first-use.md): members must not see provider setup diagnostics, while admins/operators use Workspace Health as the setup/readiness control plane.
-- Auth, Matrix, files, calendar, boards, meetings/LiveKit, E2EE posture, backups, support bundle, and latest smoke/E2E state.
-- Provider readiness is support-safe and admin/operator-facing; member UI shows ready product workflows or impact/fallback states only.
+- Provider categories are first-class product/admin concepts: identity/IDM, chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver.
+- Current dogfood defaults map into those categories as provider selections and readiness signals: Keycloak/Auth for identity/IDM, Matrix for chat, Nextcloud for files and calendar backing, OpenProject for boards/tasks validation, and LiveKit for meetings readiness.
+- Weaver is represented only as a disabled-by-default category until the later governed per-user PA runtime track is explicitly enabled by admin policy.
+- Provider readiness is support-safe and admin/operator-facing; member UI shows ready product workflows or impact/fallback states only, never raw provider setup, service endpoints, provider secrets, or diagnostics.
 
 Exit gate:
 

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -19,6 +19,15 @@ Feature: Weave v0.1 dogfood production release
     And the member does not see preview, scaffold, roadmap, or raw provider setup copy
     And provider diagnostics stay in admin/operator health surfaces
 
+  @weave-v01-admin-provider-categories
+  Scenario: Admin sees provider categories before member use
+    Given an owner or admin opens Workspace Health before inviting members
+    When provider readiness and policy are reviewed
+    Then identity/IDM, chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver are shown as provider categories
+    And current dogfood defaults map to category readiness without becoming member-facing product names
+    And Weaver is disabled by default until admin policy explicitly enables it
+    And normal members never configure raw providers, service endpoints, provider secrets, or diagnostics
+
   @weave-v01-channel-workspace
   Scenario: A channel is the primary workspace surface
     Given a workspace member enters a project channel

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -141,6 +141,41 @@
       ]
     },
     {
+      "tag": "@weave-v01-admin-provider-categories",
+      "scenario": "Admin sees provider categories before member use",
+      "feature": "e2e/features/v0_1_dogfood_release.feature",
+      "executableTest": "client/test/release_1/v0_1_release_spine_contract_test.dart",
+      "evidenceMarkers": [
+        "V01_ADMIN_PROVIDER_CATEGORIES"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "docs/product-line-and-weaver-plan.md",
+          "fragments": [
+            "Workspace/Admin Health and setup language names identity/IDM, chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver as first-class categories.",
+            "Dogfood defaults are mapped as current provider choices only: Keycloak/Auth, Matrix/Chat, Nextcloud/Files and Calendar backing, OpenProject Boards validation, and LiveKit Meetings readiness.",
+            "Weaver remains disabled by default and later than admin portal, IDM/RBAC, readiness, and whitelisting."
+          ]
+        },
+        {
+          "path": "docs/admin-provisioned-first-use.md",
+          "fragments": [
+            "Provider-category admin boundary",
+            "Normal members never configure raw providers, service endpoints, OIDC clients, provider secrets, backup/restore paths, or provider diagnostics.",
+            "Admins/operators see support-safe readiness and next actions without secret values"
+          ]
+        },
+        {
+          "path": "docs/release-v0.1-dogfood-plan.md",
+          "fragments": [
+            "Provider categories are first-class product/admin concepts",
+            "Weaver is represented only as a disabled-by-default category",
+            "never raw provider setup, service endpoints, provider secrets, or diagnostics"
+          ]
+        }
+      ]
+    },
+    {
       "tag": "@weave-v01-channel-workspace",
       "scenario": "A channel is the primary workspace surface",
       "feature": "e2e/features/v0_1_dogfood_release.feature",


### PR DESCRIPTION
## Summary

Defines the #264 provider-neutral product foundation for Weave as an organization suite/integration layer before Weaver runtime work.

## Changes

- Adds the product-line and Weaver integration plan with provider categories, admin boundaries, and phased evidence gates.
- Updates README, architecture, first-use, and v0.1 release docs to keep normal-member UX provider-neutral and admin-provisioned.
- Adds v0.1 acceptance mapping and contract coverage for provider-category admin readiness before member use.

## Validation

- `make acceptance-contract`
- `make -C client release-spine-contract`
- `git diff --check`
- `git diff --cached --check`

Fixes #264
