### PR TITLE
feat: add IDM/RBAC capability policy profiles

### DIFF
--- a/client/lib/features/agents/domain/entities/agent_capability_policy.dart
+++ b/client/lib/features/agents/domain/entities/agent_capability_policy.dart
@@ -1,3 +1,5 @@
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+
 enum AgentCapability { personalAssistant, channelAgent }
 
 enum AgentCapabilityEnablement { disabled, enabled }
@@ -51,6 +53,42 @@ class AgentCapabilityPolicy {
           capability: AgentCapability.channelAgent,
           enablement: AgentCapabilityEnablement.disabled,
           availability: AgentCapabilityAvailability.blocked,
+        ),
+      ],
+    );
+  }
+
+  factory AgentCapabilityPolicy.fromWorkspaceCapabilities({
+    required bool canManageCapabilities,
+    required WorkspaceCapabilitySnapshot workspaceCapabilities,
+  }) {
+    final weaver = workspaceCapabilities.weaver;
+    final availability = switch (weaver.policyState) {
+      WorkspaceCapabilityPolicyState.disabled =>
+        AgentCapabilityAvailability.disabledByPolicy,
+      WorkspaceCapabilityPolicyState.policyBlocked =>
+        AgentCapabilityAvailability.disabledByPolicy,
+      WorkspaceCapabilityPolicyState.unavailable =>
+        AgentCapabilityAvailability.adminSetupRequired,
+      WorkspaceCapabilityPolicyState.allowed =>
+        weaver.readiness == WorkspaceCapabilityReadiness.ready &&
+                weaver.grants('weaver.enabled')
+            ? AgentCapabilityAvailability.adminSetupRequired
+            : AgentCapabilityAvailability.disabledByPolicy,
+    };
+
+    return AgentCapabilityPolicy(
+      canManageCapabilities: canManageCapabilities,
+      capabilities: <AgentCapabilityState>[
+        AgentCapabilityState(
+          capability: AgentCapability.personalAssistant,
+          enablement: AgentCapabilityEnablement.disabled,
+          availability: availability,
+        ),
+        const AgentCapabilityState(
+          capability: AgentCapability.channelAgent,
+          enablement: AgentCapabilityEnablement.disabled,
+          availability: AgentCapabilityAvailability.adminSetupRequired,
         ),
       ],
     );

--- a/client/lib/features/agents/presentation/providers/agent_capability_policy_provider.dart
+++ b/client/lib/features/agents/presentation/providers/agent_capability_policy_provider.dart
@@ -2,22 +2,41 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weave/features/agents/domain/entities/agent_capability_policy.dart';
 import 'package:weave/features/profile/domain/entities/user_profile.dart';
 import 'package:weave/features/profile/presentation/providers/user_profile_provider.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 
 final agentCapabilityPolicyProvider =
     Provider<AsyncValue<AgentCapabilityPolicy>>((ref) {
       final profile = ref.watch(userProfileProvider);
+      final capabilities = ref.watch(
+        weaveApiWorkspaceCapabilitySnapshotProvider,
+      );
 
-      return switch (profile) {
-        AsyncData(value: final user) => AsyncData(
-          AgentCapabilityPolicy.disabled(
-            canManageCapabilities: user?.canAdministerWorkspace ?? false,
+      final canManageCapabilities = profile.maybeWhen(
+        data: (user) => user?.canAdministerWorkspace ?? false,
+        orElse: () => false,
+      );
+
+      return switch (capabilities) {
+        AsyncData(value: final snapshot?) => AsyncData(
+          AgentCapabilityPolicy.fromWorkspaceCapabilities(
+            canManageCapabilities: canManageCapabilities,
+            workspaceCapabilities: snapshot,
+          ),
+        ),
+        AsyncData() => AsyncData(
+          AgentCapabilityPolicy.failClosed(
+            canManageCapabilities: canManageCapabilities,
           ),
         ),
         AsyncError() => AsyncData(
-          AgentCapabilityPolicy.failClosed(canManageCapabilities: false),
+          AgentCapabilityPolicy.failClosed(
+            canManageCapabilities: canManageCapabilities,
+          ),
         ),
         _ => AsyncData(
-          AgentCapabilityPolicy.failClosed(canManageCapabilities: false),
+          AgentCapabilityPolicy.failClosed(
+            canManageCapabilities: canManageCapabilities,
+          ),
         ),
       };
     });

--- a/client/lib/features/app/domain/entities/workspace_capability_snapshot.dart
+++ b/client/lib/features/app/domain/entities/workspace_capability_snapshot.dart
@@ -1,8 +1,15 @@
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
 
-enum WorkspaceCapability { shellAccess, chat, files, calendar, boards }
+enum WorkspaceCapability { shellAccess, chat, files, calendar, boards, weaver }
 
 enum WorkspaceCapabilityReadiness { ready, degraded, blocked, unavailable }
+
+enum WorkspaceCapabilityPolicyState {
+  allowed,
+  policyBlocked,
+  disabled,
+  unavailable,
+}
 
 class WorkspaceCapabilityState {
   const WorkspaceCapabilityState({
@@ -10,14 +17,28 @@ class WorkspaceCapabilityState {
     required this.readiness,
     this.connectionStatus,
     this.recoveryRequirement = IntegrationRecoveryRequirement.none,
+    this.policyState = WorkspaceCapabilityPolicyState.unavailable,
+    this.profileKey,
+    this.memberImpact,
+    this.grantedCapabilities = const <String>[],
   });
 
   final WorkspaceCapability capability;
   final WorkspaceCapabilityReadiness readiness;
   final IntegrationConnectionStatus? connectionStatus;
   final IntegrationRecoveryRequirement recoveryRequirement;
+  final WorkspaceCapabilityPolicyState policyState;
+  final String? profileKey;
+  final String? memberImpact;
+  final List<String> grantedCapabilities;
 
   bool get isReady => readiness == WorkspaceCapabilityReadiness.ready;
+  bool get isPolicyBlocked =>
+      policyState == WorkspaceCapabilityPolicyState.policyBlocked;
+
+  bool grants(String capabilityKey) {
+    return grantedCapabilities.contains(capabilityKey);
+  }
 }
 
 class WorkspaceCapabilitySnapshot {
@@ -27,6 +48,13 @@ class WorkspaceCapabilitySnapshot {
     required this.files,
     required this.calendar,
     required this.boards,
+    this.weaver = const WorkspaceCapabilityState(
+      capability: WorkspaceCapability.weaver,
+      readiness: WorkspaceCapabilityReadiness.unavailable,
+      policyState: WorkspaceCapabilityPolicyState.disabled,
+      memberImpact:
+          'Weaver is disabled by workspace policy until an admin enables a governed runtime profile.',
+    ),
   });
 
   final WorkspaceCapabilityState shellAccess;
@@ -34,6 +62,7 @@ class WorkspaceCapabilitySnapshot {
   final WorkspaceCapabilityState files;
   final WorkspaceCapabilityState calendar;
   final WorkspaceCapabilityState boards;
+  final WorkspaceCapabilityState weaver;
 
   List<WorkspaceCapabilityState> get all => <WorkspaceCapabilityState>[
     shellAccess,
@@ -41,5 +70,6 @@ class WorkspaceCapabilitySnapshot {
     files,
     calendar,
     boards,
+    weaver,
   ];
 }

--- a/client/lib/features/app/presentation/providers/workspace_connection_provider.dart
+++ b/client/lib/features/app/presentation/providers/workspace_connection_provider.dart
@@ -359,6 +359,7 @@ WorkspaceCapabilitySnapshot _mapWorkspaceCapabilitySnapshot(
       capability: WorkspaceCapability.boards,
       shellAccess: connection.appAuth,
     ),
+    weaver: _mapDisabledPolicyCapability(WorkspaceCapability.weaver),
   );
 }
 
@@ -387,6 +388,10 @@ WorkspaceCapabilitySnapshot _mergeWorkspaceCapabilitySnapshots({
       local: localSnapshot.boards,
       backend: backendSnapshot.boards,
     ),
+    weaver: _mergeWorkspaceCapabilityState(
+      local: localSnapshot.weaver,
+      backend: backendSnapshot.weaver,
+    ),
   );
 }
 
@@ -399,6 +404,10 @@ WorkspaceCapabilityState _mergeWorkspaceCapabilityState({
     readiness: backend.readiness,
     connectionStatus: local.connectionStatus,
     recoveryRequirement: local.recoveryRequirement,
+    policyState: backend.policyState,
+    profileKey: backend.profileKey,
+    memberImpact: backend.memberImpact,
+    grantedCapabilities: backend.grantedCapabilities,
   );
 }
 
@@ -498,5 +507,17 @@ WorkspaceCapabilityState _mapFutureCapability({
   return WorkspaceCapabilityState(
     capability: capability,
     readiness: WorkspaceCapabilityReadiness.unavailable,
+  );
+}
+
+WorkspaceCapabilityState _mapDisabledPolicyCapability(
+  WorkspaceCapability capability,
+) {
+  return WorkspaceCapabilityState(
+    capability: capability,
+    readiness: WorkspaceCapabilityReadiness.unavailable,
+    policyState: WorkspaceCapabilityPolicyState.disabled,
+    memberImpact:
+        'This capability is disabled by workspace policy until an admin enables it.',
   );
 }

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -1280,6 +1280,12 @@ class _WorkspaceReadinessRow extends StatelessWidget {
                 label: l10n.settingsWorkspaceConnectionLabel,
                 value: _connectionLabel(l10n, connection.status),
               ),
+              _StatusPill(
+                label: 'Policy',
+                value: _policyLabel(capability.policyState),
+              ),
+              if (capability.memberImpact case final impact?)
+                _StatusPill(label: 'Impact', value: impact),
               if (connection.lastInvalidation != null)
                 _StatusPill(
                   label: l10n.settingsWorkspaceLastChangeLabel,
@@ -1328,6 +1334,15 @@ class _WorkspaceReadinessRow extends StatelessWidget {
         l10n.settingsWorkspaceCapabilityBlocked,
       WorkspaceCapabilityReadiness.unavailable =>
         l10n.settingsWorkspaceCapabilityUnavailable,
+    };
+  }
+
+  String _policyLabel(WorkspaceCapabilityPolicyState state) {
+    return switch (state) {
+      WorkspaceCapabilityPolicyState.allowed => 'Allowed',
+      WorkspaceCapabilityPolicyState.policyBlocked => 'Policy blocked',
+      WorkspaceCapabilityPolicyState.disabled => 'Disabled by policy',
+      WorkspaceCapabilityPolicyState.unavailable => 'Unavailable',
     };
   }
 

--- a/client/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
+++ b/client/lib/integrations/weave_api/data/dtos/workspace_capabilities_response_dto.dart
@@ -8,6 +8,7 @@ class WorkspaceCapabilitiesResponseDto {
     required this.files,
     required this.calendar,
     required this.boards,
+    required this.weaver,
   });
 
   factory WorkspaceCapabilitiesResponseDto.fromJson(Map<String, dynamic> json) {
@@ -27,6 +28,17 @@ class WorkspaceCapabilitiesResponseDto {
       boards: WorkspaceCapabilityStatusDto.fromJson(
         _readNestedJson(json, 'boards'),
       ),
+      weaver: WorkspaceCapabilityStatusDto.fromJson(
+        json['weaver'] is Map<String, dynamic>
+            ? _readNestedJson(json, 'weaver')
+            : const <String, dynamic>{
+                'enabled': false,
+                'readiness': 'unavailable',
+                'policyState': 'disabled',
+                'memberImpact':
+                    'Weaver is disabled by workspace policy until an admin enables a governed runtime profile.',
+              },
+      ),
     );
   }
 
@@ -35,6 +47,7 @@ class WorkspaceCapabilitiesResponseDto {
   final WorkspaceCapabilityStatusDto files;
   final WorkspaceCapabilityStatusDto calendar;
   final WorkspaceCapabilityStatusDto boards;
+  final WorkspaceCapabilityStatusDto weaver;
 
   WorkspaceCapabilitySnapshot toSnapshot() {
     return WorkspaceCapabilitySnapshot(
@@ -45,6 +58,7 @@ class WorkspaceCapabilitiesResponseDto {
       files: files.toCapabilityState(WorkspaceCapability.files),
       calendar: calendar.toCapabilityState(WorkspaceCapability.calendar),
       boards: boards.toCapabilityState(WorkspaceCapability.boards),
+      weaver: weaver.toCapabilityState(WorkspaceCapability.weaver),
     );
   }
 
@@ -68,6 +82,10 @@ class WorkspaceCapabilityStatusDto {
   const WorkspaceCapabilityStatusDto({
     required this.enabled,
     required this.readiness,
+    this.policyState = 'unavailable',
+    this.grantedCapabilities = const <String>[],
+    this.profileKey,
+    this.memberImpact,
   });
 
   factory WorkspaceCapabilityStatusDto.fromJson(Map<String, dynamic> json) {
@@ -80,11 +98,28 @@ class WorkspaceCapabilityStatusDto {
       );
     }
 
-    return WorkspaceCapabilityStatusDto(enabled: enabled, readiness: readiness);
+    return WorkspaceCapabilityStatusDto(
+      enabled: enabled,
+      readiness: readiness,
+      policyState: json['policyState'] is String
+          ? json['policyState'] as String
+          : (enabled ? 'allowed' : 'disabled'),
+      profileKey: json['profileKey'] is String
+          ? json['profileKey'] as String
+          : null,
+      memberImpact: json['memberImpact'] is String
+          ? json['memberImpact'] as String
+          : null,
+      grantedCapabilities: _readStringList(json['grantedCapabilities']),
+    );
   }
 
   final bool enabled;
   final String readiness;
+  final String policyState;
+  final String? profileKey;
+  final String? memberImpact;
+  final List<String> grantedCapabilities;
 
   WorkspaceCapabilityState toCapabilityState(WorkspaceCapability capability) {
     return WorkspaceCapabilityState(
@@ -92,7 +127,31 @@ class WorkspaceCapabilityStatusDto {
       readiness: enabled
           ? _parseReadiness(readiness)
           : WorkspaceCapabilityReadiness.unavailable,
+      policyState: _parsePolicyState(policyState),
+      profileKey: profileKey,
+      memberImpact: memberImpact,
+      grantedCapabilities: grantedCapabilities,
     );
+  }
+
+  static List<String> _readStringList(Object? value) {
+    if (value is! List<dynamic>) {
+      return const <String>[];
+    }
+    return value.whereType<String>().toList(growable: false);
+  }
+
+  WorkspaceCapabilityPolicyState _parsePolicyState(String rawValue) {
+    return switch (rawValue.trim()) {
+      'allowed' => WorkspaceCapabilityPolicyState.allowed,
+      'policy_blocked' => WorkspaceCapabilityPolicyState.policyBlocked,
+      'disabled' => WorkspaceCapabilityPolicyState.disabled,
+      'unavailable' => WorkspaceCapabilityPolicyState.unavailable,
+      _ => throw AppFailure.unknown(
+        'The backend returned an unknown workspace capability policy state.',
+        cause: rawValue,
+      ),
+    };
   }
 
   WorkspaceCapabilityReadiness _parseReadiness(String rawValue) {

--- a/client/test/core/router/app_router_test.dart
+++ b/client/test/core/router/app_router_test.dart
@@ -156,10 +156,12 @@ void main() {
           workspaceCapabilitySnapshotProvider.overrideWithValue(
             _workspaceCapabilitySnapshot(),
           ),
-          // The ready shell renders the workspace status card, which watches
-          // the backend-backed Weave Home provider. Keep router tests focused
-          // on navigation so widget-test HTTP failures do not schedule
-          // Riverpod retry timers after disposal.
+          // The ready shell renders backend-backed workspace status cards.
+          // Keep router tests focused on navigation so widget-test HTTP
+          // failures do not schedule Riverpod retry timers after disposal.
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+            (ref) async => _workspaceCapabilitySnapshot().value,
+          ),
           weaveApiWorkspaceHomeProvider.overrideWith((ref) => null),
         ],
       );

--- a/client/test/features/agents/presentation/providers/agent_capability_policy_provider_test.dart
+++ b/client/test/features/agents/presentation/providers/agent_capability_policy_provider_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/features/agents/domain/entities/agent_capability_policy.dart';
 import 'package:weave/features/agents/presentation/providers/agent_capability_policy_provider.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_api_provider.dart';
 import 'package:weave/features/profile/domain/entities/user_profile.dart';
 import 'package:weave/features/profile/presentation/providers/user_profile_provider.dart';
 
@@ -27,33 +29,79 @@ const _memberProfile = UserProfile(
   roles: ['member'],
 );
 
+const _weaverDisabledSnapshot = WorkspaceCapabilitySnapshot(
+  shellAccess: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.shellAccess,
+    readiness: WorkspaceCapabilityReadiness.ready,
+    policyState: WorkspaceCapabilityPolicyState.allowed,
+  ),
+  chat: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.chat,
+    readiness: WorkspaceCapabilityReadiness.ready,
+    policyState: WorkspaceCapabilityPolicyState.allowed,
+  ),
+  files: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.files,
+    readiness: WorkspaceCapabilityReadiness.ready,
+    policyState: WorkspaceCapabilityPolicyState.allowed,
+  ),
+  calendar: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.calendar,
+    readiness: WorkspaceCapabilityReadiness.unavailable,
+    policyState: WorkspaceCapabilityPolicyState.unavailable,
+  ),
+  boards: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.boards,
+    readiness: WorkspaceCapabilityReadiness.unavailable,
+    policyState: WorkspaceCapabilityPolicyState.unavailable,
+  ),
+  weaver: WorkspaceCapabilityState(
+    capability: WorkspaceCapability.weaver,
+    readiness: WorkspaceCapabilityReadiness.unavailable,
+    policyState: WorkspaceCapabilityPolicyState.disabled,
+    grantedCapabilities: ['weaver.exec_disabled'],
+  ),
+);
+
 void main() {
   group('agentCapabilityPolicyProvider', () {
     test('marks owner/admin profiles as capability managers', () async {
       final container = ProviderContainer.test(
         overrides: [
           userProfileProvider.overrideWith((ref) async => _ownerProfile),
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+            (ref) async => _weaverDisabledSnapshot,
+          ),
         ],
       );
       addTearDown(container.dispose);
 
       await container.read(userProfileProvider.future);
+      await container.read(weaveApiWorkspaceCapabilitySnapshotProvider.future);
       final policy = container.read(agentCapabilityPolicyProvider).requireValue;
 
       expect(policy.canManageCapabilities, isTrue);
       expect(policy.canStartAnyCapability, isFalse);
       expect(policy.isFailClosed, isFalse);
+      expect(
+        policy.stateFor(AgentCapability.personalAssistant).availability,
+        AgentCapabilityAvailability.disabledByPolicy,
+      );
     });
 
     test('keeps ordinary members read-only', () async {
       final container = ProviderContainer.test(
         overrides: [
           userProfileProvider.overrideWith((ref) async => _memberProfile),
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+            (ref) async => _weaverDisabledSnapshot,
+          ),
         ],
       );
       addTearDown(container.dispose);
 
       await container.read(userProfileProvider.future);
+      await container.read(weaveApiWorkspaceCapabilitySnapshotProvider.future);
       final policy = container.read(agentCapabilityPolicyProvider).requireValue;
 
       expect(policy.canManageCapabilities, isFalse);
@@ -63,9 +111,13 @@ void main() {
 
     test('fails closed while profile roles are unresolved', () {
       final unresolvedProfile = Completer<UserProfile?>();
+      final unresolvedCapabilities = Completer<WorkspaceCapabilitySnapshot>();
       final container = ProviderContainer.test(
         overrides: [
           userProfileProvider.overrideWith((ref) => unresolvedProfile.future),
+          weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+            (ref) => unresolvedCapabilities.future,
+          ),
         ],
       );
       addTearDown(container.dispose);

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -5,48 +5,43 @@ import 'package:flutter_test/flutter_test.dart';
 import '../tool/acceptance_contract.dart' as acceptance;
 
 void main() {
-  test(
-    'live stack feature scenarios are mapped to executable E2E evidence',
-    () {
-      final root = Directory.current.parent;
-      final scenarios = acceptance.parseFeatureDirectory(root, 'e2e/features');
-      final mappings = acceptance.loadScenarioMappings(
-        root,
-        'e2e/scenario_mappings.json',
-      );
-      final result = acceptance.validateAcceptanceContract(
-        root: root,
-        scenarios: scenarios,
-        mappings: mappings,
-        runtimeEvidence: acceptance.RuntimeEvidence.notCollected(),
-      );
+  test('live stack feature scenarios are mapped to executable E2E evidence', () {
+    final root = Directory.current.parent;
+    final scenarios = acceptance.parseFeatureDirectory(root, 'e2e/features');
+    final mappings = acceptance.loadScenarioMappings(
+      root,
+      'e2e/scenario_mappings.json',
+    );
+    final result = acceptance.validateAcceptanceContract(
+      root: root,
+      scenarios: scenarios,
+      mappings: mappings,
+      runtimeEvidence: acceptance.RuntimeEvidence.notCollected(),
+    );
 
-      expect(
-        result.findings.map((finding) => finding.message).toList(),
-        isEmpty,
-      );
-      expect(
-        result.scenarios.map((scenario) => scenario.name),
-        unorderedEquals(<String>[
-          'Sign-in restores the Weave workspace and profile',
-          'Matrix chat sends and reads a workspace message',
-          'Matrix encryption status is proved honestly',
-          'Files are uploaded, shown, downloaded, and cleaned up in Weave',
-          'Provider stack readiness stays backend-owned and support-safe',
-          'Channel calendar events keep their meeting thread reference',
-          'Boards workspace supports accessible non-drag task work',
-          'Weave Home starts the daily work loop',
-          'A normal member sees a user-ready organization flow',
-          'Admin sees provider categories before member use',
-          'A channel is the primary workspace surface',
-          'A user board write is authorized and audited',
-          'A meeting capsule keeps work connected',
-          'Decisions are captured as product records',
-          'Operators can deploy, verify, back up, restore, and diagnose safely',
-        ]),
-      );
-    },
-  );
+    expect(result.findings.map((finding) => finding.message).toList(), isEmpty);
+    expect(
+      result.scenarios.map((scenario) => scenario.name),
+      unorderedEquals(<String>[
+        'Sign-in restores the Weave workspace and profile',
+        'Matrix chat sends and reads a workspace message',
+        'Matrix encryption status is proved honestly',
+        'Files are uploaded, shown, downloaded, and cleaned up in Weave',
+        'Provider stack readiness stays backend-owned and support-safe',
+        'Channel calendar events keep their meeting thread reference',
+        'Boards workspace supports accessible non-drag task work',
+        'Weave Home starts the daily work loop',
+        'A normal member sees a user-ready organization flow',
+        'Admin sees provider categories before member use',
+        'IDM roles and groups decide capability profiles before Weaver runtime',
+        'A channel is the primary workspace surface',
+        'A user board write is authorized and audited',
+        'A meeting capsule keeps work connected',
+        'Decisions are captured as product records',
+        'Operators can deploy, verify, back up, restore, and diagnose safely',
+      ]),
+    );
+  });
 
   test('mapping guard fails a newly added unmapped scenario', () {
     final root = Directory.current.parent;

--- a/client/test/release_1/v0_1_release_spine_contract_test.dart
+++ b/client/test/release_1/v0_1_release_spine_contract_test.dart
@@ -120,6 +120,7 @@ void main() {
         '@weave-v01-home-daily-loop',
         '@weave-v01-user-ready-organization-flow',
         '@weave-v01-admin-provider-categories',
+        '@weave-v01-idm-rbac-capability-policy',
         '@weave-v01-channel-workspace',
         '@weave-v01-board-write-audit',
         '@weave-v01-meeting-capsule',

--- a/docs/admin-provisioned-first-use.md
+++ b/docs/admin-provisioned-first-use.md
@@ -83,3 +83,11 @@ Future work on first-use, settings, navigation, or Workspace Health must include
 5. Which deterministic test prevents preview/setup/provider leakage from returning to normal-user paths?
 
 The fast guard is `client/test/architecture/admin_provisioned_first_use_contract_test.dart`; role-specific widget assertions also live under `client/test/features/`.
+
+## IDM/RBAC capability profiles
+
+Admins/operators configure the selected IDM adapter and map roles/groups into Weave capability profiles before inviting members. Keycloak is the self-hosted default, while Entra ID, Authentik, Auth0, and other OIDC/SAML providers remain adapter-compatible choices.
+
+Admins/operators see support-safe effective policy state: IDM category, profile keys, role/group-derived grants, deny-by-default posture, and whether a category is disabled, unavailable, degraded, ready, or policy-blocked. They do not need secret values in normal health views.
+
+Members only see ready, disabled, degraded, or policy-blocked impact states. They never see raw provider setup, OIDC/SAML wiring, service endpoints, provider secrets, or diagnostics. Weaver appears only as a disabled-by-policy placeholder until a later governed per-user runtime policy exists.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,3 +208,11 @@ Refactors in this area must preserve:
 - semantics labels for icon-only affordances
 - readable focus order in setup/settings
 - clear announcements for bootstrap loading and retry states
+
+## IDM/RBAC capability profile contract
+
+Weave derives workspace capability visibility from the selected IDM and backend-owned policy evaluation. Keycloak is the self-hosted default IDM for dogfood deployments, but the contract is adapter-friendly for OIDC/SAML providers such as Entra ID, Authentik, and Auth0.
+
+The backend consumes realm roles and groups, normalizes them into capability profiles, and grants only category-level capability keys. Examples include chat.read, chat.send, files.read, files.upload, calendar.read, calendar.manage_events, boards.read, boards.update_task, weaver.files_read, and weaver.exec_disabled. Unknown roles/groups are deny-by-default.
+
+Capability policy responses are support-safe: they expose effective policy posture and profile keys, not provider secrets or raw setup. Weaver runtime enablement is intentionally absent from built-in profiles until a later governed runtime policy can generate per-user, audited, sandboxed runtime configuration.

--- a/docs/product-line-and-weaver-plan.md
+++ b/docs/product-line-and-weaver-plan.md
@@ -174,3 +174,11 @@ Future Weave planning should preserve this order:
 3. Weaver PA runtime as optional governed layer.
 
 Do not regress to agent-first planning. Do not assume one required provider stack. Do not expose raw provider setup to normal members.
+
+## IDM/RBAC capability profiles and whitelisting
+
+The admin portal foundation owns IDM/RBAC capability profiles and whitelisting before any Weaver runtime ships. Keycloak/Auth remains the self-hosted default identity choice, but the product contract is provider-neutral: selected IDM adapters may be Keycloak, Entra ID, Authentik, Auth0, or other OIDC/SAML-compatible providers that can supply roles and groups without leaking raw setup to members.
+
+Capability profiles are deny-by-default. Roles and groups map to category-level capabilities such as chat.read, chat.send, files.read, files.upload, calendar.read, boards.update_task, and Weaver placeholder keys. Admins/operators may inspect support-safe effective policy state and profile keys; normal members only see product impact states such as ready, disabled, degraded, or policy-blocked.
+
+Weaver remains disabled by default until a later governed runtime policy exists. Issue #265 may expose Weaver placeholder capabilities only to prove whitelisting and fail-closed behavior; it must not start a per-user PA runtime or grant broad tool access.

--- a/docs/release-v0.1-dogfood-plan.md
+++ b/docs/release-v0.1-dogfood-plan.md
@@ -170,3 +170,7 @@ Exit gate:
 - restore smoke passes
 - support bundle is redacted
 - Live Stack E2E passes against release manifest
+
+### IDM/RBAC and capability whitelisting acceptance
+
+Before Weaver runtime work, Weave must prove IDM/RBAC capability profiles and category whitelisting in the backend/admin contract. Keycloak is the self-hosted default IDM, while OIDC/SAML adapters remain provider-neutral. Unknown roles and groups are denied by default. Admin/operator views expose support-safe effective policy state; member views expose only ready, disabled, degraded, or policy-blocked impact states. Weaver remains disabled by policy until a later governed runtime profile is implemented.

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -28,6 +28,16 @@ Feature: Weave v0.1 dogfood production release
     And Weaver is disabled by default until admin policy explicitly enables it
     And normal members never configure raw providers, service endpoints, provider secrets, or diagnostics
 
+  @weave-v01-idm-rbac-capability-policy
+  Scenario: IDM roles and groups decide capability profiles before Weaver runtime
+    Given an owner has selected an IDM provider for the organization
+    When role and group claims are mapped into workspace capability profiles
+    Then Keycloak is the self-hosted default while OIDC and SAML adapters stay provider-neutral
+    And capability profiles grant category-level capabilities deny-by-default
+    And admins/operators can inspect support-safe policy state
+    And members only see ready, disabled, degraded, or policy-blocked impact states
+    And Weaver capability placeholders stay disabled by default until a governed runtime policy exists
+
   @weave-v01-channel-workspace
   Scenario: A channel is the primary workspace surface
     Given a workspace member enters a project channel

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -176,6 +176,41 @@
       ]
     },
     {
+      "tag": "@weave-v01-idm-rbac-capability-policy",
+      "scenario": "IDM roles and groups decide capability profiles before Weaver runtime",
+      "feature": "e2e/features/v0_1_dogfood_release.feature",
+      "executableTest": "server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java",
+      "evidenceMarkers": [
+        "V01_IDM_RBAC_CAPABILITY_POLICY"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "docs/product-line-and-weaver-plan.md",
+          "fragments": [
+            "IDM/RBAC capability profiles and whitelisting",
+            "Capability profiles are deny-by-default",
+            "Weaver remains disabled by default until a later governed runtime policy"
+          ]
+        },
+        {
+          "path": "docs/admin-provisioned-first-use.md",
+          "fragments": [
+            "IDM/RBAC capability profiles",
+            "Members only see ready, disabled, degraded, or policy-blocked impact states",
+            "Admins/operators see support-safe effective policy state"
+          ]
+        },
+        {
+          "path": "docs/architecture.md",
+          "fragments": [
+            "IDM/RBAC capability profile contract",
+            "Keycloak is the self-hosted default IDM",
+            "category-level capability keys"
+          ]
+        }
+      ]
+    },
+    {
       "tag": "@weave-v01-channel-workspace",
       "scenario": "A channel is the primary workspace surface",
       "feature": "e2e/features/v0_1_dogfood_release.feature",

--- a/server/src/main/java/com/massimotter/weave/backend/config/WorkspaceCapabilityProperties.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/WorkspaceCapabilityProperties.java
@@ -10,7 +10,8 @@ public record WorkspaceCapabilityProperties(
         Capability chat,
         Capability files,
         Capability calendar,
-        Capability boards) {
+        Capability boards,
+        Capability weaver) {
 
     public WorkspaceCapabilityProperties {
         shellAccess = defaultCapability(shellAccess, true, null, null);
@@ -18,6 +19,7 @@ public record WorkspaceCapabilityProperties(
         files = defaultCapability(files, true, null, null);
         calendar = defaultCapability(calendar, false, null, null);
         boards = defaultCapability(boards, false, null, null);
+        weaver = defaultCapability(weaver, false, null, null);
     }
 
     private static Capability defaultCapability(

--- a/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -2,6 +2,7 @@ package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.model.ApiErrorResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
 import com.massimotter.weave.backend.model.WorkspaceHomeResponse;
 import com.massimotter.weave.backend.model.WorkspaceReleaseReadinessResponse;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
@@ -14,6 +15,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -49,8 +53,28 @@ public class WorkspaceController {
             @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
-    public WorkspaceCapabilitiesResponse capabilities() {
-        return workspaceCapabilityService.snapshot();
+    public WorkspaceCapabilitiesResponse capabilities(@AuthenticationPrincipal Jwt jwt) {
+        return workspaceCapabilityService.snapshot(jwt);
+    }
+
+    @GetMapping({"/api/workspace/capability-policy", "/api/v1/workspace/capability-policy"})
+    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @Operation(
+            summary = "Get workspace capability policy",
+            description = "Returns an admin/operator support-safe snapshot of IDM role/group intake, profile mapping, deny-by-default posture, and Weaver-disabled-by-default policy state.",
+            security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Workspace capability policy snapshot.",
+                    content = @Content(schema = @Schema(implementation = WorkspaceCapabilityPolicyResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Bearer token is not an owner/admin/operator or is missing the weave:workspace scope.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
+    public WorkspaceCapabilityPolicyResponse capabilityPolicy(@AuthenticationPrincipal Jwt jwt) {
+        return workspaceCapabilityService.policySnapshot(jwt);
     }
 
     @GetMapping({"/api/workspace/release-readiness", "/api/v1/workspace/release-readiness"})

--- a/server/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilitiesResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilitiesResponse.java
@@ -8,5 +8,6 @@ public record WorkspaceCapabilitiesResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse chat,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse files,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse calendar,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse boards) {
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse boards,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) WorkspaceCapabilityStatusResponse weaver) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityPolicyResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityPolicyResponse.java
@@ -1,0 +1,26 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Admin/operator support-safe capability policy snapshot.")
+public record WorkspaceCapabilityPolicyResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String idmProviderCategory,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String defaultIdmProvider,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String adapterContract,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String principalSource,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> roles,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> groups,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> profileKeys,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> grantedCapabilities,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean denyByDefault,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean supportSafe,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String weaverRuntimePosture) {
+
+    public WorkspaceCapabilityPolicyResponse {
+        roles = roles == null ? List.of() : List.copyOf(roles);
+        groups = groups == null ? List.of() : List.copyOf(groups);
+        profileKeys = profileKeys == null ? List.of() : List.copyOf(profileKeys);
+        grantedCapabilities = grantedCapabilities == null ? List.of() : List.copyOf(grantedCapabilities);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityPolicyState.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityPolicyState.java
@@ -1,0 +1,23 @@
+package com.massimotter.weave.backend.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Support-safe policy state for an effective workspace capability.")
+public enum WorkspaceCapabilityPolicyState {
+    ALLOWED("allowed"),
+    POLICY_BLOCKED("policy_blocked"),
+    DISABLED("disabled"),
+    UNAVAILABLE("unavailable");
+
+    private final String value;
+
+    WorkspaceCapabilityPolicyState(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityStatusResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/WorkspaceCapabilityStatusResponse.java
@@ -1,11 +1,24 @@
 package com.massimotter.weave.backend.model;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "Availability and readiness state for one workspace capability.")
 public record WorkspaceCapabilityStatusResponse(
         @Schema(description = "Whether the capability is enabled for this workspace.", example = "true")
         boolean enabled,
         @Schema(description = "Current readiness state for this capability.")
-        WorkspaceCapabilityReadiness readiness) {
+        WorkspaceCapabilityReadiness readiness,
+        @Schema(description = "Support-safe effective policy state for the authenticated principal.")
+        WorkspaceCapabilityPolicyState policyState,
+        @Schema(description = "Policy profile key that decided this capability. Does not expose provider internals.")
+        String profileKey,
+        @Schema(description = "Member-safe impact or fallback copy for this capability.")
+        String memberImpact,
+        @Schema(description = "Category-level capability identifiers granted to the authenticated principal.")
+        List<String> grantedCapabilities) {
+
+    public WorkspaceCapabilityStatusResponse {
+        grantedCapabilities = grantedCapabilities == null ? List.of() : List.copyOf(grantedCapabilities);
+    }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -3,13 +3,46 @@ package com.massimotter.weave.backend.service;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
 @Service
 public class WorkspaceCapabilityService {
+
+    private static final List<String> OWNER_ADMIN_CAPABILITIES = List.of(
+            "chat.read",
+            "chat.send",
+            "files.read",
+            "files.upload",
+            "calendar.read",
+            "calendar.manage_events",
+            "boards.read",
+            "boards.update_task",
+            "weaver.exec_disabled");
+    private static final List<String> MEMBER_CAPABILITIES = List.of(
+            "chat.read",
+            "chat.send",
+            "files.read",
+            "files.upload",
+            "calendar.read",
+            "boards.read",
+            "weaver.exec_disabled");
+    private static final Map<String, List<String>> GROUP_CAPABILITIES = Map.of(
+            "weave-calendar-editors", List.of("calendar.manage_events"),
+            "weave-board-editors", List.of("boards.update_task"),
+            "weave-weaver-pilot", List.of("weaver.files_read", "weaver.exec_disabled"));
 
     private final OAuth2ResourceServerProperties resourceServerProperties;
     private final WeaveSecurityProperties weaveSecurityProperties;
@@ -25,43 +58,116 @@ public class WorkspaceCapabilityService {
     }
 
     public WorkspaceCapabilitiesResponse snapshot() {
+        return snapshot(null);
+    }
+
+    public WorkspaceCapabilitiesResponse snapshot(Jwt jwt) {
+        EffectivePolicy policy = effectivePolicy(jwt);
         WorkspaceCapabilityReadiness shellAccessReadiness = shellAccessReadiness();
         return new WorkspaceCapabilitiesResponse(
-                status(workspaceCapabilityProperties.shellAccess(), shellAccessReadiness),
-                dependentStatus(workspaceCapabilityProperties.chat(), shellAccessReadiness),
-                dependentStatus(workspaceCapabilityProperties.files(), shellAccessReadiness),
-                standaloneStatus(workspaceCapabilityProperties.calendar(), WorkspaceCapabilityReadiness.UNAVAILABLE),
-                standaloneStatus(workspaceCapabilityProperties.boards(), WorkspaceCapabilityReadiness.UNAVAILABLE));
+                status(
+                        workspaceCapabilityProperties.shellAccess(),
+                        shellAccessReadiness,
+                        "identity/IDM",
+                        List.of(),
+                        policy,
+                        "Weave SSO shell access is available."),
+                dependentStatus(
+                        workspaceCapabilityProperties.chat(),
+                        shellAccessReadiness,
+                        "chat",
+                        List.of("chat.read", "chat.send"),
+                        policy,
+                        "Chat is available through the Weave workspace."),
+                dependentStatus(
+                        workspaceCapabilityProperties.files(),
+                        shellAccessReadiness,
+                        "files",
+                        List.of("files.read", "files.upload"),
+                        policy,
+                        "Files are available through Weave."),
+                standaloneStatus(
+                        workspaceCapabilityProperties.calendar(),
+                        WorkspaceCapabilityReadiness.UNAVAILABLE,
+                        "calendar",
+                        List.of("calendar.read", "calendar.manage_events"),
+                        policy,
+                        "Calendar is available through the Weave workspace."),
+                standaloneStatus(
+                        workspaceCapabilityProperties.boards(),
+                        WorkspaceCapabilityReadiness.UNAVAILABLE,
+                        "boards/tasks",
+                        List.of("boards.read", "boards.update_task"),
+                        policy,
+                        "Boards and tasks are available through Weave."),
+                standaloneStatus(
+                        workspaceCapabilityProperties.weaver(),
+                        WorkspaceCapabilityReadiness.UNAVAILABLE,
+                        "Weaver",
+                        List.of("weaver.enabled", "weaver.files_read", "weaver.exec_disabled"),
+                        policy,
+                        "Weaver is disabled by default until an admin enables a governed runtime profile."));
+    }
+
+    public WorkspaceCapabilityPolicyResponse policySnapshot(Jwt jwt) {
+        EffectivePolicy policy = effectivePolicy(jwt);
+        return new WorkspaceCapabilityPolicyResponse(
+                "identity/IDM",
+                "Keycloak",
+                "OIDC/SAML adapter contract; Keycloak is the self-hosted default, not a product lock-in",
+                "JWT realm roles plus groups claims from the selected IDM",
+                policy.roles(),
+                policy.groups(),
+                policy.profileKeys(),
+                policy.capabilities().stream().sorted().toList(),
+                true,
+                true,
+                "disabled-by-default; per-user Dockerized Weaver runtime may only be generated from org policy later");
     }
 
     private WorkspaceCapabilityStatusResponse dependentStatus(
             WorkspaceCapabilityProperties.Capability capability,
-            WorkspaceCapabilityReadiness shellAccessReadiness) {
+            WorkspaceCapabilityReadiness shellAccessReadiness,
+            String category,
+            List<String> requiredCapabilities,
+            EffectivePolicy policy,
+            String readyImpact) {
         if (!capability.enabled()) {
-            return status(capability, WorkspaceCapabilityReadiness.UNAVAILABLE);
+            return status(capability, WorkspaceCapabilityReadiness.UNAVAILABLE, category, requiredCapabilities, policy,
+                    "This capability is disabled by workspace policy.");
         }
         if (shellAccessReadiness == WorkspaceCapabilityReadiness.BLOCKED) {
-            return status(capability, WorkspaceCapabilityReadiness.BLOCKED);
+            return status(capability, WorkspaceCapabilityReadiness.BLOCKED, category, requiredCapabilities, policy,
+                    "Sign-in or workspace SSO must be ready before this capability can be used.");
         }
         if (capability.readiness() != null) {
-            return status(capability, capability.readiness());
+            return status(capability, capability.readiness(), category, requiredCapabilities, policy, readyImpact);
         }
         if (hasText(capability.dependencyUrl())) {
-            return status(capability, WorkspaceCapabilityReadiness.READY);
+            return status(capability, WorkspaceCapabilityReadiness.READY, category, requiredCapabilities, policy, readyImpact);
         }
-        return status(capability, WorkspaceCapabilityReadiness.DEGRADED);
+        return status(capability, WorkspaceCapabilityReadiness.DEGRADED, category, requiredCapabilities, policy,
+                "This capability is degraded. Ask an admin to inspect Workspace Health.");
     }
 
     private WorkspaceCapabilityStatusResponse standaloneStatus(
             WorkspaceCapabilityProperties.Capability capability,
-            WorkspaceCapabilityReadiness defaultReadiness) {
+            WorkspaceCapabilityReadiness defaultReadiness,
+            String category,
+            List<String> requiredCapabilities,
+            EffectivePolicy policy,
+            String readyImpact) {
         if (!capability.enabled()) {
-            return status(capability, WorkspaceCapabilityReadiness.UNAVAILABLE);
+            return status(capability, WorkspaceCapabilityReadiness.UNAVAILABLE, category, requiredCapabilities, policy,
+                    "This capability is disabled by workspace policy.");
         }
         if (capability.readiness() != null) {
-            return status(capability, capability.readiness());
+            return status(capability, capability.readiness(), category, requiredCapabilities, policy, readyImpact);
         }
-        return status(capability, defaultReadiness);
+        return status(capability, defaultReadiness, category, requiredCapabilities, policy,
+                defaultReadiness == WorkspaceCapabilityReadiness.UNAVAILABLE
+                        ? "This capability is not ready for members in this workspace. Ask an admin to review Workspace Health."
+                        : readyImpact);
     }
 
     private WorkspaceCapabilityReadiness shellAccessReadiness() {
@@ -78,11 +184,126 @@ public class WorkspaceCapabilityService {
 
     private WorkspaceCapabilityStatusResponse status(
             WorkspaceCapabilityProperties.Capability capability,
-            WorkspaceCapabilityReadiness readiness) {
-        return new WorkspaceCapabilityStatusResponse(capability.enabled(), readiness);
+            WorkspaceCapabilityReadiness readiness,
+            String category,
+            List<String> requiredCapabilities,
+            EffectivePolicy policy,
+            String defaultImpact) {
+        List<String> granted = requiredCapabilities.stream()
+                .filter(policy.capabilities()::contains)
+                .toList();
+        boolean policyAllows = requiredCapabilities.isEmpty() || !granted.isEmpty();
+        WorkspaceCapabilityPolicyState policyState;
+        WorkspaceCapabilityReadiness effectiveReadiness = readiness;
+        String memberImpact = defaultImpact;
+        if (!capability.enabled()) {
+            policyState = WorkspaceCapabilityPolicyState.DISABLED;
+            effectiveReadiness = WorkspaceCapabilityReadiness.UNAVAILABLE;
+            memberImpact = "This capability is disabled by workspace policy.";
+        } else if (!policyAllows) {
+            policyState = WorkspaceCapabilityPolicyState.POLICY_BLOCKED;
+            effectiveReadiness = WorkspaceCapabilityReadiness.BLOCKED;
+            memberImpact = "This capability is blocked by your role or group policy. Ask an admin if you need access.";
+        } else if (effectiveReadiness == WorkspaceCapabilityReadiness.UNAVAILABLE) {
+            policyState = WorkspaceCapabilityPolicyState.UNAVAILABLE;
+        } else {
+            policyState = WorkspaceCapabilityPolicyState.ALLOWED;
+        }
+
+        return new WorkspaceCapabilityStatusResponse(
+                capability.enabled(),
+                effectiveReadiness,
+                policyState,
+                policy.profileKeyFor(category),
+                memberImpact,
+                granted);
+    }
+
+    private EffectivePolicy effectivePolicy(Jwt jwt) {
+        if (jwt == null) {
+            LinkedHashSet<String> systemCapabilities = new LinkedHashSet<>(OWNER_ADMIN_CAPABILITIES);
+            systemCapabilities.remove("weaver.enabled");
+            return new EffectivePolicy(
+                    List.of("system"),
+                    List.of(),
+                    List.of("system-internal-readiness"),
+                    Set.copyOf(systemCapabilities));
+        }
+        List<String> roles = extractRealmRoles(jwt);
+        List<String> groups = extractStringList(jwt, "groups");
+        LinkedHashSet<String> capabilities = new LinkedHashSet<>();
+        LinkedHashSet<String> profileKeys = new LinkedHashSet<>();
+
+        if (roles.stream().anyMatch(role -> role.equals("owner") || role.equals("admin") || role.equals("operator"))) {
+            capabilities.addAll(OWNER_ADMIN_CAPABILITIES);
+            profileKeys.add("workspace-admin");
+        }
+        if (roles.contains("member")) {
+            capabilities.addAll(MEMBER_CAPABILITIES);
+            profileKeys.add("member-default");
+        }
+        if (roles.contains("guest")) {
+            profileKeys.add("guest-deny-default");
+        }
+        for (String group : groups) {
+            List<String> groupCapabilities = GROUP_CAPABILITIES.get(group);
+            if (groupCapabilities != null) {
+                capabilities.addAll(groupCapabilities);
+                profileKeys.add("group:" + group);
+            }
+        }
+        if (profileKeys.isEmpty()) {
+            profileKeys.add("deny-by-default");
+        }
+        // Weaver runtime enablement is deliberately absent from built-in profiles.
+        // The placeholder may expose only constrained sub-capabilities such as files_read;
+        // runtime start still requires a later explicit admin policy carrying weaver.enabled.
+        capabilities.remove("weaver.enabled");
+        return new EffectivePolicy(roles, groups, List.copyOf(profileKeys), Set.copyOf(capabilities));
+    }
+
+    private List<String> extractRealmRoles(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+        if (realmAccess == null) {
+            return List.of();
+        }
+
+        Object roles = realmAccess.get("roles");
+        if (!(roles instanceof Collection<?> roleValues)) {
+            return List.of();
+        }
+
+        return roleValues.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .map(role -> role.trim().toLowerCase(Locale.ROOT))
+                .filter(role -> !role.isEmpty())
+                .sorted()
+                .toList();
+    }
+
+    private List<String> extractStringList(Jwt jwt, String claimName) {
+        Object claim = jwt.getClaims().get(claimName);
+        if (!(claim instanceof Collection<?> values)) {
+            return List.of();
+        }
+
+        return values.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .sorted()
+                .toList();
     }
 
     private boolean hasText(String value) {
         return value != null && !value.isBlank();
+    }
+
+    private record EffectivePolicy(List<String> roles, List<String> groups, List<String> profileKeys, Set<String> capabilities) {
+        String profileKeyFor(String category) {
+            return Stream.concat(Stream.of(category), profileKeys.stream()).toList().toString();
+        }
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -101,6 +101,12 @@ weave:
     boards:
       enabled: ${WEAVE_WORKSPACE_BOARDS_ENABLED:false}
       readiness: ${WEAVE_WORKSPACE_BOARDS_READINESS:}
+    weaver:
+      # Weaver is a policy-controlled placeholder at this stage. Runtime startup
+      # stays disabled-by-default until IDM/RBAC/capability whitelisting has
+      # generated an explicit governed per-user profile in a later issue.
+      enabled: ${WEAVE_WORKSPACE_WEAVER_ENABLED:false}
+      readiness: ${WEAVE_WORKSPACE_WEAVER_READINESS:}
   boards:
     runtime-enabled: ${WEAVE_BOARDS_RUNTIME_ENABLED:${WEAVE_BOARDS_WORKSPACE_RUNTIME_ENABLED:false}}
     provider: ${WEAVE_BOARDS_PROVIDER:${WEAVE_BOARDS_WORKSPACE_PROVIDER:local-workspace}}

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -9,6 +9,8 @@ import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import com.massimotter.weave.backend.service.WorkspaceHomeService;
 import com.massimotter.weave.backend.service.WorkspaceReleaseReadinessService;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
@@ -77,6 +79,31 @@ class WorkspaceControllerTest {
     }
 
     @Test
+    void returnsAdminCapabilityPolicySnapshot() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capability-policy").with(jwt()
+                        .jwt(jwt -> jwt
+                                .claim("realm_access", Map.of("roles", List.of("admin")))
+                                .claim("groups", List.of("weave-board-editors")))
+                        .authorities(
+                                new SimpleGrantedAuthority("SCOPE_weave:workspace"),
+                                new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.defaultIdmProvider").value("Keycloak"))
+                .andExpect(jsonPath("$.denyByDefault").value(true))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.grantedCapabilities").isArray())
+                .andExpect(jsonPath("$.weaverRuntimePosture").value(org.hamcrest.Matchers.containsString("disabled-by-default")));
+    }
+
+    @Test
+    void rejectsCapabilityPolicyForMembers() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/capability-policy").with(jwt()
+                        .jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("member"))))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void rejectsAnonymousRequests() throws Exception {
         mockMvc.perform(get("/api/workspace/capabilities"))
                 .andExpect(status().isUnauthorized());
@@ -99,6 +126,7 @@ class WorkspaceControllerTest {
 
     private void assertConfiguredWorkspaceCapabilities(String path) throws Exception {
         mockMvc.perform(get(path).with(jwt()
+                        .jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.shellAccess.enabled").value(true))
@@ -107,11 +135,15 @@ class WorkspaceControllerTest {
                 .andExpect(jsonPath("$.files.readiness").value("ready"))
                 .andExpect(jsonPath("$.calendar.enabled").value(true))
                 .andExpect(jsonPath("$.calendar.readiness").value("degraded"))
-                .andExpect(jsonPath("$.boards.readiness").value("unavailable"));
+                .andExpect(jsonPath("$.boards.readiness").value("unavailable"))
+                .andExpect(jsonPath("$.chat.policyState").value("allowed"))
+                .andExpect(jsonPath("$.weaver.enabled").value(false))
+                .andExpect(jsonPath("$.weaver.policyState").value("disabled"));
     }
 
     private void assertReleaseReadinessSnapshot(String path) throws Exception {
         mockMvc.perform(get(path).with(jwt()
+                        .jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.readiness").value("ready"))
@@ -123,6 +155,7 @@ class WorkspaceControllerTest {
 
     private void assertWeaveHomeSnapshot(String path) throws Exception {
         mockMvc.perform(get(path).with(jwt()
+                        .jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.version").value(1))

--- a/server/src/test/java/com/massimotter/weave/backend/service/OnboardingStatusServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/OnboardingStatusServiceTest.java
@@ -30,7 +30,8 @@ class OnboardingStatusServiceTest {
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", WorkspaceCapabilityReadiness.DEGRADED),
                         new WorkspaceCapabilityProperties.Capability(false, null, null),
                         new WorkspaceCapabilityProperties.Capability(false, null, null),
-                        new WorkspaceCapabilityProperties.Capability(false, null, null)),
+                        new WorkspaceCapabilityProperties.Capability(false, null, null),
+                        null),
                 new PlatformContractProperties(null, null, null, null, null, null, null, null),
                 new OnboardingStatusProperties(null, null));
 
@@ -53,7 +54,8 @@ class OnboardingStatusServiceTest {
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         new WorkspaceCapabilityProperties.Capability(false, null, null),
-                        new WorkspaceCapabilityProperties.Capability(false, null, null)),
+                        new WorkspaceCapabilityProperties.Capability(false, null, null),
+                        null),
                 new PlatformContractProperties(null, null, null, null, null, null, null, null),
                 new OnboardingStatusProperties(
                         new OnboardingStatusProperties.ModuleProvisioning(OnboardingProvisioningState.PENDING),

--- a/server/src/test/java/com/massimotter/weave/backend/service/PlatformContractServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/PlatformContractServiceTest.java
@@ -81,6 +81,7 @@ class PlatformContractServiceTest {
                         new WorkspaceCapabilityProperties.Capability(chatEnabled, "https://matrix.weave.local", null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
+                        null,
                         null));
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -2,26 +2,34 @@ package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WorkspaceCapabilityServiceTest {
+
+    // V01_IDM_RBAC_CAPABILITY_POLICY
 
     @Test
     void marksChatAndFilesDegradedUntilTheirRoutesAreConfigured() {
         WorkspaceCapabilityService service = new WorkspaceCapabilityService(
                 resourceServerProperties("https://auth.weave.local/realms/weave"),
                 new WeaveSecurityProperties("weave-app", "weave-app"),
-                new WorkspaceCapabilityProperties(null, null, null, null, null));
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
 
-        var snapshot = service.snapshot();
+        var snapshot = service.snapshot(jwt(List.of("member"), List.of("workspace-default")));
 
         assertThat(snapshot.shellAccess().readiness()).isEqualTo(WorkspaceCapabilityReadiness.READY);
         assertThat(snapshot.chat().enabled()).isTrue();
         assertThat(snapshot.chat().readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
+        assertThat(snapshot.chat().policyState()).isEqualTo(WorkspaceCapabilityPolicyState.ALLOWED);
+        assertThat(snapshot.chat().grantedCapabilities()).containsExactly("chat.read", "chat.send");
         assertThat(snapshot.files().readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
         assertThat(snapshot.calendar().readiness()).isEqualTo(WorkspaceCapabilityReadiness.UNAVAILABLE);
     }
@@ -36,9 +44,10 @@ class WorkspaceCapabilityServiceTest {
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         null,
+                        null,
                         null));
 
-        var snapshot = service.snapshot();
+        var snapshot = service.snapshot(jwt(List.of("member"), List.of("workspace-default")));
 
         assertThat(snapshot.shellAccess().readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
         assertThat(snapshot.chat().readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
@@ -55,9 +64,10 @@ class WorkspaceCapabilityServiceTest {
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", WorkspaceCapabilityReadiness.DEGRADED),
                         new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", WorkspaceCapabilityReadiness.BLOCKED),
                         new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
-                        new WorkspaceCapabilityProperties.Capability(false, null, WorkspaceCapabilityReadiness.READY)));
+                        new WorkspaceCapabilityProperties.Capability(false, null, WorkspaceCapabilityReadiness.READY),
+                        null));
 
-        var snapshot = service.snapshot();
+        var snapshot = service.snapshot(jwt(List.of("member"), List.of("workspace-default")));
 
         assertThat(snapshot.chat().readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
         assertThat(snapshot.files().readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
@@ -75,9 +85,10 @@ class WorkspaceCapabilityServiceTest {
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         null,
+                        null,
                         null));
 
-        var snapshot = service.snapshot();
+        var snapshot = service.snapshot(jwt(List.of("member"), List.of("workspace-default")));
 
         assertThat(snapshot.shellAccess().enabled()).isFalse();
         assertThat(snapshot.shellAccess().readiness()).isEqualTo(WorkspaceCapabilityReadiness.UNAVAILABLE);
@@ -85,9 +96,82 @@ class WorkspaceCapabilityServiceTest {
         assertThat(snapshot.files().readiness()).isEqualTo(WorkspaceCapabilityReadiness.READY);
     }
 
+    @Test
+    void deniesCapabilitiesByDefaultWhenNoIdmRoleOrGroupMapsToAProfile() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.weave.local/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(
+                        new WorkspaceCapabilityProperties.Capability(true, null, null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
+                        new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
+                        null,
+                        null,
+                        null));
+
+        var snapshot = service.snapshot(jwt(List.of("unmapped-role"), List.of("unmapped-group")));
+
+        assertThat(snapshot.chat().readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
+        assertThat(snapshot.chat().policyState()).isEqualTo(WorkspaceCapabilityPolicyState.POLICY_BLOCKED);
+        assertThat(snapshot.chat().grantedCapabilities()).isEmpty();
+        assertThat(snapshot.chat().memberImpact()).contains("blocked by your role or group policy");
+    }
+
+    @Test
+    void exposesSupportSafeAdminPolicySnapshotFromIdmRolesAndGroups() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.weave.local/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+
+        var policy = service.policySnapshot(jwt(List.of("admin"), List.of("weave-board-editors")));
+
+        assertThat(policy.defaultIdmProvider()).isEqualTo("Keycloak");
+        assertThat(policy.adapterContract()).contains("OIDC/SAML");
+        assertThat(policy.roles()).containsExactly("admin");
+        assertThat(policy.groups()).containsExactly("weave-board-editors");
+        assertThat(policy.profileKeys()).contains("workspace-admin", "group:weave-board-editors");
+        assertThat(policy.grantedCapabilities()).contains("chat.read", "files.upload", "boards.update_task", "weaver.exec_disabled");
+        assertThat(policy.grantedCapabilities()).doesNotContain("weaver.enabled");
+        assertThat(policy.denyByDefault()).isTrue();
+        assertThat(policy.supportSafe()).isTrue();
+        assertThat(policy.weaverRuntimePosture()).contains("disabled-by-default");
+    }
+
+    @Test
+    void keepsWeaverRuntimeDisabledByDefaultEvenForPilotGroups() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.weave.local/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        new WorkspaceCapabilityProperties.Capability(false, null, null)));
+
+        var snapshot = service.snapshot(jwt(List.of("admin"), List.of("weave-weaver-pilot")));
+
+        assertThat(snapshot.weaver().enabled()).isFalse();
+        assertThat(snapshot.weaver().readiness()).isEqualTo(WorkspaceCapabilityReadiness.UNAVAILABLE);
+        assertThat(snapshot.weaver().policyState()).isEqualTo(WorkspaceCapabilityPolicyState.DISABLED);
+        assertThat(snapshot.weaver().grantedCapabilities()).contains("weaver.files_read", "weaver.exec_disabled");
+        assertThat(snapshot.weaver().grantedCapabilities()).doesNotContain("weaver.enabled");
+    }
+
     private OAuth2ResourceServerProperties resourceServerProperties(String issuerUri) {
         OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
         properties.getJwt().setIssuerUri(issuerUri);
         return properties;
+    }
+
+    private Jwt jwt(List<String> roles, List<String> groups) {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("user-1")
+                .claim("realm_access", Map.of("roles", roles))
+                .claim("groups", groups)
+                .build();
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessServiceTest.java
@@ -20,6 +20,7 @@ class WorkspaceReleaseReadinessServiceTest {
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
                         null,
+                        null,
                         null));
 
         WorkspaceReleaseReadinessService service = new WorkspaceReleaseReadinessService(
@@ -29,6 +30,7 @@ class WorkspaceReleaseReadinessServiceTest {
                         new WorkspaceCapabilityProperties.Capability(true, null, null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", null),
                         new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", null),
+                        null,
                         null,
                         null),
                 capabilityService);
@@ -46,6 +48,7 @@ class WorkspaceReleaseReadinessServiceTest {
                 new WorkspaceCapabilityProperties.Capability(true, null, null),
                 new WorkspaceCapabilityProperties.Capability(true, null, null),
                 new WorkspaceCapabilityProperties.Capability(true, null, null),
+                null,
                 null,
                 null);
         WorkspaceCapabilityService capabilityService = new WorkspaceCapabilityService(
@@ -73,6 +76,7 @@ class WorkspaceReleaseReadinessServiceTest {
                 new WorkspaceCapabilityProperties.Capability(true, null, null),
                 new WorkspaceCapabilityProperties.Capability(true, null, null),
                 new WorkspaceCapabilityProperties.Capability(true, null, null),
+                null,
                 null,
                 null);
         WorkspaceCapabilityService capabilityService = new WorkspaceCapabilityService(


### PR DESCRIPTION
## Summary
- adds backend IDM/RBAC-derived capability profiles with deny-by-default category grants and a support-safe admin policy endpoint
- extends workspace capability payloads/client handling with policy state, member impact, and disabled-by-default Weaver placeholders
- maps #265 acceptance into Gherkin, docs, and executable server/client evidence

## Gates
- `make acceptance-contract`
- `make client-ci`
- `make server-ci`
- `make infra-static`
- `make ci`
- `git diff --check`

Closes #265
