### PR TITLE
feat: generate governed Weaver runtime profiles

### DIFF
--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -34,6 +34,7 @@ void main() {
         'A normal member sees a user-ready organization flow',
         'Admin sees provider categories before member use',
         'IDM roles and groups decide capability profiles before Weaver runtime',
+        'Weaver runtime profiles are generated from organization policy',
         'A channel is the primary workspace surface',
         'A user board write is authorized and audited',
         'A meeting capsule keeps work connected',

--- a/client/test/release_1/v0_1_release_spine_contract_test.dart
+++ b/client/test/release_1/v0_1_release_spine_contract_test.dart
@@ -121,6 +121,7 @@ void main() {
         '@weave-v01-user-ready-organization-flow',
         '@weave-v01-admin-provider-categories',
         '@weave-v01-idm-rbac-capability-policy',
+        '@weave-v01-governed-weaver-runtime-policy',
         '@weave-v01-channel-workspace',
         '@weave-v01-board-write-audit',
         '@weave-v01-meeting-capsule',

--- a/docs/admin-provisioned-first-use.md
+++ b/docs/admin-provisioned-first-use.md
@@ -91,3 +91,11 @@ Admins/operators configure the selected IDM adapter and map roles/groups into We
 Admins/operators see support-safe effective policy state: IDM category, profile keys, role/group-derived grants, deny-by-default posture, and whether a category is disabled, unavailable, degraded, ready, or policy-blocked. They do not need secret values in normal health views.
 
 Members only see ready, disabled, degraded, or policy-blocked impact states. They never see raw provider setup, OIDC/SAML wiring, service endpoints, provider secrets, or diagnostics. Weaver appears only as a disabled-by-policy placeholder until a later governed per-user runtime policy exists.
+
+## Governed Weaver runtime policy
+
+Weaver follows the same admin-provisioned boundary as every other provider category. User-rights, organization-whitelisted capabilities is the rule: a personal assistant may only receive the normal user's rights through capability channels the organization has explicitly enabled.
+
+Admins/operators control the Weaver category, the runtime generator, the groups that may receive `weaver.enabled`, and the capability/tool allowlist. Normal members do not configure Docker, OpenClaw plugins, provider adapters, service endpoints, or secrets. They either receive a ready governed profile or an impact-only disabled/policy-blocked state.
+
+The generated runtime profile is support-safe and runtime profile generation is audited. It includes per-user Docker isolation metadata, plugin/tool allowlists, and allowed capability keys, while exec and elevated surfaces remain disabled by default unless a later constrained admin profile explicitly enables them.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,3 +216,13 @@ Weave derives workspace capability visibility from the selected IDM and backend-
 The backend consumes realm roles and groups, normalizes them into capability profiles, and grants only category-level capability keys. Examples include chat.read, chat.send, files.read, files.upload, calendar.read, calendar.manage_events, boards.read, boards.update_task, weaver.files_read, and weaver.exec_disabled. Unknown roles/groups are deny-by-default.
 
 Capability policy responses are support-safe: they expose effective policy posture and profile keys, not provider secrets or raw setup. Weaver runtime enablement is intentionally absent from built-in profiles until a later governed runtime policy can generate per-user, audited, sandboxed runtime configuration.
+
+## Governed Weaver runtime profile contract
+
+Weaver runtime integration consumes the workspace capability policy produced by IDM/RBAC. The runtime endpoint returns a support-safe `workspace-capability-policy` generated profile; it does not expose raw provider setup, secrets, OpenClaw internals, or a second agent-specific policy model.
+
+The generated profile is per-user and Docker-oriented: it names the baseline profile/image, isolated workspace root, isolated agent directory, Docker network mode, plugin allowlist, tool allowlist, and the capability keys visible to the runtime. Disabled and policy-blocked users receive the same contract shape with `enabled=false` and impact-level posture.
+
+Runtime provisioning remains fail-closed unless all three gates pass: the Weaver workspace category is enabled, the governed runtime generator is enabled, and the user's Weave capability profile grants `weaver.enabled`. Allowed runtime capabilities are the intersection of Weave policy grants and the admin runtime allowlist. exec and elevated surfaces stay disabled by default and require future constrained admin policy before they can appear.
+
+Profile generation publishes a support-safe audit event so later runtime start and tool-use flows can prove who generated a profile, which policy produced it, and whether exec/elevated surfaces were absent.

--- a/docs/product-line-and-weaver-plan.md
+++ b/docs/product-line-and-weaver-plan.md
@@ -182,3 +182,20 @@ The admin portal foundation owns IDM/RBAC capability profiles and whitelisting b
 Capability profiles are deny-by-default. Roles and groups map to category-level capabilities such as chat.read, chat.send, files.read, files.upload, calendar.read, boards.update_task, and Weaver placeholder keys. Admins/operators may inspect support-safe effective policy state and profile keys; normal members only see product impact states such as ready, disabled, degraded, or policy-blocked.
 
 Weaver remains disabled by default until a later governed runtime policy exists. Issue #265 may expose Weaver placeholder capabilities only to prove whitelisting and fail-closed behavior; it must not start a per-user PA runtime or grant broad tool access.
+
+## Governed Weaver runtime integration
+
+Issue #266 adds the first governed Weaver runtime integration contract without making agents the product model. The Weaver category still follows the product order: provider-neutral Weave suite first, admin/provider/IDM/RBAC/readiness/whitelisting second, optional Weaver PA runtime third.
+
+Weave now generates a support-safe per-user Dockerized Weaver/OpenClaw-derived runtime profile only from organization capability policy. Generated Weaver/OpenClaw config is implementation output from Weave policy, not a second agent policy model. The generated profile includes the baseline image/profile, isolated per-user workspace path, isolated agent directory, Docker network posture, plugin/tool allowlists, and capability allowlist.
+
+The default posture remains fail-closed:
+
+- the Weaver provider category is disabled by default;
+- the runtime generator is disabled by default;
+- user policy must explicitly grant `weaver.enabled` through an admin-selected group/profile;
+- runtime-visible capabilities are intersected with admin-whitelisted capability keys such as `weaver.files_read`;
+- exec and elevated surfaces stay disabled unless a future constrained admin profile explicitly enables them;
+- runtime profile generation is audited before provisioning.
+
+OpenClaw remains a constrained runtime target. Forking OpenClaw is only justified if configuration, plugin, or runtime hooks cannot enforce the generated policy boundary.

--- a/docs/release-v0.1-dogfood-plan.md
+++ b/docs/release-v0.1-dogfood-plan.md
@@ -174,3 +174,7 @@ Exit gate:
 ### IDM/RBAC and capability whitelisting acceptance
 
 Before Weaver runtime work, Weave must prove IDM/RBAC capability profiles and category whitelisting in the backend/admin contract. Keycloak is the self-hosted default IDM, while OIDC/SAML adapters remain provider-neutral. Unknown roles and groups are denied by default. Admin/operator views expose support-safe effective policy state; member views expose only ready, disabled, degraded, or policy-blocked impact states. Weaver remains disabled by policy until a later governed runtime profile is implemented.
+
+## Governed Weaver runtime policy evidence
+
+The first Weaver slice is policy generation, not an agent-first product rewrite. Weaver remains optional and disabled by default, but the backend can now prove that any future runtime profile is generated from Weave IDM/RBAC capability policy, is per-user and Docker-oriented, hides non-whitelisted capabilities, keeps exec/elevated surfaces disabled by default, and emits support-safe audit evidence.

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -38,6 +38,15 @@ Feature: Weave v0.1 dogfood production release
     And members only see ready, disabled, degraded, or policy-blocked impact states
     And Weaver capability placeholders stay disabled by default until a governed runtime policy exists
 
+  @weave-v01-governed-weaver-runtime-policy
+  Scenario: Weaver runtime profiles are generated from organization policy
+    Given an admin has enabled the Weaver provider category after IDM/RBAC policy is ready
+    When a member with an explicit Weaver runtime group requests their runtime profile
+    Then Weave generates a per-user Dockerized Weaver/OpenClaw-derived profile from workspace capability policy
+    And the profile contains only admin-whitelisted capabilities and provider adapter tools
+    And exec and elevated surfaces are disabled unless explicitly constrained by admin policy
+    And runtime profile generation is audited and disabled or policy-blocked by default for everyone else
+
   @weave-v01-channel-workspace
   Scenario: A channel is the primary workspace surface
     Given a workspace member enters a project channel

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -211,6 +211,41 @@
       ]
     },
     {
+      "tag": "@weave-v01-governed-weaver-runtime-policy",
+      "scenario": "Weaver runtime profiles are generated from organization policy",
+      "feature": "e2e/features/v0_1_dogfood_release.feature",
+      "executableTest": "server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java",
+      "evidenceMarkers": [
+        "V01_GOVERNED_WEAVER_RUNTIME_POLICY"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "docs/product-line-and-weaver-plan.md",
+          "fragments": [
+            "Governed Weaver runtime integration",
+            "per-user Dockerized Weaver/OpenClaw-derived runtime profile",
+            "Generated Weaver/OpenClaw config is implementation output from Weave policy"
+          ]
+        },
+        {
+          "path": "docs/architecture.md",
+          "fragments": [
+            "Governed Weaver runtime profile contract",
+            "workspace-capability-policy",
+            "exec and elevated surfaces stay disabled by default"
+          ]
+        },
+        {
+          "path": "docs/admin-provisioned-first-use.md",
+          "fragments": [
+            "Governed Weaver runtime policy",
+            "User-rights, organization-whitelisted capabilities",
+            "runtime profile generation is audited"
+          ]
+        }
+      ]
+    },
+    {
       "tag": "@weave-v01-channel-workspace",
       "scenario": "A channel is the primary workspace surface",
       "feature": "e2e/features/v0_1_dogfood_release.feature",

--- a/server/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
+++ b/server/src/main/java/com/massimotter/weave/backend/WeaveBackendApplication.java
@@ -12,6 +12,7 @@ import com.massimotter.weave.backend.config.NextcloudFilesProperties;
 import com.massimotter.weave.backend.config.OnboardingStatusProperties;
 import com.massimotter.weave.backend.config.PlatformContractProperties;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -31,6 +32,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
         OnboardingStatusProperties.class,
         PlatformContractProperties.class,
         WeaveSecurityProperties.class,
+        WeaverRuntimeProperties.class,
         WorkspaceCapabilityProperties.class
 })
 public class WeaveBackendApplication {

--- a/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
+++ b/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
@@ -8,6 +8,7 @@ public enum AuditAction {
     BOARD_TASK_COMPLETED("board.task.completed"),
     CONSENT_GRANTED("consent.granted"),
     CONSENT_REVOKED("consent.revoked"),
+    WEAVER_RUNTIME_PROFILE_GENERATED("weaver.runtime_profile.generated"),
     TASK_CREATED("task.created"),
     TASK_MOVED("task.moved"),
     TASK_COMPLETED("task.completed"),

--- a/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
@@ -1,0 +1,52 @@
+package com.massimotter.weave.backend.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "weave.weaver.runtime")
+public record WeaverRuntimeProperties(
+        boolean enabled,
+        String baselineProfile,
+        String image,
+        String workspaceRootTemplate,
+        String isolatedAgentDirectory,
+        String dockerNetworkMode,
+        List<String> enabledGroups,
+        List<String> allowedCapabilities,
+        List<String> pluginAllowlist,
+        List<String> toolAllowlist,
+        boolean execEnabled,
+        boolean elevatedEnabled,
+        boolean auditRequired,
+        boolean forkRequired) {
+
+    public WeaverRuntimeProperties {
+        baselineProfile = hasText(baselineProfile) ? baselineProfile : "weaver-governed-baseline";
+        image = hasText(image) ? image : "ghcr.io/masssi164/weaver-openclaw:policy-generated";
+        workspaceRootTemplate = hasText(workspaceRootTemplate) ? workspaceRootTemplate : "/var/lib/weave/weaver/{userId}";
+        isolatedAgentDirectory = hasText(isolatedAgentDirectory) ? isolatedAgentDirectory : ".weaver/agents";
+        dockerNetworkMode = hasText(dockerNetworkMode) ? dockerNetworkMode : "none";
+        enabledGroups = normalize(enabledGroups, List.of("weave-weaver-runtime"));
+        allowedCapabilities = normalize(allowedCapabilities, List.of("weaver.files_read", "weaver.exec_disabled"));
+        pluginAllowlist = normalize(pluginAllowlist, List.of("weave-files-readonly"));
+        toolAllowlist = normalize(toolAllowlist, List.of("files.read"));
+        // Even when an admin enables the runtime, audit remains required by default.
+        auditRequired = true;
+    }
+
+    private static List<String> normalize(List<String> values, List<String> defaults) {
+        if (values == null || values.isEmpty()) {
+            return defaults;
+        }
+        List<String> normalized = values.stream()
+                .filter(WeaverRuntimeProperties::hasText)
+                .map(String::trim)
+                .distinct()
+                .toList();
+        return normalized.isEmpty() ? defaults : normalized;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -5,9 +5,11 @@ import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
 import com.massimotter.weave.backend.model.WorkspaceHomeResponse;
 import com.massimotter.weave.backend.model.WorkspaceReleaseReadinessResponse;
+import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import com.massimotter.weave.backend.service.WorkspaceHomeService;
 import com.massimotter.weave.backend.service.WorkspaceReleaseReadinessService;
+import com.massimotter.weave.backend.service.WeaverRuntimeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -28,14 +30,17 @@ public class WorkspaceController {
     private final WorkspaceCapabilityService workspaceCapabilityService;
     private final WorkspaceReleaseReadinessService workspaceReleaseReadinessService;
     private final WorkspaceHomeService workspaceHomeService;
+    private final WeaverRuntimeService weaverRuntimeService;
 
     public WorkspaceController(
             WorkspaceCapabilityService workspaceCapabilityService,
             WorkspaceReleaseReadinessService workspaceReleaseReadinessService,
-            WorkspaceHomeService workspaceHomeService) {
+            WorkspaceHomeService workspaceHomeService,
+            WeaverRuntimeService weaverRuntimeService) {
         this.workspaceCapabilityService = workspaceCapabilityService;
         this.workspaceReleaseReadinessService = workspaceReleaseReadinessService;
         this.workspaceHomeService = workspaceHomeService;
+        this.weaverRuntimeService = weaverRuntimeService;
     }
 
     @GetMapping({"/api/workspace/capabilities", "/api/v1/workspace/capabilities"})
@@ -75,6 +80,25 @@ public class WorkspaceController {
     })
     public WorkspaceCapabilityPolicyResponse capabilityPolicy(@AuthenticationPrincipal Jwt jwt) {
         return workspaceCapabilityService.policySnapshot(jwt);
+    }
+
+    @GetMapping({"/api/workspace/weaver/runtime-profile", "/api/v1/workspace/weaver/runtime-profile"})
+    @Operation(
+            summary = "Get generated Weaver runtime profile",
+            description = "Returns the support-safe per-user Weaver/OpenClaw runtime profile generated from organization capability policy. Runtime provisioning stays disabled unless the Weaver category, runtime generator, and user policy all allow it.",
+            security = @SecurityRequirement(name = "bearer-jwt"))
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Generated Weaver runtime profile or fail-closed disabled posture.",
+                    content = @Content(schema = @Schema(implementation = WeaverRuntimeProfileResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
+                    content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+    })
+    public WeaverRuntimeProfileResponse weaverRuntimeProfile(@AuthenticationPrincipal Jwt jwt) {
+        return weaverRuntimeService.profileFor(jwt);
     }
 
     @GetMapping({"/api/workspace/release-readiness", "/api/v1/workspace/release-readiness"})

--- a/server/src/main/java/com/massimotter/weave/backend/model/WeaverRuntimeProfileResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/WeaverRuntimeProfileResponse.java
@@ -1,0 +1,31 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record WeaverRuntimeProfileResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean enabled,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String posture,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String runtimeKind,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String generatedFrom,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String userRef,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String baselineProfile,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String containerImage,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String workspacePath,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String isolatedAgentDirectory,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String dockerNetworkMode,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> allowedCapabilities,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> pluginAllowlist,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> toolAllowlist,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean execEnabled,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean elevatedEnabled,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean auditRequired,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean forkRequired,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String memberImpact) {
+
+    public WeaverRuntimeProfileResponse {
+        allowedCapabilities = List.copyOf(allowedCapabilities == null ? List.of() : allowedCapabilities);
+        pluginAllowlist = List.copyOf(pluginAllowlist == null ? List.of() : pluginAllowlist);
+        toolAllowlist = List.copyOf(toolAllowlist == null ? List.of() : toolAllowlist);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -1,0 +1,169 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.AuditEvent;
+import com.massimotter.weave.backend.audit.AuditEventPublisher;
+import com.massimotter.weave.backend.audit.AuditRedactionLevel;
+import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WeaverRuntimeService {
+
+    private final WorkspaceCapabilityService workspaceCapabilityService;
+    private final WorkspaceCapabilityProperties workspaceCapabilityProperties;
+    private final WeaverRuntimeProperties weaverRuntimeProperties;
+    private final AuditEventPublisher auditEventPublisher;
+
+    public WeaverRuntimeService(
+            WorkspaceCapabilityService workspaceCapabilityService,
+            WorkspaceCapabilityProperties workspaceCapabilityProperties,
+            WeaverRuntimeProperties weaverRuntimeProperties,
+            AuditEventPublisher auditEventPublisher) {
+        this.workspaceCapabilityService = workspaceCapabilityService;
+        this.workspaceCapabilityProperties = workspaceCapabilityProperties;
+        this.weaverRuntimeProperties = weaverRuntimeProperties;
+        this.auditEventPublisher = auditEventPublisher;
+    }
+
+    public WeaverRuntimeProfileResponse profileFor(Jwt jwt) {
+        List<String> grantedCapabilities = workspaceCapabilityService.grantedCapabilities(jwt);
+        String userRef = supportSafeUserRef(jwt);
+        if (!workspaceCapabilityProperties.weaver().enabled()) {
+            return disabledProfile(
+                    userRef,
+                    "disabled-by-default",
+                    "Weaver is disabled by organization policy until an admin enables the provider category.");
+        }
+        if (!weaverRuntimeProperties.enabled()) {
+            return disabledProfile(
+                    userRef,
+                    "runtime-generator-disabled",
+                    "Weaver runtime generation is disabled until the organization enables a governed runtime profile.");
+        }
+        if (!grantedCapabilities.contains("weaver.enabled")) {
+            return disabledProfile(
+                    userRef,
+                    "policy-blocked",
+                    "Your role or group policy does not allow a Weaver runtime.");
+        }
+
+        List<String> allowedCapabilities = allowedCapabilities(grantedCapabilities);
+        List<String> pluginAllowlist = weaverRuntimeProperties.pluginAllowlist();
+        List<String> toolAllowlist = weaverRuntimeProperties.toolAllowlist();
+        boolean execEnabled = weaverRuntimeProperties.execEnabled() && grantedCapabilities.contains("weaver.exec_enabled");
+        boolean elevatedEnabled = weaverRuntimeProperties.elevatedEnabled() && grantedCapabilities.contains("weaver.elevated_enabled");
+        WeaverRuntimeProfileResponse response = new WeaverRuntimeProfileResponse(
+                true,
+                "ready-to-provision",
+                "per-user-docker",
+                "workspace-capability-policy",
+                userRef,
+                weaverRuntimeProperties.baselineProfile(),
+                weaverRuntimeProperties.image(),
+                workspacePath(userRef),
+                weaverRuntimeProperties.isolatedAgentDirectory(),
+                weaverRuntimeProperties.dockerNetworkMode(),
+                allowedCapabilities,
+                pluginAllowlist,
+                toolAllowlist,
+                execEnabled,
+                elevatedEnabled,
+                weaverRuntimeProperties.auditRequired(),
+                weaverRuntimeProperties.forkRequired(),
+                "Weaver is available through the governed organization profile; unavailable tools are hidden from the runtime.");
+        auditGeneratedProfile(response);
+        return response;
+    }
+
+    private WeaverRuntimeProfileResponse disabledProfile(String userRef, String posture, String impact) {
+        return new WeaverRuntimeProfileResponse(
+                false,
+                posture,
+                "per-user-docker",
+                "workspace-capability-policy",
+                userRef,
+                weaverRuntimeProperties.baselineProfile(),
+                "",
+                "",
+                weaverRuntimeProperties.isolatedAgentDirectory(),
+                "none",
+                List.of(),
+                List.of(),
+                List.of(),
+                false,
+                false,
+                true,
+                false,
+                impact);
+    }
+
+    private List<String> allowedCapabilities(List<String> grantedCapabilities) {
+        LinkedHashSet<String> allowed = new LinkedHashSet<>();
+        for (String capability : weaverRuntimeProperties.allowedCapabilities()) {
+            if (grantedCapabilities.contains(capability)) {
+                allowed.add(capability);
+            }
+        }
+        if (!weaverRuntimeProperties.execEnabled()) {
+            allowed.add("weaver.exec_disabled");
+        }
+        return List.copyOf(allowed);
+    }
+
+    private String workspacePath(String userRef) {
+        return weaverRuntimeProperties.workspaceRootTemplate().replace("{userId}", userRef.replace("user:", ""));
+    }
+
+    private String supportSafeUserRef(Jwt jwt) {
+        String subject = jwt == null ? "system" : jwt.getSubject();
+        return "user:" + sha256(subject == null || subject.isBlank() ? "unknown" : subject).substring(0, 16);
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder();
+            for (byte b : hash) {
+                builder.append(String.format("%02x", b));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is required for support-safe Weaver user refs", e);
+        }
+    }
+
+    private void auditGeneratedProfile(WeaverRuntimeProfileResponse response) {
+        if (!response.auditRequired()) {
+            throw new IllegalStateException("Weaver runtime profiles require audit before provisioning");
+        }
+        auditEventPublisher.publish(new AuditEvent(
+                "tenant:workspace",
+                null,
+                response.userRef(),
+                "weaver-runtime-generator",
+                AuditAction.WEAVER_RUNTIME_PROFILE_GENERATED,
+                Instant.now(),
+                "weaver-profile:" + response.userRef() + ":" + response.baselineProfile(),
+                AuditRedactionLevel.SUPPORT_SAFE,
+                Map.of(
+                        "posture", response.posture(),
+                        "runtimeKind", response.runtimeKind(),
+                        "generatedFrom", response.generatedFrom(),
+                        "allowedCapabilities", response.allowedCapabilities(),
+                        "execEnabled", response.execEnabled(),
+                        "elevatedEnabled", response.elevatedEnabled(),
+                        "supportSafe", true)));
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -1,6 +1,7 @@
 package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
@@ -14,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
@@ -47,14 +49,29 @@ public class WorkspaceCapabilityService {
     private final OAuth2ResourceServerProperties resourceServerProperties;
     private final WeaveSecurityProperties weaveSecurityProperties;
     private final WorkspaceCapabilityProperties workspaceCapabilityProperties;
+    private final WeaverRuntimeProperties weaverRuntimeProperties;
 
     public WorkspaceCapabilityService(
             OAuth2ResourceServerProperties resourceServerProperties,
             WeaveSecurityProperties weaveSecurityProperties,
             WorkspaceCapabilityProperties workspaceCapabilityProperties) {
+        this(
+                resourceServerProperties,
+                weaveSecurityProperties,
+                workspaceCapabilityProperties,
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+    }
+
+    @Autowired
+    public WorkspaceCapabilityService(
+            OAuth2ResourceServerProperties resourceServerProperties,
+            WeaveSecurityProperties weaveSecurityProperties,
+            WorkspaceCapabilityProperties workspaceCapabilityProperties,
+            WeaverRuntimeProperties weaverRuntimeProperties) {
         this.resourceServerProperties = resourceServerProperties;
         this.weaveSecurityProperties = weaveSecurityProperties;
         this.workspaceCapabilityProperties = workspaceCapabilityProperties;
+        this.weaverRuntimeProperties = weaverRuntimeProperties;
     }
 
     public WorkspaceCapabilitiesResponse snapshot() {
@@ -122,7 +139,13 @@ public class WorkspaceCapabilityService {
                 policy.capabilities().stream().sorted().toList(),
                 true,
                 true,
-                "disabled-by-default; per-user Dockerized Weaver runtime may only be generated from org policy later");
+                weaverRuntimeProperties.enabled()
+                        ? "governed per-user Dockerized Weaver profiles are generated only when org policy grants weaver.enabled"
+                        : "disabled-by-default; per-user Dockerized Weaver runtime may only be generated from org policy later");
+    }
+
+    public List<String> grantedCapabilities(Jwt jwt) {
+        return effectivePolicy(jwt).capabilities().stream().sorted().toList();
     }
 
     private WorkspaceCapabilityStatusResponse dependentStatus(
@@ -251,14 +274,19 @@ public class WorkspaceCapabilityService {
                 capabilities.addAll(groupCapabilities);
                 profileKeys.add("group:" + group);
             }
+            if (weaverRuntimeProperties.enabledGroups().contains(group)) {
+                profileKeys.add("group:" + group);
+                if (weaverRuntimeProperties.enabled()) {
+                    capabilities.add("weaver.enabled");
+                }
+            }
         }
         if (profileKeys.isEmpty()) {
             profileKeys.add("deny-by-default");
         }
-        // Weaver runtime enablement is deliberately absent from built-in profiles.
-        // The placeholder may expose only constrained sub-capabilities such as files_read;
-        // runtime start still requires a later explicit admin policy carrying weaver.enabled.
-        capabilities.remove("weaver.enabled");
+        // Weaver runtime enablement is deliberately absent from built-in role profiles.
+        // Only explicit admin runtime policy groups may carry weaver.enabled, and only when
+        // the runtime generator is enabled in organization configuration.
         return new EffectivePolicy(roles, groups, List.copyOf(profileKeys), Set.copyOf(capabilities));
     }
 

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -102,11 +102,29 @@ weave:
       enabled: ${WEAVE_WORKSPACE_BOARDS_ENABLED:false}
       readiness: ${WEAVE_WORKSPACE_BOARDS_READINESS:}
     weaver:
-      # Weaver is a policy-controlled placeholder at this stage. Runtime startup
-      # stays disabled-by-default until IDM/RBAC/capability whitelisting has
-      # generated an explicit governed per-user profile in a later issue.
+      # Weaver is a policy-controlled category. Runtime startup remains
+      # disabled-by-default unless organization policy enables the category and
+      # the governed runtime generator grants a per-user profile.
       enabled: ${WEAVE_WORKSPACE_WEAVER_ENABLED:false}
       readiness: ${WEAVE_WORKSPACE_WEAVER_READINESS:}
+  weaver:
+    runtime:
+      # Generated Weaver/OpenClaw config is implementation output from Weave
+      # policy, never a second product policy model. Defaults fail closed.
+      enabled: ${WEAVE_WEAVER_RUNTIME_ENABLED:false}
+      baseline-profile: ${WEAVE_WEAVER_RUNTIME_BASELINE_PROFILE:weaver-governed-baseline}
+      image: ${WEAVE_WEAVER_RUNTIME_IMAGE:ghcr.io/masssi164/weaver-openclaw:policy-generated}
+      workspace-root-template: ${WEAVE_WEAVER_RUNTIME_WORKSPACE_ROOT_TEMPLATE:/var/lib/weave/weaver/{userId}}
+      isolated-agent-directory: ${WEAVE_WEAVER_RUNTIME_AGENT_DIRECTORY:.weaver/agents}
+      docker-network-mode: ${WEAVE_WEAVER_RUNTIME_DOCKER_NETWORK_MODE:none}
+      enabled-groups: ${WEAVE_WEAVER_RUNTIME_ENABLED_GROUPS:weave-weaver-runtime}
+      allowed-capabilities: ${WEAVE_WEAVER_RUNTIME_ALLOWED_CAPABILITIES:weaver.files_read,weaver.exec_disabled}
+      plugin-allowlist: ${WEAVE_WEAVER_RUNTIME_PLUGIN_ALLOWLIST:weave-files-readonly}
+      tool-allowlist: ${WEAVE_WEAVER_RUNTIME_TOOL_ALLOWLIST:files.read}
+      exec-enabled: ${WEAVE_WEAVER_RUNTIME_EXEC_ENABLED:false}
+      elevated-enabled: ${WEAVE_WEAVER_RUNTIME_ELEVATED_ENABLED:false}
+      audit-required: true
+      fork-required: ${WEAVE_WEAVER_RUNTIME_FORK_REQUIRED:false}
   boards:
     runtime-enabled: ${WEAVE_BOARDS_RUNTIME_ENABLED:${WEAVE_BOARDS_WORKSPACE_RUNTIME_ENABLED:false}}
     provider: ${WEAVE_BOARDS_PROVIDER:${WEAVE_BOARDS_WORKSPACE_PROVIDER:local-workspace}}

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -2,13 +2,16 @@ package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
 import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
+import com.massimotter.weave.backend.audit.AuditEventPublisher;
 import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.SecurityConfig;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import com.massimotter.weave.backend.service.WorkspaceHomeService;
 import com.massimotter.weave.backend.service.WorkspaceReleaseReadinessService;
+import com.massimotter.weave.backend.service.WeaverRuntimeService;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -36,12 +39,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         WorkspaceCapabilityService.class,
         WorkspaceReleaseReadinessService.class,
         WorkspaceHomeService.class,
+        WeaverRuntimeService.class,
         ApiAuthenticationEntryPoint.class,
         ApiAccessDeniedHandler.class,
         ApiErrorResponseWriter.class
 })
 @EnableConfigurationProperties({
         WeaveSecurityProperties.class,
+        WeaverRuntimeProperties.class,
         WorkspaceCapabilityProperties.class,
         OAuth2ResourceServerProperties.class
 })
@@ -60,6 +65,9 @@ class WorkspaceControllerTest {
     @MockBean
     private JwtDecoder jwtDecoder;
 
+    @MockBean
+    private AuditEventPublisher auditEventPublisher;
+
     @Test
     void returnsConfiguredWorkspaceCapabilities() throws Exception {
         assertConfiguredWorkspaceCapabilities("/api/workspace/capabilities");
@@ -76,6 +84,23 @@ class WorkspaceControllerTest {
     void returnsWeaveHomeDailyWorkSnapshot() throws Exception {
         assertWeaveHomeSnapshot("/api/workspace/home");
         assertWeaveHomeSnapshot("/api/v1/workspace/home");
+    }
+
+    @Test
+    void returnsFailClosedWeaverRuntimeProfile() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/weaver/runtime-profile").with(jwt()
+                        .jwt(jwt -> jwt
+                                .subject("member@example.invalid")
+                                .claim("realm_access", Map.of("roles", List.of("member"))))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(false))
+                .andExpect(jsonPath("$.runtimeKind").value("per-user-docker"))
+                .andExpect(jsonPath("$.generatedFrom").value("workspace-capability-policy"))
+                .andExpect(jsonPath("$.posture").value("disabled-by-default"))
+                .andExpect(jsonPath("$.execEnabled").value(false))
+                .andExpect(jsonPath("$.elevatedEnabled").value(false))
+                .andExpect(jsonPath("$.auditRequired").value(true));
     }
 
     @Test
@@ -121,6 +146,9 @@ class WorkspaceControllerTest {
                 .andExpect(status().isUnauthorized());
 
         mockMvc.perform(get("/api/v1/workspace/home"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/workspace/weaver/runtime-profile"))
                 .andExpect(status().isUnauthorized());
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -1,0 +1,133 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WeaverRuntimeServiceTest {
+
+    @Test
+    void keepsWeaverDisabledByDefaultEvenForRuntimeGroup() {
+        // V01_GOVERNED_WEAVER_RUNTIME_POLICY
+        WeaverRuntimeService service = service(
+                false,
+                runtimeProperties(true),
+                new InMemoryAuditEventPublisher());
+
+        var profile = service.profileFor(jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot")));
+
+        assertThat(profile.enabled()).isFalse();
+        assertThat(profile.posture()).isEqualTo("disabled-by-default");
+        assertThat(profile.runtimeKind()).isEqualTo("per-user-docker");
+        assertThat(profile.generatedFrom()).isEqualTo("workspace-capability-policy");
+        assertThat(profile.execEnabled()).isFalse();
+        assertThat(profile.elevatedEnabled()).isFalse();
+        assertThat(profile.auditRequired()).isTrue();
+    }
+
+    @Test
+    void blocksRuntimeWhenUserPolicyDoesNotGrantWeaverEnabled() {
+        WeaverRuntimeService service = service(
+                true,
+                runtimeProperties(true),
+                new InMemoryAuditEventPublisher());
+
+        var profile = service.profileFor(jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-pilot")));
+
+        assertThat(profile.enabled()).isFalse();
+        assertThat(profile.posture()).isEqualTo("policy-blocked");
+        assertThat(profile.allowedCapabilities()).isEmpty();
+    }
+
+    @Test
+    void generatesAuditedPerUserDockerProfileFromCapabilityPolicy() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverRuntimeService service = service(true, runtimeProperties(true), audit);
+
+        var profile = service.profileFor(jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot")));
+
+        assertThat(profile.enabled()).isTrue();
+        assertThat(profile.posture()).isEqualTo("ready-to-provision");
+        assertThat(profile.runtimeKind()).isEqualTo("per-user-docker");
+        assertThat(profile.generatedFrom()).isEqualTo("workspace-capability-policy");
+        assertThat(profile.userRef()).startsWith("user:");
+        assertThat(profile.userRef()).doesNotContain("member@example.invalid");
+        assertThat(profile.workspacePath()).startsWith("/var/lib/weave/weaver/");
+        assertThat(profile.isolatedAgentDirectory()).isEqualTo(".weaver/agents");
+        assertThat(profile.dockerNetworkMode()).isEqualTo("none");
+        assertThat(profile.allowedCapabilities()).containsExactly("weaver.files_read", "weaver.exec_disabled");
+        assertThat(profile.pluginAllowlist()).containsExactly("weave-files-readonly");
+        assertThat(profile.toolAllowlist()).containsExactly("files.read");
+        assertThat(profile.execEnabled()).isFalse();
+        assertThat(profile.elevatedEnabled()).isFalse();
+        assertThat(profile.auditRequired()).isTrue();
+        assertThat(profile.forkRequired()).isFalse();
+
+        assertThat(audit.events()).hasSize(1);
+        assertThat(audit.events().get(0).action()).isEqualTo(AuditAction.WEAVER_RUNTIME_PROFILE_GENERATED);
+        assertThat(audit.events().get(0).payload()).containsEntry("supportSafe", true);
+        assertThat(audit.events().get(0).payload()).containsEntry("execEnabled", false);
+    }
+
+    private WeaverRuntimeService service(
+            boolean workspaceWeaverEnabled,
+            WeaverRuntimeProperties runtimeProperties,
+            InMemoryAuditEventPublisher audit) {
+        WorkspaceCapabilityProperties capabilities = new WorkspaceCapabilityProperties(
+                new WorkspaceCapabilityProperties.Capability(true, null, null),
+                new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.local", WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.local", WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityProperties.Capability(workspaceWeaverEnabled, null, WorkspaceCapabilityReadiness.READY));
+        OAuth2ResourceServerProperties resourceServerProperties = new OAuth2ResourceServerProperties();
+        resourceServerProperties.getJwt().setIssuerUri("https://auth.weave.local/realms/weave");
+        WorkspaceCapabilityService capabilityService = new WorkspaceCapabilityService(
+                resourceServerProperties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                capabilities,
+                runtimeProperties);
+        return new WeaverRuntimeService(capabilityService, capabilities, runtimeProperties, audit);
+    }
+
+    private WeaverRuntimeProperties runtimeProperties(boolean enabled) {
+        return new WeaverRuntimeProperties(
+                enabled,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of("weave-weaver-runtime"),
+                List.of("weaver.files_read", "weaver.exec_disabled"),
+                List.of("weave-files-readonly"),
+                List.of("files.read"),
+                false,
+                false,
+                true,
+                false);
+    }
+
+    private Jwt jwt(String subject, List<String> roles, List<String> groups) {
+        return new Jwt(
+                "token",
+                Instant.now(),
+                Instant.now().plusSeconds(300),
+                Map.of("alg", "none"),
+                Map.of(
+                        "sub", subject,
+                        "realm_access", Map.of("roles", roles),
+                        "groups", groups));
+    }
+}


### PR DESCRIPTION
## Summary
- adds a support-safe `/api/v1/workspace/weaver/runtime-profile` contract generated from workspace capability policy
- keeps Weaver fail-closed unless the category, runtime generator, and explicit `weaver.enabled` group policy all allow it
- documents/maps #266 acceptance with audited per-user Docker/OpenClaw-derived runtime profile evidence

## Gates
- `make acceptance-contract`
- `./gradlew test` (server)
- `make ci`
- `git diff --check`

Closes #266
