### PR TITLE
feat(admin): surface provider categories in setup

### DIFF
--- a/client/lib/features/onboarding/presentation/setup_flow.dart
+++ b/client/lib/features/onboarding/presentation/setup_flow.dart
@@ -7,6 +7,7 @@ import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provid
 import 'package:weave/core/router/app_routes.dart';
 import 'package:weave/core/widgets/weave_logo.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
+import 'package:weave/features/server_config/presentation/widgets/provider_category_summary.dart';
 import 'package:weave/features/server_config/presentation/widgets/server_configuration_form.dart';
 import 'package:weave/l10n/generated/app_localizations.dart';
 
@@ -219,6 +220,8 @@ class _ProviderStep extends StatelessWidget {
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
+          const SizedBox(height: 16),
+          const ProviderCategorySummary(compact: true),
           const SizedBox(height: 24),
           const ServerConfigurationForm(
             layout: ServerConfigurationFormLayout.providerAndIssuerOnly,

--- a/client/lib/features/server_config/presentation/widgets/provider_category_summary.dart
+++ b/client/lib/features/server_config/presentation/widgets/provider_category_summary.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:weave/l10n/generated/app_localizations.dart';
+
+class ProviderCategorySummary extends StatelessWidget {
+  const ProviderCategorySummary({super.key, this.compact = false});
+
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final categories = _categories(l10n);
+
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      label: l10n.providerCategorySummarySemanticLabel,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.18),
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: theme.colorScheme.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Semantics(
+                header: true,
+                child: Text(
+                  l10n.providerCategorySummaryTitle,
+                  style: compact
+                      ? theme.textTheme.titleMedium
+                      : theme.textTheme.titleLarge,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                l10n.providerCategorySummaryDescription,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 12),
+              for (final category in categories) ...[
+                _ProviderCategoryRow(category: category),
+                if (category != categories.last)
+                  Divider(
+                    height: compact ? 16 : 20,
+                    color: theme.colorScheme.outlineVariant,
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<_ProviderCategory> _categories(AppLocalizations l10n) {
+    return [
+      _ProviderCategory(
+        title: l10n.providerCategoryIdentityTitle,
+        state: l10n.providerCategoryStatusCurrentDefault,
+        detail: l10n.providerCategoryIdentityDetail,
+      ),
+      _ProviderCategory(
+        title: l10n.providerCategoryChatTitle,
+        state: l10n.providerCategoryStatusCurrentDefault,
+        detail: l10n.providerCategoryChatDetail,
+      ),
+      _ProviderCategory(
+        title: l10n.providerCategoryFilesTitle,
+        state: l10n.providerCategoryStatusCurrentDefault,
+        detail: l10n.providerCategoryFilesDetail,
+      ),
+      _ProviderCategory(
+        title: l10n.providerCategoryCalendarTitle,
+        state: l10n.providerCategoryStatusCurrentDefault,
+        detail: l10n.providerCategoryCalendarDetail,
+      ),
+      _ProviderCategory(
+        title: l10n.providerCategoryBoardsTitle,
+        state: l10n.providerCategoryStatusCurrentDefault,
+        detail: l10n.providerCategoryBoardsDetail,
+      ),
+      _ProviderCategory(
+        title: l10n.providerCategoryMeetingsTitle,
+        state: l10n.providerCategoryStatusAdminSetupRequired,
+        detail: l10n.providerCategoryMeetingsDetail,
+      ),
+      _ProviderCategory(
+        title: l10n.providerCategoryDocumentsTitle,
+        state: l10n.providerCategoryStatusAdminSetupRequired,
+        detail: l10n.providerCategoryDocumentsDetail,
+      ),
+      _ProviderCategory(
+        title: l10n.providerCategoryWeaverTitle,
+        state: l10n.providerCategoryStatusDisabledByDefault,
+        detail: l10n.providerCategoryWeaverDetail,
+      ),
+    ];
+  }
+}
+
+class _ProviderCategoryRow extends StatelessWidget {
+  const _ProviderCategoryRow({required this.category});
+
+  final _ProviderCategory category;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return MergeSemantics(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(
+                category.title,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              _CategoryStatePill(label: category.state),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(category.detail, style: theme.textTheme.bodySmall),
+        ],
+      ),
+    );
+  }
+}
+
+class _CategoryStatePill extends StatelessWidget {
+  const _CategoryStatePill({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        child: Text(label, style: theme.textTheme.labelSmall),
+      ),
+    );
+  }
+}
+
+class _ProviderCategory {
+  const _ProviderCategory({
+    required this.title,
+    required this.state,
+    required this.detail,
+  });
+
+  final String title;
+  final String state;
+  final String detail;
+}

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -33,6 +33,7 @@ import 'package:weave/features/profile/presentation/widgets/profile_summary_card
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/presentation/providers/'
     'server_configuration_form_controller.dart';
+import 'package:weave/features/server_config/presentation/widgets/provider_category_summary.dart';
 import 'package:weave/features/server_config/presentation/widgets/server_configuration_form.dart';
 import 'package:weave/features/shell/domain/entities/shell_module.dart';
 import 'package:weave/features/shell/presentation/providers/shell_module_preferences_provider.dart';
@@ -196,6 +197,8 @@ class _AdminSetupConfigurationCard extends ConsumerWidget {
             ),
             const SizedBox(height: 12),
             _AdminPermissionSummary(profile: profile),
+            const SizedBox(height: 16),
+            const ProviderCategorySummary(compact: true),
             const SizedBox(height: 24),
             Text(
               l10n.settingsServerConfigurationTitle,

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -5,10 +5,98 @@
   "welcomeSubtitle": "Dein einheitlicher Kollaborations-Hub — Nachrichten, Dateien und Kalender an einem Ort.",
   "continueButton": "Los geht's",
   "setupTitle": "Einrichtung",
-  "setupProviderStepTitle": "Server verbinden",
-  "setupProviderStepDescription": "Wähle deinen OIDC-Anbieter und gib die Issuer-URL deiner selbst gehosteten Umgebung ein.",
+  "setupProviderStepTitle": "Provider-Kategorien konfigurieren",
+  "setupProviderStepDescription": "Die Admin-Einrichtung beginnt mit der Kategorie Identität/IDM und hält Chat, Dateien, Kalender, Boards/Aufgaben, Besprechungen/Anrufe, Dokumente/Zusammenarbeit und Weaver als Provider-Kategorien sichtbar, bevor Mitglieder beitreten.",
   "setupServicesStepTitle": "Dienstendpunkte prüfen",
-  "setupServicesStepDescription": "Weave leitet Matrix-, Nextcloud- und Backend-API-URLs aus dem Issuer-Host ab. Prüfe und ändere sie bei Bedarf vor dem Abschluss.",
+  "setupServicesStepDescription": "Prüfe die aktuellen Dogfood-Service-Endpunkte, die aus dem Identitäts-Issuer abgeleitet wurden. Diese Provider-URLs bleiben Admin-/Operator-Konfiguration, nicht normale Mitglieder-Einrichtung.",
+  "providerCategorySummaryTitle": "Provider-Kategorien",
+  "@providerCategorySummaryTitle": {
+    "description": "Titel der Provider-Kategorien-Zusammenfassung für Admins in Einrichtung und Workspace Health"
+  },
+  "providerCategorySummaryDescription": "Weave betrachtet zuerst Zusammenarbeits-Kategorien. Die Provider-Namen unten sind aktuelle Dogfood-Auswahlen für Admins/Operatoren, keine mitgliederseitigen Produktnamen.",
+  "@providerCategorySummaryDescription": {
+    "description": "Beschreibung der Provider-Kategorien und Dogfood-Standards"
+  },
+  "providerCategorySummarySemanticLabel": "Provider-Kategorien. Aktuelle Dogfood-Provider-Auswahlen werden nur für Einrichtung und Workspace Health gezeigt.",
+  "@providerCategorySummarySemanticLabel": {
+    "description": "Barrierefreiheitslabel für die Provider-Kategorien-Zusammenfassung"
+  },
+  "providerCategoryStatusCurrentDefault": "Aktuelle Dogfood-Auswahl",
+  "@providerCategoryStatusCurrentDefault": {
+    "description": "Status-Pille für eine Provider-Kategorie mit aktueller Dogfood-Auswahl"
+  },
+  "providerCategoryStatusAdminSetupRequired": "Admin-Einrichtung erforderlich",
+  "@providerCategoryStatusAdminSetupRequired": {
+    "description": "Status-Pille für eine Provider-Kategorie, die vor Mitgliedernutzung Admin-Einrichtung benötigt"
+  },
+  "providerCategoryStatusDisabledByDefault": "Standardmäßig deaktiviert",
+  "@providerCategoryStatusDisabledByDefault": {
+    "description": "Status-Pille für eine standardmäßig deaktivierte Provider-Kategorie"
+  },
+  "providerCategoryIdentityTitle": "Identität/IDM",
+  "@providerCategoryIdentityTitle": {
+    "description": "Provider-Kategorietitel für Identität und IDM"
+  },
+  "providerCategoryIdentityDetail": "Keycloak/Auth ist die aktuelle Dogfood-Auswahl; Entra ID, Authentik oder eine andere OIDC/SAML-Quelle kann auf diese Kategorie abgebildet werden.",
+  "@providerCategoryIdentityDetail": {
+    "description": "Provider-Kategoriedetail für Identität und IDM"
+  },
+  "providerCategoryChatTitle": "Chat",
+  "@providerCategoryChatTitle": {
+    "description": "Provider-Kategorietitel für Chat"
+  },
+  "providerCategoryChatDetail": "Matrix/Chat ist die aktuelle Dogfood-Auswahl hinter der Weave-Chat-Oberfläche.",
+  "@providerCategoryChatDetail": {
+    "description": "Provider-Kategoriedetail für Chat"
+  },
+  "providerCategoryFilesTitle": "Dateien",
+  "@providerCategoryFilesTitle": {
+    "description": "Provider-Kategorietitel für Dateien"
+  },
+  "providerCategoryFilesDetail": "Nextcloud/Files ist die aktuelle Dogfood-Speicherauswahl hinter der Weave-Datei-Fassade.",
+  "@providerCategoryFilesDetail": {
+    "description": "Provider-Kategoriedetail für Dateien"
+  },
+  "providerCategoryCalendarTitle": "Kalender",
+  "@providerCategoryCalendarTitle": {
+    "description": "Provider-Kategorietitel für Kalender"
+  },
+  "providerCategoryCalendarDetail": "Nextcloud/Calendar-Anbindung ist die aktuelle Dogfood-Auswahl hinter der Weave-Kalender-Fassade.",
+  "@providerCategoryCalendarDetail": {
+    "description": "Provider-Kategoriedetail für Kalender"
+  },
+  "providerCategoryBoardsTitle": "Boards/Aufgaben",
+  "@providerCategoryBoardsTitle": {
+    "description": "Provider-Kategorietitel für Boards und Aufgaben"
+  },
+  "providerCategoryBoardsDetail": "OpenProject-Boards-Validierung ist der aktuelle providergestützte Pfad; Aufgabenänderungen durch Mitglieder bleiben durch Autorisierung, Audit und Rollback-Evidenz begrenzt.",
+  "@providerCategoryBoardsDetail": {
+    "description": "Provider-Kategoriedetail für Boards und Aufgaben"
+  },
+  "providerCategoryMeetingsTitle": "Besprechungen/Anrufe",
+  "@providerCategoryMeetingsTitle": {
+    "description": "Provider-Kategorietitel für Besprechungen und Anrufe"
+  },
+  "providerCategoryMeetingsDetail": "LiveKit-Meetings-Bereitschaft wird hinter der Token-Fassade verfolgt, bevor Mitglieder Anrufe starten oder beitreten können.",
+  "@providerCategoryMeetingsDetail": {
+    "description": "Provider-Kategoriedetail für Besprechungen und Anrufe"
+  },
+  "providerCategoryDocumentsTitle": "Dokumente/Zusammenarbeit",
+  "@providerCategoryDocumentsTitle": {
+    "description": "Provider-Kategorietitel für Dokumente und Zusammenarbeit"
+  },
+  "providerCategoryDocumentsDetail": "Dokument-Zusammenarbeit ist eine Provider-Adapter-Kategorie und bleibt Admin-Einrichtung erforderlich, bis ein backend-eigener Startpfad konfiguriert ist.",
+  "@providerCategoryDocumentsDetail": {
+    "description": "Provider-Kategoriedetail für Dokumente und Zusammenarbeit"
+  },
+  "providerCategoryWeaverTitle": "Weaver",
+  "@providerCategoryWeaverTitle": {
+    "description": "Provider-Kategorietitel für Weaver"
+  },
+  "providerCategoryWeaverDetail": "Weaver bleibt standardmäßig deaktiviert, bis regulierte persönliche PA-Richtlinie, Whitelisting, Einwilligung und Audit akzeptiert sind.",
+  "@providerCategoryWeaverDetail": {
+    "description": "Provider-Kategoriedetail für Weaver"
+  },
   "setupLanguageStepTitle": "Deine Sprache",
   "setupLanguageStepDescription": "Weave verwendet deine Gerätesprache. Du kannst sie später in den Einstellungen ändern.",
   "setupConfirmStepTitle": "Alles bereit",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -20,11 +20,11 @@
   "@setupTitle": {
     "description": "Title for the setup flow screen"
   },
-  "setupProviderStepTitle": "Connect Your Server",
+  "setupProviderStepTitle": "Configure provider categories",
   "@setupProviderStepTitle": {
     "description": "Title for the setup provider and issuer step"
   },
-  "setupProviderStepDescription": "Choose your OIDC provider and enter the issuer URL for your self-hosted setup.",
+  "setupProviderStepDescription": "Admin setup starts with the identity/IDM category and keeps chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver visible as provider categories before members join.",
   "@setupProviderStepDescription": {
     "description": "Description shown in the setup provider step"
   },
@@ -32,9 +32,97 @@
   "@setupServicesStepTitle": {
     "description": "Title for the setup services step"
   },
-  "setupServicesStepDescription": "Weave derives Matrix, Nextcloud, and backend API URLs from the issuer host. Review and edit them before finishing setup.",
+  "setupServicesStepDescription": "Review the current dogfood service endpoints derived from the identity issuer. These provider URLs stay admin/operator configuration, not normal member setup.",
   "@setupServicesStepDescription": {
     "description": "Description shown in the setup services step"
+  },
+  "providerCategorySummaryTitle": "Provider categories",
+  "@providerCategorySummaryTitle": {
+    "description": "Title for the provider category summary shown to admins during setup and workspace health"
+  },
+  "providerCategorySummaryDescription": "Weave tracks collaboration categories first. Provider names below are current dogfood choices for admins/operators, not member-facing product names.",
+  "@providerCategorySummaryDescription": {
+    "description": "Description explaining provider categories and dogfood defaults"
+  },
+  "providerCategorySummarySemanticLabel": "Provider categories. Current dogfood provider choices are shown only for setup and workspace health.",
+  "@providerCategorySummarySemanticLabel": {
+    "description": "Accessibility label for the provider category summary"
+  },
+  "providerCategoryStatusCurrentDefault": "Current dogfood choice",
+  "@providerCategoryStatusCurrentDefault": {
+    "description": "Status pill for a provider category using the current dogfood provider choice"
+  },
+  "providerCategoryStatusAdminSetupRequired": "Admin setup required",
+  "@providerCategoryStatusAdminSetupRequired": {
+    "description": "Status pill for a provider category that requires admin setup before member use"
+  },
+  "providerCategoryStatusDisabledByDefault": "Disabled by default",
+  "@providerCategoryStatusDisabledByDefault": {
+    "description": "Status pill for a provider category disabled by default"
+  },
+  "providerCategoryIdentityTitle": "Identity/IDM",
+  "@providerCategoryIdentityTitle": {
+    "description": "Provider category title for identity and IDM"
+  },
+  "providerCategoryIdentityDetail": "Keycloak/Auth is the current dogfood choice; Entra ID, Authentik, or another OIDC/SAML source can map to this category.",
+  "@providerCategoryIdentityDetail": {
+    "description": "Provider category detail for identity and IDM"
+  },
+  "providerCategoryChatTitle": "Chat",
+  "@providerCategoryChatTitle": {
+    "description": "Provider category title for chat"
+  },
+  "providerCategoryChatDetail": "Matrix/Chat is the current dogfood choice behind the Weave chat surface.",
+  "@providerCategoryChatDetail": {
+    "description": "Provider category detail for chat"
+  },
+  "providerCategoryFilesTitle": "Files",
+  "@providerCategoryFilesTitle": {
+    "description": "Provider category title for files"
+  },
+  "providerCategoryFilesDetail": "Nextcloud/Files is the current dogfood storage choice behind the Weave files facade.",
+  "@providerCategoryFilesDetail": {
+    "description": "Provider category detail for files"
+  },
+  "providerCategoryCalendarTitle": "Calendar",
+  "@providerCategoryCalendarTitle": {
+    "description": "Provider category title for calendar"
+  },
+  "providerCategoryCalendarDetail": "Nextcloud/Calendar backing is the current dogfood choice behind the Weave calendar facade.",
+  "@providerCategoryCalendarDetail": {
+    "description": "Provider category detail for calendar"
+  },
+  "providerCategoryBoardsTitle": "Boards/tasks",
+  "@providerCategoryBoardsTitle": {
+    "description": "Provider category title for boards and tasks"
+  },
+  "providerCategoryBoardsDetail": "OpenProject Boards validation is the current provider-backed path; member task writes stay gated by authorization, audit, and rollback evidence.",
+  "@providerCategoryBoardsDetail": {
+    "description": "Provider category detail for boards and tasks"
+  },
+  "providerCategoryMeetingsTitle": "Meetings/calls",
+  "@providerCategoryMeetingsTitle": {
+    "description": "Provider category title for meetings and calls"
+  },
+  "providerCategoryMeetingsDetail": "LiveKit Meetings readiness is tracked behind the token facade before members can start or join calls.",
+  "@providerCategoryMeetingsDetail": {
+    "description": "Provider category detail for meetings and calls"
+  },
+  "providerCategoryDocumentsTitle": "Documents/collaboration",
+  "@providerCategoryDocumentsTitle": {
+    "description": "Provider category title for documents and collaboration"
+  },
+  "providerCategoryDocumentsDetail": "Document collaboration is a provider adapter category and stays admin setup required until a backend-owned launch path is configured.",
+  "@providerCategoryDocumentsDetail": {
+    "description": "Provider category detail for documents and collaboration"
+  },
+  "providerCategoryWeaverTitle": "Weaver",
+  "@providerCategoryWeaverTitle": {
+    "description": "Provider category title for Weaver"
+  },
+  "providerCategoryWeaverDetail": "Weaver stays disabled by default until governed per-user PA policy, whitelisting, consent, and audit are accepted.",
+  "@providerCategoryWeaverDetail": {
+    "description": "Provider category detail for Weaver"
   },
   "setupLanguageStepTitle": "Your Language",
   "@setupLanguageStepTitle": {

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -131,13 +131,13 @@ abstract class AppLocalizations {
   /// Title for the setup provider and issuer step
   ///
   /// In en, this message translates to:
-  /// **'Connect Your Server'**
+  /// **'Configure provider categories'**
   String get setupProviderStepTitle;
 
   /// Description shown in the setup provider step
   ///
   /// In en, this message translates to:
-  /// **'Choose your OIDC provider and enter the issuer URL for your self-hosted setup.'**
+  /// **'Admin setup starts with the identity/IDM category and keeps chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver visible as provider categories before members join.'**
   String get setupProviderStepDescription;
 
   /// Title for the setup services step
@@ -149,8 +149,140 @@ abstract class AppLocalizations {
   /// Description shown in the setup services step
   ///
   /// In en, this message translates to:
-  /// **'Weave derives Matrix, Nextcloud, and backend API URLs from the issuer host. Review and edit them before finishing setup.'**
+  /// **'Review the current dogfood service endpoints derived from the identity issuer. These provider URLs stay admin/operator configuration, not normal member setup.'**
   String get setupServicesStepDescription;
+
+  /// Title for the provider category summary shown to admins during setup and workspace health
+  ///
+  /// In en, this message translates to:
+  /// **'Provider categories'**
+  String get providerCategorySummaryTitle;
+
+  /// Description explaining provider categories and dogfood defaults
+  ///
+  /// In en, this message translates to:
+  /// **'Weave tracks collaboration categories first. Provider names below are current dogfood choices for admins/operators, not member-facing product names.'**
+  String get providerCategorySummaryDescription;
+
+  /// Accessibility label for the provider category summary
+  ///
+  /// In en, this message translates to:
+  /// **'Provider categories. Current dogfood provider choices are shown only for setup and workspace health.'**
+  String get providerCategorySummarySemanticLabel;
+
+  /// Status pill for a provider category using the current dogfood provider choice
+  ///
+  /// In en, this message translates to:
+  /// **'Current dogfood choice'**
+  String get providerCategoryStatusCurrentDefault;
+
+  /// Status pill for a provider category that requires admin setup before member use
+  ///
+  /// In en, this message translates to:
+  /// **'Admin setup required'**
+  String get providerCategoryStatusAdminSetupRequired;
+
+  /// Status pill for a provider category disabled by default
+  ///
+  /// In en, this message translates to:
+  /// **'Disabled by default'**
+  String get providerCategoryStatusDisabledByDefault;
+
+  /// Provider category title for identity and IDM
+  ///
+  /// In en, this message translates to:
+  /// **'Identity/IDM'**
+  String get providerCategoryIdentityTitle;
+
+  /// Provider category detail for identity and IDM
+  ///
+  /// In en, this message translates to:
+  /// **'Keycloak/Auth is the current dogfood choice; Entra ID, Authentik, or another OIDC/SAML source can map to this category.'**
+  String get providerCategoryIdentityDetail;
+
+  /// Provider category title for chat
+  ///
+  /// In en, this message translates to:
+  /// **'Chat'**
+  String get providerCategoryChatTitle;
+
+  /// Provider category detail for chat
+  ///
+  /// In en, this message translates to:
+  /// **'Matrix/Chat is the current dogfood choice behind the Weave chat surface.'**
+  String get providerCategoryChatDetail;
+
+  /// Provider category title for files
+  ///
+  /// In en, this message translates to:
+  /// **'Files'**
+  String get providerCategoryFilesTitle;
+
+  /// Provider category detail for files
+  ///
+  /// In en, this message translates to:
+  /// **'Nextcloud/Files is the current dogfood storage choice behind the Weave files facade.'**
+  String get providerCategoryFilesDetail;
+
+  /// Provider category title for calendar
+  ///
+  /// In en, this message translates to:
+  /// **'Calendar'**
+  String get providerCategoryCalendarTitle;
+
+  /// Provider category detail for calendar
+  ///
+  /// In en, this message translates to:
+  /// **'Nextcloud/Calendar backing is the current dogfood choice behind the Weave calendar facade.'**
+  String get providerCategoryCalendarDetail;
+
+  /// Provider category title for boards and tasks
+  ///
+  /// In en, this message translates to:
+  /// **'Boards/tasks'**
+  String get providerCategoryBoardsTitle;
+
+  /// Provider category detail for boards and tasks
+  ///
+  /// In en, this message translates to:
+  /// **'OpenProject Boards validation is the current provider-backed path; member task writes stay gated by authorization, audit, and rollback evidence.'**
+  String get providerCategoryBoardsDetail;
+
+  /// Provider category title for meetings and calls
+  ///
+  /// In en, this message translates to:
+  /// **'Meetings/calls'**
+  String get providerCategoryMeetingsTitle;
+
+  /// Provider category detail for meetings and calls
+  ///
+  /// In en, this message translates to:
+  /// **'LiveKit Meetings readiness is tracked behind the token facade before members can start or join calls.'**
+  String get providerCategoryMeetingsDetail;
+
+  /// Provider category title for documents and collaboration
+  ///
+  /// In en, this message translates to:
+  /// **'Documents/collaboration'**
+  String get providerCategoryDocumentsTitle;
+
+  /// Provider category detail for documents and collaboration
+  ///
+  /// In en, this message translates to:
+  /// **'Document collaboration is a provider adapter category and stays admin setup required until a backend-owned launch path is configured.'**
+  String get providerCategoryDocumentsDetail;
+
+  /// Provider category title for Weaver
+  ///
+  /// In en, this message translates to:
+  /// **'Weaver'**
+  String get providerCategoryWeaverTitle;
+
+  /// Provider category detail for Weaver
+  ///
+  /// In en, this message translates to:
+  /// **'Weaver stays disabled by default until governed per-user PA policy, whitelisting, consent, and audit are accepted.'**
+  String get providerCategoryWeaverDetail;
 
   /// Title for the language preference step
   ///

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -25,18 +25,96 @@ class AppLocalizationsDe extends AppLocalizations {
   String get setupTitle => 'Einrichtung';
 
   @override
-  String get setupProviderStepTitle => 'Server verbinden';
+  String get setupProviderStepTitle => 'Provider-Kategorien konfigurieren';
 
   @override
   String get setupProviderStepDescription =>
-      'Wähle deinen OIDC-Anbieter und gib die Issuer-URL deiner selbst gehosteten Umgebung ein.';
+      'Die Admin-Einrichtung beginnt mit der Kategorie Identität/IDM und hält Chat, Dateien, Kalender, Boards/Aufgaben, Besprechungen/Anrufe, Dokumente/Zusammenarbeit und Weaver als Provider-Kategorien sichtbar, bevor Mitglieder beitreten.';
 
   @override
   String get setupServicesStepTitle => 'Dienstendpunkte prüfen';
 
   @override
   String get setupServicesStepDescription =>
-      'Weave leitet Matrix-, Nextcloud- und Backend-API-URLs aus dem Issuer-Host ab. Prüfe und ändere sie bei Bedarf vor dem Abschluss.';
+      'Prüfe die aktuellen Dogfood-Service-Endpunkte, die aus dem Identitäts-Issuer abgeleitet wurden. Diese Provider-URLs bleiben Admin-/Operator-Konfiguration, nicht normale Mitglieder-Einrichtung.';
+
+  @override
+  String get providerCategorySummaryTitle => 'Provider-Kategorien';
+
+  @override
+  String get providerCategorySummaryDescription =>
+      'Weave betrachtet zuerst Zusammenarbeits-Kategorien. Die Provider-Namen unten sind aktuelle Dogfood-Auswahlen für Admins/Operatoren, keine mitgliederseitigen Produktnamen.';
+
+  @override
+  String get providerCategorySummarySemanticLabel =>
+      'Provider-Kategorien. Aktuelle Dogfood-Provider-Auswahlen werden nur für Einrichtung und Workspace Health gezeigt.';
+
+  @override
+  String get providerCategoryStatusCurrentDefault => 'Aktuelle Dogfood-Auswahl';
+
+  @override
+  String get providerCategoryStatusAdminSetupRequired =>
+      'Admin-Einrichtung erforderlich';
+
+  @override
+  String get providerCategoryStatusDisabledByDefault =>
+      'Standardmäßig deaktiviert';
+
+  @override
+  String get providerCategoryIdentityTitle => 'Identität/IDM';
+
+  @override
+  String get providerCategoryIdentityDetail =>
+      'Keycloak/Auth ist die aktuelle Dogfood-Auswahl; Entra ID, Authentik oder eine andere OIDC/SAML-Quelle kann auf diese Kategorie abgebildet werden.';
+
+  @override
+  String get providerCategoryChatTitle => 'Chat';
+
+  @override
+  String get providerCategoryChatDetail =>
+      'Matrix/Chat ist die aktuelle Dogfood-Auswahl hinter der Weave-Chat-Oberfläche.';
+
+  @override
+  String get providerCategoryFilesTitle => 'Dateien';
+
+  @override
+  String get providerCategoryFilesDetail =>
+      'Nextcloud/Files ist die aktuelle Dogfood-Speicherauswahl hinter der Weave-Datei-Fassade.';
+
+  @override
+  String get providerCategoryCalendarTitle => 'Kalender';
+
+  @override
+  String get providerCategoryCalendarDetail =>
+      'Nextcloud/Calendar-Anbindung ist die aktuelle Dogfood-Auswahl hinter der Weave-Kalender-Fassade.';
+
+  @override
+  String get providerCategoryBoardsTitle => 'Boards/Aufgaben';
+
+  @override
+  String get providerCategoryBoardsDetail =>
+      'OpenProject-Boards-Validierung ist der aktuelle providergestützte Pfad; Aufgabenänderungen durch Mitglieder bleiben durch Autorisierung, Audit und Rollback-Evidenz begrenzt.';
+
+  @override
+  String get providerCategoryMeetingsTitle => 'Besprechungen/Anrufe';
+
+  @override
+  String get providerCategoryMeetingsDetail =>
+      'LiveKit-Meetings-Bereitschaft wird hinter der Token-Fassade verfolgt, bevor Mitglieder Anrufe starten oder beitreten können.';
+
+  @override
+  String get providerCategoryDocumentsTitle => 'Dokumente/Zusammenarbeit';
+
+  @override
+  String get providerCategoryDocumentsDetail =>
+      'Dokument-Zusammenarbeit ist eine Provider-Adapter-Kategorie und bleibt Admin-Einrichtung erforderlich, bis ein backend-eigener Startpfad konfiguriert ist.';
+
+  @override
+  String get providerCategoryWeaverTitle => 'Weaver';
+
+  @override
+  String get providerCategoryWeaverDetail =>
+      'Weaver bleibt standardmäßig deaktiviert, bis regulierte persönliche PA-Richtlinie, Whitelisting, Einwilligung und Audit akzeptiert sind.';
 
   @override
   String get setupLanguageStepTitle => 'Deine Sprache';

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -25,18 +25,94 @@ class AppLocalizationsEn extends AppLocalizations {
   String get setupTitle => 'Setup';
 
   @override
-  String get setupProviderStepTitle => 'Connect Your Server';
+  String get setupProviderStepTitle => 'Configure provider categories';
 
   @override
   String get setupProviderStepDescription =>
-      'Choose your OIDC provider and enter the issuer URL for your self-hosted setup.';
+      'Admin setup starts with the identity/IDM category and keeps chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver visible as provider categories before members join.';
 
   @override
   String get setupServicesStepTitle => 'Review Service Endpoints';
 
   @override
   String get setupServicesStepDescription =>
-      'Weave derives Matrix, Nextcloud, and backend API URLs from the issuer host. Review and edit them before finishing setup.';
+      'Review the current dogfood service endpoints derived from the identity issuer. These provider URLs stay admin/operator configuration, not normal member setup.';
+
+  @override
+  String get providerCategorySummaryTitle => 'Provider categories';
+
+  @override
+  String get providerCategorySummaryDescription =>
+      'Weave tracks collaboration categories first. Provider names below are current dogfood choices for admins/operators, not member-facing product names.';
+
+  @override
+  String get providerCategorySummarySemanticLabel =>
+      'Provider categories. Current dogfood provider choices are shown only for setup and workspace health.';
+
+  @override
+  String get providerCategoryStatusCurrentDefault => 'Current dogfood choice';
+
+  @override
+  String get providerCategoryStatusAdminSetupRequired => 'Admin setup required';
+
+  @override
+  String get providerCategoryStatusDisabledByDefault => 'Disabled by default';
+
+  @override
+  String get providerCategoryIdentityTitle => 'Identity/IDM';
+
+  @override
+  String get providerCategoryIdentityDetail =>
+      'Keycloak/Auth is the current dogfood choice; Entra ID, Authentik, or another OIDC/SAML source can map to this category.';
+
+  @override
+  String get providerCategoryChatTitle => 'Chat';
+
+  @override
+  String get providerCategoryChatDetail =>
+      'Matrix/Chat is the current dogfood choice behind the Weave chat surface.';
+
+  @override
+  String get providerCategoryFilesTitle => 'Files';
+
+  @override
+  String get providerCategoryFilesDetail =>
+      'Nextcloud/Files is the current dogfood storage choice behind the Weave files facade.';
+
+  @override
+  String get providerCategoryCalendarTitle => 'Calendar';
+
+  @override
+  String get providerCategoryCalendarDetail =>
+      'Nextcloud/Calendar backing is the current dogfood choice behind the Weave calendar facade.';
+
+  @override
+  String get providerCategoryBoardsTitle => 'Boards/tasks';
+
+  @override
+  String get providerCategoryBoardsDetail =>
+      'OpenProject Boards validation is the current provider-backed path; member task writes stay gated by authorization, audit, and rollback evidence.';
+
+  @override
+  String get providerCategoryMeetingsTitle => 'Meetings/calls';
+
+  @override
+  String get providerCategoryMeetingsDetail =>
+      'LiveKit Meetings readiness is tracked behind the token facade before members can start or join calls.';
+
+  @override
+  String get providerCategoryDocumentsTitle => 'Documents/collaboration';
+
+  @override
+  String get providerCategoryDocumentsDetail =>
+      'Document collaboration is a provider adapter category and stays admin setup required until a backend-owned launch path is configured.';
+
+  @override
+  String get providerCategoryWeaverTitle => 'Weaver';
+
+  @override
+  String get providerCategoryWeaverDetail =>
+      'Weaver stays disabled by default until governed per-user PA policy, whitelisting, consent, and audit are accepted.';
 
   @override
   String get setupLanguageStepTitle => 'Your Language';

--- a/client/test/features/onboarding/setup_flow_test.dart
+++ b/client/test/features/onboarding/setup_flow_test.dart
@@ -94,7 +94,11 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(WeaveLogo), findsOneWidget);
-        expect(find.text('Connect Your Server'), findsOneWidget);
+        expect(find.text('Configure provider categories'), findsOneWidget);
+        expect(find.text('Provider categories'), findsOneWidget);
+        expect(find.text('Identity/IDM'), findsOneWidget);
+        expect(find.text('Documents/collaboration'), findsOneWidget);
+        expect(find.text('Weaver'), findsOneWidget);
         expect(find.text('Provider type'), findsOneWidget);
         expect(find.text('OIDC Client ID'), findsOneWidget);
         expect(find.text('Next'), findsOneWidget);
@@ -175,7 +179,7 @@ void main() {
       await tester.tap(find.text('Back'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Connect Your Server'), findsOneWidget);
+      expect(find.text('Configure provider categories'), findsOneWidget);
     });
 
     testWidgets('meets androidTapTargetGuideline', (tester) async {

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -292,6 +292,24 @@ void main() {
         ),
         findsOneWidget,
       );
+      expect(find.text('Provider categories'), findsOneWidget);
+      expect(find.text('Identity/IDM'), findsOneWidget);
+      expect(find.text('Chat'), findsWidgets);
+      expect(find.text('Files'), findsWidgets);
+      expect(find.text('Calendar'), findsWidgets);
+      expect(find.text('Boards/tasks'), findsOneWidget);
+      expect(find.text('Meetings/calls'), findsOneWidget);
+      expect(find.text('Documents/collaboration'), findsOneWidget);
+      expect(find.text('Weaver'), findsOneWidget);
+      expect(find.text('Disabled by default'), findsOneWidget);
+      expect(find.textContaining('Keycloak/Auth'), findsOneWidget);
+      expect(find.textContaining('Matrix/Chat'), findsOneWidget);
+      expect(find.textContaining('Nextcloud/Files'), findsOneWidget);
+      expect(
+        find.textContaining('OpenProject Boards validation'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('LiveKit Meetings readiness'), findsOneWidget);
       expect(find.text('Server Configuration'), findsOneWidget);
       expect(find.text('https://auth.home.internal'), findsWidgets);
       expect(find.text('weave-app'), findsWidgets);
@@ -388,6 +406,9 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('Server Configuration'), findsNothing);
+      expect(find.text('Provider categories'), findsNothing);
+      expect(find.text('Identity/IDM'), findsNothing);
+      expect(find.text('Documents/collaboration'), findsNothing);
       expect(_textFieldWithLabel('OIDC Issuer URL'), findsNothing);
       expect(_textFieldWithLabel('Nextcloud Base URL'), findsNothing);
       expect(find.text('Provider stack readiness'), findsNothing);

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -172,6 +172,25 @@
             "Weaver is represented only as a disabled-by-default category",
             "never raw provider setup, service endpoints, provider secrets, or diagnostics"
           ]
+        },
+        {
+          "path": "client/test/features/onboarding/setup_flow_test.dart",
+          "fragments": [
+            "Configure provider categories",
+            "Provider categories",
+            "Documents/collaboration",
+            "Weaver"
+          ]
+        },
+        {
+          "path": "client/test/features/settings/settings_screen_test.dart",
+          "fragments": [
+            "Provider categories",
+            "Keycloak/Auth",
+            "Matrix/Chat",
+            "Disabled by default",
+            "hides OIDC and service endpoint setup from members"
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Summary
- add an accessible ProviderCategorySummary for admin setup and Workspace/Admin Health
- show provider categories, dogfood mappings, and Weaver disabled-by-default in admin/operator surfaces
- keep normal member settings free of provider setup/diagnostics
- extend `@weave-v01-admin-provider-categories` mapping with UI evidence

## Validation
- `cd client && flutter gen-l10n`
- `cd client && flutter test test/features/onboarding/setup_flow_test.dart test/features/settings/settings_screen_test.dart test/release_1/ux_release_copy_contract_test.dart test/release_1/v0_1_release_spine_contract_test.dart`
- `make acceptance-contract`

Follow-up to #264.
