### PR TITLE
feat(admin-health): enforce provider readiness policy

### DIFF
--- a/client/lib/features/app/domain/entities/provider_stack_snapshot.dart
+++ b/client/lib/features/app/domain/entities/provider_stack_snapshot.dart
@@ -8,6 +8,15 @@ enum ProviderState {
   unknown,
 }
 
+enum ProviderCategoryReadiness {
+  ready,
+  disabled,
+  degraded,
+  policyBlocked,
+  misconfigured,
+  unknown,
+}
+
 class ProviderStackSnapshot {
   const ProviderStackSnapshot({
     required this.releaseStatus,
@@ -15,6 +24,7 @@ class ProviderStackSnapshot {
     required this.flutterDirectProviderCallsAllowed,
     required this.supportSafe,
     required this.providers,
+    this.categories = const <ProviderCategoryStatusSnapshot>[],
     this.generatedAt,
   });
 
@@ -23,6 +33,7 @@ class ProviderStackSnapshot {
   final bool flutterDirectProviderCallsAllowed;
   final bool supportSafe;
   final DateTime? generatedAt;
+  final List<ProviderCategoryStatusSnapshot> categories;
   final List<ProviderStatusSnapshot> providers;
 
   bool get failClosed =>
@@ -35,6 +46,32 @@ class ProviderStackSnapshot {
             provider.state == ProviderState.notConfigured ||
             provider.state == ProviderState.unsupported),
   );
+}
+
+class ProviderCategoryStatusSnapshot {
+  const ProviderCategoryStatusSnapshot({
+    required this.category,
+    required this.label,
+    required this.readiness,
+    required this.policyState,
+    required this.memberImpact,
+    required this.modules,
+    required this.providerCandidates,
+    required this.diagnostics,
+  });
+
+  final String category;
+  final String label;
+  final ProviderCategoryReadiness readiness;
+  final String policyState;
+  final String memberImpact;
+  final List<String> modules;
+  final List<String> providerCandidates;
+  final Map<String, Object?> diagnostics;
+
+  bool get supportSafe =>
+      diagnostics['secretsReturned'] == false &&
+      diagnostics['rawProviderErrorsReturned'] == false;
 }
 
 class ProviderStatusSnapshot {

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -1010,6 +1010,7 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
+    final categories = stack.categories;
     final providers = stack.providers;
     final flutterCalls = stack.flutterDirectProviderCallsAllowed
         ? l10n.settingsProviderStackFlutterCallsAllowed
@@ -1075,6 +1076,45 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
                 const SizedBox(height: 12),
                 _OfficeProviderReadinessSummary(office: office),
               ],
+              if (categories.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                for (final category in categories)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 6),
+                    child: Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Text(
+                          '${category.label}: ${_providerCategoryReadinessLabel(l10n, category.readiness)}',
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        if (category.readiness ==
+                            ProviderCategoryReadiness.policyBlocked)
+                          _CompactStatusBadge(
+                            label: l10n.settingsWorkspaceCapabilityBlocked,
+                          ),
+                        if (category.readiness ==
+                            ProviderCategoryReadiness.disabled)
+                          _CompactStatusBadge(
+                            label: l10n.settingsProviderStateDisabled,
+                          ),
+                        if (category.readiness ==
+                            ProviderCategoryReadiness.misconfigured)
+                          _CompactStatusBadge(
+                            label: l10n.settingsProviderStateNotConfigured,
+                          ),
+                        if (category.supportSafe)
+                          _CompactStatusBadge(
+                            label: l10n.settingsProviderStackRedacted,
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
               if (providers.isNotEmpty) ...[
                 const SizedBox(height: 12),
                 for (final provider in providers)
@@ -1121,6 +1161,22 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  String _providerCategoryReadinessLabel(
+    AppLocalizations l10n,
+    ProviderCategoryReadiness readiness,
+  ) {
+    return switch (readiness) {
+      ProviderCategoryReadiness.ready => l10n.settingsProviderStateReady,
+      ProviderCategoryReadiness.disabled => l10n.settingsProviderStateDisabled,
+      ProviderCategoryReadiness.degraded => l10n.settingsProviderStateDegraded,
+      ProviderCategoryReadiness.policyBlocked =>
+        l10n.settingsWorkspaceCapabilityBlocked,
+      ProviderCategoryReadiness.misconfigured =>
+        l10n.settingsProviderStateNotConfigured,
+      ProviderCategoryReadiness.unknown => l10n.settingsProviderStateUnknown,
+    };
   }
 
   String _providerModuleLabel(AppLocalizations l10n, String module) {

--- a/client/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
+++ b/client/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
@@ -7,6 +7,7 @@ class ProviderRegistryResponseDto {
     required this.flutterDirectProviderCallsAllowed,
     required this.supportSafe,
     required this.generatedAt,
+    required this.categories,
     required this.providers,
   });
 
@@ -19,6 +20,9 @@ class ProviderRegistryResponseDto {
       ),
       supportSafe: _bool(json['supportSafe']),
       generatedAt: _dateTime(json['generatedAt']),
+      categories: _listOfMaps(
+        json['categories'],
+      ).map(ProviderCategoryStatusResponseDto.fromJson).toList(growable: false),
       providers: _listOfMaps(
         json['providers'],
       ).map(ProviderStatusResponseDto.fromJson).toList(growable: false),
@@ -30,6 +34,7 @@ class ProviderRegistryResponseDto {
   final bool flutterDirectProviderCallsAllowed;
   final bool supportSafe;
   final DateTime? generatedAt;
+  final List<ProviderCategoryStatusResponseDto> categories;
   final List<ProviderStatusResponseDto> providers;
 
   ProviderStackSnapshot toSnapshot() => ProviderStackSnapshot(
@@ -38,7 +43,58 @@ class ProviderRegistryResponseDto {
     flutterDirectProviderCallsAllowed: flutterDirectProviderCallsAllowed,
     supportSafe: supportSafe,
     generatedAt: generatedAt,
+    categories: categories.map((category) => category.toSnapshot()).toList(),
     providers: providers.map((provider) => provider.toSnapshot()).toList(),
+  );
+}
+
+class ProviderCategoryStatusResponseDto {
+  const ProviderCategoryStatusResponseDto({
+    required this.category,
+    required this.label,
+    required this.readiness,
+    required this.policyState,
+    required this.memberImpact,
+    required this.modules,
+    required this.providerCandidates,
+    required this.diagnostics,
+  });
+
+  factory ProviderCategoryStatusResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return ProviderCategoryStatusResponseDto(
+      category: _string(json['category'], fallback: 'unknown'),
+      label: _safeText(json['label']),
+      readiness: _providerCategoryReadiness(
+        _string(json['readiness'], fallback: 'unknown'),
+      ),
+      policyState: _string(json['policyState'], fallback: 'unknown'),
+      memberImpact: _safeText(json['memberImpact']),
+      modules: _safeStringList(json['modules']),
+      providerCandidates: _safeStringList(json['providerCandidates']),
+      diagnostics: _safeDiagnostics(json['diagnostics']),
+    );
+  }
+
+  final String category;
+  final String label;
+  final ProviderCategoryReadiness readiness;
+  final String policyState;
+  final String memberImpact;
+  final List<String> modules;
+  final List<String> providerCandidates;
+  final Map<String, Object?> diagnostics;
+
+  ProviderCategoryStatusSnapshot toSnapshot() => ProviderCategoryStatusSnapshot(
+    category: category,
+    label: label,
+    readiness: readiness,
+    policyState: policyState,
+    memberImpact: memberImpact,
+    modules: modules,
+    providerCandidates: providerCandidates,
+    diagnostics: diagnostics,
   );
 }
 
@@ -784,6 +840,17 @@ class OfficeLaunchErrorResponseDto {
     message: message,
     requestId: requestId,
   );
+}
+
+ProviderCategoryReadiness _providerCategoryReadiness(String value) {
+  return switch (value) {
+    'ready' => ProviderCategoryReadiness.ready,
+    'disabled' => ProviderCategoryReadiness.disabled,
+    'degraded' => ProviderCategoryReadiness.degraded,
+    'policy_blocked' => ProviderCategoryReadiness.policyBlocked,
+    'misconfigured' => ProviderCategoryReadiness.misconfigured,
+    _ => ProviderCategoryReadiness.unknown,
+  };
 }
 
 ProviderState _providerState(String value) {

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -650,6 +650,34 @@ void main() {
               backendOwnedFacades: true,
               flutterDirectProviderCallsAllowed: false,
               supportSafe: true,
+              categories: [
+                ProviderCategoryStatusSnapshot(
+                  category: 'calendar',
+                  label: 'calendar',
+                  readiness: ProviderCategoryReadiness.degraded,
+                  policyState: 'allowed',
+                  memberImpact: 'Calendar is degraded.',
+                  modules: ['calendar'],
+                  providerCandidates: ['nextcloud-calendar'],
+                  diagnostics: {
+                    'secretsReturned': false,
+                    'rawProviderErrorsReturned': false,
+                  },
+                ),
+                ProviderCategoryStatusSnapshot(
+                  category: 'weaver',
+                  label: 'Weaver',
+                  readiness: ProviderCategoryReadiness.policyBlocked,
+                  policyState: 'policy_blocked',
+                  memberImpact: 'Weaver is disabled by workspace policy.',
+                  modules: [],
+                  providerCandidates: [],
+                  diagnostics: {
+                    'secretsReturned': false,
+                    'rawProviderErrorsReturned': false,
+                  },
+                ),
+              ],
               providers: [
                 ProviderStatusSnapshot(
                   module: 'office',
@@ -739,6 +767,8 @@ void main() {
         find.textContaining('Office launch is fail-closed'),
         findsOneWidget,
       );
+      expect(find.text('calendar: degraded'), findsOneWidget);
+      expect(find.text('Weaver: Blocked'), findsOneWidget);
       expect(find.textContaining('provider-token-123'), findsNothing);
       expect(find.textContaining('https://gitlab.example.test'), findsNothing);
       expect(find.textContaining('https://office.example.test'), findsNothing);

--- a/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/integrations/weave_api/data/services/weave_api_client.dart';
 
@@ -281,6 +282,38 @@ void main() {
               'backendOwnedFacades': true,
               'flutterDirectProviderCallsAllowed': false,
               'supportSafe': true,
+              'categories': [
+                {
+                  'category': 'identity-idm',
+                  'label': 'identity/IDM',
+                  'readiness': 'ready',
+                  'policyState': 'allowed',
+                  'memberImpact': 'Sign-in is available.',
+                  'modules': ['identity-realm', 'matrix-auth'],
+                  'providerCandidates': ['keycloak', 'oidc'],
+                  'diagnostics': {
+                    'providerCount': 2,
+                    'allSupportSafe': true,
+                    'secretsReturned': false,
+                    'rawProviderErrorsReturned': false,
+                  },
+                },
+                {
+                  'category': 'weaver',
+                  'label': 'Weaver',
+                  'readiness': 'policy_blocked',
+                  'policyState': 'policy_blocked',
+                  'memberImpact': 'Weaver is disabled by workspace policy.',
+                  'modules': [],
+                  'providerCandidates': [],
+                  'diagnostics': {
+                    'providerCount': 0,
+                    'allSupportSafe': true,
+                    'secretsReturned': false,
+                    'rawProviderErrorsReturned': false,
+                  },
+                },
+              ],
               'providers': [
                 {
                   'module': 'office',
@@ -344,6 +377,18 @@ void main() {
         );
         expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
         expect(snapshot.failClosed, isTrue);
+        expect(snapshot.categories, hasLength(2));
+        expect(snapshot.categories.first.category, 'identity-idm');
+        expect(
+          snapshot.categories.first.readiness,
+          ProviderCategoryReadiness.ready,
+        );
+        expect(snapshot.categories.first.supportSafe, isTrue);
+        expect(snapshot.categories.last.category, 'weaver');
+        expect(
+          snapshot.categories.last.readiness,
+          ProviderCategoryReadiness.policyBlocked,
+        );
         expect(snapshot.providers.first.module, 'office');
         expect(snapshot.providers.first.failClosed, isTrue);
         final meetings = snapshot.providers.singleWhere(

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -33,6 +33,7 @@ void main() {
         'Weave Home starts the daily work loop',
         'A normal member sees a user-ready organization flow',
         'Admin sees provider categories before member use',
+        'Admin health enforces provider readiness and member policy boundaries',
         'IDM roles and groups decide capability profiles before Weaver runtime',
         'Weaver runtime profiles are generated from organization policy',
         'A channel is the primary workspace surface',

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -28,6 +28,15 @@ Feature: Weave v0.1 dogfood production release
     And Weaver is disabled by default until admin policy explicitly enables it
     And normal members never configure raw providers, service endpoints, provider secrets, or diagnostics
 
+  @weave-v01-admin-health-policy-enforcement
+  Scenario: Admin health enforces provider readiness and member policy boundaries
+    Given an owner or admin opens Workspace Health after selecting provider categories
+    When backend provider readiness and capability policy are evaluated
+    Then Workspace Health returns support-safe category readiness for ready, disabled, degraded, policy-blocked, and misconfigured states
+    And members receive only usable, disabled, degraded, or policy-blocked impact states without raw provider setup
+    And member API writes are denied when IDM capability policy does not grant the required category capability
+    And Weaver remains disabled by default unless governed organization policy explicitly enables it
+
   @weave-v01-idm-rbac-capability-policy
   Scenario: IDM roles and groups decide capability profiles before Weaver runtime
     Given an owner has selected an IDM provider for the organization

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -195,6 +195,40 @@
       ]
     },
     {
+      "tag": "@weave-v01-admin-health-policy-enforcement",
+      "scenario": "Admin health enforces provider readiness and member policy boundaries",
+      "feature": "e2e/features/v0_1_dogfood_release.feature",
+      "executableTest": "server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java",
+      "evidenceMarkers": [
+        "V01_ADMIN_HEALTH_POLICY_ENFORCEMENT"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java",
+          "fragments": [
+            "providerStatusReportsAllFacadeSeamsWithoutSecrets",
+            "identity-idm", "policy_blocked", "misconfigured", "documents-collaboration", "secretsReturned"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java",
+          "fragments": [
+            "calendarCreateIsDeniedByCapabilityPolicyBeforeProviderAccess",
+            "capability-policy-blocked",
+            "calendar.manage_events"
+          ]
+        },
+        {
+          "path": "client/test/integrations/weave_api/data/services/weave_api_client_test.dart",
+          "fragments": [
+            "fetches provider stack readiness without direct provider URLs",
+            "ProviderCategoryReadiness.policyBlocked",
+            "rawProviderErrorsReturned"
+          ]
+        }
+      ]
+    },
+    {
       "tag": "@weave-v01-idm-rbac-capability-policy",
       "scenario": "IDM roles and groups decide capability profiles before Weaver runtime",
       "feature": "e2e/features/v0_1_dogfood_release.feature",

--- a/server/src/main/java/com/massimotter/weave/backend/controller/CalendarController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/CalendarController.java
@@ -12,6 +12,7 @@ import com.massimotter.weave.backend.model.calendar.CalendarEventsResponse;
 import com.massimotter.weave.backend.model.calendar.CreateCalendarEventRequest;
 import com.massimotter.weave.backend.model.calendar.UpdateCalendarEventRequest;
 import com.massimotter.weave.backend.service.CalendarFacadeService;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import com.massimotter.weave.backend.service.calendar.AppleMobileConfigProfile;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,6 +28,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,9 +55,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class CalendarController {
 
     private final CalendarFacadeService calendarFacadeService;
+    private final WorkspaceCapabilityService workspaceCapabilityService;
 
-    public CalendarController(CalendarFacadeService calendarFacadeService) {
+    public CalendarController(CalendarFacadeService calendarFacadeService,
+            WorkspaceCapabilityService workspaceCapabilityService) {
         this.calendarFacadeService = calendarFacadeService;
+        this.workspaceCapabilityService = workspaceCapabilityService;
     }
 
     @GetMapping("/api/calendar/scopes")
@@ -142,7 +148,10 @@ public class CalendarController {
     @Operation(summary = "Create a calendar event")
     @ApiResponse(responseCode = "200", description = "Created calendar event.",
             content = @Content(schema = @Schema(implementation = CalendarEventResponse.class)))
-    public CalendarEventResponse create(@Valid @RequestBody CreateCalendarEventRequest request) {
+    public CalendarEventResponse create(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody CreateCalendarEventRequest request) {
+        workspaceCapabilityService.requireCapability(jwt, "calendar.manage_events", "calendar", "create-event");
         return calendarFacadeService.create(request);
     }
 
@@ -159,14 +168,19 @@ public class CalendarController {
     @ApiResponse(responseCode = "200", description = "Updated calendar event.",
             content = @Content(schema = @Schema(implementation = CalendarEventResponse.class)))
     public CalendarEventResponse update(
+            @AuthenticationPrincipal Jwt jwt,
             @PathVariable @Size(max = 2048) String id,
             @Valid @RequestBody UpdateCalendarEventRequest request) {
+        workspaceCapabilityService.requireCapability(jwt, "calendar.manage_events", "calendar", "update-event");
         return calendarFacadeService.update(id, request);
     }
 
     @DeleteMapping("/api/calendar/events/{id}")
     @Operation(summary = "Delete a calendar event")
-    public ResponseEntity<Void> delete(@PathVariable @Size(max = 2048) String id) {
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable @Size(max = 2048) String id) {
+        workspaceCapabilityService.requireCapability(jwt, "calendar.manage_events", "calendar", "delete-event");
         calendarFacadeService.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/server/src/main/java/com/massimotter/weave/backend/controller/ProviderRegistryController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/ProviderRegistryController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @ApiResponses({
         @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
                 content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
+        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or is not an owner/admin/operator.",
                 content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
 })
 public class ProviderRegistryController {
@@ -31,7 +32,8 @@ public class ProviderRegistryController {
     }
 
     @GetMapping("/api/providers/status")
-    @Operation(summary = "Read support-safe provider capability and readiness status")
+    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @Operation(summary = "Read support-safe admin/provider category capability and readiness status")
     @ApiResponse(responseCode = "200", description = "Provider registry snapshot.",
             content = @Content(schema = @Schema(implementation = ProviderRegistryResponse.class)))
     public ProviderRegistryResponse status() {

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryHealthMapper.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryHealthMapper.java
@@ -1,0 +1,205 @@
+package com.massimotter.weave.backend.provider;
+
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+final class ProviderCategoryHealthMapper {
+
+    private ProviderCategoryHealthMapper() {
+    }
+
+    static List<ProviderCategoryStatusResponse> categories(
+            List<ProviderStatusResponse> providers,
+            WorkspaceCapabilitiesResponse capabilities) {
+        List<ProviderStatusResponse> safeProviders = providers == null ? List.of() : List.copyOf(providers);
+        return List.of(
+                capabilityCategory(
+                        "identity-idm",
+                        "identity/IDM",
+                        capabilities.shellAccess(),
+                        safeProviders,
+                        modules(ProviderModule.IDENTITY_REALM, ProviderModule.MATRIX_AUTH)),
+                capabilityCategory(
+                        "chat",
+                        "chat",
+                        capabilities.chat(),
+                        safeProviders,
+                        modules(ProviderModule.MATRIX)),
+                capabilityCategory(
+                        "files",
+                        "files",
+                        capabilities.files(),
+                        safeProviders,
+                        modules(ProviderModule.FILES)),
+                capabilityCategory(
+                        "calendar",
+                        "calendar",
+                        capabilities.calendar(),
+                        safeProviders,
+                        modules(ProviderModule.CALENDAR)),
+                capabilityCategory(
+                        "boards-tasks",
+                        "boards/tasks",
+                        capabilities.boards(),
+                        safeProviders,
+                        modules(ProviderModule.BOARDS)),
+                providerCategory(
+                        "meetings-calls",
+                        "meetings/calls",
+                        "Meetings and calls are available only when the configured media provider is ready behind the backend token facade.",
+                        safeProviders,
+                        modules(ProviderModule.MEETINGS)),
+                providerCategory(
+                        "documents-collaboration",
+                        "documents/collaboration",
+                        "Document collaboration is available only through backend-owned launch/capability facades.",
+                        safeProviders,
+                        modules(ProviderModule.OFFICE, ProviderModule.FORMS, ProviderModule.CONTACTS)),
+                capabilityCategory(
+                        "weaver",
+                        "Weaver",
+                        capabilities.weaver(),
+                        safeProviders,
+                        Set.of()));
+    }
+
+    private static ProviderCategoryStatusResponse capabilityCategory(
+            String category,
+            String label,
+            WorkspaceCapabilityStatusResponse capability,
+            List<ProviderStatusResponse> providers,
+            Set<ProviderModule> modules) {
+        return new ProviderCategoryStatusResponse(
+                category,
+                label,
+                fromCapability(capability),
+                capability.policyState(),
+                capability.memberImpact(),
+                moduleNames(modules),
+                providerCandidates(providers, modules),
+                diagnostics(providers, modules, Map.of(
+                        "capabilityEnabled", capability.enabled(),
+                        "capabilityReadiness", capability.readiness().value(),
+                        "effectivePolicyState", capability.policyState().value(),
+                        "grantedCapabilityCount", capability.grantedCapabilities().size(),
+                        "diagnosticsRedacted", true)));
+    }
+
+    private static ProviderCategoryStatusResponse providerCategory(
+            String category,
+            String label,
+            String memberImpact,
+            List<ProviderStatusResponse> providers,
+            Set<ProviderModule> modules) {
+        List<ProviderStatusResponse> matching = matching(providers, modules);
+        ProviderCategoryReadiness readiness = fromProviders(matching);
+        WorkspaceCapabilityPolicyState policyState = readiness == ProviderCategoryReadiness.DISABLED
+                ? WorkspaceCapabilityPolicyState.DISABLED
+                : readiness == ProviderCategoryReadiness.MISCONFIGURED
+                        ? WorkspaceCapabilityPolicyState.UNAVAILABLE
+                        : WorkspaceCapabilityPolicyState.ALLOWED;
+        return new ProviderCategoryStatusResponse(
+                category,
+                label,
+                readiness,
+                policyState,
+                memberImpact,
+                moduleNames(modules),
+                providerCandidates(providers, modules),
+                diagnostics(providers, modules, Map.of(
+                        "effectivePolicyState", policyState.value(),
+                        "diagnosticsRedacted", true)));
+    }
+
+    private static ProviderCategoryReadiness fromCapability(WorkspaceCapabilityStatusResponse capability) {
+        if (capability.policyState() == WorkspaceCapabilityPolicyState.POLICY_BLOCKED) {
+            return ProviderCategoryReadiness.POLICY_BLOCKED;
+        }
+        if (capability.policyState() == WorkspaceCapabilityPolicyState.DISABLED || !capability.enabled()) {
+            return ProviderCategoryReadiness.DISABLED;
+        }
+        return switch (capability.readiness()) {
+            case READY -> ProviderCategoryReadiness.READY;
+            case DEGRADED -> ProviderCategoryReadiness.DEGRADED;
+            case BLOCKED -> ProviderCategoryReadiness.MISCONFIGURED;
+            case UNAVAILABLE -> ProviderCategoryReadiness.MISCONFIGURED;
+        };
+    }
+
+    private static ProviderCategoryReadiness fromProviders(List<ProviderStatusResponse> providers) {
+        if (providers.isEmpty() || providers.stream().noneMatch(ProviderStatusResponse::enabled)) {
+            return ProviderCategoryReadiness.DISABLED;
+        }
+        if (providers.stream().anyMatch(provider -> provider.enabled() && !provider.configured())) {
+            return ProviderCategoryReadiness.MISCONFIGURED;
+        }
+        if (providers.stream().anyMatch(provider -> provider.state() == ProviderState.DEGRADED)) {
+            return ProviderCategoryReadiness.DEGRADED;
+        }
+        if (providers.stream().anyMatch(provider -> provider.configured()
+                && (provider.state() == ProviderState.READY || provider.state() == ProviderState.CONFIGURED))) {
+            return ProviderCategoryReadiness.READY;
+        }
+        return ProviderCategoryReadiness.DEGRADED;
+    }
+
+    private static Map<String, Object> diagnostics(
+            List<ProviderStatusResponse> providers,
+            Set<ProviderModule> modules,
+            Map<String, Object> extra) {
+        List<ProviderStatusResponse> matching = matching(providers, modules);
+        Map<String, Object> diagnostics = new LinkedHashMap<>();
+        diagnostics.put("providerCount", matching.size());
+        diagnostics.put("enabledProviderCount", matching.stream().filter(ProviderStatusResponse::enabled).count());
+        diagnostics.put("configuredProviderCount", matching.stream().filter(ProviderStatusResponse::configured).count());
+        diagnostics.put("allSupportSafe", matching.stream().allMatch(ProviderStatusResponse::supportSafe));
+        diagnostics.put("allFailClosed", matching.stream().allMatch(ProviderStatusResponse::failClosed));
+        diagnostics.put("secretsReturned", false);
+        diagnostics.put("rawProviderErrorsReturned", false);
+        diagnostics.putAll(extra);
+        return diagnostics;
+    }
+
+    private static List<String> providerCandidates(List<ProviderStatusResponse> providers, Set<ProviderModule> modules) {
+        return matching(providers, modules).stream()
+                .flatMap(provider -> {
+                    List<String> values = new ArrayList<>();
+                    values.add(provider.providerKey());
+                    values.addAll(provider.candidates());
+                    return values.stream();
+                })
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private static List<String> moduleNames(Set<ProviderModule> modules) {
+        return modules.stream()
+                .map(ProviderModule::contractName)
+                .sorted()
+                .toList();
+    }
+
+    private static List<ProviderStatusResponse> matching(List<ProviderStatusResponse> providers, Set<ProviderModule> modules) {
+        Predicate<ProviderStatusResponse> predicate = modules.isEmpty()
+                ? provider -> false
+                : provider -> modules.contains(provider.module());
+        return providers.stream()
+                .filter(predicate)
+                .sorted(Comparator.comparing(provider -> provider.module().contractName()))
+                .toList();
+    }
+
+    private static Set<ProviderModule> modules(ProviderModule... modules) {
+        return Set.of(modules);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryReadiness.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryReadiness.java
@@ -1,0 +1,24 @@
+package com.massimotter.weave.backend.provider;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Admin Workspace Health readiness state for one provider-neutral category.")
+public enum ProviderCategoryReadiness {
+    READY("ready"),
+    DISABLED("disabled"),
+    DEGRADED("degraded"),
+    POLICY_BLOCKED("policy_blocked"),
+    MISCONFIGURED("misconfigured");
+
+    private final String value;
+
+    ProviderCategoryReadiness(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryStatusResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryStatusResponse.java
@@ -1,0 +1,37 @@
+package com.massimotter.weave.backend.provider;
+
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Provider-neutral admin Workspace Health category readiness with support-safe diagnostics.")
+public record ProviderCategoryStatusResponse(
+        @Schema(description = "Stable provider-neutral category key.") String category,
+        @Schema(description = "Human-readable provider-neutral category label.") String label,
+        @Schema(description = "Admin readiness state for this category.") ProviderCategoryReadiness readiness,
+        @Schema(description = "Effective capability policy state used for this category.") WorkspaceCapabilityPolicyState policyState,
+        @Schema(description = "Member-safe impact label. Does not expose raw provider setup.") String memberImpact,
+        @Schema(description = "Provider registry modules contributing to this category.") List<String> modules,
+        @Schema(description = "Support-safe provider choices/candidates for admin diagnostics.") List<String> providerCandidates,
+        @Schema(description = "Support-safe diagnostics. Values are booleans/counts/keys only; no endpoints, secrets, or raw upstream errors.") Map<String, Object> diagnostics) {
+
+    public ProviderCategoryStatusResponse {
+        category = requireText(category, "category");
+        label = requireText(label, "label");
+        readiness = readiness == null ? ProviderCategoryReadiness.DISABLED : readiness;
+        policyState = policyState == null ? WorkspaceCapabilityPolicyState.UNAVAILABLE : policyState;
+        memberImpact = requireText(memberImpact, "memberImpact");
+        modules = modules == null ? List.of() : List.copyOf(modules);
+        providerCandidates = providerCandidates == null ? List.of() : List.copyOf(providerCandidates);
+        diagnostics = diagnostics == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(diagnostics));
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
@@ -1,5 +1,6 @@
 package com.massimotter.weave.backend.provider;
 
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
@@ -9,9 +10,11 @@ import org.springframework.stereotype.Service;
 public class ProviderRegistry {
 
     private final List<ProviderPort> providers;
+    private final WorkspaceCapabilityService workspaceCapabilityService;
 
-    public ProviderRegistry(List<ProviderPort> providers) {
+    public ProviderRegistry(List<ProviderPort> providers, WorkspaceCapabilityService workspaceCapabilityService) {
         this.providers = providers == null ? List.of() : List.copyOf(providers);
+        this.workspaceCapabilityService = workspaceCapabilityService;
     }
 
     public ProviderRegistryResponse status() {
@@ -27,6 +30,7 @@ public class ProviderRegistry {
                 false,
                 statuses.stream().allMatch(ProviderStatusResponse::supportSafe),
                 Instant.now(),
+                ProviderCategoryHealthMapper.categories(statuses, workspaceCapabilityService.snapshot()),
                 statuses);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistryResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistryResponse.java
@@ -9,9 +9,11 @@ public record ProviderRegistryResponse(
         boolean flutterDirectProviderCallsAllowed,
         boolean supportSafe,
         Instant generatedAt,
+        List<ProviderCategoryStatusResponse> categories,
         List<ProviderStatusResponse> providers) {
 
     public ProviderRegistryResponse {
+        categories = categories == null ? List.of() : List.copyOf(categories);
         providers = providers == null ? List.of() : List.copyOf(providers);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -8,6 +8,7 @@ import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import com.massimotter.weave.backend.exception.ApiErrorException;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.springframework.http.HttpStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -146,6 +148,28 @@ public class WorkspaceCapabilityService {
 
     public List<String> grantedCapabilities(Jwt jwt) {
         return effectivePolicy(jwt).capabilities().stream().sorted().toList();
+    }
+
+    public void requireCapability(Jwt jwt, String capability, String module, String operation) {
+        if (jwt == null) {
+            throw new ApiErrorException(
+                    HttpStatus.UNAUTHORIZED,
+                    "unauthorized",
+                    "Authentication is required.",
+                    Map.of("module", module, "operation", operation));
+        }
+        if (!effectivePolicy(jwt).capabilities().contains(capability)) {
+            throw new ApiErrorException(
+                    HttpStatus.FORBIDDEN,
+                    "capability-policy-blocked",
+                    "This action is blocked by workspace role or group policy.",
+                    Map.of(
+                            "module", module,
+                            "operation", operation,
+                            "requiredCapability", capability,
+                            "policyState", WorkspaceCapabilityPolicyState.POLICY_BLOCKED.value(),
+                            "diagnosticsRedacted", true));
+        }
     }
 
     private WorkspaceCapabilityStatusResponse dependentStatus(

--- a/server/src/test/java/com/massimotter/weave/backend/bdd/ProviderStackReadinessStepDefinitions.java
+++ b/server/src/test/java/com/massimotter/weave/backend/bdd/ProviderStackReadinessStepDefinitions.java
@@ -71,6 +71,17 @@ public class ProviderStackReadinessStepDefinitions {
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
     }
 
+    @Given("a workspace-scoped admin product caller")
+    public void aWorkspaceScopedAdminProductCaller() {
+        caller = jwt().jwt(jwt -> jwt
+                        .subject("admin-123")
+                        .claim("aud", List.of("weave-app"))
+                        .claim("realm_access", Map.of("roles", List.of("admin"))))
+                .authorities(
+                        new SimpleGrantedAuthority("SCOPE_weave:workspace"),
+                        new SimpleGrantedAuthority("ROLE_ADMIN"));
+    }
+
     @When("the product app requests provider readiness through Weave")
     public void theProductAppRequestsProviderReadinessThroughWeave() throws Exception {
         perform(get("/api/providers/status"));

--- a/server/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
@@ -5,15 +5,21 @@ import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
 import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.ContextAuthorizationProperties;
 import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.context.authz.ContextAuthorizationDecision;
 import com.massimotter.weave.backend.context.authz.ContextAuthorizationPort;
 import com.massimotter.weave.backend.exception.ApiExceptionHandler;
 import com.massimotter.weave.backend.service.CalendarFacadeService;
 import com.massimotter.weave.backend.service.FilesFacadeService;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
@@ -42,10 +48,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         ApiErrorResponseWriter.class,
         ApiExceptionHandler.class,
         FilesFacadeService.class,
-        CalendarFacadeService.class
+        CalendarFacadeService.class,
+        WorkspaceCapabilityService.class
+})
+@EnableConfigurationProperties({
+        WeaveSecurityProperties.class,
+        WeaverRuntimeProperties.class,
+        WorkspaceCapabilityProperties.class,
+        OAuth2ResourceServerProperties.class
 })
 @TestPropertySource(properties = {
-        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave"
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
+        "weave.security.client-id=weave-app",
+        "weave.security.required-audience=weave-app"
 })
 class FilesCalendarFacadeControllerTest {
 
@@ -181,6 +196,30 @@ class FilesCalendarFacadeControllerTest {
     }
 
     @Test
+    void calendarCreateIsDeniedByCapabilityPolicyBeforeProviderAccess() throws Exception {
+        String event = """
+                {
+                  "title": "Planning",
+                  "startsAt": "2026-04-26T10:00:00+02:00",
+                  "endsAt": "2026-04-26T11:00:00+02:00",
+                  "timezone": "Europe/Berlin"
+                }
+                """;
+
+        mockMvc.perform(post("/api/calendar/events")
+                        .with(memberJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(event))
+                .andExpect(status().isForbidden())
+                .andExpect(header().exists("X-Request-Id"))
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.module").value("calendar"))
+                .andExpect(jsonPath("$.details.operation").value("create-event"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("calendar.manage_events"))
+                .andExpect(jsonPath("$.details.policyState").value("policy_blocked"));
+    }
+
+    @Test
     void calendarFacadeFailsClosedWhenContextAuthorizationDeniesAccess() throws Exception {
         when(contextAuthorizationPort.check(any()))
                 .thenReturn(ContextAuthorizationDecision.deny("no matching context membership"));
@@ -288,7 +327,19 @@ class FilesCalendarFacadeControllerTest {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
                         .claim("aud", java.util.List.of("weave-app"))
-                        .claim("weave_tenant_id", "tenant-default"))
+                        .claim("weave_tenant_id", "tenant-default")
+                .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                .claim("groups", java.util.List.of("weave-calendar-editors")))
+                .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
+    }
+
+    private org.springframework.test.web.servlet.request.RequestPostProcessor memberJwt() {
+        return jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("aud", java.util.List.of("weave-app"))
+                        .claim("weave_tenant_id", "tenant-default")
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                        .claim("groups", java.util.List.of()))
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
@@ -7,8 +7,15 @@ import com.massimotter.weave.backend.config.DevopsProviderConfiguration;
 import com.massimotter.weave.backend.config.ProviderCoreConfiguration;
 import com.massimotter.weave.backend.config.SecurityConfig;
 import com.massimotter.weave.backend.exception.ApiExceptionHandler;
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
 import com.massimotter.weave.backend.office.port.DisabledOfficeProvider;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
@@ -23,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -53,11 +61,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 class ProviderRegistryControllerTest {
 
+    // V01_ADMIN_HEALTH_POLICY_ENFORCEMENT
+
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private JwtDecoder jwtDecoder;
+
+    @MockBean
+    private WorkspaceCapabilityService workspaceCapabilityService;
+
+    @BeforeEach
+    void setUpWorkspaceCapabilitySnapshot() {
+        when(workspaceCapabilityService.snapshot()).thenReturn(new WorkspaceCapabilitiesResponse(
+                capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Weave SSO shell access is available."),
+                capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Chat is available through Weave."),
+                capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Files are available through Weave."),
+                capability(WorkspaceCapabilityReadiness.DEGRADED, WorkspaceCapabilityPolicyState.ALLOWED, "Calendar is degraded. Ask an admin to inspect Workspace Health."),
+                capability(WorkspaceCapabilityReadiness.BLOCKED, WorkspaceCapabilityPolicyState.POLICY_BLOCKED, "Boards/tasks are blocked by your role or group policy."),
+                capability(WorkspaceCapabilityReadiness.UNAVAILABLE, WorkspaceCapabilityPolicyState.DISABLED, "Weaver is disabled by workspace policy.")));
+    }
 
     @Test
     void providerStatusRequiresWorkspaceScope() throws Exception {
@@ -67,12 +91,28 @@ class ProviderRegistryControllerTest {
     }
 
     @Test
+    void providerStatusRejectsMembers() throws Exception {
+        mockMvc.perform(get("/api/providers/status").with(memberJwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void providerStatusReportsAllFacadeSeamsWithoutSecrets() throws Exception {
-        mockMvc.perform(get("/api/providers/status").with(workspaceJwt()))
+        mockMvc.perform(get("/api/providers/status").with(adminJwt()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.backendOwnedFacades").value(true))
                 .andExpect(jsonPath("$.flutterDirectProviderCallsAllowed").value(false))
                 .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.categories[*].category", hasItems(
+                        "identity-idm", "chat", "files", "calendar", "boards-tasks", "meetings-calls", "documents-collaboration", "weaver")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'identity-idm')].readiness", hasItems("ready")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'calendar')].readiness", hasItems("degraded")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'boards-tasks')].readiness", hasItems("policy_blocked")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'meetings-calls')].readiness", hasItems("misconfigured")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'documents-collaboration')].readiness", hasItems("disabled")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'weaver')].readiness", hasItems("disabled")))
+                .andExpect(jsonPath("$.categories[*].diagnostics.secretsReturned", hasItems(false)))
+                .andExpect(jsonPath("$.categories[*].diagnostics.rawProviderErrorsReturned", hasItems(false)))
                 .andExpect(jsonPath("$.providers[*].module", hasItems(
                         "identity-realm", "matrix", "matrix-auth", "files", "office", "calendar", "contacts", "forms", "boards",
                         "meetings", "source-control", "ci", "issue-tracker", "release")))
@@ -101,10 +141,34 @@ class ProviderRegistryControllerTest {
                 .andExpect(content().string(not(containsString("Authorization: Bearer"))));
     }
 
-    private org.springframework.test.web.servlet.request.RequestPostProcessor workspaceJwt() {
+    private WorkspaceCapabilityStatusResponse capability(
+            WorkspaceCapabilityReadiness readiness,
+            WorkspaceCapabilityPolicyState policyState,
+            String impact) {
+        return new WorkspaceCapabilityStatusResponse(
+                policyState != WorkspaceCapabilityPolicyState.DISABLED,
+                readiness,
+                policyState,
+                "test-profile",
+                impact,
+                List.of("test.capability"));
+    }
+
+    private org.springframework.test.web.servlet.request.RequestPostProcessor adminJwt() {
+        return jwt().jwt(jwt -> jwt
+                        .subject("admin-123")
+                        .claim("aud", java.util.List.of("weave-app"))
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("admin"))))
+                .authorities(
+                        new SimpleGrantedAuthority("SCOPE_weave:workspace"),
+                        new SimpleGrantedAuthority("ROLE_ADMIN"));
+    }
+
+    private org.springframework.test.web.servlet.request.RequestPostProcessor memberJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
-                        .claim("aud", java.util.List.of("weave-app")))
+                        .claim("aud", java.util.List.of("weave-app"))
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member"))))
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -2,6 +2,7 @@ package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import java.util.List;
@@ -11,6 +12,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2Res
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class WorkspaceCapabilityServiceTest {
 
@@ -136,6 +138,36 @@ class WorkspaceCapabilityServiceTest {
         assertThat(policy.denyByDefault()).isTrue();
         assertThat(policy.supportSafe()).isTrue();
         assertThat(policy.weaverRuntimePosture()).contains("disabled-by-default");
+    }
+
+    @Test
+    void requireCapabilityFailsClosedForUnmappedMemberActions() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.weave.local/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+
+        assertThatThrownBy(() -> service.requireCapability(
+                jwt(List.of("member"), List.of()),
+                "calendar.manage_events",
+                "calendar",
+                "create-event"))
+                .isInstanceOfSatisfying(ApiErrorException.class,
+                        exception -> assertThat(exception.code()).isEqualTo("capability-policy-blocked"));
+    }
+
+    @Test
+    void requireCapabilityAllowsExplicitGroupGrants() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.weave.local/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+
+        service.requireCapability(
+                jwt(List.of("member"), List.of("weave-calendar-editors")),
+                "calendar.manage_events",
+                "calendar",
+                "create-event");
     }
 
     @Test

--- a/server/src/test/resources/features/provider-stack-readiness.feature
+++ b/server/src/test/resources/features/provider-stack-readiness.feature
@@ -4,7 +4,7 @@ Feature: Provider stack readiness is backend-owned and fail-closed
   and closed by default when optional provider runtimes are disabled or unconfigured.
 
   Background:
-    Given a workspace-scoped product caller
+    Given a workspace-scoped admin product caller
 
   @backend-provider-registry-visible
   Scenario: Provider registry exposes support-safe backend facade readiness


### PR DESCRIPTION
## Summary\n- add admin/operator provider category readiness at /api/providers/status with support-safe diagnostics\n- surface provider category readiness in admin settings and parse category snapshots client-side\n- enforce deny-by-default calendar write capability policy before provider access\n- add v0.1 acceptance mapping and executable server/client contract coverage\n\n## Validation\n- make acceptance-contract\n- flutter test test/features/settings/settings_screen_test.dart test/integrations/weave_api/data/services/weave_api_client_test.dart\n- cd server && ./gradlew test\n- make ci\n- git diff --check\n\nCloses #272