### PR TITLE
feat(server): add admin control plane APIs

### DIFF
--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -41,6 +41,7 @@ void main() {
         'A user board write is authorized and audited',
         'A meeting capsule keeps work connected',
         'Decisions are captured as product records',
+        'Server control plane owns provider policy and audit',
         'Operators can deploy, verify, back up, restore, and diagnose safely',
       ]),
     );

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -46,6 +46,15 @@ Feature: Weave v0.1 dogfood production release
     And member API writes are denied when IDM capability policy does not grant the required category capability
     And Weaver remains disabled by default unless governed organization policy explicitly enables it
 
+  @weave-v01-org-control-plane-provider-facade
+  Scenario: Server control plane owns provider policy and audit
+    Given an owner or admin opens the Organization/Admin Console
+    When provider status, policy whitelists, readiness tests, and audit events are requested
+    Then the server returns a support-safe control-plane contract with category readiness and SecretRefs only
+    And members cannot call admin control-plane APIs directly
+    And provider readiness tests and policy changes produce redacted audit events
+    And the member client still receives only effective capability states without raw provider configuration
+
   @weave-v01-idm-rbac-capability-policy
   Scenario: IDM roles and groups decide capability profiles before Weaver runtime
     Given an owner has selected an IDM provider for the organization

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -284,6 +284,45 @@
       ]
     },
     {
+      "tag": "@weave-v01-org-control-plane-provider-facade",
+      "scenario": "Server control plane owns provider policy and audit",
+      "feature": "e2e/features/v0_1_dogfood_release.feature",
+      "executableTest": "server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java",
+      "evidenceMarkers": [
+        "V01_ORG_CONTROL_PLANE_PROVIDER_FACADE"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java",
+          "fragments": [
+            "adminControlPlaneRejectsMembers",
+            "adminControlPlaneOverviewIsSupportSafeAndProviderNeutral",
+            "adminReadinessTestsAndPolicyUpdatesAreAuditedAndRedacted",
+            "secretRefs",
+            "rawSecretExposed"
+          ]
+        },
+        {
+          "path": "server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java",
+          "fragments": [
+            "/api/admin/control-plane",
+            "/api/admin/policies/capability-whitelist",
+            "/api/admin/providers/readiness-tests",
+            "/api/admin/audit/events"
+          ]
+        },
+        {
+          "path": "server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java",
+          "fragments": [
+            "denyByDefault",
+            "secretref://weave/provider/",
+            "AuditAction.PROVIDER_READINESS_TESTED",
+            "AuditAction.ADMIN_POLICY_UPDATED"
+          ]
+        }
+      ]
+    },
+    {
       "tag": "@weave-v01-idm-rbac-capability-policy",
       "scenario": "IDM roles and groups decide capability profiles before Weaver runtime",
       "feature": "e2e/features/v0_1_dogfood_release.feature",

--- a/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
+++ b/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
@@ -8,6 +8,8 @@ public enum AuditAction {
     BOARD_TASK_COMPLETED("board.task.completed"),
     CONSENT_GRANTED("consent.granted"),
     CONSENT_REVOKED("consent.revoked"),
+    ADMIN_POLICY_UPDATED("admin.policy.updated"),
+    PROVIDER_READINESS_TESTED("provider.readiness.tested"),
     WEAVER_RUNTIME_PROFILE_GENERATED("weaver.runtime_profile.generated"),
     TASK_CREATED("task.created"),
     TASK_MOVED("task.moved"),

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -1,0 +1,89 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.model.ApiErrorResponse;
+import com.massimotter.weave.backend.model.admin.AdminAuditEventResponse;
+import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
+import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
+import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
+import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
+import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
+import com.massimotter.weave.backend.service.AdminControlPlaneService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Admin control plane", description = "Organization/Admin Console APIs for provider policy, readiness, SecretRefs, and audit.")
+@SecurityRequirement(name = "bearer-jwt")
+@PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+@ApiResponses({
+        @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
+                content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or is not an owner/admin/operator.",
+                content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
+})
+public class AdminControlPlaneController {
+
+    private final AdminControlPlaneService adminControlPlaneService;
+
+    public AdminControlPlaneController(AdminControlPlaneService adminControlPlaneService) {
+        this.adminControlPlaneService = adminControlPlaneService;
+    }
+
+    @GetMapping({"/api/admin/control-plane", "/api/v1/admin/control-plane"})
+    @Operation(summary = "Read the support-safe organization control-plane overview")
+    @ApiResponse(responseCode = "200", description = "Admin control-plane snapshot.",
+            content = @Content(schema = @Schema(implementation = AdminControlPlaneResponse.class)))
+    public AdminControlPlaneResponse overview(@AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.overview(jwt);
+    }
+
+    @GetMapping({"/api/admin/policies/capability-whitelist", "/api/v1/admin/policies/capability-whitelist"})
+    @Operation(summary = "Read deny-by-default capability whitelist policy")
+    @ApiResponse(responseCode = "200", description = "Capability whitelist snapshot.",
+            content = @Content(schema = @Schema(implementation = CapabilityWhitelistResponse.class)))
+    public CapabilityWhitelistResponse whitelist(@AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.whitelist(jwt);
+    }
+
+    @PatchMapping({"/api/admin/policies/capability-whitelist", "/api/v1/admin/policies/capability-whitelist"})
+    @Operation(summary = "Record a support-safe capability whitelist policy update")
+    @ApiResponse(responseCode = "200", description = "Updated capability whitelist snapshot.",
+            content = @Content(schema = @Schema(implementation = CapabilityWhitelistResponse.class)))
+    public CapabilityWhitelistResponse updateWhitelist(
+            @Valid @RequestBody CapabilityWhitelistUpdateRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.updateWhitelist(request, jwt);
+    }
+
+    @PostMapping({"/api/admin/providers/readiness-tests", "/api/v1/admin/providers/readiness-tests"})
+    @Operation(summary = "Run a backend-owned support-safe provider readiness test contract")
+    @ApiResponse(responseCode = "200", description = "Support-safe provider readiness test result.",
+            content = @Content(schema = @Schema(implementation = ProviderReadinessTestResponse.class)))
+    public ProviderReadinessTestResponse testProviderReadiness(
+            @Valid @RequestBody ProviderReadinessTestRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.testProviderReadiness(request, jwt);
+    }
+
+    @GetMapping({"/api/admin/audit/events", "/api/v1/admin/audit/events"})
+    @Operation(summary = "Read support-safe admin/provider audit events")
+    @ApiResponse(responseCode = "200", description = "Audit event list.")
+    public List<AdminAuditEventResponse> auditEvents() {
+        return adminControlPlaneService.auditEvents();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminAuditEventResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminAuditEventResponse.java
@@ -1,0 +1,20 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.Map;
+
+@Schema(description = "Support-safe admin audit event view.")
+public record AdminAuditEventResponse(
+        String tenantId,
+        String actorRef,
+        String sourceRef,
+        String action,
+        Instant occurredAt,
+        String idempotencyKey,
+        String redactionLevel,
+        Map<String, Object> payload) {
+    public AdminAuditEventResponse {
+        payload = payload == null ? Map.of() : Map.copyOf(payload);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
@@ -1,0 +1,29 @@
+package com.massimotter.weave.backend.model.admin;
+
+import com.massimotter.weave.backend.provider.ProviderCategoryStatusResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Organization/Admin Console control-plane snapshot served only by backend APIs.")
+public record AdminControlPlaneResponse(
+        String contractVersion,
+        String organizationId,
+        String displayName,
+        String recommendedIdentityBroker,
+        boolean backendOwnedFacades,
+        boolean denyByDefaultPolicy,
+        boolean supportSafe,
+        boolean memberClientMayConfigureProviders,
+        Instant generatedAt,
+        List<ProviderCategoryStatusResponse> categories,
+        CapabilityWhitelistResponse whitelist,
+        List<SecretRefResponse> secretRefs,
+        Map<String, String> adminApiRoutes) {
+    public AdminControlPlaneResponse {
+        categories = categories == null ? List.of() : List.copyOf(categories);
+        secretRefs = secretRefs == null ? List.of() : List.copyOf(secretRefs);
+        adminApiRoutes = adminApiRoutes == null ? Map.of() : Map.copyOf(adminApiRoutes);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/CapabilityWhitelistResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/CapabilityWhitelistResponse.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Admin-owned deny-by-default category capability whitelist snapshot.")
+public record CapabilityWhitelistResponse(
+        boolean denyByDefault,
+        boolean normalMembersMayAuthorPolicy,
+        List<String> stableMemberImpactStates,
+        Map<String, List<String>> profileCapabilities,
+        List<String> selectedProfileKeys,
+        List<String> effectiveCapabilities,
+        String sourceOfTruth) {
+    public CapabilityWhitelistResponse {
+        stableMemberImpactStates = stableMemberImpactStates == null ? List.of() : List.copyOf(stableMemberImpactStates);
+        profileCapabilities = profileCapabilities == null ? Map.of() : Map.copyOf(profileCapabilities);
+        selectedProfileKeys = selectedProfileKeys == null ? List.of() : List.copyOf(selectedProfileKeys);
+        effectiveCapabilities = effectiveCapabilities == null ? List.of() : List.copyOf(effectiveCapabilities);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/CapabilityWhitelistUpdateRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/CapabilityWhitelistUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+@Schema(description = "Contract request for admin-owned capability whitelist/profile updates.")
+public record CapabilityWhitelistUpdateRequest(
+        @NotBlank
+        @Schema(example = "workspace-admin")
+        String profileKey,
+        @Schema(example = "chat.read")
+        List<String> capabilityKeys,
+        @Schema(description = "Support-safe reason recorded in audit, without raw provider diagnostics or secrets.")
+        String reason) {
+    public CapabilityWhitelistUpdateRequest {
+        capabilityKeys = capabilityKeys == null ? List.of() : List.copyOf(capabilityKeys);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReadinessTestRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReadinessTestRequest.java
@@ -1,0 +1,15 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Admin request to exercise a support-safe provider readiness contract.")
+public record ProviderReadinessTestRequest(
+        @NotBlank
+        @Schema(example = "keycloak-realm")
+        String providerKey,
+        @Schema(example = "readiness")
+        String testKind,
+        @Schema(description = "Optional SecretRef id. Raw secret values are forbidden and ignored/redacted by the server.")
+        String secretRef) {
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReadinessTestResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReadinessTestResponse.java
@@ -1,0 +1,18 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+@Schema(description = "Support-safe provider readiness test result.")
+public record ProviderReadinessTestResponse(
+        String providerKey,
+        String state,
+        String readiness,
+        boolean auditEventPublished,
+        boolean supportSafe,
+        boolean rawSecretExposed,
+        Map<String, Object> diagnostics) {
+    public ProviderReadinessTestResponse {
+        diagnostics = diagnostics == null ? Map.of() : Map.copyOf(diagnostics);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/SecretRefResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/SecretRefResponse.java
@@ -1,0 +1,17 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Support-safe reference to a provider secret. Never contains the raw secret value.")
+public record SecretRefResponse(
+        @Schema(example = "secretref://weave/provider/keycloak-client-secret")
+        String ref,
+        @Schema(example = "keycloak-realm")
+        String providerKey,
+        @Schema(example = "oidc-client-secret")
+        String purpose,
+        boolean configured,
+        boolean rotationRequired,
+        boolean supportSafe,
+        boolean rawSecretExposed) {
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -1,0 +1,281 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.AuditEvent;
+import com.massimotter.weave.backend.audit.AuditEventPublisher;
+import com.massimotter.weave.backend.audit.AuditRedactionLevel;
+import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
+import com.massimotter.weave.backend.model.admin.AdminAuditEventResponse;
+import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
+import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
+import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
+import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
+import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
+import com.massimotter.weave.backend.model.admin.SecretRefResponse;
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
+import com.massimotter.weave.backend.provider.ProviderStatusResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminControlPlaneService {
+
+    private static final List<String> STABLE_MEMBER_IMPACT_STATES = List.of(
+            "ready",
+            "disabled",
+            "degraded",
+            "policy-blocked");
+
+    private final ProviderRegistry providerRegistry;
+    private final WorkspaceCapabilityService workspaceCapabilityService;
+    private final AuditEventPublisher auditEventPublisher;
+    private final Clock clock;
+
+    @Autowired
+    public AdminControlPlaneService(
+            ProviderRegistry providerRegistry,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            AuditEventPublisher auditEventPublisher) {
+        this(providerRegistry, workspaceCapabilityService, auditEventPublisher, Clock.systemUTC());
+    }
+
+    AdminControlPlaneService(
+            ProviderRegistry providerRegistry,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            AuditEventPublisher auditEventPublisher,
+            Clock clock) {
+        this.providerRegistry = providerRegistry;
+        this.workspaceCapabilityService = workspaceCapabilityService;
+        this.auditEventPublisher = auditEventPublisher;
+        this.clock = clock;
+    }
+
+    public AdminControlPlaneResponse overview(Jwt jwt) {
+        ProviderRegistryResponse registry = providerRegistry.status();
+        return new AdminControlPlaneResponse(
+                "admin-control-plane-v1",
+                organizationId(jwt),
+                organizationName(jwt),
+                "keycloak",
+                registry.backendOwnedFacades(),
+                true,
+                registry.supportSafe(),
+                false,
+                Instant.now(clock),
+                registry.categories(),
+                whitelist(jwt),
+                secretRefs(registry),
+                Map.of(
+                        "providers", "/api/providers/status",
+                        "policy", "/api/admin/policies/capability-whitelist",
+                        "audit", "/api/admin/audit/events",
+                        "readinessTest", "/api/admin/providers/readiness-tests"));
+    }
+
+    public CapabilityWhitelistResponse whitelist(Jwt jwt) {
+        WorkspaceCapabilityPolicyResponse policy = workspaceCapabilityService.policySnapshot(jwt);
+        Map<String, List<String>> profileCapabilities = new LinkedHashMap<>();
+        profileCapabilities.put("workspace-admin", List.of(
+                "chat.read", "chat.send", "files.read", "files.upload", "calendar.read", "calendar.manage_events",
+                "boards.read", "boards.update_task", "weaver.exec_disabled"));
+        profileCapabilities.put("member-default", List.of(
+                "chat.read", "chat.send", "files.read", "files.upload", "calendar.read", "boards.read", "weaver.exec_disabled"));
+        profileCapabilities.put("guest-deny-default", List.of());
+        profileCapabilities.put("group:weave-weaver-pilot", List.of("weaver.files_read", "weaver.exec_disabled"));
+        return new CapabilityWhitelistResponse(
+                policy.denyByDefault(),
+                false,
+                STABLE_MEMBER_IMPACT_STATES,
+                profileCapabilities,
+                policy.profileKeys(),
+                policy.grantedCapabilities(),
+                "backend-control-plane");
+    }
+
+    public CapabilityWhitelistResponse updateWhitelist(CapabilityWhitelistUpdateRequest request, Jwt jwt) {
+        if (request == null || request.profileKey() == null || request.profileKey().isBlank()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "capability-whitelist-invalid",
+                    "Capability whitelist update requires a profile key.",
+                    Map.of("reason", "profileKey is required"));
+        }
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef(jwt),
+                "organization-admin-console",
+                AuditAction.ADMIN_POLICY_UPDATED,
+                Instant.now(clock),
+                "admin-policy-" + Instant.now(clock).toEpochMilli(),
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.of(
+                        "profileKey", request.profileKey().trim(),
+                        "capabilityKeys", safeCapabilities(request.capabilityKeys()),
+                        "reason", safeText(request.reason()),
+                        "denyByDefault", true,
+                        "rawProviderError", "redacted before audit",
+                        "token", "not-stored")));
+        return whitelist(jwt);
+    }
+
+    public ProviderReadinessTestResponse testProviderReadiness(ProviderReadinessTestRequest request, Jwt jwt) {
+        if (request == null || request.providerKey() == null || request.providerKey().isBlank()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-readiness-test-invalid",
+                    "Provider readiness test requires a provider key.",
+                    Map.of("reason", "providerKey is required"));
+        }
+        String providerKey = request.providerKey().trim();
+        ProviderStatusResponse status = providerRegistry.status().providers().stream()
+                .filter(provider -> provider.providerKey().equals(providerKey))
+                .findFirst()
+                .orElseThrow(() -> new ApiErrorException(
+                        HttpStatus.NOT_FOUND,
+                        "provider-not-found",
+                        "Provider key is not registered in the backend control plane.",
+                        Map.of("providerKey", providerKey)));
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef(jwt),
+                "provider-readiness-test",
+                AuditAction.PROVIDER_READINESS_TESTED,
+                Instant.now(clock),
+                "provider-test-" + providerKey + "-" + Instant.now(clock).toEpochMilli(),
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.of(
+                        "providerKey", providerKey,
+                        "module", status.module().contractName(),
+                        "testKind", safeText(request.testKind()),
+                        "secretRef", safeSecretRef(request.secretRef()),
+                        "state", status.state().contractName(),
+                        "readiness", status.readiness(),
+                        "supportSafe", status.supportSafe(),
+                        "apiSecret", "not-stored")));
+        return new ProviderReadinessTestResponse(
+                providerKey,
+                status.state().contractName(),
+                status.readiness(),
+                true,
+                true,
+                false,
+                Map.of(
+                        "providerKey", providerKey,
+                        "module", status.module().contractName(),
+                        "configured", status.configured(),
+                        "secretsReturned", false,
+                        "rawProviderErrorsReturned", false,
+                        "secretRef", safeSecretRef(request.secretRef())));
+    }
+
+    public List<AdminAuditEventResponse> auditEvents() {
+        if (auditEventPublisher instanceof InMemoryAuditEventPublisher memoryAudit) {
+            return memoryAudit.events().stream()
+                    .map(event -> new AdminAuditEventResponse(
+                            event.tenantId(),
+                            event.actorRef(),
+                            event.sourceRef(),
+                            event.action().wireName(),
+                            event.occurredAt(),
+                            event.idempotencyKey(),
+                            event.redactionLevel().name().toLowerCase(Locale.ROOT),
+                            event.payload()))
+                    .toList();
+        }
+        return List.of();
+    }
+
+    private List<SecretRefResponse> secretRefs(ProviderRegistryResponse registry) {
+        return registry.providers().stream()
+                .filter(provider -> provider.supportSafeErrorCodes().stream().anyMatch(code -> code.contains("not-configured"))
+                        || provider.diagnostics().keySet().stream().anyMatch(key -> key.toLowerCase(Locale.ROOT).contains("secret")
+                        || key.toLowerCase(Locale.ROOT).contains("token")
+                        || key.toLowerCase(Locale.ROOT).contains("key")))
+                .map(provider -> new SecretRefResponse(
+                        "secretref://weave/provider/" + provider.providerKey(),
+                        provider.providerKey(),
+                        provider.module().contractName() + " backend credential",
+                        provider.configured(),
+                        false,
+                        true,
+                        false))
+                .toList();
+    }
+
+    private List<String> safeCapabilities(List<String> capabilities) {
+        if (capabilities == null) {
+            return List.of();
+        }
+        return capabilities.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .filter(value -> value.matches("[a-z][a-z0-9_.-]*"))
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private String safeSecretRef(String value) {
+        if (value == null || value.isBlank()) {
+            return "not-provided";
+        }
+        String trimmed = value.trim();
+        if (trimmed.toLowerCase(Locale.ROOT).startsWith("secretref://")) {
+            return trimmed;
+        }
+        return "invalid-secret-ref-redacted";
+    }
+
+    private String safeText(String value) {
+        if (value == null || value.isBlank()) {
+            return "not-provided";
+        }
+        return value.trim().replaceAll("(?i)bearer\\s+[^\\s]+", "Bearer [redacted]");
+    }
+
+    private String organizationId(Jwt jwt) {
+        return claim(jwt, "weave_tenant")
+                .or(() -> claim(jwt, "tenant"))
+                .or(() -> claim(jwt, "tid"))
+                .orElse("weave-dogfood");
+    }
+
+    private String organizationName(Jwt jwt) {
+        return claim(jwt, "weave_organization_name")
+                .or(() -> claim(jwt, "organization_name"))
+                .or(() -> claim(jwt, "org_name"))
+                .orElse("Weave Dogfood");
+    }
+
+    private String actorRef(Jwt jwt) {
+        if (jwt == null || jwt.getSubject() == null || jwt.getSubject().isBlank()) {
+            return "actor:system";
+        }
+        return "user:" + jwt.getSubject();
+    }
+
+    private Optional<String> claim(Jwt jwt, String claimName) {
+        if (jwt == null) {
+            return Optional.empty();
+        }
+        Object raw = jwt.getClaims().get(claimName);
+        if (raw instanceof String value && !value.isBlank()) {
+            return Optional.of(value.trim());
+        }
+        return Optional.empty();
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -1,0 +1,207 @@
+package com.massimotter.weave.backend.controller;
+
+import com.massimotter.weave.backend.audit.AuditEventPublisher;
+import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
+import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
+import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
+import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
+import com.massimotter.weave.backend.config.DevopsProviderConfiguration;
+import com.massimotter.weave.backend.config.ProviderCoreConfiguration;
+import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.exception.ApiExceptionHandler;
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import com.massimotter.weave.backend.office.port.DisabledOfficeProvider;
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.service.AdminControlPlaneService;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = AdminControlPlaneController.class,
+        excludeAutoConfiguration = OAuth2ResourceServerAutoConfiguration.class)
+@Import({
+        SecurityConfig.class,
+        ApiAuthenticationEntryPoint.class,
+        ApiAccessDeniedHandler.class,
+        ApiErrorResponseWriter.class,
+        ApiExceptionHandler.class,
+        ProviderRegistry.class,
+        ProviderCoreConfiguration.class,
+        DevopsProviderConfiguration.class,
+        DisabledOfficeProvider.class,
+        AdminControlPlaneService.class,
+        AdminControlPlaneControllerTest.AuditTestConfig.class
+})
+@TestPropertySource(properties = {
+        "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
+        "weave.meetings.livekit.enabled=true",
+        "weave.meetings.livekit.api-key=server-test-key-that-must-never-appear",
+        "weave.meetings.livekit.api-secret=server-test-secret-that-must-never-appear"
+})
+class AdminControlPlaneControllerTest {
+
+    // V01_ORG_CONTROL_PLANE_PROVIDER_FACADE
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JwtDecoder jwtDecoder;
+
+    @MockBean
+    private WorkspaceCapabilityService workspaceCapabilityService;
+
+    @BeforeEach
+    void setUpWorkspaceCapabilitySnapshot() {
+        WorkspaceCapabilitiesResponse capabilities = new WorkspaceCapabilitiesResponse(
+                capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "SSO ready."),
+                capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Chat ready."),
+                capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Files ready."),
+                capability(WorkspaceCapabilityReadiness.DEGRADED, WorkspaceCapabilityPolicyState.ALLOWED, "Calendar degraded."),
+                capability(WorkspaceCapabilityReadiness.BLOCKED, WorkspaceCapabilityPolicyState.POLICY_BLOCKED, "Boards blocked."),
+                capability(WorkspaceCapabilityReadiness.UNAVAILABLE, WorkspaceCapabilityPolicyState.DISABLED, "Weaver disabled."));
+        when(workspaceCapabilityService.snapshot()).thenReturn(capabilities);
+        when(workspaceCapabilityService.policySnapshot(org.mockito.ArgumentMatchers.any())).thenReturn(new WorkspaceCapabilityPolicyResponse(
+                "identity/IDM",
+                "Keycloak",
+                "OIDC/SAML adapter contract; Keycloak is the self-hosted default, not a product lock-in",
+                "JWT realm roles plus groups claims from the selected IDM",
+                List.of("admin"),
+                List.of("weave-board-editors"),
+                List.of("workspace-admin", "group:weave-board-editors"),
+                List.of("chat.read", "files.read", "boards.update_task", "weaver.exec_disabled"),
+                true,
+                true,
+                "disabled-by-default; per-user Dockerized Weaver runtime may only be generated from org policy later"));
+    }
+
+    @Test
+    void adminControlPlaneRejectsMembers() throws Exception {
+        mockMvc.perform(get("/api/admin/control-plane").with(memberJwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void adminControlPlaneOverviewIsSupportSafeAndProviderNeutral() throws Exception {
+        mockMvc.perform(get("/api/admin/control-plane").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.contractVersion").value("admin-control-plane-v1"))
+                .andExpect(jsonPath("$.organizationId").value("weave-dogfood"))
+                .andExpect(jsonPath("$.recommendedIdentityBroker").value("keycloak"))
+                .andExpect(jsonPath("$.backendOwnedFacades").value(true))
+                .andExpect(jsonPath("$.denyByDefaultPolicy").value(true))
+                .andExpect(jsonPath("$.memberClientMayConfigureProviders").value(false))
+                .andExpect(jsonPath("$.categories[*].category", hasItems(
+                        "identity-idm", "chat", "files", "calendar", "boards-tasks", "meetings-calls", "documents-collaboration", "weaver")))
+                .andExpect(jsonPath("$.whitelist.denyByDefault").value(true))
+                .andExpect(jsonPath("$.whitelist.normalMembersMayAuthorPolicy").value(false))
+                .andExpect(jsonPath("$.whitelist.stableMemberImpactStates[*]", hasItems("ready", "disabled", "degraded", "policy-blocked")))
+                .andExpect(jsonPath("$.whitelist.profileCapabilities['guest-deny-default']").isArray())
+                .andExpect(jsonPath("$.secretRefs[*].supportSafe", hasItems(true)))
+                .andExpect(jsonPath("$.secretRefs[*].rawSecretExposed", hasItems(false)))
+                .andExpect(jsonPath("$.adminApiRoutes.policy").value("/api/admin/policies/capability-whitelist"))
+                .andExpect(content().string(not(containsString("server-test-secret-that-must-never-appear"))))
+                .andExpect(content().string(not(containsString("Authorization: Bearer"))))
+                .andExpect(content().string(not(containsString("access_token"))));
+    }
+
+    @Test
+    void adminReadinessTestsAndPolicyUpdatesAreAuditedAndRedacted() throws Exception {
+        mockMvc.perform(post("/api/admin/providers/readiness-tests")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"providerKey\":\"livekit\",\"testKind\":\"readiness\",\"secretRef\":\"secretref://weave/provider/livekit\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.providerKey").value("livekit"))
+                .andExpect(jsonPath("$.auditEventPublished").value(true))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.rawSecretExposed").value(false))
+                .andExpect(jsonPath("$.diagnostics.secretsReturned").value(false));
+
+        mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"profileKey\":\"workspace-admin\",\"capabilityKeys\":[\"chat.read\",\"calendar.manage_events\"],\"reason\":\"grant through Admin Console\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.denyByDefault").value(true));
+
+        mockMvc.perform(get("/api/admin/audit/events").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].action", hasItems("provider.readiness.tested", "admin.policy.updated")))
+                .andExpect(jsonPath("$[*].payload.token", hasItems("[redacted]")))
+                .andExpect(jsonPath("$[*].payload.apiSecret", hasItems("[redacted]")))
+                .andExpect(jsonPath("$[*].payload.rawProviderError", hasItems("[redacted:provider-error]")))
+                .andExpect(content().string(not(containsString("server-test-secret-that-must-never-appear"))))
+                .andExpect(content().string(not(containsString("Bearer secret"))));
+    }
+
+    private WorkspaceCapabilityStatusResponse capability(
+            WorkspaceCapabilityReadiness readiness,
+            WorkspaceCapabilityPolicyState policyState,
+            String impact) {
+        return new WorkspaceCapabilityStatusResponse(
+                policyState != WorkspaceCapabilityPolicyState.DISABLED,
+                readiness,
+                policyState,
+                "test-profile",
+                impact,
+                List.of("test.capability"));
+    }
+
+    private org.springframework.test.web.servlet.request.RequestPostProcessor adminJwt() {
+        return jwt().jwt(jwt -> jwt
+                        .subject("admin-123")
+                        .claim("aud", java.util.List.of("weave-app"))
+                        .claim("weave_tenant", "weave-dogfood")
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("admin"))))
+                .authorities(
+                        new SimpleGrantedAuthority("SCOPE_weave:workspace"),
+                        new SimpleGrantedAuthority("ROLE_ADMIN"));
+    }
+
+    private org.springframework.test.web.servlet.request.RequestPostProcessor memberJwt() {
+        return jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("aud", java.util.List.of("weave-app"))
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member"))))
+                .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
+    }
+
+    @TestConfiguration
+    static class AuditTestConfig {
+        @Bean
+        AuditEventPublisher auditEventPublisher() {
+            return new InMemoryAuditEventPublisher();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- adds owner/admin/operator-only Admin Control Plane APIs for overview, capability whitelist, readiness-test contract, and redacted audit events
- represents provider secrets as support-safe SecretRefs and keeps member clients out of provider/admin configuration
- maps the server control-plane scenario into the acceptance contract

Fixes #275

## Acceptance / E2E mapping
- `@weave-v01-org-control-plane-provider-facade`
- marker `V01_ORG_CONTROL_PLANE_PROVIDER_FACADE`
- executable evidence: `server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java`

## Local gates
- `git diff --check`
- `make acceptance-contract`
- `make server-ci`

## Security notes
- admin endpoints require owner/admin/operator roles plus `weave:workspace`
- member tokens receive 403 on admin control-plane APIs
- readiness tests and policy updates emit redacted audit events; raw tokens/secrets/provider errors are not returned
