### PR TITLE
feat(infra): add control plane bootstrap profile

### DIFF
--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -42,6 +42,7 @@ void main() {
         'A meeting capsule keeps work connected',
         'Decisions are captured as product records',
         'Server control plane owns provider policy and audit',
+        'Infra bootstrap feeds the backend control plane safely',
         'Operators can deploy, verify, back up, restore, and diagnose safely',
       ]),
     );

--- a/docs/control-plane-infra-bootstrap.md
+++ b/docs/control-plane-infra-bootstrap.md
@@ -1,0 +1,27 @@
+# Control-plane infra bootstrap
+
+Weave's recommended self-hosted/default organization bootstrap is provider-neutral but ships with a sovereign default profile:
+
+- central Keycloak realm as the default identity broker and IDM foundation;
+- backend-owned provider registry, readiness, policy, audit, and SecretRef seams;
+- a separate Organization/Admin Console deploy target (`admin.<tenant-domain>`), not the member client;
+- optional external-provider placeholders for Microsoft-heavy or other existing organization stacks.
+
+## Generated artifacts
+
+- `infra/weave-workspace/keycloak/weave-dev-realm-contract.json` documents the expected dev/demo realm shape without raw secrets.
+- `infra/weave-workspace/provider-profiles/sovereign-default.json` maps recommended self-hosted provider categories into backend adapter keys and SecretRefs.
+- `infra/weave-workspace/provider-profiles/microsoft-hybrid-placeholder.json` records an external-provider adoption shape without enabling live credentials.
+
+## SecretRefs
+
+Profiles and support bundles may name `secretref://weave/provider/...` references. They must not contain raw client secrets, tokens, passwords, signing keys, JWT secrets, or provider error dumps.
+
+## Smoke contract
+
+`smoke-test.sh` and `operator-check.sh` verify:
+
+- Keycloak issuer discovery is reachable;
+- backend manifest/provider routes are reachable through Weave APIs;
+- `/admin/control-plane` rejects member tokens with `403`;
+- support-bundle public env output includes only no-secret admin/profile metadata.

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -102,6 +102,14 @@ Feature: Weave v0.1 dogfood production release
     Then Weave stores context, evidence, risks, open questions, and follow-up links
     And the decision is reachable from the channel, meeting, board task, and home view
 
+  @weave-v01-infra-control-plane-bootstrap
+  Scenario: Infra bootstrap feeds the backend control plane safely
+    Given an operator bootstraps the recommended sovereign default Weave stack
+    When Keycloak, provider profiles, admin console target metadata, and backend environment are generated
+    Then Keycloak is reachable as the central default identity broker
+    And the server manifest and provider registry are reachable through Weave backend APIs
+    And admin APIs reject member tokens while support bundles keep SecretRefs redacted
+
   @weave-v01-operator-release-path
   Scenario: Operators can deploy, verify, back up, restore, and diagnose safely
     Given an operator installs or updates a Weave stack

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -484,6 +484,31 @@
           ]
         }
       ]
+    },
+    {
+      "tag": "@weave-v01-infra-control-plane-bootstrap",
+      "scenario": "Infra bootstrap feeds the backend control plane safely",
+      "feature": "e2e/features/v0_1_dogfood_release.feature",
+      "executableTest": "infra/weave-workspace/tests/infra-product-contract-test.sh",
+      "evidenceMarkers": [
+        "V01_INFRA_CONTROL_PLANE_BOOTSTRAP"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "infra/weave-workspace/smoke-test.sh",
+          "fragments": [
+            "Checking admin API protection with a member token",
+            "/admin/control-plane"
+          ]
+        },
+        {
+          "path": "infra/weave-workspace/support-bundle.sh",
+          "fragments": [
+            "WEAVE_ADMIN_CONSOLE_URL",
+            "WEAVE_PROVIDER_PROFILE"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/infra/weave-workspace/.env.example
+++ b/infra/weave-workspace/.env.example
@@ -5,6 +5,7 @@ TF_VAR_tenant_domain=weave.local
 # TF_VAR_create_test_user=true
 TF_VAR_auth_subdomain=auth
 TF_VAR_api_subdomain=api
+TF_VAR_admin_subdomain=admin
 TF_VAR_nextcloud_subdomain=files
 TF_VAR_matrix_subdomain=matrix
 
@@ -31,6 +32,10 @@ TF_VAR_mas_host_port=48082
 TF_VAR_synapse_host_port=48008
 TF_VAR_nextcloud_host_port=48083
 TF_VAR_backend_host_port=48084
+# The separate React Organization/Admin Console is served by its own deploy target/profile;
+# member client builds must not use this as an admin portal.
+WEAVE_ADMIN_CONSOLE_URL=https://admin.weave.local:44443
+WEAVE_ADMIN_CONSOLE_OIDC_CLIENT_ID=weave-admin-console
 
 TF_VAR_nextcloud_trusted_proxies=172.16.0.0/12
 TF_VAR_api_upstream=weave-backend:8080

--- a/infra/weave-workspace/01-infrastructure/main.tf
+++ b/infra/weave-workspace/01-infrastructure/main.tf
@@ -36,6 +36,7 @@ locals {
   public_hosts = {
     weave  = var.tenant_domain
     api    = "${var.api_subdomain}.${var.tenant_domain}"
+    admin  = "${var.admin_subdomain}.${var.tenant_domain}"
     auth   = "${var.auth_subdomain}.${var.tenant_domain}"
     matrix = "${var.matrix_subdomain}.${var.tenant_domain}"
     files  = "${var.nextcloud_subdomain}.${var.tenant_domain}"
@@ -49,6 +50,7 @@ locals {
   site_hosts = {
     weave  = [local.public_hosts.weave]
     api    = [local.public_hosts.api]
+    admin  = [local.public_hosts.admin]
     auth   = [local.public_hosts.auth]
     matrix = [local.public_hosts.matrix]
     files  = [local.public_hosts.files]
@@ -78,6 +80,7 @@ locals {
   caddyfile_content = templatefile("${path.module}/templates/Caddyfile.tpl", {
     weave_site_addresses  = local.site_addresses.weave
     api_site_addresses    = local.site_addresses.api
+    admin_site_addresses  = local.site_addresses.admin
     auth_site_addresses   = local.site_addresses.auth
     files_site_addresses  = local.site_addresses.files
     matrix_site_addresses = local.site_addresses.matrix

--- a/infra/weave-workspace/01-infrastructure/templates/Caddyfile.tpl
+++ b/infra/weave-workspace/01-infrastructure/templates/Caddyfile.tpl
@@ -30,6 +30,14 @@ ${api_site_addresses} {
 	reverse_proxy ${api_upstream}
 }
 
+${admin_site_addresses} {
+	tls /certs/${tls_cert_filename} /certs/${tls_key_filename}
+	encode zstd gzip
+
+	header Content-Type text/plain
+	respond "Weave Organization/Admin Console deploy target. Build the React app from admin-console/ and configure it to call only the Weave backend admin APIs." 200
+}
+
 ${auth_site_addresses} {
 	tls /certs/${tls_cert_filename} /certs/${tls_key_filename}
 	encode zstd gzip

--- a/infra/weave-workspace/01-infrastructure/variables.tf
+++ b/infra/weave-workspace/01-infrastructure/variables.tf
@@ -56,6 +56,12 @@ variable "api_subdomain" {
   default     = "api"
 }
 
+variable "admin_subdomain" {
+  description = "Subdomain used for the separate Organization/Admin Console deploy target."
+  type        = string
+  default     = "admin"
+}
+
 variable "public_scheme" {
   description = "Public URL scheme for browser-facing services."
   type        = string

--- a/infra/weave-workspace/02-keycloak-setup/main.tf
+++ b/infra/weave-workspace/02-keycloak-setup/main.tf
@@ -26,6 +26,7 @@ locals {
   public_hosts = {
     weave  = var.tenant_domain
     api    = "${var.api_subdomain}.${var.tenant_domain}"
+    admin  = "${var.admin_subdomain}.${var.tenant_domain}"
     auth   = "${var.auth_subdomain}.${var.tenant_domain}"
     matrix = "${var.matrix_subdomain}.${var.tenant_domain}"
     files  = "${var.nextcloud_subdomain}.${var.tenant_domain}"
@@ -46,6 +47,7 @@ module "tenant_identity" {
   keycloak_public_url                     = local.public_urls.auth
   mas_public_url                          = local.public_urls.matrix
   nextcloud_public_url                    = local.public_urls.files
+  admin_console_public_url                = local.public_urls.admin
   matrix_mas_upstream_id                  = local.matrix_mas_upstream_id
   matrix_mas_client_secret                = var.matrix_mas_client_secret
   create_test_user                        = var.create_test_user

--- a/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/main.tf
+++ b/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/main.tf
@@ -33,17 +33,19 @@ locals {
   ]
 
   weave_product_roles = {
-    owner  = "Full local/dev workspace ownership for bootstrap operators."
-    admin  = "Workspace administration without owner bootstrap authority."
-    member = "Standard authenticated workspace member."
-    guest  = "Constrained guest identity for feature-flagged guest portal flows."
+    owner    = "Full local/dev workspace ownership for bootstrap operators."
+    admin    = "Workspace administration without owner bootstrap authority."
+    operator = "Operational readiness, backup/restore, and support-bundle authority without ownership transfer."
+    member   = "Standard authenticated workspace member."
+    guest    = "Constrained guest identity for feature-flagged guest portal flows."
   }
 
   weave_product_role_groups = {
-    owner  = "workspace-owners"
-    admin  = "workspace-admins"
-    member = "workspace-members"
-    guest  = "workspace-guests"
+    owner    = "workspace-owners"
+    admin    = "workspace-admins"
+    operator = "workspace-operators"
+    member   = "workspace-members"
+    guest    = "workspace-guests"
   }
 
   client_defaults = {
@@ -77,6 +79,25 @@ locals {
       name        = "weave-backend"
       client_id   = "weave-backend"
       access_type = "BEARER-ONLY"
+    })
+    weave_admin_console = merge(local.client_defaults, {
+      name                       = "weave-admin-console"
+      client_id                  = "weave-admin-console"
+      access_type                = "PUBLIC"
+      standard_flow_enabled      = true
+      pkce_code_challenge_method = "S256"
+      valid_redirect_uris = [
+        "${var.admin_console_public_url}/*",
+        "http://localhost:5173/*",
+      ]
+      valid_post_logout_redirect_uris = [
+        "${var.admin_console_public_url}/*",
+        "http://localhost:5173/*",
+      ]
+      web_origins = [
+        var.admin_console_public_url,
+        "http://localhost:5173",
+      ]
     })
     matrix_mas = merge(local.client_defaults, {
       name                  = "matrix-mas"
@@ -216,6 +237,18 @@ resource "keycloak_openid_hardcoded_claim_protocol_mapper" "weave_tenant_id" {
   add_to_userinfo     = true
 }
 
+resource "keycloak_openid_hardcoded_claim_protocol_mapper" "weave_organization_name" {
+  realm_id            = keycloak_realm.tenant.id
+  client_scope_id     = keycloak_openid_client_scope.weave_workspace.id
+  name                = "weave-organization-name"
+  claim_name          = "weave_organization_name"
+  claim_value         = "Weave Dogfood"
+  claim_value_type    = "String"
+  add_to_id_token     = false
+  add_to_access_token = true
+  add_to_userinfo     = true
+}
+
 resource "keycloak_openid_audience_protocol_mapper" "weave_backend_audience" {
   realm_id                 = keycloak_realm.tenant.id
   client_scope_id          = keycloak_openid_client_scope.weave_workspace.id
@@ -248,6 +281,17 @@ resource "keycloak_openid_client_optional_scopes" "weave_app" {
 resource "keycloak_openid_client_default_scopes" "weave_app" {
   realm_id  = keycloak_realm.tenant.id
   client_id = keycloak_openid_client.client["weave_app"].id
+
+  default_scopes = local.weave_app_default_scopes
+
+  depends_on = [
+    keycloak_openid_client_scope.weave_workspace,
+  ]
+}
+
+resource "keycloak_openid_client_default_scopes" "weave_admin_console" {
+  realm_id  = keycloak_realm.tenant.id
+  client_id = keycloak_openid_client.client["weave_admin_console"].id
 
   default_scopes = local.weave_app_default_scopes
 

--- a/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/outputs.tf
+++ b/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/outputs.tf
@@ -79,3 +79,13 @@ output "weave_product_role_groups" {
   description = "Default Keycloak groups mapped one-to-one to MVP product roles."
   value       = local.weave_product_role_groups
 }
+
+output "weave_admin_console_client_id" {
+  description = "Client ID configured for the separate Organization/Admin Console."
+  value       = keycloak_openid_client.client["weave_admin_console"].client_id
+}
+
+output "weave_admin_console_redirect_uris" {
+  description = "Allowed sign-in redirect URIs for the Organization/Admin Console."
+  value       = keycloak_openid_client.client["weave_admin_console"].valid_redirect_uris
+}

--- a/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/variables.tf
+++ b/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/variables.tf
@@ -18,6 +18,11 @@ variable "nextcloud_public_url" {
   type        = string
 }
 
+variable "admin_console_public_url" {
+  description = "Browser-facing Organization/Admin Console base URL."
+  type        = string
+}
+
 variable "matrix_mas_upstream_id" {
   description = "ULID used by MAS for the upstream OIDC provider."
   type        = string

--- a/infra/weave-workspace/02-keycloak-setup/outputs.tf
+++ b/infra/weave-workspace/02-keycloak-setup/outputs.tf
@@ -79,3 +79,13 @@ output "weave_product_role_groups" {
   description = "Default Keycloak groups mapped one-to-one to MVP product roles."
   value       = module.tenant_identity.weave_product_role_groups
 }
+
+output "weave_admin_console_client_id" {
+  description = "Client ID configured for the separate Organization/Admin Console."
+  value       = module.tenant_identity.weave_admin_console_client_id
+}
+
+output "weave_admin_console_redirect_uris" {
+  description = "Allowed sign-in redirect URIs for the Organization/Admin Console."
+  value       = module.tenant_identity.weave_admin_console_redirect_uris
+}

--- a/infra/weave-workspace/02-keycloak-setup/variables.tf
+++ b/infra/weave-workspace/02-keycloak-setup/variables.tf
@@ -39,6 +39,12 @@ variable "api_subdomain" {
   default     = "api"
 }
 
+variable "admin_subdomain" {
+  description = "Subdomain used for the separate Organization/Admin Console deploy target."
+  type        = string
+  default     = "admin"
+}
+
 variable "public_scheme" {
   description = "Public URL scheme used by browser-facing services."
   type        = string

--- a/infra/weave-workspace/install.sh
+++ b/infra/weave-workspace/install.sh
@@ -247,6 +247,10 @@ persist_bootstrap_env() {
     printf 'export WEAVE_API_BASE_URL=%q\n' "$(integration_test_base_url)"
     printf 'export WEAVE_BASE_URL=%q\n' "$(integration_test_base_url)"
     printf 'export WEAVE_AUTH_BASE_URL=%q\n' "$(auth_public_url)"
+    printf 'export WEAVE_ADMIN_CONSOLE_URL=%q\n' "$(admin_public_url)"
+    printf 'export WEAVE_ADMIN_CONSOLE_OIDC_CLIENT_ID=%q\n' "weave-admin-console"
+    printf 'export WEAVE_ORG_MANIFEST_URL=%q\n' "$(integration_test_base_url)/organization/manifest"
+    printf 'export WEAVE_PROVIDER_PROFILE=%q\n' "${TF_VAR_provider_stack_profile}"
     printf 'export WEAVE_FILES_PRODUCT_URL=%q\n' "$(product_public_url)/files"
     printf 'export WEAVE_CALENDAR_PRODUCT_URL=%q\n' "$(product_public_url)/calendar"
     printf 'export WEAVE_NEXTCLOUD_BASE_URL=%q\n' "${TF_VAR_public_scheme}://$(public_host "${TF_VAR_nextcloud_subdomain}")$(public_port_suffix)"
@@ -504,6 +508,10 @@ auth_public_url() {
   printf '%s://%s%s' "${TF_VAR_public_scheme}" "$(public_host "${TF_VAR_auth_subdomain}")" "$(public_port_suffix)"
 }
 
+admin_public_url() {
+  printf '%s://%s%s' "${TF_VAR_public_scheme}" "$(public_host "${TF_VAR_admin_subdomain}")" "$(public_port_suffix)"
+}
+
 product_public_url() {
   printf '%s://%s%s' "${TF_VAR_public_scheme}" "${TF_VAR_tenant_domain}" "$(public_port_suffix)"
 }
@@ -591,6 +599,10 @@ write_app_config_summary() {
     printf 'export WEAVE_API_BASE_URL=%q\n' "${api_base_url}"
     printf 'export WEAVE_BASE_URL=%q\n' "${api_base_url}"
     printf 'export WEAVE_AUTH_BASE_URL=%q\n' "${auth_base_url}"
+    printf 'export WEAVE_ADMIN_CONSOLE_URL=%q\n' "$(admin_public_url)"
+    printf 'export WEAVE_ADMIN_CONSOLE_OIDC_CLIENT_ID=%q\n' 'weave-admin-console'
+    printf 'export WEAVE_ORG_MANIFEST_URL=%q\n' "${api_base_url}/organization/manifest"
+    printf 'export WEAVE_PROVIDER_PROFILE=%q\n' "${TF_VAR_provider_stack_profile}"
     printf 'export WEAVE_OIDC_ISSUER_URL=%q\n' "$(integration_test_oidc_issuer_url)"
     printf 'export WEAVE_OIDC_CLIENT_ID=%q\n' 'weave-app'
     printf 'export WEAVE_MATRIX_HOMESERVER_URL=%q\n' "${matrix_url}"
@@ -652,6 +664,7 @@ preflight_checks() {
   local hosts=(
     "${TF_VAR_tenant_domain}"
     "$(public_host "${TF_VAR_api_subdomain}")"
+    "$(public_host "${TF_VAR_admin_subdomain}")"
     "$(public_host "${TF_VAR_auth_subdomain}")"
     "$(public_host "${TF_VAR_nextcloud_subdomain}")"
     "$(public_host "${TF_VAR_matrix_subdomain}")"
@@ -763,6 +776,7 @@ ensure_default_inputs() {
     "TF_VAR_tenant_domain=weave.local"
     "TF_VAR_auth_subdomain=auth"
     "TF_VAR_api_subdomain=api"
+    "TF_VAR_admin_subdomain=admin"
     "TF_VAR_matrix_subdomain=matrix"
     "TF_VAR_nextcloud_subdomain=files"
     "TF_VAR_public_scheme=https"
@@ -892,6 +906,7 @@ certificate_alt_names() {
   local hosts=(
     "${TF_VAR_tenant_domain}"
     "$(public_host "${TF_VAR_api_subdomain}")"
+    "$(public_host "${TF_VAR_admin_subdomain}")"
     "$(public_host "${TF_VAR_auth_subdomain}")"
     "$(public_host "${TF_VAR_nextcloud_subdomain}")"
     "$(public_host "${TF_VAR_matrix_subdomain}")"

--- a/infra/weave-workspace/keycloak/weave-dev-realm-contract.json
+++ b/infra/weave-workspace/keycloak/weave-dev-realm-contract.json
@@ -1,0 +1,50 @@
+{
+  "artifactVersion": "keycloak-realm-contract-v1",
+  "realm": "weave",
+  "issuer": "https://auth.weave.local/realms/weave",
+  "recommendedIdentityBroker": "keycloak",
+  "organizationClaims": {
+    "tenantClaim": "weave_tenant_id",
+    "displayNameClaim": "weave_organization_name",
+    "defaultTenantId": "weave-dogfood",
+    "defaultDisplayName": "Weave Dogfood"
+  },
+  "clients": [
+    {
+      "clientId": "weave-app",
+      "accessType": "PUBLIC",
+      "pkce": "S256",
+      "defaultScopes": ["profile", "email", "roles", "weave:workspace"],
+      "audience": "weave-app"
+    },
+    {
+      "clientId": "weave-admin-console",
+      "accessType": "PUBLIC",
+      "pkce": "S256",
+      "defaultScopes": ["profile", "email", "roles", "weave:workspace"],
+      "redirectUris": ["https://admin.weave.local/*"],
+      "audience": "weave-app"
+    },
+    {
+      "clientId": "weave-backend",
+      "accessType": "BEARER-ONLY"
+    }
+  ],
+  "realmRoles": ["owner", "admin", "operator", "member", "guest"],
+  "groups": [
+    { "name": "workspace-owners", "roles": ["owner"] },
+    { "name": "workspace-admins", "roles": ["admin"] },
+    { "name": "workspace-operators", "roles": ["operator"] },
+    { "name": "workspace-members", "roles": ["member"] },
+    { "name": "workspace-guests", "roles": ["guest"] },
+    { "name": "weave-board-editors", "capabilities": ["boards.update_task"] },
+    { "name": "weave-calendar-editors", "capabilities": ["calendar.manage_events"] },
+    { "name": "weave-weaver-pilot", "capabilities": ["weaver.files_read", "weaver.exec_disabled"] }
+  ],
+  "secretRefs": [
+    "secretref://weave/provider/keycloak-realm/admin-password",
+    "secretref://weave/provider/keycloak-realm/matrix-mas-client-secret",
+    "secretref://weave/provider/keycloak-realm/nextcloud-client-secret"
+  ],
+  "rawSecretsIncluded": false
+}

--- a/infra/weave-workspace/operator-check.sh
+++ b/infra/weave-workspace/operator-check.sh
@@ -550,6 +550,9 @@ assert_authenticated_backend_facades_accept_test_user() {
   ! grep -Eiq 'Authorization|api[_-]?token|/api/v3/|/work_packages/|/projects/' <<<"${provider_status}" || \
     fail "Operator check failed: provider registry leaked provider credentials or raw upstream paths"
 
+  admin_control_plane_status="$(curl_auth_status "${access_token}" "${WEAVE_BASE_URL}/admin/control-plane" || true)"
+  [[ "${admin_control_plane_status}" == "403" ]] || fail "Operator check failed: member token should receive 403 from admin control plane, got HTTP ${admin_control_plane_status}"
+
   files_status="$(curl_auth_status "${access_token}" "${WEAVE_BASE_URL}/files" || true)"
   [[ "${files_status}" == 2* ]] || fail "Operator check failed: authenticated files facade rejected the test-user app token with HTTP ${files_status}"
 }

--- a/infra/weave-workspace/provider-profiles/microsoft-hybrid-placeholder.json
+++ b/infra/weave-workspace/provider-profiles/microsoft-hybrid-placeholder.json
@@ -1,0 +1,21 @@
+{
+  "profileVersion": "provider-profile-v1",
+  "profileKey": "microsoft-hybrid-placeholder",
+  "choiceModel": "external_existing_provider",
+  "description": "Contract placeholder for organizations keeping Microsoft-heavy systems while Weave stays provider-neutral. This file is not a live credential configuration.",
+  "serverControlPlane": {
+    "secretRefPrefix": "secretref://weave/provider/",
+    "adminControlPlaneRoute": "/api/admin/control-plane",
+    "providerRegistryRoute": "/api/providers/status"
+  },
+  "categories": {
+    "identity-idm": { "selectedAdapter": "entra-id", "secretRefs": ["secretref://weave/provider/entra-id/client-secret"] },
+    "chat": { "selectedAdapter": "microsoft-teams", "secretRefs": ["secretref://weave/provider/microsoft-teams/app-secret"] },
+    "files": { "selectedAdapter": "sharepoint", "secretRefs": ["secretref://weave/provider/sharepoint/app-secret"] },
+    "calendar": { "selectedAdapter": "microsoft-graph-calendar", "secretRefs": ["secretref://weave/provider/microsoft-graph-calendar/app-secret"] },
+    "boards-tasks": { "selectedAdapter": "microsoft-planner", "secretRefs": ["secretref://weave/provider/microsoft-planner/app-secret"] },
+    "meetings-calls": { "selectedAdapter": "microsoft-teams-meetings", "secretRefs": ["secretref://weave/provider/microsoft-teams-meetings/app-secret"] },
+    "documents-collaboration": { "selectedAdapter": "microsoft-365-office-graph", "secretRefs": ["secretref://weave/provider/microsoft-365-office-graph/app-secret"] },
+    "weaver": { "selectedAdapter": "weaver-runtime-disabled", "enabledByDefault": false, "secretRefs": [] }
+  }
+}

--- a/infra/weave-workspace/provider-profiles/sovereign-default.json
+++ b/infra/weave-workspace/provider-profiles/sovereign-default.json
@@ -1,0 +1,74 @@
+{
+  "profileVersion": "provider-profile-v1",
+  "profileKey": "sovereign-default",
+  "choiceModel": "recommended_self_hosted_default",
+  "description": "Recommended self-hosted Weave dev/demo/default organization profile. This is the default bootstrap posture, not the only supported product shape.",
+  "adminConsoleDeployTarget": {
+    "app": "organization-admin-console",
+    "route": "https://admin.weave.local",
+    "backendApi": "https://api.weave.local/api",
+    "oidcIssuer": "https://auth.weave.local/realms/weave",
+    "oidcClientId": "weave-admin-console"
+  },
+  "serverControlPlane": {
+    "organizationId": "weave-dogfood",
+    "manifestRoute": "/api/organization/manifest",
+    "adminControlPlaneRoute": "/api/admin/control-plane",
+    "providerRegistryRoute": "/api/providers/status",
+    "capabilityWhitelistRoute": "/api/admin/policies/capability-whitelist",
+    "auditRoute": "/api/admin/audit/events",
+    "secretRefPrefix": "secretref://weave/provider/"
+  },
+  "categories": {
+    "identity-idm": {
+      "selectedAdapter": "keycloak-realm",
+      "providerKey": "keycloak-realm",
+      "readinessSource": "02-keycloak-setup",
+      "secretRefs": ["secretref://weave/provider/keycloak-realm/client-secret"],
+      "externalAlternatives": ["entra-id", "authentik", "auth0", "generic-oidc", "generic-saml"]
+    },
+    "chat": {
+      "selectedAdapter": "synapse-homeserver",
+      "providerKey": "synapse-homeserver",
+      "secretRefs": ["secretref://weave/provider/synapse-homeserver/signing-key"],
+      "externalAlternatives": ["microsoft-teams", "slack", "nextcloud-talk"]
+    },
+    "files": {
+      "selectedAdapter": "nextcloud-files",
+      "providerKey": "nextcloud-files",
+      "secretRefs": ["secretref://weave/provider/nextcloud-files/backend-token"],
+      "externalAlternatives": ["sharepoint", "onedrive", "s3-compatible", "smb"]
+    },
+    "calendar": {
+      "selectedAdapter": "nextcloud-caldav",
+      "providerKey": "nextcloud-caldav",
+      "secretRefs": ["secretref://weave/provider/nextcloud-caldav/backend-token"],
+      "externalAlternatives": ["microsoft-graph-calendar", "google-workspace-calendar", "generic-caldav"]
+    },
+    "boards-tasks": {
+      "selectedAdapter": "openproject-primary",
+      "providerKey": "openproject-primary",
+      "secretRefs": ["secretref://weave/provider/openproject-primary/api-token"],
+      "externalAlternatives": ["microsoft-planner", "jira", "nextcloud-deck", "vikunja"]
+    },
+    "meetings-calls": {
+      "selectedAdapter": "livekit",
+      "providerKey": "livekit",
+      "secretRefs": ["secretref://weave/provider/livekit/api-key", "secretref://weave/provider/livekit/api-secret"],
+      "externalAlternatives": ["microsoft-teams-meetings", "zoom", "google-meet", "jitsi"]
+    },
+    "documents-collaboration": {
+      "selectedAdapter": "onlyoffice-community",
+      "providerKey": "onlyoffice-community",
+      "secretRefs": ["secretref://weave/provider/onlyoffice-community/jwt-secret"],
+      "externalAlternatives": ["microsoft-365-office-graph", "collabora-code", "google-workspace-docs"]
+    },
+    "weaver": {
+      "selectedAdapter": "weaver-runtime-disabled",
+      "providerKey": "weaver-runtime-disabled",
+      "enabledByDefault": false,
+      "secretRefs": [],
+      "externalAlternatives": ["openclaw-governed-runtime"]
+    }
+  }
+}

--- a/infra/weave-workspace/smoke-test.sh
+++ b/infra/weave-workspace/smoke-test.sh
@@ -469,6 +469,10 @@ assert_json "${provider_status}" '[.providers[] | select(.module == "office" or 
 ! grep -Eiq 'Authorization|api[_-]?token|/api/v3/|/work_packages/|/projects/' <<<"${provider_status}" || \
   fail "Smoke check failed: provider registry leaked provider credentials or raw upstream paths"
 
+log "Checking admin API protection with a member token..."
+admin_control_plane_status="$(curl_auth_status "${access_token}" "${WEAVE_BASE_URL}/admin/control-plane" || true)"
+[[ "${admin_control_plane_status}" == "403" ]] || fail "Smoke check failed: member token should receive 403 from admin control plane, got ${admin_control_plane_status}"
+
 log "Checking backend files/calendar facade actor wiring..."
 assert_backend_nextcloud_actor_config
 probe_authenticated_facade "Files" "${access_token}" "${WEAVE_BASE_URL}/files"

--- a/infra/weave-workspace/support-bundle.sh
+++ b/infra/weave-workspace/support-bundle.sh
@@ -30,6 +30,7 @@ readonly PUBLIC_ENV_KEYS=(
   TF_VAR_public_scheme
   TF_VAR_auth_subdomain
   TF_VAR_api_subdomain
+  TF_VAR_admin_subdomain
   TF_VAR_matrix_subdomain
   TF_VAR_nextcloud_subdomain
   TF_VAR_proxy_host_port
@@ -64,6 +65,10 @@ readonly PUBLIC_ENV_KEYS=(
   WEAVE_API_BASE_URL
   WEAVE_BASE_URL
   WEAVE_AUTH_BASE_URL
+  WEAVE_ADMIN_CONSOLE_URL
+  WEAVE_ADMIN_CONSOLE_OIDC_CLIENT_ID
+  WEAVE_ORG_MANIFEST_URL
+  WEAVE_PROVIDER_PROFILE
   WEAVE_OIDC_ISSUER_URL
   WEAVE_OIDC_CLIENT_ID
   WEAVE_NEXTCLOUD_BASE_URL

--- a/infra/weave-workspace/tests/infra-product-contract-test.sh
+++ b/infra/weave-workspace/tests/infra-product-contract-test.sh
@@ -249,4 +249,41 @@ assert_file_absent "${release_env}" 'TF_VAR_boards_openproject_api_token=replace
 assert_file_absent "${install_script}" 'WEAVE_BOARDS_OPENPROJECT_API_TOKEN=%q'
 assert_file_contains "${connector_doc}" 'Boards provider secrets follow the same rule'
 
+# V01_INFRA_CONTROL_PLANE_BOOTSTRAP: recommended default bootstrap feeds backend control plane safely.
+provider_profile_sovereign="${ROOT_DIR}/provider-profiles/sovereign-default.json"
+provider_profile_ms="${ROOT_DIR}/provider-profiles/microsoft-hybrid-placeholder.json"
+keycloak_realm_contract="${ROOT_DIR}/keycloak/weave-dev-realm-contract.json"
+control_plane_bootstrap_doc="${ROOT_DIR}/../../docs/control-plane-infra-bootstrap.md"
+for file in "${provider_profile_sovereign}" "${provider_profile_ms}" "${keycloak_realm_contract}" "${control_plane_bootstrap_doc}"; do
+  [[ -f "${file}" ]] || fail "Missing control-plane bootstrap artifact: ${file}"
+done
+assert_file_contains "${provider_profile_sovereign}" '"profileKey": "sovereign-default"'
+assert_file_contains "${provider_profile_sovereign}" '"recommended_self_hosted_default"'
+assert_file_contains "${provider_profile_sovereign}" '"adminControlPlaneRoute": "/api/admin/control-plane"'
+assert_file_contains "${provider_profile_sovereign}" '"secretRefPrefix": "secretref://weave/provider/"'
+assert_file_contains "${provider_profile_sovereign}" '"selectedAdapter": "keycloak-realm"'
+assert_file_contains "${provider_profile_ms}" '"profileKey": "microsoft-hybrid-placeholder"'
+assert_file_contains "${provider_profile_ms}" '"selectedAdapter": "entra-id"'
+assert_file_contains "${provider_profile_ms}" '"selectedAdapter": "sharepoint"'
+assert_file_contains "${keycloak_realm_contract}" '"clientId": "weave-admin-console"'
+assert_file_contains "${keycloak_realm_contract}" '"operator"'
+assert_file_contains "${keycloak_realm_contract}" '"rawSecretsIncluded": false'
+assert_file_contains "${keycloak_main}" 'weave_admin_console'
+assert_file_contains "${keycloak_main}" 'workspace-operators'
+assert_file_contains "${keycloak_main}" 'claim_name          = "weave_organization_name"'
+assert_file_contains "${install_script}" 'TF_VAR_admin_subdomain=admin'
+assert_file_contains "${install_script}" 'WEAVE_ADMIN_CONSOLE_URL'
+assert_file_contains "${install_script}" 'WEAVE_ADMIN_CONSOLE_OIDC_CLIENT_ID'
+assert_file_contains "${install_script}" 'WEAVE_ORG_MANIFEST_URL'
+assert_file_contains "${support_bundle}" 'WEAVE_ADMIN_CONSOLE_URL'
+assert_file_contains "${support_bundle}" 'WEAVE_PROVIDER_PROFILE'
+assert_file_contains "${ROOT_DIR}/smoke-test.sh" 'Checking admin API protection with a member token'
+assert_file_contains "${ROOT_DIR}/smoke-test.sh" '/admin/control-plane'
+assert_file_contains "${ROOT_DIR}/operator-check.sh" 'member token should receive 403 from admin control plane'
+assert_file_contains "${caddy_template}" 'Weave Organization/Admin Console deploy target'
+assert_file_absent "${provider_profile_sovereign}" 'client_secret'
+assert_file_absent "${provider_profile_sovereign}" 'api_token'
+assert_file_absent "${provider_profile_ms}" 'client_secret'
+assert_file_absent "${keycloak_realm_contract}" 'replace-me'
+
 printf '%s\n' 'infra product contract tests passed'


### PR DESCRIPTION
## Summary
- adds sovereign-default and Microsoft-hybrid provider profile artifacts plus a no-secret Keycloak realm contract
- wires a separate Admin Console deploy target/profile into bootstrap env, Caddy, Keycloak, smoke checks, and support-bundle public metadata
- verifies member tokens cannot access `/admin/control-plane` and maps the infra bootstrap acceptance scenario

Fixes #276

## Acceptance / E2E mapping
- `@weave-v01-infra-control-plane-bootstrap`
- marker `V01_INFRA_CONTROL_PLANE_BOOTSTRAP`
- executable evidence: `infra/weave-workspace/tests/infra-product-contract-test.sh`
- live smoke hooks: `infra/weave-workspace/smoke-test.sh`, `infra/weave-workspace/operator-check.sh`

## Local gates
- `git diff --check`
- `terraform fmt -recursive infra/weave-workspace/01-infrastructure infra/weave-workspace/02-keycloak-setup`
- `make acceptance-contract`
- `make infra-static`

## Security notes
- generated profile artifacts use SecretRefs only and contain no raw secrets
- support bundles expose only no-secret admin/profile metadata
- Admin Console is a separate target; member client remains provider-agnostic
