### PR TITLE
docs: add MkDocs handbook foundation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,8 @@
 
 ## Checks run
 
+- [ ] `make docs-check` / `make docs-build` (for docs or release notes changes)
+- [ ] `make release-notes-check` (for release-affecting changes)
 - [ ] `flutter pub get`
 - [ ] `flutter gen-l10n`
 - [ ] `dart run build_runner build --delete-conflicting-outputs`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,18 @@
 - [ ] No public API/auth/topology/spec contract change
 - [ ] Contract/spec change documented:
 
+## Release notes label
+
+Choose exactly one before review/merge; CI fails otherwise.
+
+- [ ] `release-notes-feature`
+- [ ] `release-notes-bugfix`
+- [ ] `release-notes-skip`
+
+## Review readiness
+
+- [ ] Copilot review requested for this review-ready PR
+
 ## Checks run
 
 - [ ] `make docs-check` / `make docs-build` (for docs or release notes changes)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
 
   docs-checks:
     name: Docs Checks
+    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -56,6 +57,7 @@ jobs:
 
   acceptance-contract:
     name: Acceptance Contract
+    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -70,6 +72,7 @@ jobs:
 
   client-offline-checks:
     name: Client Offline Checks
+    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -114,6 +117,7 @@ jobs:
 
   admin-console-checks:
     name: Admin Console Checks
+    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -130,6 +134,7 @@ jobs:
 
   server-checks:
     name: Server Checks
+    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -143,6 +148,7 @@ jobs:
 
   infra-static-checks:
     name: Infra Static Checks
+    if: github.event_name != 'pull_request' || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,21 @@ permissions:
   contents: read
 
 jobs:
+  docs-checks:
+    name: Docs Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+      - name: Install docs dependencies
+        run: python -m pip install -r docs/requirements.txt
+      - name: Build documentation site
+        run: make docs-check
+
   acceptance-contract:
     name: Acceptance Contract
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,17 @@ permissions:
 jobs:
   release-notes-label-check:
     name: Release Notes Label Check
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Validate exactly one release-notes label
+        if: github.event_name == 'pull_request'
         env:
           PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: python3 tools/release_notes_label_check.py
+      - name: Skip release-notes label validation outside PRs
+        if: github.event_name != 'pull_request'
+        run: echo 'Release notes label validation only applies to pull requests.'
 
   docs-checks:
     name: Docs Checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 on:
   push:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
   workflow_dispatch:
     inputs:
       capture_marketing_screenshots:
@@ -18,6 +25,17 @@ permissions:
   contents: read
 
 jobs:
+  release-notes-label-check:
+    name: Release Notes Label Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Validate exactly one release-notes label
+        env:
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: python3 tools/release_notes_label_check.py
+
   docs-checks:
     name: Docs Checks
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
-.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract live-stack-help
+.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve release-notes-check live-stack-help
 
-ci: acceptance-contract client-ci server-ci infra-static admin-ci
+ci: acceptance-contract client-ci server-ci infra-static admin-ci docs-check
+
+# Install docs tooling with: python3 -m pip install -r docs/requirements.txt
+docs-build: release-notes-check
+	python3 -m mkdocs build --strict
+
+docs-check: release-notes-check
+	python3 -m mkdocs build --strict
+
+docs-serve:
+	python3 -m mkdocs serve
+
+release-notes-check:
+	python3 tools/docs_check.py
 
 client-ci:
 	$(MAKE) -C client offline-contract-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve release-notes-check release-notes-label-check live-stack-help
+.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve docs-structure-check release-notes-check release-notes-label-check live-stack-help
 
 ci: acceptance-contract client-ci server-ci infra-static admin-ci docs-check
 
@@ -6,14 +6,17 @@ ci: acceptance-contract client-ci server-ci infra-static admin-ci docs-check
 docs-build: release-notes-check
 	python3 -m mkdocs build --strict
 
-docs-check: release-notes-check
+docs-check: docs-structure-check release-notes-check
 	python3 -m mkdocs build --strict
 
 docs-serve:
 	python3 -m mkdocs serve
 
-release-notes-check:
+docs-structure-check:
 	python3 tools/docs_check.py
+
+release-notes-check:
+	python3 tools/docs_check.py --release-notes-only
 
 release-notes-label-check:
 	python3 tools/release_notes_label_check.py

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve docs-structure-check release-notes-check release-notes-label-check live-stack-help
 
-ci: acceptance-contract client-ci server-ci infra-static admin-ci docs-check
+ci: acceptance-contract client-ci server-ci infra-static admin-ci
 
 # Install docs tooling with: python3 -m pip install -r docs/requirements.txt
 docs-build: release-notes-check

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ci: acceptance-contract client-ci server-ci infra-static admin-ci
 docs-build: release-notes-check
 	python3 -m mkdocs build --strict
 
-docs-check: docs-structure-check release-notes-check
+docs-check: docs-structure-check
 	python3 -m mkdocs build --strict
 
 docs-serve:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ci: acceptance-contract client-ci server-ci infra-static admin-ci
 
 # Install docs tooling with: python3 -m pip install -r docs/requirements.txt
-docs-build: release-notes-check
+docs-build:
 	python3 -m mkdocs build --strict
 
 docs-check: docs-structure-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve release-notes-check live-stack-help
+.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve release-notes-check release-notes-label-check live-stack-help
 
 ci: acceptance-contract client-ci server-ci infra-static admin-ci docs-check
 
@@ -14,6 +14,9 @@ docs-serve:
 
 release-notes-check:
 	python3 tools/docs_check.py
+
+release-notes-label-check:
+	python3 tools/release_notes_label_check.py
 
 client-ci:
 	$(MAKE) -C client offline-contract-test

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Settings and readiness surfaces should explain configured, disabled, degraded, o
 - `server/` — Spring Boot product API/BFF, provider facades, authorization, audit, support-safe errors, and backend acceptance tests.
 - `infra/` — Docker/OpenTofu operator stack, local and single-host deployment scripts, provider profiles, backup/restore, smoke checks, and support bundles.
 - `e2e/` — product-language Gherkin scenarios, scenario mappings, and sanitized evidence contracts.
-- `docs/` — product architecture, release scope, acceptance flows, roadmap boundaries, and research notes.
+- `docs/` — MkDocs-backed product, user/admin/operator/developer handbooks, architecture, release scope, acceptance flows, roadmap boundaries, release notes, and research notes.
 - `release/` — release manifests and stack compatibility metadata.
 
 ## v0.1 product truth
@@ -129,6 +129,7 @@ Run the smallest meaningful gate for your change:
 
 ```bash
 make acceptance-contract
+make docs-check
 make client-ci
 make server-ci
 make infra-static
@@ -141,6 +142,7 @@ Use these defaults:
 - `make client-ci` for Flutter/client changes.
 - `make server-ci` for backend/provider changes.
 - `make infra-static` for infrastructure, operator scripts, and OpenTofu-facing changes.
+- `make docs-check` for documentation site, diagrams, or release notes changes.
 - `make ci` when a change crosses product-stack boundaries.
 
 Live-stack E2E is intentionally opt-in. Run it only with explicit runner power/storage budget and sanitized evidence handling.

--- a/docs/admin-operator-handbook.md
+++ b/docs/admin-operator-handbook.md
@@ -1,0 +1,84 @@
+# Admin/Operator Handbook
+
+This handbook is for organization owners, admins, and operators responsible for provisioning and running Weave. Normal members should receive an invite/deep link or organization auth URL, complete SSO, and consume effective capability states; they should not configure provider internals.
+
+## Organization setup
+
+Admin/operator setup owns:
+
+- organization creation and verified domains;
+- identity provider configuration;
+- provider category selection;
+- endpoint URL management and rotation;
+- `SecretRef` wiring for provider credentials;
+- capability/RBAC profiles and deny-by-default policy;
+- provider/tool/agent whitelists;
+- readiness, audit, backup/restore, and support bundles.
+
+The current product order remains: provider-neutral Weave suite first, admin portal/IDM/RBAC/readiness/whitelisting second, optional governed Weaver runtime later.
+
+## Identity and Keycloak default
+
+Keycloak is the self-hosted default identity choice for dogfood deployments. The product contract remains provider-neutral: Entra ID, Authentik, Auth0, OIDC/SAML, SCIM, or LDAP-style sources can attach through adapter contracts when supported.
+
+Admins map identity claims, groups, and roles into Weave capability profiles. Unknown roles, groups, or provider states must fail closed.
+
+## Provider selection
+
+Provider categories are first-class product concepts:
+
+- identity/IDM;
+- chat;
+- files;
+- calendar;
+- boards/tasks;
+- meetings/calls;
+- documents/collaboration;
+- Weaver runtime (disabled by default until later governed policy work).
+
+Record provider posture as `recommended_self_hosted_default`, `external_existing_provider`, or `managed_cloud_provider`. Provider-specific risk notes belong in admin/operator surfaces, not normal member UX.
+
+## Provider URLs and SecretRefs
+
+Provider URLs, credentials, OAuth client secrets, app passwords, signing keys, and bearer tokens must stay out of the member client and support artifacts. Store and display secret handles as `SecretRef` values only. Rotate provider URLs/secrets through admin/operator workflows and audit the change.
+
+## Whitelisting and policies
+
+Weave policy is deny-by-default. Capability profiles should use category-level permissions before low-level adapter details, for example:
+
+- `chat.read`, `chat.send`;
+- `files.read`, `files.upload`;
+- `calendar.read`, `calendar.manage_events`;
+- `boards.read`, `boards.update_task`;
+- placeholder Weaver keys only when explicitly gated.
+
+Whitelists restrict which providers, adapters, tools, and later Weaver capabilities are visible to an organization or role. A missing whitelist entry does not grant access.
+
+## Readiness and audit
+
+Readiness states must be support-safe and action-oriented. They can explain that a capability is ready, disabled, degraded, or policy-blocked, but they must not expose raw downstream bodies, provider-internal IDs, credential-bearing URLs, tokens, cookies, or private keys.
+
+Audit records should cover admin changes, denied access, provider writes, readiness transitions, SecretRef rotations, mapping-loss events, and support-bundle generation.
+
+## Infra and bootstrap
+
+OpenTofu is the operator-facing infrastructure tool. User-facing workflows and docs should use OpenTofu language unless they are explicitly describing Terraform-compatible internals.
+
+Use the infra tree for local/single-host stack bootstrap, smoke checks, backup/restore, rollback, and support-bundle flows. State-destructive operations require explicit operator confirmation and a backup/restore or rollback path.
+
+## Support bundles
+
+Support bundles must redact secrets, tokens, cookies, private keys, raw provider errors, credential-bearing URLs, generated credentials, and unnecessary provider internals. Include enough sanitized readiness and audit evidence to diagnose operator issues without leaking user or provider data.
+
+## Validation gates
+
+Use the smallest meaningful gate:
+
+```sh
+make acceptance-contract
+make infra-static
+make server-ci
+make docs-check
+```
+
+Use live-stack E2E only when explicitly authorized and runner power/storage budget is available.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ Weave is product-first and provider-neutral. It models organization capabilities
 
 ## Provider-neutral capability contracts
 
-Canonical feature models come before control-plane, Admin Console, infra, or concrete adapter implementation. The active canonical model strategy is documented in [Canonical feature models and provider facades](canonical-feature-models.md), with Mermaid domain diagrams in [`docs/diagrams/`](diagrams/). Server facades expose Weave-owned models per capability; they are not thin provider proxies and must not leak provider IDs, raw provider payloads, secrets, or downstream diagnostics into member or Admin Console product contracts.
+Canonical feature models come before control-plane, Admin Console, infra, or concrete adapter implementation. The active canonical model strategy is documented in [Canonical feature models and provider facades](canonical-feature-models.md), with Mermaid domain diagrams in [`docs/diagrams/`](diagrams/index.md). Server facades expose Weave-owned models per capability; they are not thin provider proxies and must not leak provider IDs, raw provider payloads, secrets, or downstream diagnostics into member or Admin Console product contracts.
 
 Workspace/Admin Health is organized around feature capability categories, not concrete systems. The stable contract categories are identity/IDM, chat, files, office/docs collaboration, meetings/calls, boards/tasks, calendar, and Weaver runtime. Each category publishes category-level capability keys, current dogfood/default adapters, external adapter placeholders, operational readiness modules, and the stable member impact states `usable`, `disabled`, `degraded`, and `policy-blocked`.
 

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -66,6 +66,32 @@ make offline-contract-test
 - Run `dart run build_runner build --delete-conflicting-outputs` after model/provider/codegen changes.
 - Keep user-facing strings localizable; do not add hard-coded English text in widgets when the surrounding feature already uses l10n.
 
+## Documentation site
+
+Weave docs are published as a MkDocs site configured by `mkdocs.yml`. The site uses MkDocs Material; its MIT license was verified from upstream on 2026-05-24 and is safe for project use.
+
+For documentation-only changes:
+
+```sh
+python3 -m pip install -r docs/requirements.txt
+make docs-check
+make docs-build
+```
+
+`make docs-check` runs the lightweight repository docs validator and a strict MkDocs build. Keep existing docs linked from navigation or from handbook pages so product truth does not drift into orphaned Markdown.
+
+## Release notes workflow
+
+Release-affecting changes should update [Unreleased release notes](release-notes/unreleased.md) in the same PR. Use the fixed categories `Added`, `Changed`, `Fixed`, `Security`, `Accessibility`, `Migration/Operator Notes`, and `Known Issues`. Put provider setup, SecretRef, OpenTofu/bootstrap, backup/restore, support-bundle, readiness, audit, and policy/whitelist impacts under `Migration/Operator Notes`.
+
+Run:
+
+```sh
+make release-notes-check
+```
+
+before requesting review when release notes are relevant.
+
 ## Architecture conventions
 
 Weave uses feature-first clean architecture under `lib/features/<feature>/`:

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -85,10 +85,9 @@ For documentation-only changes:
 ```sh
 python3 -m pip install -r docs/requirements.txt
 make docs-check
-make docs-build
 ```
 
-`make docs-check` runs the lightweight repository docs validator and a strict MkDocs build. Keep existing docs linked from navigation or from handbook pages so product truth does not drift into orphaned Markdown.
+`make docs-check` runs the lightweight repository docs validator and a strict MkDocs build. `make docs-build` is available when you only need the strict MkDocs build after dependencies are installed. Keep existing docs linked from navigation or from handbook pages so product truth does not drift into orphaned Markdown.
 
 ## Release notes workflow
 

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -66,6 +66,16 @@ make offline-contract-test
 - Run `dart run build_runner build --delete-conflicting-outputs` after model/provider/codegen changes.
 - Keep user-facing strings localizable; do not add hard-coded English text in widgets when the surrounding feature already uses l10n.
 
+## GitFlow and PR workflow
+
+Use short-lived PR branches from `main`, keep changes issue/spec-driven, and request Copilot review on every review-ready PR. Every PR must deliberately choose exactly one release-notes label before review/merge:
+
+- `release-notes-feature`
+- `release-notes-bugfix`
+- `release-notes-skip`
+
+Release notes are generated from merged PR labels, not manually reconstructed later. The CI `Release Notes Label Check` fails PRs with zero or multiple release-notes labels. See [GitFlow and PR workflow](gitflow-pr-workflow.md) for the full chapter, label semantics, and merge rules.
+
 ## Documentation site
 
 Weave docs are published as a MkDocs site configured by `mkdocs.yml`. The site uses MkDocs Material; its MIT license was verified from upstream on 2026-05-24 and is safe for project use.
@@ -82,7 +92,9 @@ make docs-build
 
 ## Release notes workflow
 
-Release-affecting changes should update [Unreleased release notes](release-notes/unreleased.md) in the same PR. Use the fixed categories `Added`, `Changed`, `Fixed`, `Security`, `Accessibility`, `Migration/Operator Notes`, and `Known Issues`. Put provider setup, SecretRef, OpenTofu/bootstrap, backup/restore, support-bundle, readiness, audit, and policy/whitelist impacts under `Migration/Operator Notes`.
+Release-affecting changes must choose exactly one release-notes label in the PR. Use the fixed page categories `Added`, `Changed`, `Fixed`, `Security`, `Accessibility`, `Migration/Operator Notes`, and `Known Issues` when drafting checked-in notes. Put provider setup, SecretRef, OpenTofu/bootstrap, backup/restore, support-bundle, readiness, audit, and policy/whitelist impacts under `Migration/Operator Notes`.
+
+Generated release notes come from merged PR metadata and labels. Until [issue #291](https://github.com/masssi164/weave/issues/291) adds full automation, checked-in release note pages are a companion draft, not the primary source for reconstructing changes.
 
 Run:
 

--- a/docs/diagrams/index.md
+++ b/docs/diagrams/index.md
@@ -1,0 +1,33 @@
+# Diagrams
+
+These Mermaid sources make the canonical feature/capability model discoverable from the documentation site. The canonical model narrative lives in [Canonical feature models and provider facades](../canonical-feature-models.md).
+
+MkDocs Material renders inline Mermaid fences in Markdown pages. The checked-in `.mmd` files remain source artifacts and are linked here so they can also be linted or rendered by external Mermaid tooling later.
+
+## Facade architecture
+
+- [Facade architecture source](architecture_facade.mmd)
+
+```mermaid
+flowchart LR
+  Member[Weave Client\nmember features only] -->|stable Weave models only| FeatureAPI[Canonical feature APIs]
+  Admin[Organization/Admin Console\nprovider choice + policy] --> ControlPlane[Backend control-plane APIs]
+  FeatureAPI --> Policy[Deny-by-default policy]
+  ControlPlane --> Registry[Adapter registry]
+  FeatureAPI --> Registry
+  Registry --> Mapper[Mapping layer\nWeave IDs <-> provider IDs]
+  Mapper --> Providers[Provider adapters]
+  Policy --> Audit[Support-safe audit]
+```
+
+## Domain ER sources
+
+- [Chat ER source](er_chat.mmd)
+- [Files and documents ER source](er_files_docs.mmd)
+- [Calendar and meetings ER source](er_calendar_meetings.mmd)
+- [Boards and tasks ER source](er_boards_tasks.mmd)
+- [Identity, admin, and policy ER source](er_identity_admin.mmd)
+
+## Boundary rule
+
+The client and Admin Console consume stable Weave APIs/manifests. Provider-specific SDKs, external IDs, SecretRefs, readiness probes, raw provider URLs, and adapter diagnostics stay behind backend/admin/operator boundaries.

--- a/docs/gitflow-pr-workflow.md
+++ b/docs/gitflow-pr-workflow.md
@@ -1,0 +1,55 @@
+# GitFlow and PR workflow
+
+Weave uses short-lived PR branches on top of `main`. Keep changes spec-driven: intent -> issue/spec note -> acceptance/evidence -> implementation -> review.
+
+## Branch and PR rules
+
+1. Start from current `origin/main`.
+2. Create a focused branch named for the scope, for example `docs/mkdocs-handbook-foundation`, `feat/admin-policy-profiles`, or `fix/chat-empty-state`.
+3. Keep unrelated local files and assistant workspace files out of commits.
+4. Open a PR early enough for CI and review, but mark it draft if it is not review-ready.
+5. Before requesting review, run the smallest meaningful local gate and record it in the PR body.
+6. Request GitHub Copilot review on every review-ready PR.
+7. Do not merge until CI is green and the release-notes label gate passes.
+
+## Mandatory release-notes label policy
+
+Every PR must deliberately choose exactly one release notes label before review/merge:
+
+| Label | Use when | Release notes behavior |
+| --- | --- | --- |
+| `release-notes-feature` | The PR adds or changes user, admin/operator, developer, docs, infrastructure, or product behavior worth mentioning. | Included in generated release notes under Added/Changed-style sections. |
+| `release-notes-bugfix` | The PR fixes a bug, regression, broken docs, failed gate, supportability issue, or release-blocking defect. | Included in generated release notes under Fixed. |
+| `release-notes-skip` | The PR has no release-facing impact, such as pure refactors, formatting-only changes, dependency metadata with no user/operator effect, or test-only maintenance. | Excluded from generated release notes. |
+
+The labels are mutually exclusive. A PR with zero or multiple `release-notes-*` labels is not review-ready and must fail the CI label gate.
+
+Release notes are generated from merged PR labels, not manually reconstructed later. Until full automation lands in [release notes automation follow-up](https://github.com/masssi164/weave/issues/291), the label gate is the durable source of truth and release-note pages may be maintained only as a checked-in draft companion, not as the primary reconstruction mechanism.
+
+## PR creation checklist
+
+Before review-ready:
+
+- Link the issue or spec note that explains intent and acceptance criteria.
+- Choose exactly one release-notes label.
+- Fill the PR template, including user/admin/operator impact and checks run.
+- Note contract/spec changes or explicitly mark that there are none.
+- For UI-facing changes, include accessibility and localization impact.
+- For docs/release process changes, run `make docs-check` and `make release-notes-check`.
+- Request Copilot review with `gh pr edit <number> --add-reviewer @copilot` or through the GitHub UI.
+
+## CI enforcement
+
+The `Release Notes Label Check` job reads PR labels and fails unless exactly one of the release-notes labels is present. The workflow runs on PR open, synchronize, ready-for-review, label, and unlabel events so fixing labels reruns the check.
+
+The docs gate also checks that release-note pages and diagram navigation remain present. Full release notes generation from merged PR metadata is tracked separately in issue #291.
+
+## Merge expectations
+
+A PR is merge-ready only when:
+
+- it has exactly one release-notes label;
+- Copilot review was requested for the review-ready PR;
+- required CI is green or an explicit accepted exception is documented;
+- acceptance/evidence changes are mapped where product behavior changed;
+- no unrelated local, generated, secret, or OpenClaw agent files are included.

--- a/docs/gitflow-pr-workflow.md
+++ b/docs/gitflow-pr-workflow.md
@@ -40,7 +40,7 @@ Before review-ready:
 
 ## CI enforcement
 
-The `Release Notes Label Check` job reads PR labels and fails unless exactly one of the release-notes labels is present. The workflow runs on PR open, synchronize, ready-for-review, label, and unlabel events so fixing labels reruns the check.
+The `Release Notes Label Check` job reads PR labels and fails unless exactly one of the release-notes labels is present. Add the label before pushing review-ready updates when possible. The workflow runs on PR open, synchronize, ready-for-review, label, and unlabel events so fixing labels reruns the check.
 
 The docs gate also checks that release-note pages and diagram navigation remain present. Full release notes generation from merged PR metadata is tracked separately in issue #291.
 

--- a/docs/gitflow-pr-workflow.md
+++ b/docs/gitflow-pr-workflow.md
@@ -35,7 +35,7 @@ Before review-ready:
 - Fill the PR template, including user/admin/operator impact and checks run.
 - Note contract/spec changes or explicitly mark that there are none.
 - For UI-facing changes, include accessibility and localization impact.
-- For docs/release process changes, run `make docs-check` and `make release-notes-check`.
+- For docs/release process changes, run `make docs-check`; use `make release-notes-check` alone only for release-note page or label-policy edits that do not need a site build.
 - Request Copilot review with `gh pr edit <number> --add-reviewer @copilot` or through the GitHub UI.
 
 ## CI enforcement

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Weave is a provider-neutral organization suite and integration layer for chat, f
 
 - [User Handbook](user-handbook.md) for members joining an already-provisioned organization.
 - [Admin/Operator Handbook](admin-operator-handbook.md) for organization setup, provider selection, policies, readiness, audit, infra, and support bundles.
-- [Developer Handbook](developer-handbook.md) for architecture, canonical models, facades/adapters, testing, release process, and contribution rules.
+- [Developer Handbook](developer-handbook.md) and [GitFlow/PR workflow](gitflow-pr-workflow.md) for architecture, canonical models, facades/adapters, testing, release-note labels, release process, and contribution rules.
 - [Diagrams](diagrams/index.md) for Mermaid domain and facade architecture sources.
 - [Release Notes](release-notes/index.md) for unreleased notes, v0.1 notes, categories, and operator-impact tracking.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+# Weave documentation
+
+Weave is a provider-neutral organization suite and integration layer for chat, files, shared calendars, boards/tasks, meetings, decisions, and operator health. The documentation site is organized by the people who need it:
+
+- [User Handbook](user-handbook.md) for members joining an already-provisioned organization.
+- [Admin/Operator Handbook](admin-operator-handbook.md) for organization setup, provider selection, policies, readiness, audit, infra, and support bundles.
+- [Developer Handbook](developer-handbook.md) for architecture, canonical models, facades/adapters, testing, release process, and contribution rules.
+- [Diagrams](diagrams/index.md) for Mermaid domain and facade architecture sources.
+- [Release Notes](release-notes/index.md) for unreleased notes, v0.1 notes, categories, and operator-impact tracking.
+
+## Current product truth
+
+The active product direction is [Weave product line and Weaver integration plan](product-line-and-weaver-plan.md): Weave is product-first and provider-neutral. Admin/provider setup, IDM/RBAC, readiness, whitelisting, and support-safe diagnostics come before optional Weaver personal-assistant runtime work.
+
+v0.1 is a dogfood-production release, not a preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets.
+
+## Documentation stack
+
+The site uses MkDocs with MkDocs Material. MkDocs Material is licensed under the MIT License, verified from the upstream `squidfunk/mkdocs-material` repository license on 2026-05-24, which is safe for this project's commercial and open-source usage.
+
+Build locally with:
+
+```sh
+python3 -m pip install -r docs/requirements.txt
+make docs-check
+make docs-build
+```

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -21,11 +21,18 @@ Every release notes page uses these categories:
 
 Use `Migration/Operator Notes` for admin/operator-impacting changes such as provider configuration, SecretRefs, OpenTofu/bootstrap behavior, backup/restore, support bundles, readiness, audit, and policy/whitelist changes.
 
-## Process
+## Label-driven process
 
-1. For release-affecting changes, add an entry to `docs/release-notes/unreleased.md` in the same PR.
-2. Keep entries concise and user/admin/operator-oriented; link deeper docs when needed.
-3. At release cut, move entries into the versioned release notes file and reset `unreleased.md` to empty category headings.
-4. Run `make release-notes-check` or `make docs-check` before requesting review.
+Every PR must deliberately choose exactly one release notes label before review/merge:
+
+- `release-notes-feature` — included in generated release notes under Added/Changed-style sections.
+- `release-notes-bugfix` — included in generated release notes under Fixed.
+- `release-notes-skip` — excluded from generated release notes.
+
+Release notes are generated from merged PR labels, not manually reconstructed later. The CI `Release Notes Label Check` fails PRs with zero or multiple release-notes labels.
+
+Full generation from merged PR metadata is tracked in [release notes automation follow-up](https://github.com/masssi164/weave/issues/291). Until then, checked-in release notes pages are draft companions to the label source of truth: keep entries concise, user/admin/operator-oriented, and linked to deeper docs when needed.
+
+At release cut, generated notes should move into the versioned release notes file and `unreleased.md` should reset to empty category headings. Run `make release-notes-check` or `make docs-check` before requesting review.
 
 Release notes must stay honest about shipped, gated, disabled, degraded, or future behavior. Do not describe preview-only or guarded surfaces as generally available.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,0 +1,31 @@
+# Release notes
+
+Release notes are the durable, user/admin/operator-facing record of what changed. They complement PR descriptions and acceptance evidence; they do not replace tests or support-safe artifacts.
+
+## Files
+
+- [Unreleased](unreleased.md) collects changes that have merged but are not cut into a tagged release yet.
+- [v0.1](v0.1.md) records the dogfood-production release notes.
+
+## Categories
+
+Every release notes page uses these categories:
+
+- Added
+- Changed
+- Fixed
+- Security
+- Accessibility
+- Migration/Operator Notes
+- Known Issues
+
+Use `Migration/Operator Notes` for admin/operator-impacting changes such as provider configuration, SecretRefs, OpenTofu/bootstrap behavior, backup/restore, support bundles, readiness, audit, and policy/whitelist changes.
+
+## Process
+
+1. For release-affecting changes, add an entry to `docs/release-notes/unreleased.md` in the same PR.
+2. Keep entries concise and user/admin/operator-oriented; link deeper docs when needed.
+3. At release cut, move entries into the versioned release notes file and reset `unreleased.md` to empty category headings.
+4. Run `make release-notes-check` or `make docs-check` before requesting review.
+
+Release notes must stay honest about shipped, gated, disabled, degraded, or future behavior. Do not describe preview-only or guarded surfaces as generally available.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,0 +1,31 @@
+# Unreleased
+
+Use this page for release-affecting changes that have merged but are not included in a tagged release yet.
+
+## Added
+
+- MkDocs documentation site foundation with handbook navigation, diagrams, and release notes process.
+
+## Changed
+
+- Documentation validation now has a dedicated docs check/build path.
+
+## Fixed
+
+- Nothing yet.
+
+## Security
+
+- Nothing yet.
+
+## Accessibility
+
+- Nothing yet.
+
+## Migration/Operator Notes
+
+- Operators can build the documentation site locally with `python3 -m pip install -r docs/requirements.txt` and `make docs-build`.
+
+## Known Issues
+
+- Nothing yet.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -4,11 +4,12 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Added
 
-- MkDocs documentation site foundation with handbook navigation, diagrams, and release notes process.
+- MkDocs documentation site foundation with handbook navigation, diagrams, GitFlow/PR workflow, and release notes process.
 
 ## Changed
 
 - Documentation validation now has a dedicated docs check/build path.
+- PR CI now enforces exactly one release-notes label before review/merge.
 
 ## Fixed
 

--- a/docs/release-notes/v0.1.md
+++ b/docs/release-notes/v0.1.md
@@ -1,0 +1,34 @@
+# v0.1 release notes
+
+v0.1 is the dogfood-production release line. Entries below should reflect shipped, evidence-backed behavior only. Guarded, disabled, or future surfaces must be named as such.
+
+## Added
+
+- Provider-neutral Weave product positioning for identity, chat, files, calendar, boards/tasks, meetings, documents/collaboration, and later Weaver runtime.
+- Canonical feature model and facade architecture documentation for server/admin/infra implementation planning.
+- Quality and acceptance evidence documentation for release gating.
+
+## Changed
+
+- Normal member setup is admin-provisioned: members join with an organization auth URL, invite, or deep link rather than configuring raw providers.
+
+## Fixed
+
+- Nothing yet.
+
+## Security
+
+- Provider secrets, tokens, raw downstream provider errors, credential-bearing URLs, and private keys stay out of member clients and support artifacts by contract.
+
+## Accessibility
+
+- Accessibility remains a release blocker, with documented evidence gates for perceptibility, keyboard/screen-reader paths, and localized support-safe copy.
+
+## Migration/Operator Notes
+
+- OpenTofu is the operator-facing infrastructure language for Weave workflows.
+- Provider/category readiness, SecretRefs, audit, support bundles, backup/restore, and whitelisting are admin/operator-owned surfaces.
+
+## Known Issues
+
+- Live-stack E2E remains opt-in because it requires explicit runner power/storage budget.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material>=9.5,<10

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
-mkdocs-material>=9.5,<10
+mkdocs==1.6.1
+mkdocs-material==9.7.6

--- a/docs/user-handbook.md
+++ b/docs/user-handbook.md
@@ -8,7 +8,7 @@ This handbook is for people using a Weave organization after an owner/admin has 
 2. Complete SSO in the configured identity provider.
 3. Weave fetches the authenticated organization manifest and shows only the work surfaces and capability states available to you.
 
-If your organization is not ready yet, Weave should explain the impact in plain language: `ready`, `disabled`, `degraded`, or `policy-blocked`. Provider setup details stay with admins/operators.
+If your organization is not usable yet, Weave should explain the impact in plain language: `usable`/`ready`, `disabled`, `degraded`, or `policy-blocked`. `usable` is the member-facing concept; backend manifests may encode the same state as `ready`. Provider setup details stay with admins/operators.
 
 ## Workspaces and channels
 
@@ -48,7 +48,7 @@ Boards/tasks, shared calendar, and meeting capsules are capability-backed worksp
 
 | State | What it means for you |
 | --- | --- |
-| `ready` | The capability is available for your role and organization. |
+| `usable` / `ready` | The capability is available for your role and organization. |
 | `disabled` | The organization has not enabled this capability. |
 | `degraded` | The capability exists but has a temporary health or provider problem. |
 | `policy-blocked` | Your role/group does not currently have access. |

--- a/docs/user-handbook.md
+++ b/docs/user-handbook.md
@@ -1,0 +1,69 @@
+# User Handbook
+
+This handbook is for people using a Weave organization after an owner/admin has provisioned it. Members do not configure raw providers, service endpoints, OAuth clients, backup jobs, provider URLs, or secrets.
+
+## Onboarding and login
+
+1. Open the organization invite, deep link, or organization auth URL from your admin.
+2. Complete SSO in the configured identity provider.
+3. Weave fetches the authenticated organization manifest and shows only the work surfaces and capability states available to you.
+
+If your organization is not ready yet, Weave should explain the impact in plain language: `ready`, `disabled`, `degraded`, or `policy-blocked`. Provider setup details stay with admins/operators.
+
+## Workspaces and channels
+
+Channels are workspace containers for collaboration. A channel can expose tabs for chat, files, boards/tasks, calendar, meetings, and decisions when those capabilities are enabled for your organization and role.
+
+Expected member boundaries:
+
+- Use Weave-owned channel and work surfaces.
+- Follow links or prompts shown by Weave for available capabilities.
+- Report degraded or blocked states with the support-safe text shown in the app.
+- Do not enter raw Matrix, Nextcloud, OpenProject, LiveKit, Keycloak, or other provider admin details in the member client.
+
+## Chat
+
+Chat is a Weave product experience backed by the organization-selected chat provider. Matrix is the current dogfood provider, but provider names are not the everyday product model.
+
+Use chat for:
+
+- personal messages;
+- channel conversations;
+- accessible message composition;
+- reactions, attachments, and threaded context as the backend facades expose them.
+
+## Files and documents
+
+Files use Weave-owned product routes and backend facades. The client should not receive storage-provider credentials or raw provider URLs with secrets. Documents/collaboration launch through safe backend-issued sessions when enabled.
+
+## Tasks, boards, meetings, and calendar
+
+Boards/tasks, shared calendar, and meeting capsules are capability-backed workspace surfaces. They may be ready, disabled, degraded, or policy-blocked depending on admin/provider readiness and your role.
+
+- Calendar focuses on shared workspace/team/channel scheduling in the current product path.
+- Boards/tasks use a Weave task model behind provider adapters.
+- Meetings use backend token facades; media-provider secrets stay server-side.
+
+## Capability states
+
+| State | What it means for you |
+| --- | --- |
+| `ready` | The capability is available for your role and organization. |
+| `disabled` | The organization has not enabled this capability. |
+| `degraded` | The capability exists but has a temporary health or provider problem. |
+| `policy-blocked` | Your role/group does not currently have access. |
+
+## Accessibility
+
+Weave treats accessibility as release scope. Member surfaces should support keyboard use, screen readers, visible focus, sufficient target sizes, localized copy, and non-color-only state communication. See [Accessibility Release Gate](accessibility-release-gate.md) for the evidence model.
+
+## Troubleshooting
+
+Before asking an admin/operator for help, capture the support-safe information shown by Weave:
+
+- the organization name/auth URL you used;
+- the visible capability state and plain-language message;
+- the time of the failure;
+- your platform, app target, and app version if available.
+
+Do not paste secrets, bearer tokens, cookies, private keys, raw provider URLs with credentials, or full downstream provider responses into support reports.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Admin/Operator Handbook: admin-operator-handbook.md
   - Developer Handbook:
       - Overview: developer-handbook.md
+      - GitFlow and PR workflow: gitflow-pr-workflow.md
       - Architecture: architecture.md
       - Canonical feature models: canonical-feature-models.md
       - Acceptance contracts: acceptance-contracts.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Weave Documentation
 site_description: Provider-neutral Weave product, operator, and developer documentation.
 repo_url: https://github.com/masssi164/weave
 repo_name: masssi164/weave
+edit_uri: edit/main/docs/
 docs_dir: docs
 site_dir: build/docs-site
 strict: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,71 @@
+site_name: Weave Documentation
+site_description: Provider-neutral Weave product, operator, and developer documentation.
+repo_url: https://github.com/masssi164/weave
+repo_name: masssi164/weave
+docs_dir: docs
+site_dir: build/docs-site
+strict: true
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.indexes
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - scheme: default
+      primary: teal
+      accent: blue
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+nav:
+  - Home: index.md
+  - User Handbook: user-handbook.md
+  - Admin/Operator Handbook: admin-operator-handbook.md
+  - Developer Handbook:
+      - Overview: developer-handbook.md
+      - Architecture: architecture.md
+      - Canonical feature models: canonical-feature-models.md
+      - Acceptance contracts: acceptance-contracts.md
+      - Quality and evidence: quality-and-evidence.md
+      - Accessibility release gate: accessibility-release-gate.md
+      - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md
+  - Product and Release Scope:
+      - Product line and Weaver plan: product-line-and-weaver-plan.md
+      - v0.1 dogfood plan: release-v0.1-dogfood-plan.md
+      - Admin-provisioned first use: admin-provisioned-first-use.md
+      - Product acceptance flows: product-acceptance-flows.md
+      - Product flow activity diagrams: product-flow-activity-diagrams.md
+      - Calendar, E2EE, and boards scope: product-calendar-e2ee-boards-scope.md
+      - Roadmap and guarded surfaces: roadmap-and-guarded-surfaces.md
+      - Interop gateway and external collaboration: interop-gateway-and-external-collaboration.md
+      - Control plane and infra bootstrap: control-plane-infra-bootstrap.md
+  - Diagrams:
+      - Overview: diagrams/index.md
+      - Facade architecture source: diagrams/architecture_facade.mmd
+      - Chat ER source: diagrams/er_chat.mmd
+      - Files and docs ER source: diagrams/er_files_docs.mmd
+      - Calendar and meetings ER source: diagrams/er_calendar_meetings.mmd
+      - Boards and tasks ER source: diagrams/er_boards_tasks.mmd
+      - Identity/admin ER source: diagrams/er_identity_admin.mmd
+  - Release Notes:
+      - Process: release-notes/index.md
+      - Unreleased: release-notes/unreleased.md
+      - v0.1: release-notes/v0.1.md
+  - Research:
+      - Boards provider spike artifacts: research/boards-provider-spike-artifacts.md
+      - Boards provider spikes 119-121: research/boards-provider-spikes-119-121.md
+      - Boards task domain contract: research/boards-task-domain-contract.md
+      - Boards task module provider strategy: research/boards-task-module-provider-strategy.md

--- a/tools/docs_check.py
+++ b/tools/docs_check.py
@@ -24,6 +24,7 @@ REQUIRED_DOCS = [
     "user-handbook.md",
     "admin-operator-handbook.md",
     "developer-handbook.md",
+    "gitflow-pr-workflow.md",
     "diagrams/index.md",
     "release-notes/index.md",
     "release-notes/unreleased.md",

--- a/tools/docs_check.py
+++ b/tools/docs_check.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 DOCS = ROOT / "docs"
@@ -38,6 +40,11 @@ REQUIRED_MERMAID = [
     "er_boards_tasks.mmd",
     "er_identity_admin.mmd",
 ]
+RELEASE_NOTE_LABELS = [
+    "release-notes-feature",
+    "release-notes-bugfix",
+    "release-notes-skip",
+]
 
 
 def fail(message: str) -> None:
@@ -52,28 +59,81 @@ def read(path: Path) -> str:
         fail(f"missing required file: {path.relative_to(ROOT)}")
 
 
-def main() -> None:
-    mkdocs = read(MKDOCS)
+def mkdocs_nav_paths() -> set[str]:
+    try:
+        import yaml
+    except ImportError as error:
+        fail("PyYAML is required for docs structure checks; install docs/requirements.txt")
+
+    try:
+        config = yaml.load(read(MKDOCS), Loader=yaml.BaseLoader)
+    except yaml.YAMLError as error:
+        fail(f"could not parse mkdocs.yml: {error}")
+
+    paths: set[str] = set()
+
+    def walk(node: Any) -> None:
+        if isinstance(node, str):
+            paths.add(node)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+        elif isinstance(node, dict):
+            for value in node.values():
+                walk(value)
+
+    if not isinstance(config, dict):
+        fail("mkdocs.yml did not parse as a mapping")
+    walk(config.get("nav", []))
+    return paths
+
+
+def check_required_docs() -> None:
+    nav_paths = mkdocs_nav_paths()
     for rel in REQUIRED_DOCS:
-        path = DOCS / rel
-        read(path)
-        if rel not in mkdocs:
+        read(DOCS / rel)
+        if rel not in nav_paths:
             fail(f"{rel} is not linked from mkdocs.yml nav")
 
+
+def check_release_notes() -> None:
     for rel in ("release-notes/unreleased.md", "release-notes/v0.1.md"):
         content = read(DOCS / rel)
         for heading in REQUIRED_RELEASE_HEADINGS:
             if not re.search(rf"^## {re.escape(heading)}$", content, re.MULTILINE):
                 fail(f"{rel} is missing release notes category: {heading}")
 
+    workflow = read(DOCS / "gitflow-pr-workflow.md")
+    for label in RELEASE_NOTE_LABELS:
+        if label not in workflow:
+            fail(f"gitflow-pr-workflow.md is missing release notes label {label}")
+
+
+def check_diagrams() -> None:
+    nav_paths = mkdocs_nav_paths()
     diagrams_index = read(DOCS / "diagrams" / "index.md")
     for name in REQUIRED_MERMAID:
         source = DOCS / "diagrams" / name
         text = read(source).lstrip()
         if not (text.startswith("flowchart") or text.startswith("erDiagram")):
             fail(f"{source.relative_to(ROOT)} does not look like Mermaid source")
-        if name not in diagrams_index or f"diagrams/{name}" not in mkdocs:
+        if name not in diagrams_index or f"diagrams/{name}" not in nav_paths:
             fail(f"{name} is not linked from diagrams index and mkdocs nav")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--release-notes-only",
+        action="store_true",
+        help="check only release notes headings and label policy docs",
+    )
+    args = parser.parse_args()
+
+    check_release_notes()
+    if not args.release_notes_only:
+        check_required_docs()
+        check_diagrams()
 
     print("docs-check: ok")
 

--- a/tools/docs_check.py
+++ b/tools/docs_check.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Lightweight documentation structure checks for the Weave MkDocs site."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+MKDOCS = ROOT / "mkdocs.yml"
+REQUIRED_RELEASE_HEADINGS = [
+    "Added",
+    "Changed",
+    "Fixed",
+    "Security",
+    "Accessibility",
+    "Migration/Operator Notes",
+    "Known Issues",
+]
+REQUIRED_DOCS = [
+    "index.md",
+    "user-handbook.md",
+    "admin-operator-handbook.md",
+    "developer-handbook.md",
+    "diagrams/index.md",
+    "release-notes/index.md",
+    "release-notes/unreleased.md",
+    "release-notes/v0.1.md",
+]
+REQUIRED_MERMAID = [
+    "architecture_facade.mmd",
+    "er_chat.mmd",
+    "er_files_docs.mmd",
+    "er_calendar_meetings.mmd",
+    "er_boards_tasks.mmd",
+    "er_identity_admin.mmd",
+]
+
+
+def fail(message: str) -> None:
+    print(f"docs-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        fail(f"missing required file: {path.relative_to(ROOT)}")
+
+
+def main() -> None:
+    mkdocs = read(MKDOCS)
+    for rel in REQUIRED_DOCS:
+        path = DOCS / rel
+        read(path)
+        if rel not in mkdocs:
+            fail(f"{rel} is not linked from mkdocs.yml nav")
+
+    for rel in ("release-notes/unreleased.md", "release-notes/v0.1.md"):
+        content = read(DOCS / rel)
+        for heading in REQUIRED_RELEASE_HEADINGS:
+            if not re.search(rf"^## {re.escape(heading)}$", content, re.MULTILINE):
+                fail(f"{rel} is missing release notes category: {heading}")
+
+    diagrams_index = read(DOCS / "diagrams" / "index.md")
+    for name in REQUIRED_MERMAID:
+        source = DOCS / "diagrams" / name
+        text = read(source).lstrip()
+        if not (text.startswith("flowchart") or text.startswith("erDiagram")):
+            fail(f"{source.relative_to(ROOT)} does not look like Mermaid source")
+        if name not in diagrams_index or f"diagrams/{name}" not in mkdocs:
+            fail(f"{name} is not linked from diagrams index and mkdocs nav")
+
+    print("docs-check: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/docs_check.py
+++ b/tools/docs_check.py
@@ -65,10 +65,20 @@ def mkdocs_nav_paths() -> set[str]:
     except ImportError as error:
         fail("PyYAML is required for docs structure checks; install docs/requirements.txt")
 
+    nav_lines: list[str] = []
+    in_nav = False
+    for line in read(MKDOCS).splitlines():
+        if line.startswith("nav:"):
+            in_nav = True
+        elif in_nav and line and not line.startswith(" "):
+            break
+        if in_nav:
+            nav_lines.append(line)
+
     try:
-        config = yaml.load(read(MKDOCS), Loader=yaml.BaseLoader)
+        config = yaml.safe_load("\n".join(nav_lines))
     except yaml.YAMLError as error:
-        fail(f"could not parse mkdocs.yml: {error}")
+        fail(f"could not parse mkdocs.yml nav: {error}")
 
     paths: set[str] = set()
 

--- a/tools/release_notes_label_check.py
+++ b/tools/release_notes_label_check.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Validate that a pull request chose exactly one release-notes label."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+RELEASE_NOTES_LABELS = {
+    "release-notes-feature",
+    "release-notes-bugfix",
+    "release-notes-skip",
+}
+
+
+def load_labels() -> list[str]:
+    if len(sys.argv) > 1:
+        return sys.argv[1:]
+
+    raw = os.environ.get("PR_LABELS_JSON")
+    if raw is None:
+        print("release-notes-label-check: PR_LABELS_JSON is not set", file=sys.stderr)
+        raise SystemExit(2)
+
+    try:
+        labels = json.loads(raw)
+    except json.JSONDecodeError as error:
+        print(f"release-notes-label-check: invalid PR_LABELS_JSON: {error}", file=sys.stderr)
+        raise SystemExit(2) from error
+
+    if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+        print("release-notes-label-check: PR_LABELS_JSON must be a JSON array of strings", file=sys.stderr)
+        raise SystemExit(2)
+
+    return labels
+
+
+def main() -> None:
+    labels = load_labels()
+    selected = sorted(RELEASE_NOTES_LABELS.intersection(labels))
+
+    if len(selected) != 1:
+        allowed = ", ".join(sorted(RELEASE_NOTES_LABELS))
+        actual = ", ".join(selected) if selected else "none"
+        print(
+            "release-notes-label-check: every PR must have exactly one "
+            f"release-notes label before review/merge. Allowed: {allowed}. Found: {actual}.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    print(f"release-notes-label-check: ok ({selected[0]})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add MkDocs Material site configuration and first-class docs nav for user, admin/operator, developer, diagrams, and release notes.
- Add User Handbook and Admin/Operator Handbook foundations that preserve provider-neutral/member-vs-admin boundaries.
- Add GitFlow/PR workflow docs with mandatory release-notes label policy and Copilot-review rule.
- Add release notes structure/process plus docs validation, release-notes label validation, Make targets, CI docs job, CI label gate, and PR checklist entries.

## Scope and user impact

Documentation/process foundation only. No runtime client/server/infra behavior changes.

Closes #286.
Closes #287.
Refs #289.
Follow-up for full release notes automation: #291.

## Screenshots or docs impact

Docs site now builds into `build/docs-site` with MkDocs Material. Mermaid diagrams are linked in docs navigation and the diagrams index; inline Mermaid rendering is configured for Markdown pages.

Developer Handbook now includes/links a GitFlow/PR workflow chapter covering:

- exactly one of `release-notes-feature`, `release-notes-bugfix`, `release-notes-skip` before review/merge;
- release notes generated from merged PR labels, with `release-notes-skip` excluded;
- Copilot review required on review-ready PRs;
- first safe CI gate now, full generation tracked in #291.

## Accessibility and localization

Documentation preserves accessibility as a release gate and adds member/operator guidance for support-safe capability states.

## Contract impact

- [x] No public API/auth/topology/spec contract change
- [ ] Contract/spec change documented:

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [x] Copilot review requested for this review-ready PR

## Checks run

- [x] `make release-notes-check`
- [x] `PR_LABELS_JSON='["release-notes-feature"]' make release-notes-label-check`
- [x] negative local label-check smoke: `PR_LABELS_JSON='[]' python3 tools/release_notes_label_check.py` failed as expected
- [x] `PATH=/tmp/weave-docs-venv/bin:$PATH make docs-check`
- [x] `PATH=/tmp/weave-docs-venv/bin:$PATH make docs-build`

Notes: MkDocs Material emits an informational warning about future MkDocs 2.0; the pinned installed MkDocs 1.6.1 build completed successfully.

## Notes for reviewers

MkDocs Material license was verified as MIT from upstream on 2026-05-24 and recorded in docs.
