### PR TITLE
fix(ci): explain unconfirmed live stack dispatch

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -30,6 +30,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  live-stack-e2e-not-confirmed:
+    name: Explain missing manual dispatch confirmation
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.power_storage_confirmation != 'I_HAVE_SOLAR_STORAGE_BUDGET'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain why live-stack E2E did not start
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          # Live Stack E2E was not started
+
+          The expensive self-hosted live-stack run is gated behind an explicit
+          power/storage confirmation. Re-dispatch this workflow with
+          `power_storage_confirmation` set exactly to
+          `I_HAVE_SOLAR_STORAGE_BUDGET` when an operator has confirmed runner
+          power and storage budget.
+          EOF
+          echo "::error::Live Stack E2E not started: set power_storage_confirmation=I_HAVE_SOLAR_STORAGE_BUDGET after operator budget approval."
+          exit 1
+
   live-stack-e2e:
     name: Bootstrap Stack And Run App E2E
     if: github.event_name != 'workflow_dispatch' || github.event.inputs.power_storage_confirmation == 'I_HAVE_SOLAR_STORAGE_BUDGET'


### PR DESCRIPTION
## Summary
- add a cheap `live-stack-e2e-not-confirmed` job for manual dispatches without the exact power/storage confirmation
- fail fast with a GitHub summary and error instead of letting the whole expensive workflow appear silently skipped
- keep the self-hosted live-stack job gated behind the existing explicit operator confirmation

## Evidence
- `python3 - <<'PY' ... yaml.safe_load(...)` parsed `.github/workflows/live-stack-e2e.yml` and verified both jobs
- `make acceptance-contract` passed on 25 mapped scenarios
- `python3 tools/release_notes_label_check_test.py` passed

Fixes #246.