### PR TITLE
chore: harden provider-neutral control plane

### DIFF
--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -9,11 +9,11 @@ function mockApi(overrides: Partial<AdminControlPlaneApi> = {}): AdminControlPla
   return {
     getControlPlane: vi.fn().mockResolvedValue(sampleControlPlane),
     updateWhitelistPolicy: vi.fn().mockResolvedValue({
-      denyByDefault: true,
+      ...sampleControlPlane.whitelistPolicy,
       allowedCapabilities: ['files.read'],
-      blockedCapabilities: ['weaver.exec'],
     }),
-    testProviderReadiness: vi.fn().mockResolvedValue({ providerKey: 'identity-idm', state: 'ready', summary: 'Ready' }),
+    selectProvider: vi.fn().mockResolvedValue(undefined),
+    testProviderReadiness: vi.fn().mockResolvedValue({ providerKey: 'keycloak-realm', state: 'ready', summary: 'Ready' }),
     listAuditEvents: vi.fn().mockResolvedValue(sampleControlPlane.auditEvents),
     ...overrides,
   } as unknown as AdminControlPlaneApi;
@@ -32,10 +32,12 @@ describe('Admin Console MVP', () => {
     expect(await screen.findByRole('heading', { name: /weave organization admin console/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /organization overview/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /provider categories/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /provider detail and readiness/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /provider selection and readiness/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /policy and whitelist/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /secretref inventory/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /audit trail/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/identity \/ idm status is ready/i)).toBeInTheDocument();
+    expect(screen.getByText(/provider source of truth/i)).toBeInTheDocument();
     expect(screen.getByText(/policy is deny-by-default/i)).toBeInTheDocument();
   });
 
@@ -43,7 +45,8 @@ describe('Admin Console MVP', () => {
     render(<App api={mockApi()} />);
 
     expect(await screen.findByText(/calls only Weave backend admin APIs/i)).toBeInTheDocument();
-    expect(screen.getByText(/it does not call Keycloak, Nextcloud, Matrix, Microsoft Graph/i)).toBeInTheDocument();
+    expect(screen.getByText(/it does not call Keycloak, Nextcloud, Matrix, Microsoft Graph, Slack, Teams/i)).toBeInTheDocument();
+    expect(screen.getByText(/Secrets stay as SecretRef handles/i)).toBeInTheDocument();
     expect(screen.getByText(/use the provider-agnostic weave client/i)).toBeInTheDocument();
   });
 
@@ -61,6 +64,28 @@ describe('Admin Console MVP', () => {
     expect(await screen.findByRole('status')).toHaveTextContent(/whitelist policy saved/i);
   });
 
+  it('applies selected providers as Admin Console source of truth through the backend API', async () => {
+    const api = mockApi();
+    const user = userEvent.setup();
+    render(<App api={api} />);
+
+    await user.click(await screen.findByRole('button', { name: /apply selected provider/i }));
+
+    await waitFor(() => expect(api.selectProvider).toHaveBeenCalledWith('identity-idm', 'keycloak-realm', 'recommended_self_hosted_default', false));
+    expect(await screen.findByRole('status')).toHaveTextContent(/provider selection applied/i);
+  });
+
+  it('dry-runs selected providers through the backend API before applying', async () => {
+    const api = mockApi();
+    const user = userEvent.setup();
+    render(<App api={api} />);
+
+    await user.click(await screen.findByRole('button', { name: /dry-run provider selection/i }));
+
+    await waitFor(() => expect(api.selectProvider).toHaveBeenCalledWith('identity-idm', 'keycloak-realm', 'recommended_self_hosted_default', true));
+    expect(await screen.findByRole('status')).toHaveTextContent(/dry-run validated/i);
+  });
+
   it('queues provider readiness tests through the backend API', async () => {
     const api = mockApi();
     const user = userEvent.setup();
@@ -68,7 +93,7 @@ describe('Admin Console MVP', () => {
 
     await user.click(await screen.findByRole('button', { name: /test readiness through backend/i }));
 
-    await waitFor(() => expect(api.testProviderReadiness).toHaveBeenCalledWith('identity-idm'));
+    await waitFor(() => expect(api.testProviderReadiness).toHaveBeenCalledWith('keycloak-realm'));
     expect(await screen.findByRole('status')).toHaveTextContent(/readiness test queued/i);
   });
 });

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -115,15 +115,9 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
       setStatusMessage(`Dry-run validated for ${selectedCategoryDetails.key}: ${providerDraft}.`);
       return;
     }
-    setControlPlane((current) => ({
-      ...current,
-      providerCategories: current.providerCategories.map((category) =>
-        category.key === selectedCategoryDetails.key
-          ? { ...category, selectedAdapter: providerDraft, selectedByAdmin: true, bootstrapSuggestionOnly: false, choiceModel: choiceModelDraft }
-          : category,
-      ),
-    }));
-    setStatusMessage(`Provider selection applied for ${selectedCategoryDetails.key}: ${providerDraft}.`);
+    const refreshed = await api.getControlPlane();
+    setControlPlane(refreshed);
+    setStatusMessage(`Provider selection applied for ${selectedCategoryDetails.key}: ${providerDraft}. Backend control plane refreshed as source of truth.`);
   }
 
   async function testReadiness(providerKey: string) {

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -24,19 +24,26 @@ import {
   Toolbar,
   Typography,
 } from '@mui/material';
-import { AdminControlPlaneApi, adminConsoleConfig, ControlPlaneResponse, ProviderCategory, sampleControlPlane } from './api';
+import { AdminControlPlaneApi, adminConsoleConfig, CapabilityState, ControlPlaneResponse, ProviderCategory, sampleControlPlane } from './api';
 
-const stateColor: Record<ProviderCategory['state'], 'success' | 'default' | 'warning' | 'error' | 'info'> = {
+const stateColor: Record<CapabilityState, 'success' | 'default' | 'warning' | 'error' | 'info'> = {
   ready: 'success',
   disabled: 'default',
   degraded: 'warning',
   'policy-blocked': 'info',
   misconfigured: 'error',
   unsupported: 'error',
+  not_configured: 'default',
+  configured: 'info',
 };
 
-function readableState(state: ProviderCategory['state']): string {
-  return state.replace('-', ' ');
+function readableState(state: string): string {
+  return state.replace(/[-_]/g, ' ');
+}
+
+function defaultProviderKey(category?: ProviderCategory): string {
+  if (!category) return '';
+  return category.selectedAdapter === 'awaiting_admin_selection' ? category.providerCandidates[0] ?? '' : category.selectedAdapter;
 }
 
 interface AppProps {
@@ -47,7 +54,9 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
   const [controlPlane, setControlPlane] = useState<ControlPlaneResponse>(sampleControlPlane);
   const [loadState, setLoadState] = useState<'loading' | 'loaded' | 'offline-sample'>('loading');
   const [error, setError] = useState<string | null>(null);
-  const [selectedProvider, setSelectedProvider] = useState(sampleControlPlane.providerCategories[0]?.key ?? '');
+  const [selectedCategory, setSelectedCategory] = useState(sampleControlPlane.providerCategories[0]?.key ?? '');
+  const [providerDraft, setProviderDraft] = useState(defaultProviderKey(sampleControlPlane.providerCategories[0]));
+  const [choiceModelDraft, setChoiceModelDraft] = useState('recommended_self_hosted_default');
   const [policyDraft, setPolicyDraft] = useState(sampleControlPlane.whitelistPolicy.allowedCapabilities.join('\n'));
   const [statusMessage, setStatusMessage] = useState('Admin Console is loading backend control-plane data.');
 
@@ -57,9 +66,12 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
       .getControlPlane()
       .then((response) => {
         if (!alive) return;
+        const firstCategory = response.providerCategories[0];
         setControlPlane(response);
         setPolicyDraft(response.whitelistPolicy.allowedCapabilities.join('\n'));
-        setSelectedProvider(response.providerCategories[0]?.key ?? '');
+        setSelectedCategory(firstCategory?.key ?? '');
+        setProviderDraft(defaultProviderKey(firstCategory));
+        setChoiceModelDraft(firstCategory?.choiceModel === 'not_selected' ? 'recommended_self_hosted_default' : firstCategory?.choiceModel ?? 'recommended_self_hosted_default');
         setLoadState('loaded');
         setStatusMessage('Backend control-plane data loaded.');
       })
@@ -74,10 +86,17 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
     };
   }, [api]);
 
-  const selectedProviderDetails = useMemo(
-    () => controlPlane.providerCategories.find((provider) => provider.key === selectedProvider) ?? controlPlane.providerCategories[0],
-    [controlPlane.providerCategories, selectedProvider],
+  const selectedCategoryDetails = useMemo(
+    () => controlPlane.providerCategories.find((category) => category.key === selectedCategory) ?? controlPlane.providerCategories[0],
+    [controlPlane.providerCategories, selectedCategory],
   );
+
+  function changeCategory(categoryKey: string) {
+    const category = controlPlane.providerCategories.find((candidate) => candidate.key === categoryKey);
+    setSelectedCategory(categoryKey);
+    setProviderDraft(defaultProviderKey(category));
+    setChoiceModelDraft(category?.choiceModel === 'not_selected' ? 'recommended_self_hosted_default' : category?.choiceModel ?? 'recommended_self_hosted_default');
+  }
 
   async function savePolicy() {
     const allowedCapabilities = policyDraft
@@ -86,7 +105,25 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
       .filter(Boolean);
     const response = await api.updateWhitelistPolicy(allowedCapabilities);
     setControlPlane((current) => ({ ...current, whitelistPolicy: response }));
-    setStatusMessage(`Whitelist policy saved with ${response.allowedCapabilities.length} allowed capabilities.`);
+    setStatusMessage(`Whitelist policy saved with ${allowedCapabilities.length} requested capabilities.`);
+  }
+
+  async function selectProvider(dryRun: boolean) {
+    if (!selectedCategoryDetails || !providerDraft) return;
+    await api.selectProvider(selectedCategoryDetails.key, providerDraft, choiceModelDraft, dryRun);
+    if (dryRun) {
+      setStatusMessage(`Dry-run validated for ${selectedCategoryDetails.key}: ${providerDraft}.`);
+      return;
+    }
+    setControlPlane((current) => ({
+      ...current,
+      providerCategories: current.providerCategories.map((category) =>
+        category.key === selectedCategoryDetails.key
+          ? { ...category, selectedAdapter: providerDraft, selectedByAdmin: true, bootstrapSuggestionOnly: false, choiceModel: choiceModelDraft }
+          : category,
+      ),
+    }));
+    setStatusMessage(`Provider selection applied for ${selectedCategoryDetails.key}: ${providerDraft}.`);
   }
 
   async function testReadiness(providerKey: string) {
@@ -118,7 +155,7 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
               </Typography>
               <Typography>
                 Sign in through OIDC/Keycloak client <strong>{adminConsoleConfig.oidcClientId}</strong>. This console calls only Weave backend admin APIs;
-                it does not call Keycloak, Nextcloud, Matrix, Microsoft Graph, or other providers directly.
+                it does not call Keycloak, Nextcloud, Matrix, Microsoft Graph, Slack, Teams, or other providers directly.
               </Typography>
               <Typography sx={{ mt: 1 }}>
                 Issuer: <code>{adminConsoleConfig.oidcIssuerUrl}</code>
@@ -139,11 +176,12 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
                   <strong>{controlPlane.organization.displayName}</strong> ({controlPlane.organization.id})
                 </Typography>
                 <Typography>
-                  Member manifest: <code>{controlPlane.organization.manifestUrl}</code>
+                  Provider source of truth: <code>{controlPlane.providerConfigSource}</code>
                 </Typography>
                 <Typography>
-                  Auth issuer: <code>{controlPlane.organization.authIssuerUrl}</code>
+                  Bootstrap defaults are suggestions only: <strong>{controlPlane.bootstrapDefaultsAreSuggestionsOnly ? 'yes' : 'no'}</strong>
                 </Typography>
+                <Typography>Member clients may configure providers: <strong>no</strong></Typography>
               </Stack>
             </CardContent>
           </Card>
@@ -153,20 +191,23 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
               <Typography id="providers-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 2 }}>
                 Provider categories
               </Typography>
-              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
-                {controlPlane.providerCategories.map((provider) => (
-                  <Card key={provider.key} variant="outlined" sx={{ flex: 1 }}>
+              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ flexWrap: 'wrap' }} useFlexGap>
+                {controlPlane.providerCategories.map((category) => (
+                  <Card key={category.key} variant="outlined" sx={{ flex: '1 1 260px' }}>
                     <CardContent>
                       <Typography variant="h3" sx={{ fontSize: '1.05rem' }}>
-                        {provider.label}
+                        {category.label}
                       </Typography>
                       <Chip
                         sx={{ mt: 1 }}
-                        color={stateColor[provider.state]}
-                        label={`Status: ${readableState(provider.state)}`}
-                        aria-label={`${provider.label} status is ${readableState(provider.state)}`}
+                        color={stateColor[category.state]}
+                        label={`Status: ${readableState(category.state)}`}
+                        aria-label={`${category.label} status is ${readableState(category.state)}`}
                       />
-                      <Typography sx={{ mt: 1 }}>{provider.summary}</Typography>
+                      <Typography sx={{ mt: 1 }}>{category.summary}</Typography>
+                      <Typography variant="body2" sx={{ mt: 1 }}>
+                        Selected: {category.selectedAdapter}; candidates: {category.providerCandidates.join(', ')}
+                      </Typography>
                     </CardContent>
                   </Card>
                 ))}
@@ -174,38 +215,63 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
             </CardContent>
           </Card>
 
-          <Card component="section" aria-labelledby="provider-detail-heading">
+          <Card component="section" aria-labelledby="provider-selection-heading">
             <CardContent>
-              <Typography id="provider-detail-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 2 }}>
-                Provider detail and readiness
+              <Typography id="provider-selection-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 2 }}>
+                Provider selection and readiness
               </Typography>
-              <FormControl fullWidth sx={{ mb: 2 }}>
-                <InputLabel id="provider-select-label">Provider category</InputLabel>
-                <Select
-                  labelId="provider-select-label"
-                  id="provider-select"
-                  value={selectedProvider}
-                  label="Provider category"
-                  onChange={(event) => setSelectedProvider(event.target.value)}
-                >
-                  {controlPlane.providerCategories.map((provider) => (
-                    <MenuItem key={provider.key} value={provider.key}>
-                      {provider.label}
-                    </MenuItem>
-                  ))}
-                </Select>
-                <FormHelperText>Readiness tests are sent to the backend control plane.</FormHelperText>
-              </FormControl>
-              {selectedProviderDetails ? (
-                <Stack spacing={1}>
-                  <Typography>Adapter: {selectedProviderDetails.selectedAdapter}</Typography>
-                  <Typography>Status text: {readableState(selectedProviderDetails.state)}</Typography>
-                  <Typography>Secret references: {selectedProviderDetails.secretRefs.length ? selectedProviderDetails.secretRefs.join(', ') : 'none'}</Typography>
-                  <Button variant="contained" onClick={() => void testReadiness(selectedProviderDetails.key)}>
-                    Test readiness through backend
-                  </Button>
-                </Stack>
-              ) : null}
+              <Alert severity="info" sx={{ mb: 2 }}>
+                Admin Console-selected mappings are the source of truth. Secrets stay as SecretRef handles; readiness tests run only through backend admin APIs.
+              </Alert>
+              <Stack spacing={2}>
+                <FormControl fullWidth>
+                  <InputLabel id="provider-category-select-label">Provider category</InputLabel>
+                  <Select labelId="provider-category-select-label" id="provider-category-select" value={selectedCategory} label="Provider category" onChange={(event) => changeCategory(event.target.value)}>
+                    {controlPlane.providerCategories.map((category) => (
+                      <MenuItem key={category.key} value={category.key}>
+                        {category.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  <FormHelperText>Category-first canonical Weave contracts stay separate from adapter choices.</FormHelperText>
+                </FormControl>
+
+                {selectedCategoryDetails ? (
+                  <>
+                    <FormControl fullWidth>
+                      <InputLabel id="provider-candidate-select-label">Selected provider adapter</InputLabel>
+                      <Select labelId="provider-candidate-select-label" id="provider-candidate-select" value={providerDraft} label="Selected provider adapter" onChange={(event) => setProviderDraft(event.target.value)}>
+                        {selectedCategoryDetails.providerCandidates.map((candidate) => (
+                          <MenuItem key={candidate} value={candidate}>
+                            {candidate}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                    <FormControl fullWidth>
+                      <InputLabel id="choice-model-select-label">Choice model</InputLabel>
+                      <Select labelId="choice-model-select-label" id="choice-model-select" value={choiceModelDraft} label="Choice model" onChange={(event) => setChoiceModelDraft(event.target.value)}>
+                        <MenuItem value="recommended_self_hosted_default">recommended self-hosted default</MenuItem>
+                        <MenuItem value="external_existing_provider">external existing provider</MenuItem>
+                        <MenuItem value="managed_cloud_provider">managed cloud provider</MenuItem>
+                      </Select>
+                    </FormControl>
+                    <Typography>SecretRefs: {selectedCategoryDetails.secretRefs.join(', ') || `secretref://weave/provider/${providerDraft}`}</Typography>
+                    <Typography>Never paste raw secrets, bearer tokens, provider URLs with credentials, or downstream diagnostics.</Typography>
+                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                      <Button variant="outlined" onClick={() => void selectProvider(true)}>
+                        Dry-run provider selection
+                      </Button>
+                      <Button variant="contained" onClick={() => void selectProvider(false)}>
+                        Apply selected provider
+                      </Button>
+                      <Button variant="contained" color="secondary" onClick={() => void testReadiness(providerDraft)}>
+                        Test readiness through backend
+                      </Button>
+                    </Stack>
+                  </>
+                ) : null}
+              </Stack>
             </CardContent>
           </Card>
 
@@ -215,22 +281,29 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
                 Policy and whitelist
               </Typography>
               <Alert severity="info" sx={{ mb: 2 }}>
-                Policy is deny-by-default. Add one capability per line only after the organization has approved it.
+                Policy is deny-by-default. Add one canonical Weave capability per line only after the organization has approved it.
               </Alert>
-              <TextField
-                label="Allowed capabilities"
-                value={policyDraft}
-                onChange={(event) => setPolicyDraft(event.target.value)}
-                fullWidth
-                multiline
-                minRows={5}
-                helperText="Example: files.read. Do not paste secrets, provider tokens, or raw diagnostics here."
-              />
+              <TextField label="Allowed capabilities" value={policyDraft} onChange={(event) => setPolicyDraft(event.target.value)} fullWidth multiline minRows={5} helperText="Example: files.read. Do not paste secrets, provider tokens, raw diagnostics, or provider-specific payloads here." />
               <Button sx={{ mt: 2 }} variant="contained" onClick={() => void savePolicy()}>
                 Save whitelist policy
               </Button>
               <Divider sx={{ my: 2 }} />
               <Typography>Blocked examples: {controlPlane.whitelistPolicy.blockedCapabilities.join(', ')}</Typography>
+            </CardContent>
+          </Card>
+
+          <Card component="section" aria-labelledby="secrets-heading">
+            <CardContent>
+              <Typography id="secrets-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 1 }}>
+                SecretRef inventory
+              </Typography>
+              <List aria-label="Support-safe SecretRef handles">
+                {controlPlane.providerCategories.flatMap((category) => category.secretRefs.map((secretRef) => ({ category, secretRef }))).map(({ category, secretRef }) => (
+                  <ListItem key={`${category.key}-${secretRef}`} alignItems="flex-start">
+                    <ListItemText primary={`${category.label}: SecretRef handle`} secondary={`${secretRef} — raw secret exposed: no`} />
+                  </ListItem>
+                ))}
+              </List>
             </CardContent>
           </Card>
 
@@ -251,8 +324,7 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
 
           <Box component="footer">
             <Typography variant="body2">
-              Need member behavior? Use the provider-agnostic Weave Client. Admin/provider setup belongs here and in backend policy.{' '}
-              <Link href="/api/organization/manifest">Organization manifest</Link>
+              Need member behavior? Use the provider-agnostic Weave Client. Admin/provider setup belongs here and in backend policy. <Link href="/api/organization/manifest">Organization manifest</Link>
             </Typography>
           </Box>
         </Stack>

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -1,4 +1,4 @@
-export type CapabilityState = 'ready' | 'disabled' | 'degraded' | 'policy-blocked' | 'misconfigured' | 'unsupported';
+export type CapabilityState = 'ready' | 'disabled' | 'degraded' | 'policy-blocked' | 'misconfigured' | 'unsupported' | 'not_configured' | 'configured';
 
 export interface ProviderCategory {
   key: string;
@@ -7,6 +7,10 @@ export interface ProviderCategory {
   state: CapabilityState;
   summary: string;
   supportSafe: boolean;
+  selectedByAdmin: boolean;
+  bootstrapSuggestionOnly: boolean;
+  choiceModel: string;
+  providerCandidates: string[];
   lastCheckedAt?: string;
   secretRefs: string[];
 }
@@ -32,6 +36,8 @@ export interface ControlPlaneResponse {
     manifestUrl: string;
     authIssuerUrl: string;
   };
+  providerConfigSource: string;
+  bootstrapDefaultsAreSuggestionsOnly: boolean;
   providerCategories: ProviderCategory[];
   whitelistPolicy: WhitelistPolicy;
   auditEvents: AuditEvent[];
@@ -62,6 +68,46 @@ export class AdminApiError extends Error {
   }
 }
 
+interface ServerControlPlaneResponse {
+  organizationId?: string;
+  organizationName?: string;
+  providerConfigSource?: string;
+  bootstrapDefaultsAreSuggestionsOnly?: boolean;
+  generatedAt?: string;
+  categories?: ServerProviderCategory[];
+  selectedProviderMappings?: Array<{ category?: string; providerKey?: string; secretRef?: string }>;
+  whitelist?: ServerWhitelistPolicy;
+  secretRefs?: Array<{ ref?: string; providerKey?: string }>;
+}
+
+interface ServerProviderCategory {
+  category?: string;
+  label?: string;
+  readiness?: string;
+  memberImpact?: string;
+  providerCandidates?: string[];
+  selectedProviderKey?: string;
+  choiceModel?: string;
+  selectedByAdmin?: boolean;
+  bootstrapSuggestionOnly?: boolean;
+  diagnostics?: Record<string, unknown>;
+}
+
+interface ServerWhitelistPolicy {
+  denyByDefault?: boolean;
+  profileCapabilities?: Record<string, string[]>;
+  effectiveCapabilities?: string[];
+}
+
+interface ServerAuditEvent {
+  idempotencyKey?: string;
+  action?: string;
+  actorRef?: string;
+  occurredAt?: string;
+  sourceRef?: string;
+  payload?: Record<string, unknown>;
+}
+
 export class AdminControlPlaneApi {
   constructor(
     private readonly config: AdminConsoleConfig = adminConsoleConfig,
@@ -70,25 +116,54 @@ export class AdminControlPlaneApi {
   ) {}
 
   async getControlPlane(): Promise<ControlPlaneResponse> {
-    return this.request<ControlPlaneResponse>('/admin/control-plane');
+    const controlPlane = await this.request<ServerControlPlaneResponse>('/admin/control-plane');
+    const auditEvents = await this.listAuditEvents().catch(() => []);
+    return normalizeControlPlane(controlPlane, auditEvents);
   }
 
-  async updateWhitelistPolicy(allowedCapabilities: string[]): Promise<WhitelistPolicy> {
-    return this.request<WhitelistPolicy>('/admin/policies/capability-whitelist', {
-      method: 'PUT',
-      body: JSON.stringify({ allowedCapabilities }),
+  async updateWhitelistPolicy(allowedCapabilities: string[], profileKey = 'workspace-admin'): Promise<WhitelistPolicy> {
+    const response = await this.request<ServerWhitelistPolicy>('/admin/policies/capability-whitelist', {
+      method: 'PATCH',
+      body: JSON.stringify({ profileKey, capabilityKeys: allowedCapabilities, reason: 'Updated through Organization/Admin Console' }),
+    });
+    return normalizeWhitelist(response);
+  }
+
+  async selectProvider(category: string, providerKey: string, choiceModel = 'recommended_self_hosted_default', dryRun = false): Promise<void> {
+    await this.request('/admin/providers/selections', {
+      method: 'POST',
+      body: JSON.stringify({
+        category,
+        providerKey,
+        choiceModel,
+        dryRun,
+        secretRef: `secretref://weave/provider/${providerKey}`,
+        reason: dryRun ? 'Dry-run through Organization/Admin Console' : 'Selected through Organization/Admin Console',
+      }),
     });
   }
 
   async testProviderReadiness(providerKey: string): Promise<{ providerKey: string; state: CapabilityState; summary: string }> {
-    return this.request('/admin/providers/readiness-tests', {
+    const response = await this.request<{ providerKey?: string; state?: string; readiness?: string }>('/admin/providers/readiness-tests', {
       method: 'POST',
       body: JSON.stringify({ providerKey }),
     });
+    return {
+      providerKey: response.providerKey ?? providerKey,
+      state: normalizeState(response.state ?? response.readiness),
+      summary: response.readiness ?? 'readiness tested through backend control plane',
+    };
   }
 
   async listAuditEvents(): Promise<AuditEvent[]> {
-    return this.request<AuditEvent[]>('/admin/audit/events');
+    const events = await this.request<ServerAuditEvent[]>('/admin/audit/events');
+    return events.map((event) => ({
+      id: event.idempotencyKey ?? `${event.action ?? 'audit'}-${event.occurredAt ?? 'unknown'}`,
+      action: event.action ?? 'unknown',
+      actor: event.actorRef ?? 'unknown-actor',
+      createdAt: event.occurredAt ?? '',
+      summary: supportSafeSummary(event),
+    }));
   }
 
   private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
@@ -106,6 +181,84 @@ export class AdminControlPlaneApi {
   }
 }
 
+function normalizeControlPlane(controlPlane: ServerControlPlaneResponse, auditEvents: AuditEvent[]): ControlPlaneResponse {
+  const selections = controlPlane.selectedProviderMappings ?? [];
+  const secretRefs = controlPlane.secretRefs ?? [];
+  return {
+    organization: {
+      id: controlPlane.organizationId ?? 'weave-dogfood',
+      displayName: controlPlane.organizationName ?? 'Weave Dogfood',
+      manifestUrl: '/api/v1/organization/manifest',
+      authIssuerUrl: adminConsoleConfig.oidcIssuerUrl,
+    },
+    providerConfigSource: controlPlane.providerConfigSource ?? 'admin-control-plane-selected-provider-mappings',
+    bootstrapDefaultsAreSuggestionsOnly: controlPlane.bootstrapDefaultsAreSuggestionsOnly ?? true,
+    providerCategories: (controlPlane.categories ?? []).map((category) => normalizeCategory(category, selections, secretRefs, controlPlane.generatedAt)),
+    whitelistPolicy: normalizeWhitelist(controlPlane.whitelist),
+    auditEvents,
+  };
+}
+
+function normalizeCategory(
+  category: ServerProviderCategory,
+  selections: Array<{ category?: string; providerKey?: string }>,
+  secretRefs: Array<{ ref?: string; providerKey?: string }>,
+  generatedAt?: string,
+): ProviderCategory {
+  const key = category.category ?? 'unknown';
+  const selectedAdapter = category.selectedProviderKey ?? selections.find((selection) => selection.category === key)?.providerKey ?? 'awaiting_admin_selection';
+  return {
+    key,
+    label: category.label ?? key,
+    selectedAdapter,
+    state: normalizeState(category.readiness),
+    summary: category.memberImpact ?? 'Backend control-plane status is support-safe.',
+    supportSafe: category.diagnostics?.secretsReturned === false && category.diagnostics?.rawProviderErrorsReturned === false,
+    selectedByAdmin: category.selectedByAdmin ?? false,
+    bootstrapSuggestionOnly: category.bootstrapSuggestionOnly ?? true,
+    choiceModel: category.choiceModel ?? 'not_selected',
+    providerCandidates: category.providerCandidates ?? [],
+    lastCheckedAt: generatedAt,
+    secretRefs: secretRefs.filter((secretRef) => secretRef.providerKey === selectedAdapter).map((secretRef) => secretRef.ref ?? '').filter(Boolean),
+  };
+}
+
+function normalizeWhitelist(whitelist?: ServerWhitelistPolicy): WhitelistPolicy {
+  const profileCapabilities = whitelist?.profileCapabilities ?? {};
+  const allowedCapabilities = Array.from(new Set([...(whitelist?.effectiveCapabilities ?? []), ...Object.values(profileCapabilities).flat()])).sort();
+  return {
+    denyByDefault: whitelist?.denyByDefault ?? true,
+    allowedCapabilities,
+    blockedCapabilities: ['provider.direct_call', 'provider.secret_export', 'weaver.exec_without_policy'],
+  };
+}
+
+function normalizeState(value?: string): CapabilityState {
+  switch (value) {
+    case 'ready':
+    case 'disabled':
+    case 'degraded':
+    case 'misconfigured':
+    case 'unsupported':
+    case 'not_configured':
+    case 'configured':
+      return value;
+    case 'policy_blocked':
+    case 'policy-blocked':
+      return 'policy-blocked';
+    default:
+      return 'degraded';
+  }
+}
+
+function supportSafeSummary(event: ServerAuditEvent): string {
+  const payload = event.payload ?? {};
+  const providerKey = typeof payload.providerKey === 'string' ? payload.providerKey : undefined;
+  const category = typeof payload.category === 'string' ? payload.category : undefined;
+  const target = providerKey ?? category ?? event.sourceRef ?? 'admin control plane';
+  return `${event.action ?? 'audit'} for ${target}; payload is redacted and support-safe.`;
+}
+
 export const sampleControlPlane: ControlPlaneResponse = {
   organization: {
     id: 'weave-dogfood',
@@ -113,33 +266,112 @@ export const sampleControlPlane: ControlPlaneResponse = {
     manifestUrl: '/api/organization/manifest',
     authIssuerUrl: 'https://auth.weave.local/realms/weave',
   },
+  providerConfigSource: 'admin-control-plane-selected-provider-mappings',
+  bootstrapDefaultsAreSuggestionsOnly: true,
   providerCategories: [
     {
       key: 'identity-idm',
       label: 'Identity / IDM',
       selectedAdapter: 'keycloak-realm',
       state: 'ready',
-      summary: 'Central Keycloak realm is the recommended self-hosted identity broker.',
+      summary: 'Central Keycloak realm is the recommended self-hosted identity broker; admin selection is the source of truth.',
       supportSafe: true,
+      selectedByAdmin: true,
+      bootstrapSuggestionOnly: false,
+      choiceModel: 'recommended_self_hosted_default',
+      providerCandidates: ['keycloak-realm', 'entra-id', 'authentik', 'auth0', 'generic-oidc', 'generic-saml', 'scim-ldap'],
       lastCheckedAt: '2026-05-24T18:00:00Z',
       secretRefs: ['secretref://weave/provider/keycloak-realm/client-secret'],
+    },
+    {
+      key: 'chat',
+      label: 'Chat',
+      selectedAdapter: 'synapse-homeserver',
+      state: 'ready',
+      summary: 'Chat is available through Weave conversations.',
+      supportSafe: true,
+      selectedByAdmin: true,
+      bootstrapSuggestionOnly: false,
+      choiceModel: 'recommended_self_hosted_default',
+      providerCandidates: ['synapse-homeserver', 'slack', 'microsoft-teams'],
+      secretRefs: ['secretref://weave/provider/synapse-homeserver'],
     },
     {
       key: 'files',
       label: 'Files',
       selectedAdapter: 'nextcloud-files',
       state: 'degraded',
-      summary: 'Backend facade can answer manifest requests; live provider smoke still needs operator proof.',
+      summary: 'Files are exposed through Weave canonical file facades; Nextcloud, SharePoint, S3, and SMB adapters remain backend-owned.',
       supportSafe: true,
-      secretRefs: ['secretref://weave/provider/nextcloud-files/backend-token'],
+      selectedByAdmin: true,
+      bootstrapSuggestionOnly: false,
+      choiceModel: 'recommended_self_hosted_default',
+      providerCandidates: ['nextcloud-files', 'sharepoint', 's3-compatible', 'smb'],
+      secretRefs: ['secretref://weave/provider/nextcloud-files'],
+    },
+    {
+      key: 'calendar',
+      label: 'Calendar',
+      selectedAdapter: 'nextcloud-caldav',
+      state: 'degraded',
+      summary: 'Calendar access is normalized through Weave; CalDAV and Microsoft Graph remain adapter choices only.',
+      supportSafe: true,
+      selectedByAdmin: true,
+      bootstrapSuggestionOnly: false,
+      choiceModel: 'recommended_self_hosted_default',
+      providerCandidates: ['nextcloud-caldav', 'microsoft-graph-calendar', 'generic-caldav'],
+      secretRefs: ['secretref://weave/provider/nextcloud-caldav'],
+    },
+    {
+      key: 'boards-tasks',
+      label: 'Boards / tasks',
+      selectedAdapter: 'openproject-primary',
+      state: 'policy-blocked',
+      summary: 'Boards/tasks stay provider-neutral across OpenProject, Planner, Jira, Vikunja, and Deck adapters.',
+      supportSafe: true,
+      selectedByAdmin: true,
+      bootstrapSuggestionOnly: false,
+      choiceModel: 'recommended_self_hosted_default',
+      providerCandidates: ['openproject-primary', 'microsoft-planner', 'jira', 'vikunja', 'nextcloud-deck'],
+      secretRefs: ['secretref://weave/provider/openproject-primary'],
+    },
+    {
+      key: 'meetings-calls',
+      label: 'Meetings / calls',
+      selectedAdapter: 'livekit',
+      state: 'misconfigured',
+      summary: 'Meetings are surfaced through Weave calls; LiveKit and external meeting links are backend-selected providers.',
+      supportSafe: true,
+      selectedByAdmin: true,
+      bootstrapSuggestionOnly: false,
+      choiceModel: 'recommended_self_hosted_default',
+      providerCandidates: ['livekit', 'microsoft-teams-meetings', 'external-meeting-link'],
+      secretRefs: ['secretref://weave/provider/livekit'],
+    },
+    {
+      key: 'documents-collaboration',
+      label: 'Documents / collaboration',
+      selectedAdapter: 'onlyoffice-community',
+      state: 'disabled',
+      summary: 'Documents use Weave/WOPI collaboration contracts; Nextcloud/SharePoint/WOPI providers are not member-facing setup.',
+      supportSafe: true,
+      selectedByAdmin: true,
+      bootstrapSuggestionOnly: false,
+      choiceModel: 'recommended_self_hosted_default',
+      providerCandidates: ['onlyoffice-community', 'collabora-code', 'wopi-host', 'microsoft-365-office-graph'],
+      secretRefs: ['secretref://weave/provider/onlyoffice-community'],
     },
     {
       key: 'weaver',
       label: 'Weaver runtime',
-      selectedAdapter: 'weaver-runtime-disabled',
+      selectedAdapter: 'awaiting_admin_selection',
       state: 'policy-blocked',
-      summary: 'Governed per-user PA runtime remains disabled by default.',
+      summary: 'Governed per-user PA runtime remains disabled by default and Weave-owned decisions stay backend-policy controlled.',
       supportSafe: true,
+      selectedByAdmin: false,
+      bootstrapSuggestionOnly: true,
+      choiceModel: 'not_selected',
+      providerCandidates: ['openclaw-governed-runtime'],
       secretRefs: [],
     },
   ],

--- a/client/lib/features/app/domain/entities/provider_stack_snapshot.dart
+++ b/client/lib/features/app/domain/entities/provider_stack_snapshot.dart
@@ -23,6 +23,9 @@ class ProviderStackSnapshot {
     required this.backendOwnedFacades,
     required this.flutterDirectProviderCallsAllowed,
     required this.supportSafe,
+    this.providerConfigSource = 'unknown',
+    this.bootstrapDefaultsAreSuggestionsOnly = true,
+    this.adminSelectedMappingsRequired = true,
     required this.providers,
     this.categories = const <ProviderCategoryStatusSnapshot>[],
     this.generatedAt,
@@ -32,6 +35,9 @@ class ProviderStackSnapshot {
   final bool backendOwnedFacades;
   final bool flutterDirectProviderCallsAllowed;
   final bool supportSafe;
+  final String providerConfigSource;
+  final bool bootstrapDefaultsAreSuggestionsOnly;
+  final bool adminSelectedMappingsRequired;
   final DateTime? generatedAt;
   final List<ProviderCategoryStatusSnapshot> categories;
   final List<ProviderStatusSnapshot> providers;
@@ -58,6 +64,11 @@ class ProviderCategoryStatusSnapshot {
     required this.memberImpact,
     required this.modules,
     required this.providerCandidates,
+    this.selectedProviderKey = 'awaiting_admin_selection',
+    this.choiceModel = 'not_selected',
+    this.selectedByAdmin = false,
+    this.bootstrapSuggestionOnly = true,
+    this.lossyMappingNotes = const <String>[],
     required this.diagnostics,
   });
 
@@ -69,6 +80,11 @@ class ProviderCategoryStatusSnapshot {
   final String memberImpact;
   final List<String> modules;
   final List<String> providerCandidates;
+  final String selectedProviderKey;
+  final String choiceModel;
+  final bool selectedByAdmin;
+  final bool bootstrapSuggestionOnly;
+  final List<String> lossyMappingNotes;
   final Map<String, Object?> diagnostics;
 
   bool get supportSafe =>

--- a/client/lib/features/auth/presentation/sign_in_screen.dart
+++ b/client/lib/features/auth/presentation/sign_in_screen.dart
@@ -7,7 +7,6 @@ import 'package:weave/core/widgets/error_state.dart';
 import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/core/widgets/weave_logo.dart';
 import 'package:weave/features/auth/presentation/providers/auth_flow_controller.dart';
-import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
 import 'package:weave/l10n/generated/app_localizations.dart';
 
@@ -105,13 +104,8 @@ class SignInScreen extends ConsumerWidget {
                                   ).textTheme.titleMedium,
                                 ),
                                 const SizedBox(height: 12),
-                                Text(
-                                  l10n.signInConfigurationProvider(
-                                    _providerLabel(
-                                      configuration.providerType,
-                                      l10n,
-                                    ),
-                                  ),
+                                const Text(
+                                  'Identity provider is selected by the Weave Admin Console; this client uses the organization sign-in endpoint.',
                                 ),
                                 const SizedBox(height: 8),
                                 Text(
@@ -187,13 +181,6 @@ class SignInScreen extends ConsumerWidget {
         ),
       ),
     );
-  }
-
-  String _providerLabel(OidcProviderType providerType, AppLocalizations l10n) {
-    return switch (providerType) {
-      OidcProviderType.authentik => l10n.oidcProviderAuthentik,
-      OidcProviderType.keycloak => l10n.oidcProviderKeycloak,
-    };
   }
 }
 

--- a/client/lib/features/server_config/presentation/widgets/server_configuration_form.dart
+++ b/client/lib/features/server_config/presentation/widgets/server_configuration_form.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:weave/core/a11y/semantic_button.dart';
-import 'package:weave/features/auth/domain/entities/oidc_constants.dart';
-import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration_save_result.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_form_controller.dart';
@@ -124,38 +122,20 @@ class _ServerConfigurationFormState
     AppLocalizations l10n,
     ServerConfigurationFormState formState,
   ) {
+    final theme = Theme.of(context);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        Text('Identity endpoint', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
         Text(
-          l10n.serverConfigurationProviderLabel,
-          style: Theme.of(context).textTheme.titleMedium,
-        ),
-        const SizedBox(height: 12),
-        DropdownButtonFormField<OidcProviderType>(
-          initialValue: formState.providerType,
-          decoration: InputDecoration(
-            labelText: l10n.serverConfigurationProviderFieldLabel,
+          'Provider selection is owned by the Weave Admin Console and backend control plane. This member client stores only canonical Weave endpoints needed to sign in.',
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
           ),
-          items: [
-            DropdownMenuItem(
-              value: OidcProviderType.authentik,
-              child: Text(l10n.oidcProviderAuthentik),
-            ),
-            DropdownMenuItem(
-              value: OidcProviderType.keycloak,
-              child: Text(l10n.oidcProviderKeycloak),
-            ),
-          ],
-          onChanged: (value) {
-            if (value != null) {
-              ref
-                  .read(serverConfigurationFormControllerProvider.notifier)
-                  .updateProviderType(value);
-            }
-          },
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: 16),
         TextField(
           controller: _issuerController,
           keyboardType: TextInputType.url,
@@ -188,8 +168,6 @@ class _ServerConfigurationFormState
               .read(serverConfigurationFormControllerProvider.notifier)
               .updateClientId,
         ),
-        const SizedBox(height: 24),
-        _OidcRegistrationHelpCard(providerType: formState.providerType),
       ],
     );
   }
@@ -293,61 +271,6 @@ class _ServerConfigurationFormState
     controller.value = TextEditingValue(
       text: nextValue,
       selection: TextSelection.collapsed(offset: nextValue.length),
-    );
-  }
-}
-
-class _OidcRegistrationHelpCard extends StatelessWidget {
-  const _OidcRegistrationHelpCard({required this.providerType});
-
-  final OidcProviderType providerType;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    final providerSteps = switch (providerType) {
-      OidcProviderType.authentik => l10n.oidcRegistrationHelpAuthentikSteps,
-      OidcProviderType.keycloak => l10n.oidcRegistrationHelpKeycloakSteps,
-    };
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              l10n.oidcRegistrationHelpTitle,
-              style: theme.textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-            Text(l10n.oidcRegistrationHelpDescription),
-            const SizedBox(height: 8),
-            Text(
-              l10n.oidcRegistrationHelpNoSecret,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-            const SizedBox(height: 12),
-            Text(providerSteps),
-            const SizedBox(height: 12),
-            Text(
-              l10n.oidcRegistrationHelpRedirectsTitle,
-              style: theme.textTheme.titleSmall,
-            ),
-            const SizedBox(height: 8),
-            Text(l10n.oidcRegistrationHelpRedirectValue(oidcRedirectUri)),
-            const SizedBox(height: 4),
-            Text(
-              l10n.oidcRegistrationHelpPostLogoutRedirectValue(
-                oidcPostLogoutRedirectUri,
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/client/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
+++ b/client/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
@@ -6,6 +6,9 @@ class ProviderRegistryResponseDto {
     required this.backendOwnedFacades,
     required this.flutterDirectProviderCallsAllowed,
     required this.supportSafe,
+    required this.providerConfigSource,
+    required this.bootstrapDefaultsAreSuggestionsOnly,
+    required this.adminSelectedMappingsRequired,
     required this.generatedAt,
     required this.categories,
     required this.providers,
@@ -19,6 +22,18 @@ class ProviderRegistryResponseDto {
         json['flutterDirectProviderCallsAllowed'],
       ),
       supportSafe: _bool(json['supportSafe']),
+      providerConfigSource: _string(
+        json['providerConfigSource'],
+        fallback: 'unknown',
+      ),
+      bootstrapDefaultsAreSuggestionsOnly:
+          json.containsKey('bootstrapDefaultsAreSuggestionsOnly')
+          ? _bool(json['bootstrapDefaultsAreSuggestionsOnly'])
+          : true,
+      adminSelectedMappingsRequired:
+          json.containsKey('adminSelectedMappingsRequired')
+          ? _bool(json['adminSelectedMappingsRequired'])
+          : true,
       generatedAt: _dateTime(json['generatedAt']),
       categories: _listOfMaps(
         json['categories'],
@@ -33,6 +48,9 @@ class ProviderRegistryResponseDto {
   final bool backendOwnedFacades;
   final bool flutterDirectProviderCallsAllowed;
   final bool supportSafe;
+  final String providerConfigSource;
+  final bool bootstrapDefaultsAreSuggestionsOnly;
+  final bool adminSelectedMappingsRequired;
   final DateTime? generatedAt;
   final List<ProviderCategoryStatusResponseDto> categories;
   final List<ProviderStatusResponseDto> providers;
@@ -42,6 +60,9 @@ class ProviderRegistryResponseDto {
     backendOwnedFacades: backendOwnedFacades,
     flutterDirectProviderCallsAllowed: flutterDirectProviderCallsAllowed,
     supportSafe: supportSafe,
+    providerConfigSource: providerConfigSource,
+    bootstrapDefaultsAreSuggestionsOnly: bootstrapDefaultsAreSuggestionsOnly,
+    adminSelectedMappingsRequired: adminSelectedMappingsRequired,
     generatedAt: generatedAt,
     categories: categories.map((category) => category.toSnapshot()).toList(),
     providers: providers.map((provider) => provider.toSnapshot()).toList(),
@@ -58,6 +79,11 @@ class ProviderCategoryStatusResponseDto {
     required this.memberImpact,
     required this.modules,
     required this.providerCandidates,
+    required this.selectedProviderKey,
+    required this.choiceModel,
+    required this.selectedByAdmin,
+    required this.bootstrapSuggestionOnly,
+    required this.lossyMappingNotes,
     required this.diagnostics,
   });
 
@@ -80,6 +106,16 @@ class ProviderCategoryStatusResponseDto {
       memberImpact: _safeText(json['memberImpact']),
       modules: _safeStringList(json['modules']),
       providerCandidates: _safeStringList(json['providerCandidates']),
+      selectedProviderKey: _string(
+        json['selectedProviderKey'],
+        fallback: 'awaiting_admin_selection',
+      ),
+      choiceModel: _string(json['choiceModel'], fallback: 'not_selected'),
+      selectedByAdmin: _bool(json['selectedByAdmin']),
+      bootstrapSuggestionOnly: json.containsKey('bootstrapSuggestionOnly')
+          ? _bool(json['bootstrapSuggestionOnly'])
+          : true,
+      lossyMappingNotes: _safeStringList(json['lossyMappingNotes']),
       diagnostics: _safeDiagnostics(json['diagnostics']),
     );
   }
@@ -92,6 +128,11 @@ class ProviderCategoryStatusResponseDto {
   final String memberImpact;
   final List<String> modules;
   final List<String> providerCandidates;
+  final String selectedProviderKey;
+  final String choiceModel;
+  final bool selectedByAdmin;
+  final bool bootstrapSuggestionOnly;
+  final List<String> lossyMappingNotes;
   final Map<String, Object?> diagnostics;
 
   ProviderCategoryStatusSnapshot toSnapshot() => ProviderCategoryStatusSnapshot(
@@ -103,6 +144,11 @@ class ProviderCategoryStatusResponseDto {
     memberImpact: memberImpact,
     modules: modules,
     providerCandidates: providerCandidates,
+    selectedProviderKey: selectedProviderKey,
+    choiceModel: choiceModel,
+    selectedByAdmin: selectedByAdmin,
+    bootstrapSuggestionOnly: bootstrapSuggestionOnly,
+    lossyMappingNotes: lossyMappingNotes,
     diagnostics: diagnostics,
   );
 }

--- a/client/test/features/onboarding/setup_flow_test.dart
+++ b/client/test/features/onboarding/setup_flow_test.dart
@@ -88,7 +88,7 @@ void main() {
     });
 
     testWidgets(
-      'renders first step with provider, issuer, and client id fields',
+      'renders first step with identity endpoint and client id fields',
       (tester) async {
         await tester.pumpWidget(buildApp());
         await tester.pumpAndSettle();
@@ -99,21 +99,18 @@ void main() {
         expect(find.text('Identity/IDM'), findsOneWidget);
         expect(find.text('Documents/collaboration'), findsOneWidget);
         expect(find.text('Weaver'), findsOneWidget);
-        expect(find.text('Provider type'), findsOneWidget);
+        expect(find.text('Identity endpoint'), findsOneWidget);
+        expect(
+          find.textContaining(
+            'Provider selection is owned by the Weave Admin Console',
+          ),
+          findsOneWidget,
+        );
+        expect(find.text('Provider type'), findsNothing);
         expect(find.text('OIDC Client ID'), findsOneWidget);
         expect(find.text('Next'), findsOneWidget);
       },
     );
-
-    testWidgets('shows public client registration guidance', (tester) async {
-      await tester.pumpWidget(buildApp());
-      await tester.pumpAndSettle();
-
-      expect(
-        find.text('Register Weave as a native/public client'),
-        findsOneWidget,
-      );
-    });
 
     testWidgets('derives service endpoints from the issuer host', (
       tester,

--- a/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -484,7 +484,11 @@ void main() {
           httpClient: _RecordingHttpClient((request) async {
             capturedRequest = request;
             return _jsonResponse({
-              'releaseStatus': 'contract-preview',
+              'releaseStatus': 'provider-stack-contract-v1',
+              'providerConfigSource':
+                  'admin-control-plane-selected-provider-mappings',
+              'bootstrapDefaultsAreSuggestionsOnly': true,
+              'adminSelectedMappingsRequired': true,
               'backendOwnedFacades': true,
               'flutterDirectProviderCallsAllowed': false,
               'supportSafe': true,
@@ -533,6 +537,11 @@ void main() {
                   'memberImpact': 'Sign-in is available.',
                   'modules': ['identity-realm', 'matrix-auth'],
                   'providerCandidates': ['keycloak', 'oidc'],
+                  'selectedProviderKey': 'keycloak-realm',
+                  'choiceModel': 'recommended_self_hosted_default',
+                  'selectedByAdmin': true,
+                  'bootstrapSuggestionOnly': false,
+                  'lossyMappingNotes': [],
                   'diagnostics': {
                     'providerCount': 2,
                     'allSupportSafe': true,
@@ -571,6 +580,11 @@ void main() {
                   'memberImpact': 'Weaver is disabled by workspace policy.',
                   'modules': [],
                   'providerCandidates': [],
+                  'selectedProviderKey': 'awaiting_admin_selection',
+                  'choiceModel': 'not_selected',
+                  'selectedByAdmin': false,
+                  'bootstrapSuggestionOnly': true,
+                  'lossyMappingNotes': [],
                   'diagnostics': {
                     'providerCount': 0,
                     'allSupportSafe': true,
@@ -642,6 +656,12 @@ void main() {
         );
         expect(capturedRequest.headers['Authorization'], 'Bearer token-123');
         expect(snapshot.failClosed, isTrue);
+        expect(
+          snapshot.providerConfigSource,
+          'admin-control-plane-selected-provider-mappings',
+        );
+        expect(snapshot.bootstrapDefaultsAreSuggestionsOnly, isTrue);
+        expect(snapshot.adminSelectedMappingsRequired, isTrue);
         expect(snapshot.categories, hasLength(2));
         expect(snapshot.categories.first.category, 'identity-idm');
         expect(
@@ -682,6 +702,9 @@ void main() {
           snapshot.categories.first.readiness,
           ProviderCategoryReadiness.ready,
         );
+        expect(snapshot.categories.first.selectedProviderKey, 'keycloak-realm');
+        expect(snapshot.categories.first.selectedByAdmin, isTrue);
+        expect(snapshot.categories.first.bootstrapSuggestionOnly, isFalse);
         expect(snapshot.categories.first.supportSafe, isTrue);
         expect(snapshot.categories.last.category, 'weaver');
         expect(

--- a/server/src/main/java/com/massimotter/weave/backend/config/ProviderCoreConfiguration.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/ProviderCoreConfiguration.java
@@ -22,7 +22,7 @@ public class ProviderCoreConfiguration {
                 "Identity realm provider seam is reserved for the Keycloak dry-run/readiness contract from backend PR #103.",
                 Set.of("realm-readiness", "realm-dry-run", "client-scope-diff", "role-diff"),
                 Set.of("direct-frontend-keycloak-admin", "secret-export", "live-realm-mutation-without-audit"),
-                List.of("keycloak"),
+                List.of("keycloak", "entra-id", "authentik", "auth0", "generic-oidc", "generic-saml", "scim-ldap"),
                 Map.of("dependency", "weave-backend#103", "compatibleSeam", true));
     }
 
@@ -34,7 +34,7 @@ public class ProviderCoreConfiguration {
                 "Matrix/Synapse is the chat and room substrate; provider status stays support-safe and does not expose room keys or raw homeserver errors.",
                 Set.of("workspace-room-readiness", "message-sync-readiness", "e2ee-status-readiness", "homeserver-discovery"),
                 Set.of("room-key-export", "raw-homeserver-errors", "direct-flutter-admin-api", "credential-exposure"),
-                List.of("synapse"),
+                List.of("synapse-homeserver", "matrix", "synapse", "slack", "microsoft-teams"),
                 Map.of("substrate", "matrix", "chatE2eeBoundary", "matrix-chat-only", "mediaCallsCovered", false));
     }
 
@@ -58,7 +58,7 @@ public class ProviderCoreConfiguration {
                 "Files facade is backend-owned and backed by Nextcloud WebDAV/OCS when configured.",
                 Set.of("list", "upload", "download", "create-folder", "delete", "quota-status"),
                 Set.of("direct-flutter-webdav", "html-scraping", "credential-exposure", "public-links-by-default"),
-                List.of("nextcloud"),
+                List.of("nextcloud-files", "nextcloud", "webdav", "sharepoint", "onedrive", "microsoft-graph-files", "s3", "s3-compatible", "smb"),
                 Map.of("facade", "/api/files", "rawProviderUiIsProductSurface", false));
     }
 
@@ -70,7 +70,7 @@ public class ProviderCoreConfiguration {
                 "Calendar facade is backend-owned and maps workspace/team/channel scopes to CalDAV when configured.",
                 Set.of("list-events", "read-event", "create-event", "update-event", "delete-event", "client-setup-metadata"),
                 Set.of("private-user-calendar-ingestion", "credential-export", "direct-flutter-caldav"),
-                List.of("nextcloud-caldav"),
+                List.of("nextcloud-caldav", "generic-caldav", "microsoft-graph-calendar", "workspace-calendar", "team-channel-calendar"),
                 Map.of("facade", "/api/calendar", "scopeModel", "workspace/team/channel"));
     }
 
@@ -106,7 +106,7 @@ public class ProviderCoreConfiguration {
                 "Boards/PM facade remains provider-neutral; OpenProject is the primary workspace-sync provider, Deck stays optional.",
                 Set.of("project-list", "board-list", "task-list", "task-create-local-workspace", "task-move-local-workspace", "task-complete-local-workspace", "workspace-sync"),
                 Set.of("raw-openproject-ui-as-product", "provider-writes-without-audit", "direct-flutter-provider-api"),
-                List.of("openproject", "nextcloud-deck", "vikunja-comparison"),
+                List.of("openproject-primary", "openproject", "microsoft-planner", "jira", "vikunja", "nextcloud-deck"),
                 Map.of("primaryProvider", "openproject", "optionalProvider", "nextcloud-deck", "facade", "/api/boards/workspace"));
     }
 
@@ -146,7 +146,7 @@ public class ProviderCoreConfiguration {
                         "raw-provider-errors"),
                 List.of("meetings-provider-not-configured", "meetings-provider-disabled", "meetings-provider-unavailable", "meetings-token-unavailable"),
                 "support-safe: no LiveKit API keys, API secrets, bearer tokens, room tokens, credential-bearing URLs, or raw provider errors",
-                List.of("livekit"),
+                List.of("livekit", "microsoft-teams-meetings", "managed-meetings-provider", "external-meeting-link"),
                 Map.of(
                         "activeProvider", "livekit",
                         "livekitUrlConfigured", liveKit.urlConfigured(),

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -7,6 +7,8 @@ import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
+import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
+import com.massimotter.weave.backend.model.admin.ProviderSelectionResponse;
 import com.massimotter.weave.backend.service.AdminControlPlaneService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -68,6 +70,16 @@ public class AdminControlPlaneController {
             @Valid @RequestBody CapabilityWhitelistUpdateRequest request,
             @AuthenticationPrincipal Jwt jwt) {
         return adminControlPlaneService.updateWhitelist(request, jwt);
+    }
+
+    @PostMapping({"/api/admin/providers/selections", "/api/v1/admin/providers/selections"})
+    @Operation(summary = "Apply or dry-run an Admin Console selected provider mapping")
+    @ApiResponse(responseCode = "200", description = "Support-safe selected provider mapping.",
+            content = @Content(schema = @Schema(implementation = ProviderSelectionResponse.class)))
+    public ProviderSelectionResponse selectProvider(
+            @Valid @RequestBody ProviderSelectionRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.selectProvider(request, jwt);
     }
 
     @PostMapping({"/api/admin/providers/readiness-tests", "/api/v1/admin/providers/readiness-tests"})

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
@@ -12,17 +12,21 @@ public record AdminControlPlaneResponse(
         String organizationId,
         String displayName,
         String recommendedIdentityBroker,
+        String providerConfigSource,
+        boolean bootstrapDefaultsAreSuggestionsOnly,
         boolean backendOwnedFacades,
         boolean denyByDefaultPolicy,
         boolean supportSafe,
         boolean memberClientMayConfigureProviders,
         Instant generatedAt,
         List<ProviderCategoryStatusResponse> categories,
+        List<ProviderSelectionResponse> selectedProviderMappings,
         CapabilityWhitelistResponse whitelist,
         List<SecretRefResponse> secretRefs,
         Map<String, String> adminApiRoutes) {
     public AdminControlPlaneResponse {
         categories = categories == null ? List.of() : List.copyOf(categories);
+        selectedProviderMappings = selectedProviderMappings == null ? List.of() : List.copyOf(selectedProviderMappings);
         secretRefs = secretRefs == null ? List.of() : List.copyOf(secretRefs);
         adminApiRoutes = adminApiRoutes == null ? Map.of() : Map.copyOf(adminApiRoutes);
     }

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderSelectionRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderSelectionRequest.java
@@ -1,0 +1,19 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+@Schema(description = "Admin-selected provider mapping. This is control-plane state; bootstrap defaults are only suggestions until this request is applied.")
+public record ProviderSelectionRequest(
+        @NotBlank String category,
+        @NotBlank String providerKey,
+        String choiceModel,
+        String secretRef,
+        boolean dryRun,
+        List<String> lossyMappingNotes,
+        String reason) {
+    public ProviderSelectionRequest {
+        lossyMappingNotes = lossyMappingNotes == null ? List.of() : List.copyOf(lossyMappingNotes);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderSelectionResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderSelectionResponse.java
@@ -1,0 +1,25 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+
+@Schema(description = "Support-safe selected provider mapping owned by the Admin Console/backend control plane.")
+public record ProviderSelectionResponse(
+        String category,
+        String providerKey,
+        String choiceModel,
+        String secretRef,
+        String selectedBy,
+        Instant selectedAt,
+        boolean applied,
+        boolean dryRun,
+        boolean supportSafe,
+        boolean bootstrapSuggestionOnly,
+        boolean migrationDryRunRequired,
+        List<String> lossyMappingNotes,
+        String readiness) {
+    public ProviderSelectionResponse {
+        lossyMappingNotes = lossyMappingNotes == null ? List.of() : List.copyOf(lossyMappingNotes);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/office/port/DisabledOfficeProvider.java
+++ b/server/src/main/java/com/massimotter/weave/backend/office/port/DisabledOfficeProvider.java
@@ -37,7 +37,7 @@ public class DisabledOfficeProvider implements OfficeProvider {
             Set.of("launch-session", "credential-bearing-url", "document-server-token-exposure", "raw-provider-errors"),
             List.of("office-provider-not-configured", "office-provider-unavailable", "office-unsupported-mode"),
             "support-safe: no document-server JWTs, signed URLs, app passwords, bearer tokens, callbacks secrets, or raw provider errors",
-            List.of("onlyoffice-community", "collabora-code"),
+            List.of("onlyoffice-community", "collabora-code", "microsoft-365-office-graph", "wopi-host"),
             Map.of(
                     "defaultProvider", "onlyoffice-community",
                     "nonDefaultProvider", "collabora-code",

--- a/server/src/main/java/com/massimotter/weave/backend/provider/InMemoryProviderSelectionRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/InMemoryProviderSelectionRepository.java
@@ -1,0 +1,34 @@
+package com.massimotter.weave.backend.provider;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryProviderSelectionRepository implements ProviderSelectionRepository {
+
+    private final ConcurrentHashMap<String, ProviderSelection> selections = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<ProviderSelection> findByCategory(String category) {
+        if (category == null || category.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(selections.get(category.trim()));
+    }
+
+    @Override
+    public List<ProviderSelection> findAll() {
+        return selections.values().stream()
+                .sorted(Comparator.comparing(ProviderSelection::category))
+                .toList();
+    }
+
+    @Override
+    public ProviderSelection save(ProviderSelection selection) {
+        selections.put(selection.category(), selection);
+        return selection;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/InMemoryProviderSelectionRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/InMemoryProviderSelectionRepository.java
@@ -31,4 +31,8 @@ public class InMemoryProviderSelectionRepository implements ProviderSelectionRep
         selections.put(selection.category(), selection);
         return selection;
     }
+
+    public void clear() {
+        selections.clear();
+    }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-final class ProviderCapabilityContracts {
+public final class ProviderCapabilityContracts {
 
     private static final List<String> STABLE_MEMBER_IMPACT_STATES = List.of(
             "usable",
@@ -50,10 +50,7 @@ final class ProviderCapabilityContracts {
     }
 
     static ProviderCategoryContractResponse contract(String category, Set<ProviderModule> modules) {
-        Definition definition = DEFINITIONS.get(category);
-        if (definition == null) {
-            definition = new Definition(List.of(), List.of(), List.of());
-        }
+        Definition definition = definition(category);
         return new ProviderCategoryContractResponse(
                 category,
                 definition.featureCapabilities(),
@@ -64,6 +61,22 @@ final class ProviderCapabilityContracts {
                 STABLE_MEMBER_IMPACT_STATES,
                 true,
                 false);
+    }
+
+    public static List<String> providerCandidates(String category) {
+        Definition definition = definition(category);
+        return java.util.stream.Stream.concat(definition.defaultAdapters().stream(), definition.externalAdapters().stream())
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private static Definition definition(String category) {
+        Definition definition = DEFINITIONS.get(category);
+        if (definition == null) {
+            return new Definition(List.of(), List.of(), List.of());
+        }
+        return definition;
     }
 
     private static List<ProviderChoiceModelResponse> choiceModels(

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
@@ -16,7 +16,7 @@ final class ProviderCapabilityContracts {
             "identity-idm", new Definition(
                     List.of("identity.sign_in", "identity.groups", "identity.roles"),
                     List.of("keycloak-realm", "matrix-authentication-service"),
-                    List.of("entra-id", "authentik", "auth0", "generic-oidc", "generic-saml")),
+                    List.of("entra-id", "authentik", "auth0", "generic-oidc", "generic-saml", "scim-ldap")),
             "chat", new Definition(
                     List.of("chat.read", "chat.send", "chat.channels"),
                     List.of("synapse-homeserver"),
@@ -28,7 +28,7 @@ final class ProviderCapabilityContracts {
             "calendar", new Definition(
                     List.of("calendar.read", "calendar.manage_events", "calendar.thread_refs"),
                     List.of("nextcloud-caldav"),
-                    List.of("microsoft-graph-calendar", "google-workspace-calendar", "generic-caldav")),
+                    List.of("microsoft-graph-calendar", "generic-caldav", "workspace-calendar", "team-channel-calendar")),
             "boards-tasks", new Definition(
                     List.of("boards.read", "boards.update_task", "boards.sync_workspace"),
                     List.of("openproject-primary"),
@@ -36,11 +36,11 @@ final class ProviderCapabilityContracts {
             "meetings-calls", new Definition(
                     List.of("meetings.join", "meetings.host", "meetings.recording_policy"),
                     List.of("livekit"),
-                    List.of("microsoft-teams-meetings", "zoom", "google-meet", "jitsi")),
+                    List.of("microsoft-teams-meetings", "managed-meetings-provider", "external-meeting-link")),
             "documents-collaboration", new Definition(
                     List.of("documents.view", "documents.edit", "documents.comment", "documents.collaborate"),
                     List.of("onlyoffice-community"),
-                    List.of("microsoft-365-office-graph", "collabora-code", "google-workspace-docs")),
+                    List.of("microsoft-365-office-graph", "collabora-code", "wopi-host")),
             "weaver", new Definition(
                     List.of("weaver.enabled", "weaver.files_read", "weaver.exec_disabled"),
                     List.of("weaver-runtime-disabled"),

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryCatalog.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryCatalog.java
@@ -1,0 +1,49 @@
+package com.massimotter.weave.backend.provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public final class ProviderCategoryCatalog {
+
+    private static final Map<String, Category> CATEGORIES = Map.of(
+            "identity-idm", new Category("identity-idm", "identity/IDM", Set.of(ProviderModule.IDENTITY_REALM, ProviderModule.MATRIX_AUTH), true),
+            "chat", new Category("chat", "chat", Set.of(ProviderModule.MATRIX), true),
+            "files", new Category("files", "files", Set.of(ProviderModule.FILES), true),
+            "calendar", new Category("calendar", "calendar", Set.of(ProviderModule.CALENDAR), true),
+            "boards-tasks", new Category("boards-tasks", "boards/tasks", Set.of(ProviderModule.BOARDS), true),
+            "meetings-calls", new Category("meetings-calls", "meetings/calls", Set.of(ProviderModule.MEETINGS), false),
+            "documents-collaboration", new Category("documents-collaboration", "documents/collaboration", Set.of(ProviderModule.OFFICE, ProviderModule.FORMS, ProviderModule.CONTACTS), false),
+            "weaver", new Category("weaver", "Weaver", Set.of(), true));
+
+    private ProviderCategoryCatalog() {
+    }
+
+    public static List<String> categoryKeys() {
+        return List.of("identity-idm", "chat", "files", "calendar", "boards-tasks", "meetings-calls", "documents-collaboration", "weaver");
+    }
+
+    public static Optional<Category> category(String key) {
+        return Optional.ofNullable(CATEGORIES.get(key));
+    }
+
+    public static Optional<String> categoryForModule(ProviderModule module) {
+        return CATEGORIES.values().stream()
+                .filter(category -> category.modules().contains(module))
+                .map(Category::key)
+                .findFirst();
+    }
+
+    public static boolean providerMatchesCategory(ProviderStatusResponse provider, String categoryKey) {
+        return category(categoryKey)
+                .map(category -> category.modules().contains(provider.module()))
+                .orElse(false);
+    }
+
+    public record Category(String key, String label, Set<ProviderModule> modules, boolean capabilityBacked) {
+        public Category {
+            modules = modules == null ? Set.of() : Set.copyOf(modules);
+        }
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryHealthMapper.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryHealthMapper.java
@@ -102,7 +102,7 @@ final class ProviderCategoryHealthMapper {
                         ? capability.memberImpact()
                         : "Admin provider mapping is required before this category becomes product-ready.",
                 moduleNames(modules),
-                providerCandidates(providers, modules),
+                providerCandidates(category, providers, modules),
                 selection.providerKey(),
                 selection.choiceModel(),
                 selection.selectedByAdmin(),
@@ -143,7 +143,7 @@ final class ProviderCategoryHealthMapper {
                 policyState,
                 selection.selectedByAdmin() ? memberImpact : "Admin provider mapping is required before this category becomes product-ready.",
                 moduleNames(modules),
-                providerCandidates(providers, modules),
+                providerCandidates(category, providers, modules),
                 selection.providerKey(),
                 selection.choiceModel(),
                 selection.selectedByAdmin(),
@@ -205,8 +205,8 @@ final class ProviderCategoryHealthMapper {
         return diagnostics;
     }
 
-    private static List<String> providerCandidates(List<ProviderStatusResponse> providers, Set<ProviderModule> modules) {
-        return matching(providers, modules).stream()
+    private static List<String> providerCandidates(String category, List<ProviderStatusResponse> providers, Set<ProviderModule> modules) {
+        List<String> registeredCandidates = matching(providers, modules).stream()
                 .flatMap(provider -> {
                     List<String> values = new ArrayList<>();
                     values.add(provider.providerKey());
@@ -216,6 +216,10 @@ final class ProviderCategoryHealthMapper {
                 .distinct()
                 .sorted()
                 .toList();
+        if (!registeredCandidates.isEmpty()) {
+            return registeredCandidates;
+        }
+        return ProviderCapabilityContracts.providerCandidates(category);
     }
 
     private static List<String> moduleNames(Set<ProviderModule> modules) {

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryHealthMapper.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryHealthMapper.java
@@ -19,7 +19,8 @@ final class ProviderCategoryHealthMapper {
 
     static List<ProviderCategoryStatusResponse> categories(
             List<ProviderStatusResponse> providers,
-            WorkspaceCapabilitiesResponse capabilities) {
+            WorkspaceCapabilitiesResponse capabilities,
+            ProviderSelectionRepository selections) {
         List<ProviderStatusResponse> safeProviders = providers == null ? List.of() : List.copyOf(providers);
         return List.of(
                 capabilityCategory(
@@ -27,49 +28,57 @@ final class ProviderCategoryHealthMapper {
                         "identity/IDM",
                         capabilities.shellAccess(),
                         safeProviders,
-                        modules(ProviderModule.IDENTITY_REALM, ProviderModule.MATRIX_AUTH)),
+                        modules(ProviderModule.IDENTITY_REALM, ProviderModule.MATRIX_AUTH),
+                        selections),
                 capabilityCategory(
                         "chat",
                         "chat",
                         capabilities.chat(),
                         safeProviders,
-                        modules(ProviderModule.MATRIX)),
+                        modules(ProviderModule.MATRIX),
+                        selections),
                 capabilityCategory(
                         "files",
                         "files",
                         capabilities.files(),
                         safeProviders,
-                        modules(ProviderModule.FILES)),
+                        modules(ProviderModule.FILES),
+                        selections),
                 capabilityCategory(
                         "calendar",
                         "calendar",
                         capabilities.calendar(),
                         safeProviders,
-                        modules(ProviderModule.CALENDAR)),
+                        modules(ProviderModule.CALENDAR),
+                        selections),
                 capabilityCategory(
                         "boards-tasks",
                         "boards/tasks",
                         capabilities.boards(),
                         safeProviders,
-                        modules(ProviderModule.BOARDS)),
+                        modules(ProviderModule.BOARDS),
+                        selections),
                 providerCategory(
                         "meetings-calls",
                         "meetings/calls",
                         "Meetings and calls are available only when the configured media provider is ready behind the backend token facade.",
                         safeProviders,
-                        modules(ProviderModule.MEETINGS)),
+                        modules(ProviderModule.MEETINGS),
+                        selections),
                 providerCategory(
                         "documents-collaboration",
                         "documents/collaboration",
                         "Document collaboration is available only through backend-owned launch/capability facades.",
                         safeProviders,
-                        modules(ProviderModule.OFFICE, ProviderModule.FORMS, ProviderModule.CONTACTS)),
+                        modules(ProviderModule.OFFICE, ProviderModule.FORMS, ProviderModule.CONTACTS),
+                        selections),
                 capabilityCategory(
                         "weaver",
                         "Weaver",
                         capabilities.weaver(),
                         safeProviders,
-                        Set.of()));
+                        Set.of(),
+                        selections));
     }
 
     private static ProviderCategoryStatusResponse capabilityCategory(
@@ -77,21 +86,35 @@ final class ProviderCategoryHealthMapper {
             String label,
             WorkspaceCapabilityStatusResponse capability,
             List<ProviderStatusResponse> providers,
-            Set<ProviderModule> modules) {
+            Set<ProviderModule> modules,
+            ProviderSelectionRepository selections) {
+        SelectionView selection = selectionView(category, selections);
+        ProviderCategoryReadiness readiness = selection.selectedByAdmin() || modules.isEmpty()
+                ? fromCapability(capability)
+                : ProviderCategoryReadiness.MISCONFIGURED;
         return new ProviderCategoryStatusResponse(
                 category,
                 label,
                 ProviderCapabilityContracts.contract(category, modules),
-                fromCapability(capability),
+                readiness,
                 capability.policyState(),
-                capability.memberImpact(),
+                selection.selectedByAdmin() || modules.isEmpty()
+                        ? capability.memberImpact()
+                        : "Admin provider mapping is required before this category becomes product-ready.",
                 moduleNames(modules),
                 providerCandidates(providers, modules),
+                selection.providerKey(),
+                selection.choiceModel(),
+                selection.selectedByAdmin(),
+                !selection.selectedByAdmin(),
+                selection.lossyMappingNotes(),
                 diagnostics(providers, modules, Map.of(
                         "capabilityEnabled", capability.enabled(),
                         "capabilityReadiness", capability.readiness().value(),
                         "effectivePolicyState", capability.policyState().value(),
                         "grantedCapabilityCount", capability.grantedCapabilities().size(),
+                        "providerConfigSource", ProviderRegistry.PROVIDER_CONFIG_SOURCE,
+                        "selectionRequiredBeforeProviderUse", !selection.selectedByAdmin() && !modules.isEmpty(),
                         "diagnosticsRedacted", true)));
     }
 
@@ -100,9 +123,13 @@ final class ProviderCategoryHealthMapper {
             String label,
             String memberImpact,
             List<ProviderStatusResponse> providers,
-            Set<ProviderModule> modules) {
+            Set<ProviderModule> modules,
+            ProviderSelectionRepository selections) {
         List<ProviderStatusResponse> matching = matching(providers, modules);
-        ProviderCategoryReadiness readiness = fromProviders(matching);
+        SelectionView selection = selectionView(category, selections);
+        ProviderCategoryReadiness readiness = selection.selectedByAdmin()
+                ? fromProviders(matching)
+                : ProviderCategoryReadiness.MISCONFIGURED;
         WorkspaceCapabilityPolicyState policyState = readiness == ProviderCategoryReadiness.DISABLED
                 ? WorkspaceCapabilityPolicyState.DISABLED
                 : readiness == ProviderCategoryReadiness.MISCONFIGURED
@@ -114,11 +141,18 @@ final class ProviderCategoryHealthMapper {
                 ProviderCapabilityContracts.contract(category, modules),
                 readiness,
                 policyState,
-                memberImpact,
+                selection.selectedByAdmin() ? memberImpact : "Admin provider mapping is required before this category becomes product-ready.",
                 moduleNames(modules),
                 providerCandidates(providers, modules),
+                selection.providerKey(),
+                selection.choiceModel(),
+                selection.selectedByAdmin(),
+                !selection.selectedByAdmin(),
+                selection.lossyMappingNotes(),
                 diagnostics(providers, modules, Map.of(
                         "effectivePolicyState", policyState.value(),
+                        "providerConfigSource", ProviderRegistry.PROVIDER_CONFIG_SOURCE,
+                        "selectionRequiredBeforeProviderUse", !selection.selectedByAdmin(),
                         "diagnosticsRedacted", true)));
     }
 
@@ -201,7 +235,34 @@ final class ProviderCategoryHealthMapper {
                 .toList();
     }
 
+    private static SelectionView selectionView(String category, ProviderSelectionRepository selections) {
+        if (selections == null) {
+            return SelectionView.awaiting();
+        }
+        return selections.findByCategory(category)
+                .map(selection -> new SelectionView(
+                        selection.providerKey(),
+                        selection.choiceModel(),
+                        true,
+                        selection.lossyMappingNotes()))
+                .orElseGet(SelectionView::awaiting);
+    }
+
     private static Set<ProviderModule> modules(ProviderModule... modules) {
         return Set.of(modules);
+    }
+
+    private record SelectionView(
+            String providerKey,
+            String choiceModel,
+            boolean selectedByAdmin,
+            List<String> lossyMappingNotes) {
+        private static SelectionView awaiting() {
+            return new SelectionView("awaiting_admin_selection", "not_selected", false, List.of());
+        }
+
+        private SelectionView {
+            lossyMappingNotes = lossyMappingNotes == null ? List.of() : List.copyOf(lossyMappingNotes);
+        }
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryStatusResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryStatusResponse.java
@@ -17,6 +17,11 @@ public record ProviderCategoryStatusResponse(
         @Schema(description = "Member-safe impact label. Does not expose raw provider setup.") String memberImpact,
         @Schema(description = "Provider registry modules contributing to this category.") List<String> modules,
         @Schema(description = "Support-safe provider choices/candidates for admin diagnostics.") List<String> providerCandidates,
+        @Schema(description = "Admin Console-selected provider key, or awaiting_admin_selection when not applied.") String selectedProviderKey,
+        @Schema(description = "Selected provider choice model: recommended_self_hosted_default, external_existing_provider, or managed_cloud_provider.") String choiceModel,
+        @Schema(description = "True only after an admin has applied a provider mapping for this category.") boolean selectedByAdmin,
+        @Schema(description = "True when defaults are being shown only as bootstrap/profile suggestions, not product truth.") boolean bootstrapSuggestionOnly,
+        @Schema(description = "Support-safe notes for known lossy mappings across provider families.") List<String> lossyMappingNotes,
         @Schema(description = "Support-safe diagnostics. Values are booleans/counts/keys only; no endpoints, secrets, or raw upstream errors.") Map<String, Object> diagnostics) {
 
     public ProviderCategoryStatusResponse {
@@ -30,6 +35,9 @@ public record ProviderCategoryStatusResponse(
         memberImpact = requireText(memberImpact, "memberImpact");
         modules = modules == null ? List.of() : List.copyOf(modules);
         providerCandidates = providerCandidates == null ? List.of() : List.copyOf(providerCandidates);
+        selectedProviderKey = selectedProviderKey == null || selectedProviderKey.isBlank() ? "awaiting_admin_selection" : selectedProviderKey.trim();
+        choiceModel = choiceModel == null || choiceModel.isBlank() ? "not_selected" : choiceModel.trim();
+        lossyMappingNotes = lossyMappingNotes == null ? List.of() : List.copyOf(lossyMappingNotes);
         diagnostics = diagnostics == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(diagnostics));
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
@@ -3,34 +3,165 @@ package com.massimotter.weave.backend.provider;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ProviderRegistry {
 
+    public static final String PROVIDER_CONFIG_SOURCE = "admin-control-plane-selected-provider-mappings";
+
     private final List<ProviderPort> providers;
     private final WorkspaceCapabilityService workspaceCapabilityService;
+    private final ProviderSelectionRepository selectionRepository;
 
-    public ProviderRegistry(List<ProviderPort> providers, WorkspaceCapabilityService workspaceCapabilityService) {
+    public ProviderRegistry(
+            List<ProviderPort> providers,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            ProviderSelectionRepository selectionRepository) {
         this.providers = providers == null ? List.of() : List.copyOf(providers);
         this.workspaceCapabilityService = workspaceCapabilityService;
+        this.selectionRepository = selectionRepository;
     }
 
     public ProviderRegistryResponse status() {
+        List<ProviderSelection> selections = selectionRepository.findAll();
         List<ProviderStatusResponse> statuses = providers.stream()
                 .map(ProviderPort::status)
+                .map(status -> applyAdminSelection(status, selections))
                 .sorted(Comparator
                         .comparing((ProviderStatusResponse status) -> status.module().contractName())
                         .thenComparing(ProviderStatusResponse::providerKey))
                 .toList();
         return new ProviderRegistryResponse(
-                "provider-stack-contract-preview",
+                "provider-stack-contract-v1",
+                PROVIDER_CONFIG_SOURCE,
+                true,
+                true,
                 true,
                 false,
                 statuses.stream().allMatch(ProviderStatusResponse::supportSafe),
                 Instant.now(),
-                ProviderCategoryHealthMapper.categories(statuses, workspaceCapabilityService.snapshot()),
+                selections,
+                ProviderCategoryHealthMapper.categories(statuses, workspaceCapabilityService.snapshot(), selectionRepository),
                 statuses);
+    }
+
+    private ProviderStatusResponse applyAdminSelection(ProviderStatusResponse status, List<ProviderSelection> selections) {
+        Optional<String> maybeCategory = ProviderCategoryCatalog.categoryForModule(status.module());
+        if (maybeCategory.isEmpty()) {
+            return withDiagnostics(status, Map.of(
+                    "providerConfigSource", PROVIDER_CONFIG_SOURCE,
+                    "selectedByAdmin", false,
+                    "bootstrapSuggestionOnly", true));
+        }
+        String category = maybeCategory.get();
+        Optional<ProviderSelection> maybeSelection = selections.stream()
+                .filter(selection -> selection.category().equals(category))
+                .findFirst();
+        if (maybeSelection.isEmpty()) {
+            return new ProviderStatusResponse(
+                    status.module(),
+                    status.providerKey(),
+                    ProviderState.DISABLED,
+                    "awaiting_admin_selection",
+                    false,
+                    false,
+                    status.readOnly(),
+                    true,
+                    status.supportSafe(),
+                    status.paidFeaturesRequired(),
+                    status.summary() + " Bootstrap/profile default only; Admin Console has not selected this category mapping.",
+                    status.supportedCapabilities(),
+                    status.unsupportedOperations(),
+                    status.supportSafeErrorCodes(),
+                    status.redactionPolicy(),
+                    status.candidates(),
+                    diagnostics(status, Map.of(
+                            "category", category,
+                            "providerConfigSource", PROVIDER_CONFIG_SOURCE,
+                            "selectedByAdmin", false,
+                            "bootstrapSuggestionOnly", true,
+                            "selectionRequiredBeforeProviderUse", true)));
+        }
+        ProviderSelection selection = maybeSelection.get();
+        boolean selectedProvider = selection.providerKey().equals(status.providerKey())
+                || status.candidates().stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(value -> value.equals(selection.providerKey().toLowerCase(Locale.ROOT)));
+        if (!selectedProvider) {
+            return new ProviderStatusResponse(
+                    status.module(),
+                    status.providerKey(),
+                    ProviderState.DISABLED,
+                    "not_selected_by_admin",
+                    false,
+                    false,
+                    status.readOnly(),
+                    true,
+                    status.supportSafe(),
+                    status.paidFeaturesRequired(),
+                    status.summary() + " This adapter candidate is not the Admin Console-selected mapping for " + category + ".",
+                    status.supportedCapabilities(),
+                    status.unsupportedOperations(),
+                    status.supportSafeErrorCodes(),
+                    status.redactionPolicy(),
+                    status.candidates(),
+                    diagnostics(status, Map.of(
+                            "category", category,
+                            "providerConfigSource", PROVIDER_CONFIG_SOURCE,
+                            "selectedByAdmin", false,
+                            "selectedCategoryProviderKey", selection.providerKey(),
+                            "bootstrapSuggestionOnly", false)));
+        }
+        boolean configured = status.configured();
+        ProviderState state = configured ? status.state() : ProviderState.NOT_CONFIGURED;
+        String readiness = configured ? status.readiness() : "admin_selected_pending_backend_configuration";
+        return new ProviderStatusResponse(
+                status.module(),
+                status.providerKey(),
+                state,
+                readiness,
+                true,
+                configured,
+                status.readOnly(),
+                true,
+                true,
+                status.paidFeaturesRequired(),
+                status.summary() + " Admin Console selection is the source of truth; SecretRefs are control-plane handles only and readiness remains backend-owned/support-safe.",
+                status.supportedCapabilities(),
+                status.unsupportedOperations(),
+                status.supportSafeErrorCodes(),
+                status.redactionPolicy(),
+                status.candidates(),
+                diagnostics(status, Map.of(
+                        "category", category,
+                        "providerConfigSource", PROVIDER_CONFIG_SOURCE,
+                        "selectedByAdmin", true,
+                        "choiceModel", selection.choiceModel(),
+                        "bootstrapSuggestionOnly", false,
+                        "secretRefConfigured", selection.hasSecretRef(),
+                        "secretsReturned", false,
+                        "rawProviderErrorsReturned", false,
+                        "migrationDryRunRequired", selection.migrationDryRunRequired(),
+                        "lossyMappingNoteCount", selection.lossyMappingNotes().size())));
+    }
+
+    private ProviderStatusResponse withDiagnostics(ProviderStatusResponse status, Map<String, Object> extra) {
+        return new ProviderStatusResponse(
+                status.module(), status.providerKey(), status.state(), status.readiness(), status.enabled(), status.configured(),
+                status.readOnly(), status.failClosed(), status.supportSafe(), status.paidFeaturesRequired(), status.summary(),
+                status.supportedCapabilities(), status.unsupportedOperations(), status.supportSafeErrorCodes(), status.redactionPolicy(),
+                status.candidates(), diagnostics(status, extra));
+    }
+
+    private Map<String, Object> diagnostics(ProviderStatusResponse status, Map<String, Object> extra) {
+        Map<String, Object> diagnostics = new LinkedHashMap<>(status.diagnostics());
+        diagnostics.put("secretsReturned", false);
+        diagnostics.put("rawProviderErrorsReturned", false);
+        diagnostics.putAll(extra);
+        return diagnostics;
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistryResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistryResponse.java
@@ -5,14 +5,19 @@ import java.util.List;
 
 public record ProviderRegistryResponse(
         String releaseStatus,
+        String providerConfigSource,
+        boolean bootstrapDefaultsAreSuggestionsOnly,
+        boolean adminSelectedMappingsRequired,
         boolean backendOwnedFacades,
         boolean flutterDirectProviderCallsAllowed,
         boolean supportSafe,
         Instant generatedAt,
+        List<ProviderSelection> selectedProviderMappings,
         List<ProviderCategoryStatusResponse> categories,
         List<ProviderStatusResponse> providers) {
 
     public ProviderRegistryResponse {
+        selectedProviderMappings = selectedProviderMappings == null ? List.of() : List.copyOf(selectedProviderMappings);
         categories = categories == null ? List.of() : List.copyOf(categories);
         providers = providers == null ? List.of() : List.copyOf(providers);
     }

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderSelection.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderSelection.java
@@ -1,0 +1,64 @@
+package com.massimotter.weave.backend.provider;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+
+public record ProviderSelection(
+        String category,
+        String providerKey,
+        String choiceModel,
+        String secretRef,
+        String selectedBy,
+        Instant selectedAt,
+        boolean applied,
+        boolean supportSafe,
+        boolean migrationDryRunRequired,
+        List<String> lossyMappingNotes) {
+
+    public ProviderSelection {
+        category = requireText(category, "category");
+        providerKey = requireText(providerKey, "providerKey");
+        choiceModel = normalizeChoiceModel(choiceModel);
+        secretRef = normalizeSecretRef(secretRef);
+        selectedBy = selectedBy == null || selectedBy.isBlank() ? "actor:system" : selectedBy.trim();
+        selectedAt = selectedAt == null ? Instant.EPOCH : selectedAt;
+        supportSafe = true;
+        lossyMappingNotes = lossyMappingNotes == null ? List.of() : List.copyOf(lossyMappingNotes);
+    }
+
+    public boolean hasSecretRef() {
+        return secretRef != null && !secretRef.isBlank() && secretRef.toLowerCase(Locale.ROOT).startsWith("secretref://");
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    private static String normalizeChoiceModel(String value) {
+        if (value == null || value.isBlank()) {
+            return "recommended_self_hosted_default";
+        }
+        String normalized = value.trim();
+        if (normalized.equals("recommended_self_hosted_default")
+                || normalized.equals("external_existing_provider")
+                || normalized.equals("managed_cloud_provider")) {
+            return normalized;
+        }
+        throw new IllegalArgumentException("choiceModel must be a provider choice contract value");
+    }
+
+    private static String normalizeSecretRef(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (!trimmed.toLowerCase(Locale.ROOT).startsWith("secretref://")) {
+            throw new IllegalArgumentException("secretRef must use the SecretRef URI contract");
+        }
+        return trimmed;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderSelectionRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderSelectionRepository.java
@@ -1,0 +1,12 @@
+package com.massimotter.weave.backend.provider;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProviderSelectionRepository {
+    Optional<ProviderSelection> findByCategory(String category);
+
+    List<ProviderSelection> findAll();
+
+    ProviderSelection save(ProviderSelection selection);
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -16,6 +16,7 @@ import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionResponse;
 import com.massimotter.weave.backend.model.admin.SecretRefResponse;
+import com.massimotter.weave.backend.provider.ProviderCapabilityContracts;
 import com.massimotter.weave.backend.provider.ProviderCategoryCatalog;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
 import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
@@ -184,7 +185,7 @@ public class AdminControlPlaneService {
         }
         String providerKey = request.providerKey().trim();
         ProviderStatusResponse status = providerRegistry.status().providers().stream()
-                .filter(provider -> provider.providerKey().equals(providerKey))
+                .filter(provider -> providerKeyMatches(provider, providerKey))
                 .findFirst()
                 .orElseThrow(() -> new ApiErrorException(
                         HttpStatus.NOT_FOUND,
@@ -218,6 +219,7 @@ public class AdminControlPlaneService {
                 false,
                 Map.of(
                         "providerKey", providerKey,
+                        "backendAdapterKey", status.providerKey(),
                         "module", status.module().contractName(),
                         "configured", status.configured(),
                         "secretsReturned", false,
@@ -281,11 +283,22 @@ public class AdminControlPlaneService {
     }
 
     private boolean providerMatchesCategory(String providerKey, String category) {
-        String normalized = providerKey.toLowerCase(Locale.ROOT);
-        return providerRegistry.status().providers().stream()
+        boolean registeredCandidate = providerRegistry.status().providers().stream()
                 .filter(provider -> ProviderCategoryCatalog.providerMatchesCategory(provider, category))
-                .anyMatch(provider -> provider.providerKey().equals(providerKey)
-                        || provider.candidates().stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(normalized::equals));
+                .anyMatch(provider -> providerKeyMatches(provider, providerKey));
+        if (registeredCandidate) {
+            return true;
+        }
+        String normalized = providerKey.toLowerCase(Locale.ROOT);
+        return ProviderCapabilityContracts.providerCandidates(category).stream()
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .anyMatch(normalized::equals);
+    }
+
+    private boolean providerKeyMatches(ProviderStatusResponse provider, String providerKey) {
+        String normalized = providerKey.toLowerCase(Locale.ROOT);
+        return provider.providerKey().equals(providerKey)
+                || provider.candidates().stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(normalized::equals);
     }
 
     private String selectionChoiceModel(String value) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -13,9 +13,14 @@ import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
+import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
+import com.massimotter.weave.backend.model.admin.ProviderSelectionResponse;
 import com.massimotter.weave.backend.model.admin.SecretRefResponse;
+import com.massimotter.weave.backend.provider.ProviderCategoryCatalog;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
 import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
+import com.massimotter.weave.backend.provider.ProviderSelection;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import com.massimotter.weave.backend.provider.ProviderStatusResponse;
 import java.time.Clock;
 import java.time.Instant;
@@ -40,6 +45,7 @@ public class AdminControlPlaneService {
 
     private final ProviderRegistry providerRegistry;
     private final WorkspaceCapabilityService workspaceCapabilityService;
+    private final ProviderSelectionRepository providerSelectionRepository;
     private final AuditEventPublisher auditEventPublisher;
     private final Clock clock;
 
@@ -47,17 +53,20 @@ public class AdminControlPlaneService {
     public AdminControlPlaneService(
             ProviderRegistry providerRegistry,
             WorkspaceCapabilityService workspaceCapabilityService,
+            ProviderSelectionRepository providerSelectionRepository,
             AuditEventPublisher auditEventPublisher) {
-        this(providerRegistry, workspaceCapabilityService, auditEventPublisher, Clock.systemUTC());
+        this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, auditEventPublisher, Clock.systemUTC());
     }
 
     AdminControlPlaneService(
             ProviderRegistry providerRegistry,
             WorkspaceCapabilityService workspaceCapabilityService,
+            ProviderSelectionRepository providerSelectionRepository,
             AuditEventPublisher auditEventPublisher,
             Clock clock) {
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
+        this.providerSelectionRepository = providerSelectionRepository;
         this.auditEventPublisher = auditEventPublisher;
         this.clock = clock;
     }
@@ -69,19 +78,53 @@ public class AdminControlPlaneService {
                 organizationId(jwt),
                 organizationName(jwt),
                 "keycloak",
+                registry.providerConfigSource(),
+                registry.bootstrapDefaultsAreSuggestionsOnly(),
                 registry.backendOwnedFacades(),
                 true,
                 registry.supportSafe(),
                 false,
                 Instant.now(clock),
                 registry.categories(),
+                registry.selectedProviderMappings().stream()
+                        .map(selection -> toSelectionResponse(selection, false, readinessFor(selection.category(), registry)))
+                        .toList(),
                 whitelist(jwt),
                 secretRefs(registry),
                 Map.of(
                         "providers", "/api/providers/status",
                         "policy", "/api/admin/policies/capability-whitelist",
                         "audit", "/api/admin/audit/events",
-                        "readinessTest", "/api/admin/providers/readiness-tests"));
+                        "readinessTest", "/api/admin/providers/readiness-tests",
+                        "providerSelections", "/api/admin/providers/selections"));
+    }
+
+    public ProviderSelectionResponse selectProvider(ProviderSelectionRequest request, Jwt jwt) {
+        ProviderSelection selection = validateProviderSelection(request, jwt);
+        boolean dryRun = request.dryRun();
+        ProviderSelection applied = dryRun ? selection : providerSelectionRepository.save(selection);
+        if (!dryRun) {
+            auditEventPublisher.publish(new AuditEvent(
+                    organizationId(jwt),
+                    "admin-control-plane",
+                    actorRef(jwt),
+                    "provider-selection",
+                    AuditAction.ADMIN_POLICY_UPDATED,
+                    Instant.now(clock),
+                    "provider-selection-" + selection.category() + "-" + Instant.now(clock).toEpochMilli(),
+                    AuditRedactionLevel.SECRET_REDACTED,
+                    Map.of(
+                            "category", selection.category(),
+                            "providerKey", selection.providerKey(),
+                            "choiceModel", selection.choiceModel(),
+                            "secretRef", safeSecretRef(selection.secretRef()),
+                            "reason", safeText(request.reason()),
+                            "providerConfigSource", ProviderRegistry.PROVIDER_CONFIG_SOURCE,
+                            "migrationDryRunRequired", selection.migrationDryRunRequired(),
+                            "lossyMappingNoteCount", selection.lossyMappingNotes().size(),
+                            "token", "not-stored")));
+        }
+        return toSelectionResponse(applied, dryRun, dryRun ? "dry_run_valid" : "admin_selected_pending_readiness");
     }
 
     public CapabilityWhitelistResponse whitelist(Jwt jwt) {
@@ -197,6 +240,127 @@ public class AdminControlPlaneService {
                     .toList();
         }
         return List.of();
+    }
+
+    private ProviderSelection validateProviderSelection(ProviderSelectionRequest request, Jwt jwt) {
+        if (request == null || request.category() == null || request.category().isBlank()
+                || request.providerKey() == null || request.providerKey().isBlank()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-selection-invalid",
+                    "Provider selection requires category and provider key.",
+                    Map.of("reason", "category and providerKey are required"));
+        }
+        String category = request.category().trim();
+        String providerKey = request.providerKey().trim();
+        if (ProviderCategoryCatalog.category(category).isEmpty()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-category-unknown",
+                    "Provider category is not part of the Weave canonical control-plane contract.",
+                    Map.of("category", category));
+        }
+        if (!providerMatchesCategory(providerKey, category)) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-selection-category-mismatch",
+                    "Provider key is not registered as a support-safe candidate for the selected category.",
+                    Map.of("category", category, "providerKey", providerKey));
+        }
+        return new ProviderSelection(
+                category,
+                providerKey,
+                selectionChoiceModel(request.choiceModel()),
+                selectionSecretRef(request.secretRef()),
+                actorRef(jwt),
+                Instant.now(clock),
+                !request.dryRun(),
+                true,
+                requiresMigrationDryRun(request),
+                safeLossyMappingNotes(request.lossyMappingNotes()));
+    }
+
+    private boolean providerMatchesCategory(String providerKey, String category) {
+        String normalized = providerKey.toLowerCase(Locale.ROOT);
+        return providerRegistry.status().providers().stream()
+                .filter(provider -> ProviderCategoryCatalog.providerMatchesCategory(provider, category))
+                .anyMatch(provider -> provider.providerKey().equals(providerKey)
+                        || provider.candidates().stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(normalized::equals));
+    }
+
+    private String selectionChoiceModel(String value) {
+        if (value == null || value.isBlank()) {
+            return "recommended_self_hosted_default";
+        }
+        String trimmed = value.trim();
+        if (trimmed.equals("recommended_self_hosted_default")
+                || trimmed.equals("external_existing_provider")
+                || trimmed.equals("managed_cloud_provider")) {
+            return trimmed;
+        }
+        throw new ApiErrorException(
+                HttpStatus.BAD_REQUEST,
+                "provider-selection-choice-model-invalid",
+                "Provider selection choice model is not part of the Weave provider choice contract.",
+                Map.of("choiceModel", "invalid-choice-model-redacted"));
+    }
+
+    private String selectionSecretRef(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.toLowerCase(Locale.ROOT).startsWith("secretref://")) {
+            return trimmed;
+        }
+        throw new ApiErrorException(
+                HttpStatus.BAD_REQUEST,
+                "provider-selection-secretref-invalid",
+                "Provider selections may reference credentials only through SecretRef URIs.",
+                Map.of("secretRef", "invalid-secret-ref-redacted"));
+    }
+
+    private boolean requiresMigrationDryRun(ProviderSelectionRequest request) {
+        return request.lossyMappingNotes() != null && !request.lossyMappingNotes().isEmpty()
+                || "external_existing_provider".equals(request.choiceModel())
+                || "managed_cloud_provider".equals(request.choiceModel());
+    }
+
+    private List<String> safeLossyMappingNotes(List<String> notes) {
+        if (notes == null) {
+            return List.of();
+        }
+        return notes.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(this::safeText)
+                .distinct()
+                .limit(10)
+                .toList();
+    }
+
+    private ProviderSelectionResponse toSelectionResponse(ProviderSelection selection, boolean dryRun, String readiness) {
+        return new ProviderSelectionResponse(
+                selection.category(),
+                selection.providerKey(),
+                selection.choiceModel(),
+                selection.secretRef(),
+                selection.selectedBy(),
+                selection.selectedAt(),
+                selection.applied() && !dryRun,
+                dryRun,
+                true,
+                !selection.applied() || dryRun,
+                selection.migrationDryRunRequired(),
+                selection.lossyMappingNotes(),
+                readiness);
+    }
+
+    private String readinessFor(String category, ProviderRegistryResponse registry) {
+        return registry.categories().stream()
+                .filter(value -> value.category().equals(category))
+                .map(value -> value.readiness().value())
+                .findFirst()
+                .orElse("unknown");
     }
 
     private List<SecretRefResponse> secretRefs(ProviderRegistryResponse registry) {

--- a/server/src/test/java/com/massimotter/weave/backend/bdd/ProviderStackReadinessStepDefinitions.java
+++ b/server/src/test/java/com/massimotter/weave/backend/bdd/ProviderStackReadinessStepDefinitions.java
@@ -119,7 +119,9 @@ public class ProviderStackReadinessStepDefinitions {
     @Then("the provider registry is visible through {string}")
     public void theProviderRegistryIsVisibleThrough(String route) {
         assertThat(route).isEqualTo("GET /api/providers/status");
-        assertThat(lastJson.path("releaseStatus").asText()).isEqualTo("provider-stack-contract-preview");
+        assertThat(lastJson.path("releaseStatus").asText()).isEqualTo("provider-stack-contract-v1");
+        assertThat(lastJson.path("providerConfigSource").asText()).isEqualTo("admin-control-plane-selected-provider-mappings");
+        assertThat(lastJson.path("adminSelectedMappingsRequired").asBoolean()).isTrue();
         assertThat(lastJson.path("providers")).isNotEmpty();
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -114,6 +114,9 @@ class AdminControlPlaneControllerTest {
     }
 
     private void selectDefaultProviders() {
+        if (providerSelectionRepository instanceof InMemoryProviderSelectionRepository memoryRepository) {
+            memoryRepository.clear();
+        }
         providerSelectionRepository.save(selection("identity-idm", "keycloak-realm", "recommended_self_hosted_default"));
         providerSelectionRepository.save(selection("chat", "synapse-homeserver", "recommended_self_hosted_default"));
         providerSelectionRepository.save(selection("files", "nextcloud-files", "recommended_self_hosted_default"));
@@ -207,12 +210,13 @@ class AdminControlPlaneControllerTest {
         mockMvc.perform(post("/api/admin/providers/readiness-tests")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"providerKey\":\"livekit\",\"testKind\":\"readiness\",\"secretRef\":\"secretref://weave/provider/livekit\"}"))
+                        .content("{\"providerKey\":\"slack\",\"testKind\":\"readiness\",\"secretRef\":\"secretref://weave/provider/slack\"}"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.providerKey").value("livekit"))
+                .andExpect(jsonPath("$.providerKey").value("slack"))
                 .andExpect(jsonPath("$.auditEventPublished").value(true))
                 .andExpect(jsonPath("$.supportSafe").value(true))
                 .andExpect(jsonPath("$.rawSecretExposed").value(false))
+                .andExpect(jsonPath("$.diagnostics.backendAdapterKey").value("synapse-homeserver"))
                 .andExpect(jsonPath("$.diagnostics.secretsReturned").value(false));
 
         mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
@@ -231,6 +235,26 @@ class AdminControlPlaneControllerTest {
                 .andExpect(jsonPath("$[*].payload.rawProviderError", hasItems("[redacted:provider-error]")))
                 .andExpect(content().string(not(containsString("server-test-secret-that-must-never-appear"))))
                 .andExpect(content().string(not(containsString("Bearer secret"))));
+    }
+
+    @Test
+    void weaverSelectionUsesContractCandidatesEvenWithoutRawProviderPort() throws Exception {
+        mockMvc.perform(post("/api/admin/providers/selections")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"category\":\"weaver\",\"providerKey\":\"openclaw-governed-runtime\",\"choiceModel\":\"managed_cloud_provider\",\"secretRef\":\"secretref://weave/provider/openclaw-governed-runtime\",\"reason\":\"governed runtime pilot\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.category").value("weaver"))
+                .andExpect(jsonPath("$.providerKey").value("openclaw-governed-runtime"))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.migrationDryRunRequired").value(true));
+
+        mockMvc.perform(get("/api/admin/control-plane").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.categories[?(@.category == 'weaver')].selectedByAdmin", hasItems(true)))
+                .andExpect(jsonPath("$.categories[?(@.category == 'weaver')].selectedProviderKey", hasItems("openclaw-governed-runtime")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'weaver')].providerCandidates[*]", hasItems("openclaw-governed-runtime")))
+                .andExpect(content().string(not(containsString("raw provider"))));
     }
 
     private WorkspaceCapabilityStatusResponse capability(

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -15,7 +15,11 @@ import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
 import com.massimotter.weave.backend.office.port.DisabledOfficeProvider;
+import com.massimotter.weave.backend.provider.InMemoryProviderSelectionRepository;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderSelection;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import java.time.Instant;
 import com.massimotter.weave.backend.service.AdminControlPlaneService;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.util.List;
@@ -81,8 +85,12 @@ class AdminControlPlaneControllerTest {
     @MockBean
     private WorkspaceCapabilityService workspaceCapabilityService;
 
+    @Autowired
+    private ProviderSelectionRepository providerSelectionRepository;
+
     @BeforeEach
     void setUpWorkspaceCapabilitySnapshot() {
+        selectDefaultProviders();
         WorkspaceCapabilitiesResponse capabilities = new WorkspaceCapabilitiesResponse(
                 capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "SSO ready."),
                 capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Chat ready."),
@@ -105,6 +113,30 @@ class AdminControlPlaneControllerTest {
                 "disabled-by-default; per-user Dockerized Weaver runtime may only be generated from org policy later"));
     }
 
+    private void selectDefaultProviders() {
+        providerSelectionRepository.save(selection("identity-idm", "keycloak-realm", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("chat", "synapse-homeserver", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("files", "nextcloud-files", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("calendar", "nextcloud-caldav", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("boards-tasks", "openproject-primary", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("meetings-calls", "livekit", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("documents-collaboration", "onlyoffice-community", "recommended_self_hosted_default"));
+    }
+
+    private ProviderSelection selection(String category, String providerKey, String choiceModel) {
+        return new ProviderSelection(
+                category,
+                providerKey,
+                choiceModel,
+                "secretref://weave/provider/" + providerKey,
+                "actor:test-admin",
+                Instant.parse("2026-05-24T18:00:00Z"),
+                true,
+                true,
+                false,
+                List.of());
+    }
+
     @Test
     void adminControlPlaneRejectsMembers() throws Exception {
         mockMvc.perform(get("/api/admin/control-plane").with(memberJwt()))
@@ -118,11 +150,17 @@ class AdminControlPlaneControllerTest {
                 .andExpect(jsonPath("$.contractVersion").value("admin-control-plane-v1"))
                 .andExpect(jsonPath("$.organizationId").value("weave-dogfood"))
                 .andExpect(jsonPath("$.recommendedIdentityBroker").value("keycloak"))
+                .andExpect(jsonPath("$.providerConfigSource").value("admin-control-plane-selected-provider-mappings"))
+                .andExpect(jsonPath("$.bootstrapDefaultsAreSuggestionsOnly").value(true))
                 .andExpect(jsonPath("$.backendOwnedFacades").value(true))
                 .andExpect(jsonPath("$.denyByDefaultPolicy").value(true))
                 .andExpect(jsonPath("$.memberClientMayConfigureProviders").value(false))
                 .andExpect(jsonPath("$.categories[*].category", hasItems(
                         "identity-idm", "chat", "files", "calendar", "boards-tasks", "meetings-calls", "documents-collaboration", "weaver")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'chat')].selectedByAdmin", hasItems(true)))
+                .andExpect(jsonPath("$.categories[?(@.category == 'chat')].selectedProviderKey", hasItems("synapse-homeserver")))
+                .andExpect(jsonPath("$.selectedProviderMappings[*].category", hasItems("identity-idm", "chat", "files")))
+                .andExpect(jsonPath("$.selectedProviderMappings[*].supportSafe", hasItems(true)))
                 .andExpect(jsonPath("$.whitelist.denyByDefault").value(true))
                 .andExpect(jsonPath("$.whitelist.normalMembersMayAuthorPolicy").value(false))
                 .andExpect(jsonPath("$.whitelist.stableMemberImpactStates[*]", hasItems("ready", "disabled", "degraded", "policy-blocked")))
@@ -136,7 +174,36 @@ class AdminControlPlaneControllerTest {
     }
 
     @Test
+    void providerSelectionRejectsRawSecretsAndUnknownChoiceModels() throws Exception {
+        mockMvc.perform(post("/api/admin/providers/selections")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"category\":\"chat\",\"providerKey\":\"slack\",\"choiceModel\":\"external_existing_provider\",\"secretRef\":\"xoxb-raw-token\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("provider-selection-secretref-invalid"))
+                .andExpect(content().string(not(containsString("xoxb-raw-token"))));
+
+        mockMvc.perform(post("/api/admin/providers/selections")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"category\":\"chat\",\"providerKey\":\"slack\",\"choiceModel\":\"hardcoded_default\",\"secretRef\":\"secretref://weave/provider/slack\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("provider-selection-choice-model-invalid"));
+    }
+
+    @Test
     void adminReadinessTestsAndPolicyUpdatesAreAuditedAndRedacted() throws Exception {
+        mockMvc.perform(post("/api/admin/providers/selections")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"category\":\"chat\",\"providerKey\":\"slack\",\"choiceModel\":\"external_existing_provider\",\"secretRef\":\"secretref://weave/provider/slack\",\"lossyMappingNotes\":[\"Slack thread/broadcast semantics require migration dry-run.\"],\"reason\":\"compare external provider\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.category").value("chat"))
+                .andExpect(jsonPath("$.providerKey").value("slack"))
+                .andExpect(jsonPath("$.applied").value(true))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.migrationDryRunRequired").value(true));
+
         mockMvc.perform(post("/api/admin/providers/readiness-tests")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -158,6 +225,7 @@ class AdminControlPlaneControllerTest {
         mockMvc.perform(get("/api/admin/audit/events").with(adminJwt()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[*].action", hasItems("provider.readiness.tested", "admin.policy.updated")))
+                .andExpect(jsonPath("$[*].payload.providerConfigSource", hasItems("admin-control-plane-selected-provider-mappings")))
                 .andExpect(jsonPath("$[*].payload.token", hasItems("[redacted]")))
                 .andExpect(jsonPath("$[*].payload.apiSecret", hasItems("[redacted]")))
                 .andExpect(jsonPath("$[*].payload.rawProviderError", hasItems("[redacted:provider-error]")))
@@ -202,6 +270,11 @@ class AdminControlPlaneControllerTest {
         @Bean
         AuditEventPublisher auditEventPublisher() {
             return new InMemoryAuditEventPublisher();
+        }
+
+        @Bean
+        ProviderSelectionRepository providerSelectionRepository() {
+            return new InMemoryProviderSelectionRepository();
         }
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
@@ -12,7 +12,11 @@ import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
 import com.massimotter.weave.backend.office.port.DisabledOfficeProvider;
+import com.massimotter.weave.backend.provider.InMemoryProviderSelectionRepository;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderSelection;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import java.time.Instant;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +51,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         ApiErrorResponseWriter.class,
         ApiExceptionHandler.class,
         ProviderRegistry.class,
+        InMemoryProviderSelectionRepository.class,
         ProviderCoreConfiguration.class,
         DevopsProviderConfiguration.class,
         DisabledOfficeProvider.class
@@ -72,8 +77,12 @@ class ProviderRegistryControllerTest {
     @MockBean
     private WorkspaceCapabilityService workspaceCapabilityService;
 
+    @Autowired
+    private ProviderSelectionRepository providerSelectionRepository;
+
     @BeforeEach
     void setUpWorkspaceCapabilitySnapshot() {
+        selectDefaultProviders();
         when(workspaceCapabilityService.snapshot()).thenReturn(new WorkspaceCapabilitiesResponse(
                 capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Weave SSO shell access is available."),
                 capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Chat is available through Weave."),
@@ -81,6 +90,30 @@ class ProviderRegistryControllerTest {
                 capability(WorkspaceCapabilityReadiness.DEGRADED, WorkspaceCapabilityPolicyState.ALLOWED, "Calendar is degraded. Ask an admin to inspect Workspace Health."),
                 capability(WorkspaceCapabilityReadiness.BLOCKED, WorkspaceCapabilityPolicyState.POLICY_BLOCKED, "Boards/tasks are blocked by your role or group policy."),
                 capability(WorkspaceCapabilityReadiness.UNAVAILABLE, WorkspaceCapabilityPolicyState.DISABLED, "Weaver is disabled by workspace policy.")));
+    }
+
+    private void selectDefaultProviders() {
+        providerSelectionRepository.save(selection("identity-idm", "keycloak-realm", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("chat", "synapse-homeserver", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("files", "nextcloud-files", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("calendar", "nextcloud-caldav", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("boards-tasks", "openproject-primary", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("meetings-calls", "livekit", "recommended_self_hosted_default"));
+        providerSelectionRepository.save(selection("documents-collaboration", "onlyoffice-community", "recommended_self_hosted_default"));
+    }
+
+    private ProviderSelection selection(String category, String providerKey, String choiceModel) {
+        return new ProviderSelection(
+                category,
+                providerKey,
+                choiceModel,
+                "secretref://weave/provider/" + providerKey,
+                "actor:test-admin",
+                Instant.parse("2026-05-24T18:00:00Z"),
+                true,
+                true,
+                false,
+                List.of());
     }
 
     @Test
@@ -100,12 +133,19 @@ class ProviderRegistryControllerTest {
     void providerStatusReportsAllFacadeSeamsWithoutSecrets() throws Exception {
         mockMvc.perform(get("/api/providers/status").with(adminJwt()))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.releaseStatus").value("provider-stack-contract-v1"))
+                .andExpect(jsonPath("$.providerConfigSource").value("admin-control-plane-selected-provider-mappings"))
+                .andExpect(jsonPath("$.bootstrapDefaultsAreSuggestionsOnly").value(true))
+                .andExpect(jsonPath("$.adminSelectedMappingsRequired").value(true))
                 .andExpect(jsonPath("$.backendOwnedFacades").value(true))
                 .andExpect(jsonPath("$.flutterDirectProviderCallsAllowed").value(false))
                 .andExpect(jsonPath("$.supportSafe").value(true))
                 .andExpect(jsonPath("$.categories[*].category", hasItems(
                         "identity-idm", "chat", "files", "calendar", "boards-tasks", "meetings-calls", "documents-collaboration", "weaver")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'identity-idm')].readiness", hasItems("ready")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'identity-idm')].selectedByAdmin", hasItems(true)))
+                .andExpect(jsonPath("$.categories[?(@.category == 'identity-idm')].bootstrapSuggestionOnly", hasItems(false)))
+                .andExpect(jsonPath("$.selectedProviderMappings[*].providerKey", hasItems("keycloak-realm", "synapse-homeserver", "openproject-primary")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'identity-idm')].contract.defaultAdapters[*]", hasItems("keycloak-realm")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'identity-idm')].contract.externalAdapters[*]", hasItems("entra-id", "generic-oidc")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'identity-idm')].contract.choiceModels[*].choiceModel", hasItems("recommended_self_hosted_default", "external_existing_provider", "managed_cloud_provider")))
@@ -114,15 +154,15 @@ class ProviderRegistryControllerTest {
                 .andExpect(jsonPath("$.categories[?(@.category == 'calendar')].readiness", hasItems("degraded")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'boards-tasks')].readiness", hasItems("policy_blocked")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'meetings-calls')].readiness", hasItems("misconfigured")))
-                .andExpect(jsonPath("$.categories[?(@.category == 'documents-collaboration')].readiness", hasItems("disabled")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'documents-collaboration')].readiness", hasItems("misconfigured")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'documents-collaboration')].contract.featureCapabilities[*]", hasItems("documents.collaborate")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'documents-collaboration')].contract.externalAdapters[*]", hasItems("microsoft-365-office-graph")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'weaver')].readiness", hasItems("disabled")))
                 .andExpect(jsonPath("$.categories[*].contract.stableMemberImpactStates[*]", hasItems("usable", "disabled", "degraded", "policy-blocked")))
                 .andExpect(jsonPath("$.categories[*].contract.normalMembersConfigureProviders", hasItems(false)))
                 .andExpect(jsonPath("$.categories[?(@.category == 'chat')].contract.defaultAdapters[*]", hasItems("synapse-homeserver")))
-                .andExpect(jsonPath("$.categories[?(@.category == 'chat')].contract.externalAdapters[*]", hasItems("microsoft-teams")))
-                .andExpect(jsonPath("$.categories[?(@.category == 'files')].contract.externalAdapters[*]", hasItems("sharepoint", "onedrive")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'chat')].contract.externalAdapters[*]", hasItems("microsoft-teams", "slack")))
+                .andExpect(jsonPath("$.categories[?(@.category == 'files')].contract.externalAdapters[*]", hasItems("sharepoint", "onedrive", "smb")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'boards-tasks')].contract.defaultAdapters[*]", hasItems("openproject-primary")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'boards-tasks')].contract.externalAdapters[*]", hasItems("microsoft-planner", "jira")))
                 .andExpect(jsonPath("$.categories[*].diagnostics.secretsReturned", hasItems(false)))

--- a/server/src/test/java/com/massimotter/weave/backend/provider/ProviderRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/ProviderRegistryTest.java
@@ -1,0 +1,122 @@
+package com.massimotter.weave.backend.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ProviderRegistryTest {
+
+    @Test
+    void bootstrapDefaultsRemainSuggestionsUntilAdminSelection() {
+        ProviderRegistry registry = new ProviderRegistry(
+                List.of(StaticProviderPort.pending(
+                        ProviderModule.MATRIX,
+                        "synapse-homeserver",
+                        "Chat adapter candidate.",
+                        Set.of("chat.read"),
+                        Set.of("direct-flutter-provider-api"),
+                        List.of("synapse", "slack", "microsoft-teams"),
+                        Map.of())),
+                capabilityService(),
+                new InMemoryProviderSelectionRepository());
+
+        ProviderRegistryResponse response = registry.status();
+
+        assertThat(response.providerConfigSource()).isEqualTo("admin-control-plane-selected-provider-mappings");
+        assertThat(response.bootstrapDefaultsAreSuggestionsOnly()).isTrue();
+        assertThat(response.adminSelectedMappingsRequired()).isTrue();
+        assertThat(response.selectedProviderMappings()).isEmpty();
+        ProviderCategoryStatusResponse chat = response.categories().stream()
+                .filter(category -> category.category().equals("chat"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(chat.readiness()).isEqualTo(ProviderCategoryReadiness.MISCONFIGURED);
+        assertThat(chat.selectedByAdmin()).isFalse();
+        assertThat(chat.bootstrapSuggestionOnly()).isTrue();
+        assertThat(chat.selectedProviderKey()).isEqualTo("awaiting_admin_selection");
+        assertThat(chat.diagnostics()).containsEntry("selectionRequiredBeforeProviderUse", true);
+        assertThat(response.providers().get(0).enabled()).isFalse();
+        assertThat(response.providers().get(0).diagnostics()).containsEntry("selectedByAdmin", false);
+    }
+
+    @Test
+    void adminSelectionBecomesSourceOfTruthWithoutExposingSecrets() {
+        InMemoryProviderSelectionRepository selections = new InMemoryProviderSelectionRepository();
+        selections.save(new ProviderSelection(
+                "chat",
+                "slack",
+                "external_existing_provider",
+                "secretref://weave/provider/slack",
+                "actor:admin",
+                Instant.parse("2026-05-24T18:00:00Z"),
+                true,
+                true,
+                true,
+                List.of("Thread and channel semantics require migration dry-run.")));
+        ProviderRegistry registry = new ProviderRegistry(
+                List.of(StaticProviderPort.pending(
+                        ProviderModule.MATRIX,
+                        "synapse-homeserver",
+                        "Chat adapter candidate.",
+                        Set.of("chat.read"),
+                        Set.of("direct-flutter-provider-api"),
+                        List.of("synapse", "slack", "microsoft-teams"),
+                        Map.of("rawProviderErrorsReturned", false))),
+                capabilityService(),
+                selections);
+
+        ProviderRegistryResponse response = registry.status();
+
+        assertThat(response.selectedProviderMappings()).extracting(ProviderSelection::providerKey).containsExactly("slack");
+        ProviderCategoryStatusResponse chat = response.categories().stream()
+                .filter(category -> category.category().equals("chat"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(chat.readiness()).isEqualTo(ProviderCategoryReadiness.READY);
+        assertThat(chat.selectedByAdmin()).isTrue();
+        assertThat(chat.selectedProviderKey()).isEqualTo("slack");
+        assertThat(chat.choiceModel()).isEqualTo("external_existing_provider");
+        assertThat(chat.lossyMappingNotes()).contains("Thread and channel semantics require migration dry-run.");
+        assertThat(response.providers().get(0).enabled()).isTrue();
+        assertThat(response.providers().get(0).configured()).isFalse();
+        assertThat(response.providers().get(0).diagnostics())
+                .containsEntry("selectedByAdmin", true)
+                .containsEntry("secretsReturned", false)
+                .containsEntry("rawProviderErrorsReturned", false);
+    }
+
+    private WorkspaceCapabilityService capabilityService() {
+        WorkspaceCapabilityService service = Mockito.mock(WorkspaceCapabilityService.class);
+        when(service.snapshot()).thenReturn(new WorkspaceCapabilitiesResponse(
+                capability(), capability(), capability(), capability(), capability(),
+                new WorkspaceCapabilityStatusResponse(
+                        false,
+                        WorkspaceCapabilityReadiness.UNAVAILABLE,
+                        WorkspaceCapabilityPolicyState.DISABLED,
+                        "test-profile",
+                        "Weaver disabled.",
+                        List.of())));
+        return service;
+    }
+
+    private WorkspaceCapabilityStatusResponse capability() {
+        return new WorkspaceCapabilityStatusResponse(
+                true,
+                WorkspaceCapabilityReadiness.READY,
+                WorkspaceCapabilityPolicyState.ALLOWED,
+                "test-profile",
+                "Ready through Weave.",
+                List.of("test.capability"));
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/provider/ProviderRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/ProviderRegistryTest.java
@@ -46,6 +46,11 @@ class ProviderRegistryTest {
         assertThat(chat.bootstrapSuggestionOnly()).isTrue();
         assertThat(chat.selectedProviderKey()).isEqualTo("awaiting_admin_selection");
         assertThat(chat.diagnostics()).containsEntry("selectionRequiredBeforeProviderUse", true);
+        ProviderCategoryStatusResponse weaver = response.categories().stream()
+                .filter(category -> category.category().equals("weaver"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(weaver.providerCandidates()).containsExactly("openclaw-governed-runtime", "weaver-runtime-disabled");
         assertThat(response.providers().get(0).enabled()).isFalse();
         assertThat(response.providers().get(0).diagnostics()).containsEntry("selectedByAdmin", false);
     }


### PR DESCRIPTION
## Summary
- Make Admin Console/provider selections the server source of truth instead of bootstrap defaults.
- Add support-safe provider selection contracts, category catalog, readiness/category mapping, SecretRef validation, audit coverage, and provider-family candidates.
- Align Admin Console and member client contracts so members consume canonical Weave capability/readiness state without raw provider setup or diagnostics.

## Verification
- git diff --check
- make acceptance-contract
- make server-ci
- make client-ci
- make infra-static
- make admin-ci
- make ci

Live E2E runtime evidence was not collected; the offline acceptance contract/mapping gate passed.