### PR TITLE
feat(server): add non-chat domain facade contracts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -86,6 +86,8 @@ The first implementation slice keeps Matrix as the conversation source, classifi
 
 The server now owns a Chat domain facade seam. Member routes under `/api/chat/*` return Weave-domain readiness/conversation/message contracts and fail closed for missing, unsupported, degraded, blocked, or unconfigured Chat mappings. Admin/operator routes under `/api/admin/chat/*` may show support-safe selected mapping, redacted readiness diagnostics, and migration dry-run/preflight reports; destructive migration apply is intentionally out of scope.
 
+The remaining canonical server domain facades are represented by non-Chat skeleton contracts for Files/Documents, Calendar/Meetings, Boards/Tasks, and Identity/Admin/Policy. They are Weave product contracts, not provider proxies: each names canonical object kinds and adapter-boundary operations, evaluates capability policy before provider lookup, fails closed for unknown capabilities, returns empty Weave-domain collections until a promoted adapter exists, and exposes only support-safe admin mappings with SecretRef presence flags rather than secret material, raw provider URLs, downstream payloads, or provider errors.
+
 ## Shared server configuration
 `features/server_config/` owns the shared configuration model used by both onboarding and settings.
 

--- a/server/README.md
+++ b/server/README.md
@@ -36,6 +36,7 @@ Currently implemented or contract-backed surfaces:
 - `GET /api/onboarding/status`.
 - `GET /api/workspace/capabilities` and `GET /api/workspace/release-readiness`.
 - Chat domain facade at `/api/chat/*` and `/api/admin/chat/*`: member APIs expose canonical Weave conversations/messages/readiness and fail closed; admin APIs expose selected Chat mapping, support-safe readiness, and audited migration dry-run/preflight reports.
+- Canonical non-Chat domain facade contracts for Files/Documents, Calendar/Meetings, Boards/Tasks, and Identity/Admin/Policy. These server-side seams evaluate Weave capability policy before provider lookup, fail closed for unknown capabilities, expose SecretRef-only admin mappings, and return empty Weave-domain skeleton collections until concrete adapters are promoted.
 - Files facade backed by Nextcloud when a backend actor is configured; otherwise fail-closed.
 - Calendar facade for workspace/team/channel collections; unsafe private-personal calendar templates fail closed.
 - Secret-free calendar client setup metadata at `GET /api/calendar/client-setup`.
@@ -52,7 +53,7 @@ The provider stack is backend-owned by design:
 - Missing credentials produce unavailable/degraded readiness instead of insecure fallback behavior.
 - Optional providers default off or not configured.
 - Diagnostics must not expose raw provider URLs, response bodies, bearer tokens, API tokens, cookies, app passwords, or signing secrets.
-- Chat member responses use stable product states (`ready`, `disabled`, `degraded`, `policy_blocked`, `unavailable`, `misconfigured`) and never ask members to configure raw Chat providers, endpoints, credentials, or migration diagnostics.
+- Chat and canonical non-Chat domain responses use stable product states (`ready`, `disabled`, `degraded`, `policy_blocked`, `unavailable`, `misconfigured`, `unsupported`) and never ask members to configure raw providers, endpoints, credentials, downstream payloads, or migration diagnostics.
 - DevOps provider modules expose no linked projects, repositories, issues, merge requests, pipelines, or releases while disabled.
 - Office launch refuses unsafe states with stable error codes instead of leaking downstream details.
 - Matrix/MAS status stays support-safe: Matrix client protocol remains the direct-client exception, encrypted message bodies are not server-readable, and video-call/meeting support is deferred/fail-closed.

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/AbstractCanonicalDomainFacade.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/AbstractCanonicalDomainFacade.java
@@ -1,0 +1,59 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.time.Clock;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+abstract class AbstractCanonicalDomainFacade implements CanonicalDomainFacade {
+
+    private final CanonicalDomainFacadeSupport support;
+
+    AbstractCanonicalDomainFacade(
+            CanonicalDomainDefinition definition,
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService) {
+        this(definition, providerRegistry, providerSelectionRepository, workspaceCapabilityService, Clock.systemUTC());
+    }
+
+    AbstractCanonicalDomainFacade(
+            CanonicalDomainDefinition definition,
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            Clock clock) {
+        this.support = new CanonicalDomainFacadeSupport(
+                definition,
+                providerRegistry,
+                providerSelectionRepository,
+                workspaceCapabilityService,
+                clock);
+    }
+
+    @Override
+    public CanonicalDomainContract contract() {
+        return support.contract();
+    }
+
+    @Override
+    public CanonicalDomainReadiness memberReadiness(Jwt jwt) {
+        return support.readiness(jwt, false);
+    }
+
+    @Override
+    public CanonicalDomainReadiness adminReadiness(Jwt jwt) {
+        return support.readiness(jwt, true);
+    }
+
+    @Override
+    public CanonicalDomainItems items(Jwt jwt) {
+        return support.items(jwt);
+    }
+
+    @Override
+    public CanonicalCapabilityDecision evaluateCapability(Jwt jwt, String capability, String operation) {
+        return support.evaluateCapability(jwt, capability, operation);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/BoardsTasksDomainFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/BoardsTasksDomainFacadeService.java
@@ -1,0 +1,28 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.time.Clock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BoardsTasksDomainFacadeService extends AbstractCanonicalDomainFacade {
+
+    @Autowired
+    public BoardsTasksDomainFacadeService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService) {
+        super(CanonicalDomainDefinition.BOARDS_TASKS, providerRegistry, providerSelectionRepository, workspaceCapabilityService);
+    }
+
+    BoardsTasksDomainFacadeService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            Clock clock) {
+        super(CanonicalDomainDefinition.BOARDS_TASKS, providerRegistry, providerSelectionRepository, workspaceCapabilityService, clock);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CalendarMeetingsDomainFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CalendarMeetingsDomainFacadeService.java
@@ -1,0 +1,28 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.time.Clock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CalendarMeetingsDomainFacadeService extends AbstractCanonicalDomainFacade {
+
+    @Autowired
+    public CalendarMeetingsDomainFacadeService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService) {
+        super(CanonicalDomainDefinition.CALENDAR_MEETINGS, providerRegistry, providerSelectionRepository, workspaceCapabilityService);
+    }
+
+    CalendarMeetingsDomainFacadeService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            Clock clock) {
+        super(CanonicalDomainDefinition.CALENDAR_MEETINGS, providerRegistry, providerSelectionRepository, workspaceCapabilityService, clock);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalCapabilityDecision.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalCapabilityDecision.java
@@ -1,0 +1,23 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+@Schema(description = "Fail-closed canonical capability decision made before provider access.")
+public record CanonicalCapabilityDecision(
+        String domain,
+        String capability,
+        boolean allowed,
+        CanonicalMemberState state,
+        String reason,
+        boolean providerAccessAllowed,
+        boolean failClosed,
+        boolean supportSafe,
+        boolean secretMaterialReturned,
+        boolean rawProviderErrorsReturned,
+        Map<String, Object> supportSafeDiagnostics) {
+
+    public CanonicalCapabilityDecision {
+        supportSafeDiagnostics = supportSafeDiagnostics == null ? Map.of() : Map.copyOf(supportSafeDiagnostics);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainContract.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainContract.java
@@ -1,0 +1,42 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Provider-neutral Weave domain contract. Adapter names are implementation candidates, not product vocabulary.")
+public record CanonicalDomainContract(
+        String contractVersion,
+        String domain,
+        String label,
+        List<String> providerCategoryKeys,
+        List<String> readCapabilities,
+        List<String> writeCapabilities,
+        List<String> adapterBoundaryOperations,
+        List<String> unsupportedUntilAdapterMapped,
+        List<String> canonicalObjectKinds,
+        boolean policyEvaluatedBeforeProviderAccess,
+        boolean unknownCapabilitiesFailClosed,
+        boolean normalMembersConfigureProviders) {
+
+    public CanonicalDomainContract {
+        contractVersion = text(contractVersion, "contractVersion");
+        domain = text(domain, "domain");
+        label = text(label, "label");
+        providerCategoryKeys = providerCategoryKeys == null ? List.of() : List.copyOf(providerCategoryKeys);
+        readCapabilities = readCapabilities == null ? List.of() : List.copyOf(readCapabilities);
+        writeCapabilities = writeCapabilities == null ? List.of() : List.copyOf(writeCapabilities);
+        adapterBoundaryOperations = adapterBoundaryOperations == null ? List.of() : List.copyOf(adapterBoundaryOperations);
+        unsupportedUntilAdapterMapped = unsupportedUntilAdapterMapped == null ? List.of() : List.copyOf(unsupportedUntilAdapterMapped);
+        canonicalObjectKinds = canonicalObjectKinds == null ? List.of() : List.copyOf(canonicalObjectKinds);
+        policyEvaluatedBeforeProviderAccess = true;
+        unknownCapabilitiesFailClosed = true;
+        normalMembersConfigureProviders = false;
+    }
+
+    private static String text(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainDefinition.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainDefinition.java
@@ -1,0 +1,133 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import java.util.List;
+import java.util.Set;
+
+public enum CanonicalDomainDefinition {
+    FILES_DOCS(
+            "files-docs",
+            "Files and documents",
+            List.of("files", "documents-collaboration"),
+            List.of("files.read", "documents.view"),
+            List.of("files.upload", "files.delete", "documents.edit", "documents.comment", "documents.collaborate"),
+            List.of("list_items", "read_metadata", "upload_binary", "delete_item", "request_document_session"),
+            List.of("document_edit_session", "coauthoring_presence", "provider_native_share_links"),
+            List.of("drive", "folder", "file", "document", "comment", "version")),
+    CALENDAR_MEETINGS(
+            "calendar-meetings",
+            "Calendar and meetings",
+            List.of("calendar", "meetings-calls"),
+            List.of("calendar.read", "meetings.join"),
+            List.of("calendar.manage_events", "meetings.host", "meetings.recording_policy"),
+            List.of("list_events", "read_event", "create_event", "update_event", "delete_event", "request_meeting_join"),
+            List.of("meeting_recording_control", "provider_native_recurrence_extensions", "external_meeting_admin"),
+            List.of("calendar", "event", "availability", "meeting", "join_capability")),
+    BOARDS_TASKS(
+            "boards-tasks",
+            "Boards and tasks",
+            List.of("boards-tasks"),
+            List.of("boards.read"),
+            List.of("boards.update_task", "boards.sync_workspace"),
+            List.of("list_boards", "list_tasks", "create_task", "move_task", "update_task_status", "link_decision"),
+            List.of("raw_project_admin", "provider_native_workflow_mutation", "cross_provider_bulk_migration_apply"),
+            List.of("board", "column", "task", "task_status", "decision_link")),
+    IDENTITY_ADMIN_POLICY(
+            "identity-admin-policy",
+            "Identity, admin, and policy",
+            List.of("identity-idm"),
+            List.of("identity.sign_in", "identity.groups", "identity.roles", "policy.read"),
+            List.of("policy.manage", "admin.provider_mapping.write", "admin.user_lifecycle.write"),
+            List.of("resolve_subject", "read_effective_policy", "list_support_safe_admin_policy", "dry_run_policy_change"),
+            List.of("direct_idm_mutation", "credential_export", "raw_claims_dump", "policy_apply_without_audit"),
+            List.of("subject", "group", "role", "capability_profile", "policy_decision", "audit_ref"));
+
+    private static final String CONTRACT_VERSION = "canonical-domain-facade-v1";
+
+    private final String domain;
+    private final String label;
+    private final List<String> providerCategoryKeys;
+    private final List<String> readCapabilities;
+    private final List<String> writeCapabilities;
+    private final List<String> adapterBoundaryOperations;
+    private final List<String> unsupportedUntilAdapterMapped;
+    private final List<String> canonicalObjectKinds;
+
+    CanonicalDomainDefinition(
+            String domain,
+            String label,
+            List<String> providerCategoryKeys,
+            List<String> readCapabilities,
+            List<String> writeCapabilities,
+            List<String> adapterBoundaryOperations,
+            List<String> unsupportedUntilAdapterMapped,
+            List<String> canonicalObjectKinds) {
+        this.domain = domain;
+        this.label = label;
+        this.providerCategoryKeys = List.copyOf(providerCategoryKeys);
+        this.readCapabilities = List.copyOf(readCapabilities);
+        this.writeCapabilities = List.copyOf(writeCapabilities);
+        this.adapterBoundaryOperations = List.copyOf(adapterBoundaryOperations);
+        this.unsupportedUntilAdapterMapped = List.copyOf(unsupportedUntilAdapterMapped);
+        this.canonicalObjectKinds = List.copyOf(canonicalObjectKinds);
+    }
+
+    public CanonicalDomainContract contract() {
+        return new CanonicalDomainContract(
+                CONTRACT_VERSION,
+                domain,
+                label,
+                providerCategoryKeys,
+                readCapabilities,
+                writeCapabilities,
+                adapterBoundaryOperations,
+                unsupportedUntilAdapterMapped,
+                canonicalObjectKinds,
+                true,
+                true,
+                false);
+    }
+
+    public WorkspaceCapabilityStatusResponse primaryCapability(WorkspaceCapabilitiesResponse snapshot) {
+        return switch (this) {
+            case FILES_DOCS -> snapshot.files();
+            case CALENDAR_MEETINGS -> snapshot.calendar();
+            case BOARDS_TASKS -> snapshot.boards();
+            case IDENTITY_ADMIN_POLICY -> snapshot.shellAccess();
+        };
+    }
+
+    public boolean knownCapability(String capability) {
+        return allCapabilities().contains(capability);
+    }
+
+    public Set<String> allCapabilities() {
+        return java.util.stream.Stream.concat(readCapabilities.stream(), writeCapabilities.stream())
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+    }
+
+    public String domain() {
+        return domain;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public List<String> providerCategoryKeys() {
+        return providerCategoryKeys;
+    }
+
+    public List<String> readCapabilities() {
+        return readCapabilities;
+    }
+
+    public List<String> writeCapabilities() {
+        return writeCapabilities;
+    }
+
+    public List<String> canonicalObjectKinds() {
+        return canonicalObjectKinds;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacade.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacade.java
@@ -1,0 +1,15 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public interface CanonicalDomainFacade {
+    CanonicalDomainContract contract();
+
+    CanonicalDomainReadiness memberReadiness(Jwt jwt);
+
+    CanonicalDomainReadiness adminReadiness(Jwt jwt);
+
+    CanonicalDomainItems items(Jwt jwt);
+
+    CanonicalCapabilityDecision evaluateCapability(Jwt jwt, String capability, String operation);
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeSupport.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeSupport.java
@@ -1,0 +1,348 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import com.massimotter.weave.backend.provider.ProviderCategoryCatalog;
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
+import com.massimotter.weave.backend.provider.ProviderSelection;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.provider.ProviderState;
+import com.massimotter.weave.backend.provider.ProviderStatusResponse;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public final class CanonicalDomainFacadeSupport {
+
+    private final CanonicalDomainDefinition definition;
+    private final ProviderRegistry providerRegistry;
+    private final ProviderSelectionRepository providerSelectionRepository;
+    private final WorkspaceCapabilityService workspaceCapabilityService;
+    private final Clock clock;
+
+    public CanonicalDomainFacadeSupport(
+            CanonicalDomainDefinition definition,
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            Clock clock) {
+        this.definition = definition;
+        this.providerRegistry = providerRegistry;
+        this.providerSelectionRepository = providerSelectionRepository;
+        this.workspaceCapabilityService = workspaceCapabilityService;
+        this.clock = clock == null ? Clock.systemUTC() : clock;
+    }
+
+    public CanonicalDomainContract contract() {
+        return definition.contract();
+    }
+
+    public CanonicalDomainReadiness readiness(Jwt jwt, boolean includeAdminDiagnostics) {
+        WorkspaceCapabilitiesResponse capabilities = workspaceCapabilityService.snapshot(jwt);
+        WorkspaceCapabilityStatusResponse primaryCapability = definition.primaryCapability(capabilities);
+        CanonicalMemberState policyState = policyState(primaryCapability);
+        if (policyState == CanonicalMemberState.POLICY_BLOCKED || policyState == CanonicalMemberState.DISABLED) {
+            return readinessWithoutProviderLookup(primaryCapability, policyState, includeAdminDiagnostics);
+        }
+
+        ProviderRegistryResponse registry = providerRegistry.status();
+        List<CanonicalProviderMapping> mappings = new ArrayList<>();
+        CanonicalMemberState aggregateState = CanonicalMemberState.READY;
+        for (String providerCategoryKey : definition.providerCategoryKeys()) {
+            Optional<ProviderSelection> maybeSelection = providerSelectionRepository.findByCategory(providerCategoryKey);
+            Optional<ProviderStatusResponse> maybeProvider = maybeSelection.flatMap(selection -> registry.providers().stream()
+                    .filter(provider -> ProviderCategoryCatalog.providerMatchesCategory(provider, providerCategoryKey))
+                    .filter(provider -> providerKeyMatches(provider, selection.providerKey()))
+                    .findFirst());
+            CanonicalMemberState state = mapState(primaryCapability, maybeSelection, maybeProvider);
+            aggregateState = worst(aggregateState, state);
+            if (includeAdminDiagnostics) {
+                mappings.add(mapping(providerCategoryKey, maybeSelection, maybeProvider, state));
+            }
+        }
+        Map<String, Object> diagnostics = includeAdminDiagnostics
+                ? adminDiagnostics(primaryCapability, aggregateState, mappings, true)
+                : memberDiagnostics(primaryCapability, aggregateState, true);
+        return new CanonicalDomainReadiness(
+                contract().contractVersion(),
+                definition.domain(),
+                aggregateState,
+                memberImpact(aggregateState, primaryCapability.memberImpact()),
+                aggregateState != CanonicalMemberState.READY,
+                true,
+                true,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                contract(),
+                includeAdminDiagnostics ? mappings : List.of(),
+                diagnostics,
+                Instant.now(clock));
+    }
+
+    public CanonicalDomainItems items(Jwt jwt) {
+        CanonicalDomainReadiness readiness = readiness(jwt, false);
+        return new CanonicalDomainItems(readiness, List.of());
+    }
+
+    public CanonicalCapabilityDecision evaluateCapability(Jwt jwt, String capability, String operation) {
+        WorkspaceCapabilitiesResponse capabilities = workspaceCapabilityService.snapshot(jwt);
+        WorkspaceCapabilityStatusResponse primaryCapability = definition.primaryCapability(capabilities);
+        String safeCapability = safeIdentifier(capability, "unsupported-capability");
+        boolean known = capability != null && definition.knownCapability(capability);
+        boolean policyAllowed = known && primaryCapability.grantedCapabilities().contains(capability);
+        CanonicalMemberState state = !known
+                ? CanonicalMemberState.UNSUPPORTED
+                : primaryCapability.policyState() == WorkspaceCapabilityPolicyState.POLICY_BLOCKED
+                        ? CanonicalMemberState.POLICY_BLOCKED
+                        : policyAllowed ? CanonicalMemberState.READY : CanonicalMemberState.POLICY_BLOCKED;
+        boolean allowed = state == CanonicalMemberState.READY;
+        Map<String, Object> diagnostics = new LinkedHashMap<>();
+        diagnostics.put("domain", definition.domain());
+        diagnostics.put("operation", safeIdentifier(operation, "unspecified-operation"));
+        diagnostics.put("knownCapability", known);
+        diagnostics.put("effectivePolicyState", primaryCapability.policyState().value());
+        diagnostics.put("providerLookupPerformed", false);
+        diagnostics.put("policyEvaluatedBeforeProviderAccess", true);
+        diagnostics.put("secretsReturned", false);
+        diagnostics.put("rawProviderErrorsReturned", false);
+        diagnostics.put("diagnosticsRedacted", true);
+        return new CanonicalCapabilityDecision(
+                definition.domain(),
+                safeCapability,
+                allowed,
+                state,
+                allowed ? "allowed_by_weave_policy" : known ? "capability_policy_blocked" : "unsupported_capability_fail_closed",
+                allowed,
+                !allowed,
+                true,
+                false,
+                false,
+                diagnostics);
+    }
+
+    private CanonicalDomainReadiness readinessWithoutProviderLookup(
+            WorkspaceCapabilityStatusResponse primaryCapability,
+            CanonicalMemberState state,
+            boolean includeAdminDiagnostics) {
+        Map<String, Object> diagnostics = includeAdminDiagnostics
+                ? adminDiagnostics(primaryCapability, state, List.of(), false)
+                : memberDiagnostics(primaryCapability, state, false);
+        return new CanonicalDomainReadiness(
+                contract().contractVersion(),
+                definition.domain(),
+                state,
+                memberImpact(state, primaryCapability.memberImpact()),
+                true,
+                true,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                false,
+                contract(),
+                List.of(),
+                diagnostics,
+                Instant.now(clock));
+    }
+
+    private CanonicalMemberState policyState(WorkspaceCapabilityStatusResponse capability) {
+        if (capability.policyState() == WorkspaceCapabilityPolicyState.POLICY_BLOCKED) {
+            return CanonicalMemberState.POLICY_BLOCKED;
+        }
+        if (capability.policyState() == WorkspaceCapabilityPolicyState.DISABLED || !capability.enabled()) {
+            return CanonicalMemberState.DISABLED;
+        }
+        return CanonicalMemberState.READY;
+    }
+
+    private CanonicalMemberState mapState(
+            WorkspaceCapabilityStatusResponse primaryCapability,
+            Optional<ProviderSelection> maybeSelection,
+            Optional<ProviderStatusResponse> maybeProvider) {
+        if (primaryCapability.policyState() == WorkspaceCapabilityPolicyState.POLICY_BLOCKED) {
+            return CanonicalMemberState.POLICY_BLOCKED;
+        }
+        if (primaryCapability.policyState() == WorkspaceCapabilityPolicyState.DISABLED || !primaryCapability.enabled()) {
+            return CanonicalMemberState.DISABLED;
+        }
+        if (maybeSelection.isEmpty()) {
+            return CanonicalMemberState.MISCONFIGURED;
+        }
+        if (maybeProvider.isEmpty()) {
+            return CanonicalMemberState.UNAVAILABLE;
+        }
+        ProviderStatusResponse provider = maybeProvider.get();
+        if (!provider.enabled() || provider.state() == ProviderState.DISABLED) {
+            return CanonicalMemberState.DISABLED;
+        }
+        if (!provider.configured() || provider.state() == ProviderState.NOT_CONFIGURED) {
+            return CanonicalMemberState.MISCONFIGURED;
+        }
+        if (provider.state() == ProviderState.DEGRADED) {
+            return CanonicalMemberState.DEGRADED;
+        }
+        if (primaryCapability.readiness() == WorkspaceCapabilityReadiness.DEGRADED) {
+            return CanonicalMemberState.DEGRADED;
+        }
+        if (provider.state() == ProviderState.READY || provider.state() == ProviderState.CONFIGURED) {
+            return CanonicalMemberState.READY;
+        }
+        return CanonicalMemberState.UNAVAILABLE;
+    }
+
+    private CanonicalProviderMapping mapping(
+            String providerCategoryKey,
+            Optional<ProviderSelection> maybeSelection,
+            Optional<ProviderStatusResponse> maybeProvider,
+            CanonicalMemberState state) {
+        Map<String, Object> diagnostics = new LinkedHashMap<>();
+        diagnostics.put("domain", definition.domain());
+        diagnostics.put("providerCategoryKey", providerCategoryKey);
+        diagnostics.put("providerConfigSource", ProviderRegistry.PROVIDER_CONFIG_SOURCE);
+        diagnostics.put("selectedByAdmin", maybeSelection.isPresent());
+        diagnostics.put("configured", maybeProvider.map(ProviderStatusResponse::configured).orElse(false));
+        diagnostics.put("readinessState", state.value());
+        diagnostics.put("missingConfigurationCategory", missingConfigurationCategory(maybeSelection, maybeProvider, state));
+        diagnostics.put("supportedCapabilities", maybeProvider.map(provider -> List.copyOf(provider.supportedCapabilities())).orElse(List.of()));
+        diagnostics.put("unsupportedOperations", maybeProvider.map(provider -> List.copyOf(provider.unsupportedOperations())).orElse(List.of()));
+        diagnostics.put("secretRefConfigured", maybeSelection.map(ProviderSelection::hasSecretRef).orElse(false));
+        diagnostics.put("secretsReturned", false);
+        diagnostics.put("rawProviderErrorsReturned", false);
+        diagnostics.put("downstreamPayloadsReturned", false);
+        diagnostics.put("diagnosticsRedacted", true);
+        return new CanonicalProviderMapping(
+                definition.domain(),
+                providerCategoryKey,
+                maybeSelection.map(ProviderSelection::providerKey).orElse("awaiting_admin_selection"),
+                ProviderRegistry.PROVIDER_CONFIG_SOURCE,
+                maybeSelection.isPresent(),
+                maybeProvider.map(ProviderStatusResponse::configured).orElse(false),
+                state,
+                state != CanonicalMemberState.READY,
+                true,
+                maybeSelection.map(ProviderSelection::hasSecretRef).orElse(false),
+                false,
+                false,
+                false,
+                maybeSelection.map(ProviderSelection::lossyMappingNotes).orElse(List.of()),
+                diagnostics);
+    }
+
+    private Map<String, Object> memberDiagnostics(
+            WorkspaceCapabilityStatusResponse primaryCapability,
+            CanonicalMemberState state,
+            boolean providerLookupPerformed) {
+        Map<String, Object> diagnostics = new LinkedHashMap<>();
+        diagnostics.put("domain", definition.domain());
+        diagnostics.put("state", state.value());
+        diagnostics.put("effectivePolicyState", primaryCapability.policyState().value());
+        diagnostics.put("diagnosticsExposed", false);
+        diagnostics.put("providerLookupPerformed", providerLookupPerformed);
+        diagnostics.put("policyEvaluatedBeforeProviderAccess", true);
+        diagnostics.put("secretsReturned", false);
+        diagnostics.put("rawProviderErrorsReturned", false);
+        diagnostics.put("downstreamPayloadsReturned", false);
+        return diagnostics;
+    }
+
+    private Map<String, Object> adminDiagnostics(
+            WorkspaceCapabilityStatusResponse primaryCapability,
+            CanonicalMemberState state,
+            List<CanonicalProviderMapping> mappings,
+            boolean providerLookupPerformed) {
+        Map<String, Object> diagnostics = new LinkedHashMap<>();
+        diagnostics.put("domain", definition.domain());
+        diagnostics.put("state", state.value());
+        diagnostics.put("effectivePolicyState", primaryCapability.policyState().value());
+        diagnostics.put("providerConfigSource", ProviderRegistry.PROVIDER_CONFIG_SOURCE);
+        diagnostics.put("providerLookupPerformed", providerLookupPerformed);
+        diagnostics.put("policyEvaluatedBeforeProviderAccess", true);
+        diagnostics.put("providerCategoryCount", definition.providerCategoryKeys().size());
+        diagnostics.put("mappingCount", mappings.size());
+        diagnostics.put("secretRefOnly", mappings.stream().allMatch(mapping -> !mapping.secretMaterialReturned()));
+        diagnostics.put("secretsReturned", false);
+        diagnostics.put("rawProviderErrorsReturned", false);
+        diagnostics.put("downstreamPayloadsReturned", false);
+        diagnostics.put("diagnosticsRedacted", true);
+        return diagnostics;
+    }
+
+    private String missingConfigurationCategory(
+            Optional<ProviderSelection> maybeSelection,
+            Optional<ProviderStatusResponse> maybeProvider,
+            CanonicalMemberState state) {
+        if (state == CanonicalMemberState.POLICY_BLOCKED) {
+            return "policy";
+        }
+        if (maybeSelection.isEmpty()) {
+            return "admin_provider_selection";
+        }
+        if (maybeProvider.isEmpty()) {
+            return "unsupported_provider_mapping";
+        }
+        if (!maybeProvider.get().configured()) {
+            return "backend_provider_configuration";
+        }
+        return "none";
+    }
+
+    private String memberImpact(CanonicalMemberState state, String capabilityImpact) {
+        return switch (state) {
+            case READY -> capabilityImpact == null || capabilityImpact.isBlank()
+                    ? definition.label() + " are available through Weave."
+                    : capabilityImpact;
+            case DISABLED -> definition.label() + " are disabled by workspace policy.";
+            case DEGRADED -> definition.label() + " are degraded. Ask an admin to review Workspace Health.";
+            case POLICY_BLOCKED -> definition.label() + " are blocked by your role or group policy. Ask an admin if you need access.";
+            case UNAVAILABLE -> definition.label() + " are unavailable for this workspace right now.";
+            case MISCONFIGURED -> definition.label() + " are not ready for members. Ask an admin to review Workspace Health.";
+            case UNSUPPORTED -> definition.label() + " requested capability is unsupported and failed closed.";
+        };
+    }
+
+    private boolean providerKeyMatches(ProviderStatusResponse provider, String providerKey) {
+        String normalized = providerKey.toLowerCase(Locale.ROOT);
+        return provider.providerKey().equals(providerKey)
+                || provider.candidates().stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(normalized::equals);
+    }
+
+    private CanonicalMemberState worst(CanonicalMemberState current, CanonicalMemberState candidate) {
+        return rank(candidate) > rank(current) ? candidate : current;
+    }
+
+    private int rank(CanonicalMemberState state) {
+        return switch (state) {
+            case READY -> 0;
+            case DEGRADED -> 1;
+            case DISABLED -> 2;
+            case MISCONFIGURED -> 3;
+            case UNAVAILABLE -> 4;
+            case POLICY_BLOCKED -> 5;
+            case UNSUPPORTED -> 6;
+        };
+    }
+
+    private String safeIdentifier(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        String safe = value.trim().toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9_.-]", "-");
+        return safe.isBlank() ? fallback : safe;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainItem.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainItem.java
@@ -1,0 +1,23 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Provider-neutral canonical item skeleton emitted by a Weave domain facade.")
+public record CanonicalDomainItem(
+        String itemId,
+        String kind,
+        String title,
+        CanonicalMemberState state,
+        String memberImpact,
+        Instant updatedAt,
+        List<String> capabilityHints,
+        Map<String, Object> annotations) {
+
+    public CanonicalDomainItem {
+        capabilityHints = capabilityHints == null ? List.of() : List.copyOf(capabilityHints);
+        annotations = annotations == null ? Map.of() : Map.copyOf(annotations);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainItems.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainItems.java
@@ -1,0 +1,13 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Canonical collection skeleton for a Weave domain facade. Provider adapters fill items later.")
+public record CanonicalDomainItems(
+        CanonicalDomainReadiness readiness,
+        List<CanonicalDomainItem> items) {
+    public CanonicalDomainItems {
+        items = items == null ? List.of() : List.copyOf(items);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainReadiness.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainReadiness.java
@@ -1,0 +1,32 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Canonical domain readiness returned by Weave-owned facades before any provider adapter access.")
+public record CanonicalDomainReadiness(
+        String contractVersion,
+        String domain,
+        CanonicalMemberState memberState,
+        String memberImpact,
+        boolean failClosed,
+        boolean supportSafe,
+        boolean policyEvaluatedBeforeProviderAccess,
+        boolean providerLookupPerformed,
+        boolean memberClientMayConfigureProvider,
+        boolean downstreamDiagnosticsExposedToMember,
+        boolean rawProviderPayloadsReturned,
+        boolean rawProviderErrorsReturned,
+        boolean secretMaterialReturned,
+        CanonicalDomainContract contract,
+        List<CanonicalProviderMapping> providerMappings,
+        Map<String, Object> supportSafeDiagnostics,
+        Instant checkedAt) {
+
+    public CanonicalDomainReadiness {
+        providerMappings = providerMappings == null ? List.of() : List.copyOf(providerMappings);
+        supportSafeDiagnostics = supportSafeDiagnostics == null ? Map.of() : Map.copyOf(supportSafeDiagnostics);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalMemberState.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalMemberState.java
@@ -1,0 +1,26 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Stable member-visible state for canonical Weave domain facades.")
+public enum CanonicalMemberState {
+    READY("ready"),
+    DISABLED("disabled"),
+    DEGRADED("degraded"),
+    POLICY_BLOCKED("policy_blocked"),
+    UNAVAILABLE("unavailable"),
+    MISCONFIGURED("misconfigured"),
+    UNSUPPORTED("unsupported");
+
+    private final String value;
+
+    CanonicalMemberState(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalProviderMapping.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalProviderMapping.java
@@ -1,0 +1,29 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Support-safe admin/operator provider mapping summary for a canonical Weave domain.")
+public record CanonicalProviderMapping(
+        String domain,
+        String providerCategoryKey,
+        String selectedProviderKey,
+        String selectionSource,
+        boolean selectedByAdmin,
+        boolean configured,
+        CanonicalMemberState readinessState,
+        boolean failClosed,
+        boolean supportSafe,
+        boolean secretRefConfigured,
+        boolean secretMaterialReturned,
+        boolean downstreamPayloadsReturned,
+        boolean rawProviderErrorsReturned,
+        List<String> lossyMappingWarnings,
+        Map<String, Object> supportSafeDiagnostics) {
+
+    public CanonicalProviderMapping {
+        lossyMappingWarnings = lossyMappingWarnings == null ? List.of() : List.copyOf(lossyMappingWarnings);
+        supportSafeDiagnostics = supportSafeDiagnostics == null ? Map.of() : Map.copyOf(supportSafeDiagnostics);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/FilesDocsDomainFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/FilesDocsDomainFacadeService.java
@@ -1,0 +1,28 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.time.Clock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FilesDocsDomainFacadeService extends AbstractCanonicalDomainFacade {
+
+    @Autowired
+    public FilesDocsDomainFacadeService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService) {
+        super(CanonicalDomainDefinition.FILES_DOCS, providerRegistry, providerSelectionRepository, workspaceCapabilityService);
+    }
+
+    FilesDocsDomainFacadeService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            Clock clock) {
+        super(CanonicalDomainDefinition.FILES_DOCS, providerRegistry, providerSelectionRepository, workspaceCapabilityService, clock);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/IdentityAdminPolicyDomainFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/IdentityAdminPolicyDomainFacadeService.java
@@ -1,0 +1,28 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.time.Clock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class IdentityAdminPolicyDomainFacadeService extends AbstractCanonicalDomainFacade {
+
+    @Autowired
+    public IdentityAdminPolicyDomainFacadeService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService) {
+        super(CanonicalDomainDefinition.IDENTITY_ADMIN_POLICY, providerRegistry, providerSelectionRepository, workspaceCapabilityService);
+    }
+
+    IdentityAdminPolicyDomainFacadeService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            Clock clock) {
+        super(CanonicalDomainDefinition.IDENTITY_ADMIN_POLICY, providerRegistry, providerSelectionRepository, workspaceCapabilityService, clock);
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeServicesTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeServicesTest.java
@@ -1,0 +1,311 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import com.massimotter.weave.backend.provider.InMemoryProviderSelectionRepository;
+import com.massimotter.weave.backend.provider.ProviderModule;
+import com.massimotter.weave.backend.provider.ProviderPort;
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderSelection;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.provider.ProviderState;
+import com.massimotter.weave.backend.provider.ProviderStatusResponse;
+import com.massimotter.weave.backend.provider.StaticProviderPort;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+class CanonicalDomainFacadeServicesTest {
+
+    private static final Clock FIXED = Clock.fixed(Instant.parse("2026-05-25T09:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void contractsCoverRemainingNonChatDomainsWithoutThinProviderProxyVocabulary() {
+        var services = services(new InMemoryProviderSelectionRepository(), configuredProviders(), allowedCapabilities());
+
+        assertThat(services).extracting(service -> service.contract().domain())
+                .containsExactly("files-docs", "calendar-meetings", "boards-tasks", "identity-admin-policy");
+
+        for (CanonicalDomainFacade service : services) {
+            CanonicalDomainContract contract = service.contract();
+            assertThat(contract.contractVersion()).isEqualTo("canonical-domain-facade-v1");
+            assertThat(contract.policyEvaluatedBeforeProviderAccess()).isTrue();
+            assertThat(contract.unknownCapabilitiesFailClosed()).isTrue();
+            assertThat(contract.normalMembersConfigureProviders()).isFalse();
+            assertThat(contract.providerCategoryKeys()).isNotEmpty();
+            assertThat(contract.canonicalObjectKinds()).isNotEmpty();
+            assertThat(contract.adapterBoundaryOperations()).isNotEmpty();
+            assertThat(contract.unsupportedUntilAdapterMapped()).isNotEmpty();
+            assertThat(contract.toString().toLowerCase())
+                    .doesNotContain("webdav", "caldav", "openproject", "keycloak", "nextcloud", "onlyoffice");
+        }
+    }
+
+    @Test
+    void memberReadinessFailsClosedWithoutAdminSelectedMappingsAndHidesProviderDiagnostics() {
+        var services = services(new InMemoryProviderSelectionRepository(), configuredProviders(), allowedCapabilities());
+
+        for (CanonicalDomainFacade service : services) {
+            CanonicalDomainReadiness readiness = service.memberReadiness(memberJwt());
+            CanonicalDomainItems items = service.items(memberJwt());
+
+            assertThat(readiness.memberState()).isEqualTo(CanonicalMemberState.MISCONFIGURED);
+            assertThat(readiness.failClosed()).isTrue();
+            assertThat(readiness.supportSafe()).isTrue();
+            assertThat(readiness.memberClientMayConfigureProvider()).isFalse();
+            assertThat(readiness.downstreamDiagnosticsExposedToMember()).isFalse();
+            assertThat(readiness.rawProviderPayloadsReturned()).isFalse();
+            assertThat(readiness.rawProviderErrorsReturned()).isFalse();
+            assertThat(readiness.secretMaterialReturned()).isFalse();
+            assertThat(readiness.providerMappings()).isEmpty();
+            assertThat(readiness.supportSafeDiagnostics())
+                    .containsEntry("diagnosticsExposed", false)
+                    .containsEntry("secretsReturned", false)
+                    .containsEntry("rawProviderErrorsReturned", false)
+                    .containsEntry("downstreamPayloadsReturned", false);
+            assertThat(items.items()).isEmpty();
+            assertThat(readiness.toString())
+                    .doesNotContain("https://", "Bearer ", "access_token", "secretref://", "downstream body");
+        }
+    }
+
+    @Test
+    void adminReadinessUsesSecretRefsOnlyAndSupportSafeMappingDiagnostics() {
+        InMemoryProviderSelectionRepository selections = selectedMappings();
+        var services = services(selections, configuredProviders(), allowedCapabilities());
+
+        for (CanonicalDomainFacade service : services) {
+            CanonicalDomainReadiness readiness = service.adminReadiness(adminJwt());
+
+            assertThat(readiness.memberState()).isEqualTo(CanonicalMemberState.READY);
+            assertThat(readiness.providerMappings()).isNotEmpty();
+            assertThat(readiness.supportSafeDiagnostics())
+                    .containsEntry("diagnosticsRedacted", true)
+                    .containsEntry("secretRefOnly", true)
+                    .containsEntry("rawProviderErrorsReturned", false);
+            assertThat(readiness.providerMappings())
+                    .allSatisfy(mapping -> {
+                        assertThat(mapping.selectedByAdmin()).isTrue();
+                        assertThat(mapping.configured()).isTrue();
+                        assertThat(mapping.secretRefConfigured()).isTrue();
+                        assertThat(mapping.secretMaterialReturned()).isFalse();
+                        assertThat(mapping.downstreamPayloadsReturned()).isFalse();
+                        assertThat(mapping.rawProviderErrorsReturned()).isFalse();
+                        assertThat(mapping.supportSafeDiagnostics())
+                                .containsEntry("secretRefConfigured", true)
+                                .containsEntry("secretsReturned", false)
+                                .containsEntry("downstreamPayloadsReturned", false);
+                    });
+            assertThat(readiness.toString()).doesNotContain("secretref://", "client-secret", "Bearer ", "access_token", "downstream body");
+        }
+    }
+
+    @Test
+    void policyBlockedReadinessSkipsProviderLookupAndFailsClosed() {
+        AtomicInteger providerCalls = new AtomicInteger();
+        ProviderPort explodingProvider = () -> {
+            providerCalls.incrementAndGet();
+            throw new AssertionError("provider status must not be read before policy allows the domain");
+        };
+        var service = filesDocs(new InMemoryProviderSelectionRepository(), List.of(explodingProvider), blockedCapabilities());
+
+        CanonicalDomainReadiness readiness = service.memberReadiness(guestJwt());
+
+        assertThat(readiness.memberState()).isEqualTo(CanonicalMemberState.POLICY_BLOCKED);
+        assertThat(readiness.failClosed()).isTrue();
+        assertThat(readiness.providerLookupPerformed()).isFalse();
+        assertThat(readiness.supportSafeDiagnostics())
+                .containsEntry("providerLookupPerformed", false)
+                .containsEntry("policyEvaluatedBeforeProviderAccess", true)
+                .containsEntry("secretsReturned", false)
+                .containsEntry("rawProviderErrorsReturned", false);
+        assertThat(providerCalls).hasValue(0);
+    }
+
+    @Test
+    void unknownAndDenyByDefaultCapabilitiesFailClosedBeforeProviderAccess() {
+        AtomicInteger providerCalls = new AtomicInteger();
+        ProviderPort provider = () -> {
+            providerCalls.incrementAndGet();
+            return configuredProvider(ProviderModule.FILES, "generic-file-storage", Set.of("files.read"));
+        };
+        var service = filesDocs(new InMemoryProviderSelectionRepository(), List.of(provider), blockedCapabilities());
+
+        CanonicalCapabilityDecision unknown = service.evaluateCapability(memberJwt(), "files.raw_provider_url", "open-raw-url");
+        CanonicalCapabilityDecision denied = service.evaluateCapability(guestJwt(), "files.read", "list-files");
+
+        assertThat(unknown.allowed()).isFalse();
+        assertThat(unknown.state()).isEqualTo(CanonicalMemberState.UNSUPPORTED);
+        assertThat(unknown.reason()).isEqualTo("unsupported_capability_fail_closed");
+        assertThat(unknown.providerAccessAllowed()).isFalse();
+        assertThat(unknown.supportSafeDiagnostics())
+                .containsEntry("knownCapability", false)
+                .containsEntry("providerLookupPerformed", false);
+        assertThat(denied.allowed()).isFalse();
+        assertThat(denied.state()).isEqualTo(CanonicalMemberState.POLICY_BLOCKED);
+        assertThat(denied.reason()).isEqualTo("capability_policy_blocked");
+        assertThat(denied.providerAccessAllowed()).isFalse();
+        assertThat(providerCalls).hasValue(0);
+    }
+
+    private List<CanonicalDomainFacade> services(
+            ProviderSelectionRepository selections,
+            List<ProviderPort> providers,
+            WorkspaceCapabilitiesResponse capabilities) {
+        WorkspaceCapabilityService capabilityService = capabilityService(capabilities);
+        ProviderRegistry registry = new ProviderRegistry(providers, capabilityService, selections);
+        return List.of(
+                new FilesDocsDomainFacadeService(registry, selections, capabilityService, FIXED),
+                new CalendarMeetingsDomainFacadeService(registry, selections, capabilityService, FIXED),
+                new BoardsTasksDomainFacadeService(registry, selections, capabilityService, FIXED),
+                new IdentityAdminPolicyDomainFacadeService(registry, selections, capabilityService, FIXED));
+    }
+
+    private FilesDocsDomainFacadeService filesDocs(
+            ProviderSelectionRepository selections,
+            List<ProviderPort> providers,
+            WorkspaceCapabilitiesResponse capabilities) {
+        WorkspaceCapabilityService capabilityService = capabilityService(capabilities);
+        ProviderRegistry registry = new ProviderRegistry(providers, capabilityService, selections);
+        return new FilesDocsDomainFacadeService(registry, selections, capabilityService, FIXED);
+    }
+
+    private WorkspaceCapabilityService capabilityService(WorkspaceCapabilitiesResponse capabilities) {
+        WorkspaceCapabilityService service = Mockito.mock(WorkspaceCapabilityService.class);
+        when(service.snapshot()).thenReturn(capabilities);
+        when(service.snapshot(any())).thenReturn(capabilities);
+        return service;
+    }
+
+    private WorkspaceCapabilitiesResponse allowedCapabilities() {
+        return new WorkspaceCapabilitiesResponse(
+                capability("identity/IDM", List.of("identity.sign_in", "identity.groups", "identity.roles", "policy.read"), WorkspaceCapabilityPolicyState.ALLOWED),
+                capability("chat", List.of("chat.read"), WorkspaceCapabilityPolicyState.ALLOWED),
+                capability("files", List.of("files.read", "files.upload", "documents.view", "documents.edit"), WorkspaceCapabilityPolicyState.ALLOWED),
+                capability("calendar", List.of("calendar.read", "calendar.manage_events", "meetings.join"), WorkspaceCapabilityPolicyState.ALLOWED),
+                capability("boards/tasks", List.of("boards.read", "boards.update_task"), WorkspaceCapabilityPolicyState.ALLOWED),
+                capability("Weaver", List.of("weaver.exec_disabled"), WorkspaceCapabilityPolicyState.ALLOWED));
+    }
+
+    private WorkspaceCapabilitiesResponse blockedCapabilities() {
+        return new WorkspaceCapabilitiesResponse(
+                capability("identity/IDM", List.of(), WorkspaceCapabilityPolicyState.POLICY_BLOCKED),
+                capability("chat", List.of(), WorkspaceCapabilityPolicyState.POLICY_BLOCKED),
+                capability("files", List.of(), WorkspaceCapabilityPolicyState.POLICY_BLOCKED),
+                capability("calendar", List.of(), WorkspaceCapabilityPolicyState.POLICY_BLOCKED),
+                capability("boards/tasks", List.of(), WorkspaceCapabilityPolicyState.POLICY_BLOCKED),
+                capability("Weaver", List.of(), WorkspaceCapabilityPolicyState.POLICY_BLOCKED));
+    }
+
+    private WorkspaceCapabilityStatusResponse capability(
+            String profile,
+            List<String> granted,
+            WorkspaceCapabilityPolicyState policyState) {
+        return new WorkspaceCapabilityStatusResponse(
+                policyState != WorkspaceCapabilityPolicyState.DISABLED,
+                policyState == WorkspaceCapabilityPolicyState.POLICY_BLOCKED
+                        ? WorkspaceCapabilityReadiness.BLOCKED
+                        : WorkspaceCapabilityReadiness.READY,
+                policyState,
+                profile,
+                "Ready through Weave policy.",
+                granted);
+    }
+
+    private InMemoryProviderSelectionRepository selectedMappings() {
+        InMemoryProviderSelectionRepository selections = new InMemoryProviderSelectionRepository();
+        selections.save(selection("files", "generic-file-storage"));
+        selections.save(selection("documents-collaboration", "generic-document-session"));
+        selections.save(selection("calendar", "generic-calendar"));
+        selections.save(selection("meetings-calls", "generic-meetings"));
+        selections.save(selection("boards-tasks", "generic-boards"));
+        selections.save(selection("identity-idm", "generic-identity"));
+        return selections;
+    }
+
+    private ProviderSelection selection(String category, String providerKey) {
+        return new ProviderSelection(
+                category,
+                providerKey,
+                "external_existing_provider",
+                "secretref://weave/provider/" + providerKey,
+                "actor:test-admin",
+                Instant.parse("2026-05-24T18:00:00Z"),
+                true,
+                true,
+                false,
+                List.of("Provider-specific fields are normalized into Weave annotations."));
+    }
+
+    private List<ProviderPort> configuredProviders() {
+        return List.of(
+                new StaticProviderPort(configuredProvider(ProviderModule.FILES, "generic-file-storage", Set.of("files.read", "files.upload"))),
+                new StaticProviderPort(configuredProvider(ProviderModule.OFFICE, "generic-document-session", Set.of("documents.view", "documents.edit"))),
+                new StaticProviderPort(configuredProvider(ProviderModule.CALENDAR, "generic-calendar", Set.of("calendar.read", "calendar.manage_events"))),
+                new StaticProviderPort(configuredProvider(ProviderModule.MEETINGS, "generic-meetings", Set.of("meetings.join", "meetings.host"))),
+                new StaticProviderPort(configuredProvider(ProviderModule.BOARDS, "generic-boards", Set.of("boards.read", "boards.update_task"))),
+                new StaticProviderPort(configuredProvider(ProviderModule.IDENTITY_REALM, "generic-identity", Set.of("identity.sign_in", "identity.groups", "identity.roles"))));
+    }
+
+    private ProviderStatusResponse configuredProvider(ProviderModule module, String key, Set<String> capabilities) {
+        return new ProviderStatusResponse(
+                module,
+                key,
+                ProviderState.CONFIGURED,
+                "configured",
+                true,
+                true,
+                true,
+                true,
+                true,
+                false,
+                "Canonical domain adapter seam is configured with support-safe diagnostics.",
+                capabilities,
+                Set.of("direct-member-provider-api", "raw-provider-errors", "credential-exposure"),
+                List.of("provider-not-configured", "provider-disabled", "unsupported-capability"),
+                "support-safe redaction policy",
+                List.of(key),
+                Map.of("secretsReturned", false, "rawProviderErrorsReturned", false, "downstreamPayloadsReturned", false));
+    }
+
+    private Jwt memberJwt() {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("member-123")
+                .claim("weave_tenant", "weave-dogfood")
+                .claim("realm_access", Map.of("roles", List.of("member")))
+                .build();
+    }
+
+    private Jwt adminJwt() {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("admin-123")
+                .claim("weave_tenant", "weave-dogfood")
+                .claim("realm_access", Map.of("roles", List.of("admin")))
+                .build();
+    }
+
+    private Jwt guestJwt() {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("guest-123")
+                .claim("weave_tenant", "weave-dogfood")
+                .claim("realm_access", Map.of("roles", List.of("guest")))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds canonical server-side non-Chat domain facade skeletons for Files/Documents, Calendar/Meetings, Boards/Tasks, and Identity/Admin/Policy.
- Keeps these as Weave product contracts rather than provider proxy APIs: contracts name canonical object kinds, capability seams, adapter-boundary operations, and unsupported operations pending promoted adapters.
- Adds support-safe readiness/mapping/capability decision shapes that evaluate Weave capability policy before provider lookup and expose SecretRef presence only.

## Acceptance coverage for #282 Slice 2
- [x] Facade interfaces are not thin provider proxies: canonical contracts use Weave domain/object/capability vocabulary and adapter-boundary operation names.
- [x] Unknown/unsupported capabilities fail closed via `CanonicalCapabilityDecision`.
- [x] Policy/capability evaluation occurs before provider lookup; blocked/disabled states return without touching `ProviderRegistry`.
- [x] Normal member readiness hides provider mappings, raw URLs, credentials, SecretRefs, downstream payloads, and provider errors.
- [x] Admin/operator readiness exposes only support-safe mapping diagnostics and `secretRefConfigured` booleans.
- [x] No concrete provider implementations, Weaver runtime, Office/ONLYOFFICE, or OpenProject vertical mapping added.
- [x] Tests cover support-safe readiness, SecretRef-only boundaries, deny-by-default policy, unknown capability fail-closed behavior, and no raw provider payload/error leakage.

## Gates
- `git diff --check` ✅
- `cd server && ./gradlew test --tests com.massimotter.weave.backend.domainfacade.CanonicalDomainFacadeServicesTest` ✅
- `cd server && ./gradlew test` ✅
- `npm ci` in `admin-console` before full CI because the fresh worktree lacked admin dependencies ✅
- `make ci` ✅

## Independent review
- Read-only Gemini review of the committed diff: no blockers; noted non-blocking hardcoded safety flags and the intentional `shellAccess()` identity/admin/policy mapping.

Closes #282 when merged.
