### PR TITLE
docs: record sprint 1 completion and sprint 2 charter

### DIFF
--- a/docs/build-evidence-delivery-system.md
+++ b/docs/build-evidence-delivery-system.md
@@ -1,0 +1,46 @@
+# Build, Evidence & Delivery System charter
+
+Sprint 2 turns Weave's engineering loop into one professional, reproducible path: one root command, one task graph, one sanitized evidence model, and one documented GitFlow.
+
+## North Star
+
+Root Gradle is the build and delivery source of truth. `./gradlew ci` is the canonical local and CI command. Make remains only as a temporary compatibility shim during migration and must not contain long-term duplicated logic.
+
+## Non-negotiables
+
+- Same task names locally and in CI/CD.
+- Evidence is generated as artifacts under `build/**`, not reconstructed from chat or raw logs.
+- Default checks do not mutate tracked source; mutations happen only through explicit update tasks.
+- Default checks require no secrets, live services, nondeterministic GitHub API calls, or remote CDN assets.
+- Flutter/Dart and admin/npm checks are orchestrated through typed Gradle `Exec` tasks first; do not force Flutter Android into root Gradle prematurely.
+- Live E2E remains opt-in and preserves explicit operator/budget confirmation semantics.
+
+## Stable Gradle command surface
+
+| Task | Contract |
+| --- | --- |
+| `doctor` | Fail fast with actionable missing-tool messages. |
+| `acceptanceContract` | Verify Gherkin scenario mappings and acceptance contracts. |
+| `clientCi` | Run the cheap Flutter/offline client gate. |
+| `serverCi` | Run server tests. |
+| `adminCi` | Run admin console checks. |
+| `infraStatic` | Run static infrastructure checks. |
+| `docsBuild` | Build user/admin manuals deterministically. |
+| `releaseEvidenceCheck` | Validate release labels, README release markers, and generated-release evidence behavior. |
+| `ci` | Canonical aggregate for default PR-safe checks. |
+
+## Branch map for small PRs
+
+Use short-lived branches from `origin/main`:
+
+- `build/gradle-root-ssot` — Gradle wrapper/foundation, doctor, and Make delegation.
+- `build/gradle-ci-parity` — parity tasks where `./gradlew ci` equals the current cheap gate set.
+- `build/evidence-artifacts` — sanitized `build/evidence/ci-summary.json` and PR checklist integration.
+- `docs/mkdocs-help-foundation` — pinned MkDocs user/admin manual build outputs.
+- `release/evidence-automation` — release evidence checks, generated release-note artifacts, explicit README update task.
+- `build/ci-gradle-migration` — GitHub Actions migration to `./gradlew ci` and least permissions.
+- `build/make-transition-reduction` — remove or reduce Make after Gradle parity is proven.
+
+## Stop condition
+
+If `./gradlew ci` cannot prove parity with the existing cheap gates, Sprint 2 is blocked. Do not claim completion from partial local-only or hidden evidence.

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -42,7 +42,9 @@ The app accepts local development service URLs such as `https://api.weave.local/
 
 ## Root Gradle orchestration
 
-The root `./gradlew` is a monorepo task runner, not a rewrite of the subproject build systems. It delegates to the existing Makefile targets and preserves current CI behavior while giving one discoverable command surface:
+Sprint 2 makes the root `./gradlew` the monorepo build and delivery source of truth. During the transition it is still a task runner around proven client/server/admin/infra/docs commands, but the stable command surface is Gradle-first: use `./gradlew ci` locally and in CI, then reduce Make to temporary compatibility aliases after parity is proven. See [Build, Evidence & Delivery System charter](build-evidence-delivery-system.md) for the current task graph, evidence, and branch plan.
+
+The root Gradle build delegates to existing proven targets while preserving current CI behavior:
 
 | Gradle task | Delegates to | Purpose |
 | --- | --- | --- |
@@ -88,7 +90,9 @@ make offline-contract-test
 
 ## GitFlow and PR workflow
 
-Use short-lived PR branches from `main`, keep changes issue/spec-driven, and request Copilot review on every review-ready PR. Every PR must deliberately choose exactly one release-notes label before review/merge:
+Use short-lived PR branches from `main`, keep changes issue/spec-driven, and request Copilot review on every review-ready PR. Sprint 2 build/delivery work uses the branch families documented in [Build, Evidence & Delivery System charter](build-evidence-delivery-system.md): `build/gradle-root-ssot`, `build/gradle-ci-parity`, `build/evidence-artifacts`, `docs/mkdocs-help-foundation`, `release/evidence-automation`, `build/ci-gradle-migration`, and `build/make-transition-reduction`.
+
+Every PR must deliberately choose exactly one release-notes label before review/merge:
 
 - `release-notes-feature`
 - `release-notes-bugfix`

--- a/docs/sprint-1-completion-report.md
+++ b/docs/sprint-1-completion-report.md
@@ -1,0 +1,55 @@
+# Sprint 1 completion report: provider-neutral facade contracts
+
+Date: 2026-05-25
+
+## Goal
+
+Complete the provider-neutral domain facade contract foundation so Weave can treat Chat, Files/Documents, Calendar/Meetings, Boards/Tasks, Identity/Admin, Readiness, and Audit as governed product contracts instead of fixed-provider implementation details.
+
+## Slices completed
+
+1. **Chat domain facade contracts** — message, room, membership, receipt, attachment, and audit contract surfaces for provider-neutral chat.
+2. **Non-Chat domain facade contracts** — Files/Documents, Calendar/Meetings, Boards/Tasks, Identity/Admin, Readiness, and Audit contract surfaces aligned with the product-line plan.
+3. **Backlog and closed-worktree reconciliation** — closed superseded/debt issues so Sprint 2 starts from current repo/GitHub truth, not stale worktrees.
+
+## PRs and commits
+
+| PR | Merge commit | Head branch | Result |
+| --- | --- | --- | --- |
+| [#302](https://github.com/masssi164/weave/pull/302) `feat(server): add Chat domain facade contracts` | `5accc2454c833aace175fe9b5ef5c6da48072576` | `sprint/chat-domain-facade` at `9df1189e65376464bfc6448185bf60c6adf285b3` | Merged 2026-05-25 09:37 UTC. |
+| [#303](https://github.com/masssi164/weave/pull/303) `feat(server): add non-chat domain facade contracts` | `2a15dd1819a6097f9d878a206fb03ae8153f3088` | `feat/domain-facade-contracts-slice-2` at `f2a257dc3005a083e12b5f148b8862f93d62fbc0` | Merged 2026-05-25 10:33 UTC. |
+
+## Issues closed or updated
+
+| Issue | Outcome |
+| --- | --- |
+| [#295](https://github.com/masssi164/weave/issues/295) | Closed by PR #302. |
+| [#282](https://github.com/masssi164/weave/issues/282) | Closed by PR #303. |
+| [#299](https://github.com/masssi164/weave/issues/299) | Closed after backlog triage. |
+| [#298](https://github.com/masssi164/weave/issues/298) | Closed after closed-worktree reconciliation. |
+| [#284](https://github.com/masssi164/weave/issues/284) | Closed as superseded/covered by PRs #301/#302. |
+
+## Docs updated
+
+- Server/provider facade contract documentation and generated contract references were updated with the merged Chat and non-Chat surfaces.
+- Product-line ordering remains anchored in `docs/product-line-and-weaver-plan.md`: Weave provider-neutral organization suite first; admin portal/IDM/RBAC/readiness/whitelisting second; Weaver governed per-user PA runtime later.
+- Sprint 2 now starts from root build/evidence/delivery documentation instead of reopening Sprint 1 contract questions.
+
+## Gates
+
+- PR #302 passed Acceptance Contract, Admin Console Checks, Client Offline Checks, Docs Checks, Infra Static Checks, Release Notes Label Check, and Server Checks before merge.
+- PR #303 passed the same full gate set before merge. A later merge-event run produced skipped jobs plus the release-label result; those skipped merge-event jobs are not a PR gate failure.
+- Copilot review/check signal was present for PR #303.
+
+## Non-collected evidence
+
+- No live-stack E2E was collected. Sprint 1 contract work did not require operator confirmation, live services, secrets, or budget-consuming infrastructure.
+- No screenshots or manual UX accessibility captures were collected because the delivered scope was backend contract/documentation oriented.
+- No raw provider payloads, credentials, live URLs, or provider error bodies were stored as evidence.
+
+## Risks carried into Sprint 2
+
+- Build orchestration is still transitioning: Make and GitHub Actions have not yet fully converged on root Gradle as the delivery SSOT.
+- Evidence is still partly reconstructed from workflow/check state instead of being emitted as a sanitized build artifact.
+- Docs and release-note generation exist, but deterministic Gradle-owned output locations and explicit update-vs-check boundaries need hardening.
+- Live E2E must remain opt-in with existing confirmation semantics while acceptance mappings stay executable and non-decorative.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,8 @@ nav:
       - Canonical feature models: canonical-feature-models.md
       - Acceptance contracts: acceptance-contracts.md
       - Quality and evidence: quality-and-evidence.md
+      - Build, evidence, and delivery system: build-evidence-delivery-system.md
+      - Sprint 1 completion report: sprint-1-completion-report.md
       - Accessibility release gate: accessibility-release-gate.md
       - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md
   - Product and Release Scope:


### PR DESCRIPTION
## Summary
- adds the compact Sprint 1 completion report requested before Sprint 2 implementation
- adds the Sprint 2 Build, Evidence & Delivery System charter and small-PR branch map
- updates the developer handbook/MkDocs nav so the GitFlow and Gradle-SSOT transition are documented from the start

## Evidence
- `build/docs-venv/bin/python -m mkdocs build --strict` ✅

## Non-collected evidence
- No live E2E; documentation-only change, no live services or secrets required.
- No raw provider payloads or credential-bearing logs collected.

## Release notes
- `release-notes-feature`