### PR TITLE
build: make root Gradle the orchestration entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,49 @@
-.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve docs-structure-check release-notes-check release-notes-label-check live-stack-help
+.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve docs-structure-check release-notes-check release-notes-label-check release-evidence-check live-stack-help doctor
 
-ci: acceptance-contract client-ci server-ci infra-static admin-ci
+GRADLE ?= ./gradlew
+
+ci:
+	$(GRADLE) ci
+
+doctor:
+	$(GRADLE) doctor
+
+client-ci:
+	$(GRADLE) clientCi
+
+server-ci:
+	$(GRADLE) serverCi
+
+infra-static:
+	$(GRADLE) infraStatic
+
+admin-ci:
+	$(GRADLE) adminCi
+
+acceptance-contract:
+	$(GRADLE) acceptanceContract
 
 # Install docs tooling with: python3 -m pip install -r docs/requirements.txt
 docs-build:
-	python3 -m mkdocs build --strict
+	$(GRADLE) docsBuild
 
-docs-check: docs-structure-check
-	python3 -m mkdocs build --strict
+docs-check:
+	$(GRADLE) docsCheck
 
 docs-serve:
-	python3 -m mkdocs serve
+	$(GRADLE) docsServe
 
 docs-structure-check:
-	python3 tools/docs_check.py
+	$(GRADLE) docsStructureCheck
 
 release-notes-check:
-	python3 tools/docs_check.py --release-notes-only
-	python3 tools/release_notes_label_check_test.py
-	python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check
+	$(GRADLE) releaseEvidenceCheck
+
+release-evidence-check:
+	$(GRADLE) releaseEvidenceCheck
 
 release-notes-label-check:
-	python3 tools/release_notes_label_check.py
-
-client-ci:
-	$(MAKE) -C client offline-contract-test
-
-server-ci:
-	cd server && ./gradlew test
-
-infra-static:
-	@find infra/weave-workspace/tests -maxdepth 1 -type f -name '*-test.sh' -print0 | sort -z | xargs -0 -n1 bash
-
-admin-ci:
-	cd admin-console && npm run ci
-
-acceptance-contract:
-	cd client && dart run tool/acceptance_contract.dart guard --root .. --features e2e/features --mapping e2e/scenario_mappings.json
+	$(GRADLE) releaseNotesLabelCheck
 
 live-stack-help:
-	@printf '%s\n' 'Live stack E2E is intentionally opt-in. Use the GitHub workflow with I_HAVE_SOLAR_STORAGE_BUDGET when runner power/storage budget is available.'
+	$(GRADLE) liveStackHelp

--- a/build.gradle
+++ b/build.gradle
@@ -2,28 +2,128 @@ plugins {
     id 'base'
 }
 
-ext.registerMakeTask = { String taskName, String makeTarget, String taskDescription ->
+import org.gradle.internal.os.OperatingSystem
+
+ext.execCommand = { List<String> args ->
+    OperatingSystem.current().isWindows() ? ['cmd', '/c'] + args : args
+}
+
+ext.registerCommandTask = { String taskName, Object taskWorkingDir, List<String> args, String taskDescription ->
     tasks.register(taskName, Exec) {
         group = 'verification'
         description = taskDescription
-        commandLine 'make', makeTarget
+        workingDir taskWorkingDir
+        commandLine execCommand(args)
         outputs.upToDateWhen { false }
     }
 }
 
-registerMakeTask('serverCi', 'server-ci', 'Run server checks through the existing server Gradle build.')
-registerMakeTask('clientCi', 'client-ci', 'Run Flutter offline contract checks through the existing client Makefile.')
-registerMakeTask('adminCi', 'admin-ci', 'Run admin console npm CI checks through the existing Makefile.')
-registerMakeTask('infraStatic', 'infra-static', 'Run static infrastructure script checks through the existing Makefile.')
-registerMakeTask('docsBuild', 'docs-build', 'Build the MkDocs site with strict validation.')
-registerMakeTask('docsCheck', 'docs-check', 'Run documentation structure checks and strict MkDocs build.')
-registerMakeTask('acceptanceContract', 'acceptance-contract', 'Verify Gherkin scenario mappings and acceptance contracts.')
-registerMakeTask('releaseNotesCheck', 'release-notes-check', 'Validate release notes structure, labels, and generator fixtures.')
+ext.registerRootCommandTask = { String taskName, List<String> args, String taskDescription ->
+    registerCommandTask(taskName, projectDir, args, taskDescription)
+}
+
+registerRootCommandTask('acceptanceContract', ['bash', '-lc', 'cd client && dart run tool/acceptance_contract.dart guard --root .. --features e2e/features --mapping e2e/scenario_mappings.json'], 'Verify Gherkin scenario mappings and acceptance contracts.')
+registerCommandTask('clientCi', file('client'), ['bash', '-lc', 'flutter gen-l10n && dart run build_runner build --delete-conflicting-outputs && dart format --output=none --set-exit-if-changed . && flutter analyze --fatal-infos && flutter test && make marketing-screenshots && git -C .. diff --exit-code -- client/lib client/test docs/assets/marketing docs/assets/roadmap && make offline-contract-test'], 'Run Flutter generated-code, format, analysis, tests, screenshots, and offline contract checks.')
+registerCommandTask('serverCi', file('server'), ['./gradlew', 'test'], 'Run server checks through the existing server Gradle build.')
+registerCommandTask('adminCi', file('admin-console'), ['npm', 'run', 'ci'], 'Run admin console npm CI checks.')
+registerRootCommandTask('infraStatic', ['bash', '-lc', "cd infra/weave-workspace/01-infrastructure && tofu fmt -check -recursive && tofu init -backend=false && tofu validate && cd ../02-keycloak-setup && tofu fmt -check -recursive && tofu init -backend=false && tofu validate && cd ../../.. && find infra/weave-workspace/tests -maxdepth 1 -type f -name '*-test.sh' -print0 | sort -z | xargs -0 -n1 bash"], 'Run OpenTofu format/validate and static infrastructure script checks.')
+registerRootCommandTask('docsBuild', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs build --strict'], 'Build the MkDocs site with strict validation.')
+registerRootCommandTask('docsStructureCheck', ['python3', 'tools/docs_check.py'], 'Run lightweight documentation structure checks.')
+registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs serve'], 'Serve the MkDocs site locally.')
+registerRootCommandTask('releaseNotesLabelCheck', ['python3', 'tools/release_notes_label_check.py'], 'Validate the current PR release-notes label set from PR_LABELS_JSON.')
+registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'python3 tools/docs_check.py --release-notes-only && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check'], 'Validate release notes structure, labels, and generator fixture evidence.')
+
+tasks.register('docsCheck') {
+    group = 'verification'
+    description = 'Run documentation structure checks and strict MkDocs build.'
+    dependsOn 'docsStructureCheck', 'docsBuild'
+}
+
+tasks.register('releaseNotesCheck') {
+    group = 'verification'
+    description = 'Compatibility alias for releaseEvidenceCheck.'
+    dependsOn 'releaseEvidenceCheck'
+}
+
+tasks.register('liveStackHelp') {
+    group = 'help'
+    description = 'Explain that live stack E2E is intentionally opt-in.'
+    doLast {
+        println 'Live stack E2E is intentionally opt-in. Use the GitHub workflow with I_HAVE_SOLAR_STORAGE_BUDGET when runner power/storage budget is available.'
+    }
+}
+
+tasks.register('doctor') {
+    group = 'verification'
+    description = 'Check required local build tools and pinned dependency files with actionable failures.'
+    doLast {
+        def failures = []
+        def checkCommand = { String label, List<String> args, String hint ->
+            def output = new ByteArrayOutputStream()
+            try {
+                def result = exec {
+                    commandLine execCommand(args)
+                    standardOutput = output
+                    errorOutput = output
+                    ignoreExitValue = true
+                }
+                if (result.exitValue != 0) {
+                    failures << "${label}: missing or unusable. ${hint}"
+                } else {
+                    def firstLine = output.toString('UTF-8').readLines().find { it.trim() }
+                    println "${label}: ${firstLine ?: 'ok'}"
+                }
+            } catch (Exception ignored) {
+                failures << "${label}: missing or unusable. ${hint}"
+            }
+        }
+        def checkFile = { String label, String path, String hint ->
+            if (!file(path).exists()) {
+                failures << "${label}: ${path} not found. ${hint}"
+            } else {
+                println "${label}: ${path}"
+            }
+        }
+
+        println "Gradle: ${gradle.gradleVersion} via ${gradle.gradleHomeDir ?: 'wrapper/runtime'}"
+        println "JDK: ${System.getProperty('java.version')} (${System.getProperty('java.vendor')})"
+        if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+            failures << 'JDK: Java 21 or newer is required. Install Temurin 21+ or run with JAVA_HOME pointing at a supported JDK.'
+        }
+
+        checkFile('Gradle wrapper pin', 'gradle/wrapper/gradle-wrapper.properties', 'Restore the checked-in Gradle wrapper metadata.')
+        checkFile('Admin npm lockfile', 'admin-console/package-lock.json', 'Run npm install in admin-console only when intentionally updating dependencies, then commit the lockfile.')
+        checkFile('Admin npm dependencies', 'admin-console/node_modules/.bin/tsc', 'Run npm ci in admin-console before adminCi/ci.')
+        checkFile('Client Flutter lockfile', 'client/pubspec.lock', 'Run flutter pub get in client/ and commit the lockfile if dependencies intentionally changed.')
+        checkFile('Client Flutter dependencies', 'client/.dart_tool/package_config.json', 'Run flutter pub get in client before clientCi/ci.')
+        checkFile('MkDocs requirements pin', 'docs/requirements.txt', 'Restore pinned docs dependencies.')
+
+        checkCommand('git', ['git', '--version'], 'Install Git and ensure it is on PATH.')
+        checkCommand('bash', ['bash', '--version'], 'Install Bash and ensure it is on PATH.')
+        checkCommand('python3', ['python3', '--version'], 'Install Python 3 and ensure it is on PATH.')
+        checkCommand('flutter', ['flutter', '--version'], 'Install Flutter stable and ensure flutter is on PATH.')
+        checkCommand('dart', ['dart', '--version'], 'Install the Dart SDK or use the Dart bundled with Flutter.')
+        checkCommand('node', ['node', '--version'], 'Install Node matching the CI setup or the repo .nvm policy when added.')
+        checkCommand('npm', ['npm', '--version'], 'Install npm and run npm ci in admin-console when needed.')
+        checkCommand('tofu', ['tofu', '--version'], 'Install OpenTofu for infraStatic, matching the CI setup version.')
+        checkCommand('mkdocs', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs --version'], 'Install pinned docs dependencies with: python3 -m pip install -r docs/requirements.txt (or use build/docs-venv).')
+
+        if (!failures.isEmpty()) {
+            throw new GradleException('Doctor found problems:\n - ' + failures.join('\n - '))
+        }
+    }
+}
 
 tasks.register('ci') {
     group = 'verification'
-    description = 'Run the monorepo CI orchestration checks. Requires the same local prerequisites as the delegated Make targets.'
-    dependsOn 'acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesCheck'
+    description = 'Run the canonical monorepo CI orchestration checks.'
+    dependsOn 'doctor', 'acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseEvidenceCheck'
+}
+
+['acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseEvidenceCheck'].each { taskName ->
+    tasks.named(taskName) {
+        mustRunAfter tasks.named('doctor')
+    }
 }
 
 tasks.named('check') {

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -42,21 +42,23 @@ The app accepts local development service URLs such as `https://api.weave.local/
 
 ## Root Gradle orchestration
 
-The root `./gradlew` is a monorepo task runner, not a rewrite of the subproject build systems. It delegates to the existing Makefile targets and preserves current CI behavior while giving one discoverable command surface:
+The root `./gradlew` is the monorepo build/delivery source of truth. Make targets are temporary compatibility aliases that delegate to Gradle during the transition; do not add new root Make-only build logic.
 
-| Gradle task | Delegates to | Purpose |
-| --- | --- | --- |
-| `acceptanceContract` | `make acceptance-contract` | Gherkin mapping and acceptance contract guard. |
-| `clientCi` | `make client-ci` | Flutter offline contract path. |
-| `serverCi` | `make server-ci` | Existing server Gradle test path. |
-| `adminCi` | `make admin-ci` | Admin console npm CI path. |
-| `infraStatic` | `make infra-static` | Infrastructure script/static checks. |
-| `docsBuild` | `make docs-build` | Strict MkDocs build. |
-| `docsCheck` | `make docs-check` | Docs structure check plus strict MkDocs build. |
-| `releaseNotesCheck` | `make release-notes-check` | Release notes structure, label behavior, and generator fixture checks. |
-| `ci` | aggregate | Runs the delegated monorepo gate set. |
+| Gradle task | Purpose |
+| --- | --- |
+| `doctor` | Checks required tools and pinned dependency files with actionable failures. |
+| `acceptanceContract` | Gherkin mapping and acceptance contract guard. |
+| `clientCi` | Flutter generated-code, format, analysis, tests, screenshot drift, and offline contract path. |
+| `serverCi` | Existing server Gradle test path. |
+| `adminCi` | Admin console npm CI path. |
+| `infraStatic` | OpenTofu format/validate plus infrastructure script/static checks. |
+| `docsBuild` | Strict MkDocs build. |
+| `docsCheck` | Docs structure check plus strict MkDocs build. |
+| `releaseEvidenceCheck` | Release notes structure, label behavior, and generator fixture checks. |
+| `releaseNotesCheck` | Compatibility alias for `releaseEvidenceCheck`. |
+| `ci` | Canonical aggregate for the PR-safe monorepo gate set. |
 
-Each task requires the same tools and dependency setup as its delegated Make target; for example docs tasks need `python3 -m pip install -r docs/requirements.txt`, server checks need Java, client checks need Flutter, and admin checks need npm dependencies.
+Each task requires the same tools and dependency setup as the underlying ecosystem command; for example docs tasks need `python3 -m pip install -r docs/requirements.txt`, server checks need Java 21+, client checks need Flutter/Dart, and admin checks need Node/npm dependencies.
 
 ## Everyday Flutter workflow
 


### PR DESCRIPTION
## Summary
- moves root build/delivery orchestration into Gradle tasks and reduces root Make to temporary Gradle aliases
- adds stable `doctor`, `releaseEvidenceCheck`, `releaseNotesCheck`, docs, infra, admin, client, server, acceptance, and `ci` task names
- updates the developer handbook to make `./gradlew ci` the canonical command surface

## Evidence
- `./gradlew tasks --all` ✅
- `./gradlew docsCheck releaseEvidenceCheck` ✅ (with pinned MkDocs deps installed in `build/docs-venv`)
- `make docs-check` ✅ (delegates to `./gradlew docsCheck`)
- `make release-evidence-check` ✅ (delegates to `./gradlew releaseEvidenceCheck`)
- `./gradlew ci` ⚠️ blocked locally by `doctor`: this host only has JDK 17 and admin npm dependencies were not installed. The failure is actionable and expected for this host; CI uses Java 21 and dependency setup.

## Non-collected evidence
- Full local `./gradlew ci` parity was not collected on this host because `doctor` correctly requires Java 21+ and installed admin dependencies.
- Live E2E not run; remains opt-in only.

## Release notes
- `release-notes-feature`