### PR TITLE
build: emit sanitized CI evidence summary

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,8 +33,9 @@ Choose exactly one before review/merge; CI fails otherwise.
 
 ## Checks run
 
-- [ ] `make docs-check` / `make docs-build` (for docs or release notes changes)
-- [ ] `make release-notes-check` (for release-affecting changes)
+- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
+- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
+- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
 - [ ] `flutter pub get`
 - [ ] `flutter gen-l10n`
 - [ ] `dart run build_runner build --delete-conflicting-outputs`

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,49 @@
-.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve docs-structure-check release-notes-check release-notes-label-check live-stack-help
+.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve docs-structure-check release-notes-check release-notes-label-check release-evidence-check live-stack-help doctor
 
-ci: acceptance-contract client-ci server-ci infra-static admin-ci
+GRADLE ?= ./gradlew
+
+ci:
+	$(GRADLE) ci
+
+doctor:
+	$(GRADLE) doctor
+
+client-ci:
+	$(GRADLE) clientCi
+
+server-ci:
+	$(GRADLE) serverCi
+
+infra-static:
+	$(GRADLE) infraStatic
+
+admin-ci:
+	$(GRADLE) adminCi
+
+acceptance-contract:
+	$(GRADLE) acceptanceContract
 
 # Install docs tooling with: python3 -m pip install -r docs/requirements.txt
 docs-build:
-	python3 -m mkdocs build --strict
+	$(GRADLE) docsBuild
 
-docs-check: docs-structure-check
-	python3 -m mkdocs build --strict
+docs-check:
+	$(GRADLE) docsCheck
 
 docs-serve:
-	python3 -m mkdocs serve
+	$(GRADLE) docsServe
 
 docs-structure-check:
-	python3 tools/docs_check.py
+	$(GRADLE) docsStructureCheck
 
 release-notes-check:
-	python3 tools/docs_check.py --release-notes-only
-	python3 tools/release_notes_label_check_test.py
-	python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check
+	$(GRADLE) releaseEvidenceCheck
+
+release-evidence-check:
+	$(GRADLE) releaseEvidenceCheck
 
 release-notes-label-check:
-	python3 tools/release_notes_label_check.py
-
-client-ci:
-	$(MAKE) -C client offline-contract-test
-
-server-ci:
-	cd server && ./gradlew test
-
-infra-static:
-	@find infra/weave-workspace/tests -maxdepth 1 -type f -name '*-test.sh' -print0 | sort -z | xargs -0 -n1 bash
-
-admin-ci:
-	cd admin-console && npm run ci
-
-acceptance-contract:
-	cd client && dart run tool/acceptance_contract.dart guard --root .. --features e2e/features --mapping e2e/scenario_mappings.json
+	$(GRADLE) releaseNotesLabelCheck
 
 live-stack-help:
-	@printf '%s\n' 'Live stack E2E is intentionally opt-in. Use the GitHub workflow with I_HAVE_SOLAR_STORAGE_BUDGET when runner power/storage budget is available.'
+	$(GRADLE) liveStackHelp

--- a/build.gradle
+++ b/build.gradle
@@ -2,28 +2,123 @@ plugins {
     id 'base'
 }
 
-ext.registerMakeTask = { String taskName, String makeTarget, String taskDescription ->
+import org.gradle.internal.os.OperatingSystem
+
+ext.execCommand = { List<String> args ->
+    OperatingSystem.current().isWindows() ? ['cmd', '/c'] + args : args
+}
+
+ext.registerCommandTask = { String taskName, Object taskWorkingDir, List<String> args, String taskDescription ->
     tasks.register(taskName, Exec) {
         group = 'verification'
         description = taskDescription
-        commandLine 'make', makeTarget
+        workingDir taskWorkingDir
+        commandLine execCommand(args)
         outputs.upToDateWhen { false }
     }
 }
 
-registerMakeTask('serverCi', 'server-ci', 'Run server checks through the existing server Gradle build.')
-registerMakeTask('clientCi', 'client-ci', 'Run Flutter offline contract checks through the existing client Makefile.')
-registerMakeTask('adminCi', 'admin-ci', 'Run admin console npm CI checks through the existing Makefile.')
-registerMakeTask('infraStatic', 'infra-static', 'Run static infrastructure script checks through the existing Makefile.')
-registerMakeTask('docsBuild', 'docs-build', 'Build the MkDocs site with strict validation.')
-registerMakeTask('docsCheck', 'docs-check', 'Run documentation structure checks and strict MkDocs build.')
-registerMakeTask('acceptanceContract', 'acceptance-contract', 'Verify Gherkin scenario mappings and acceptance contracts.')
-registerMakeTask('releaseNotesCheck', 'release-notes-check', 'Validate release notes structure, labels, and generator fixtures.')
+ext.registerRootCommandTask = { String taskName, List<String> args, String taskDescription ->
+    registerCommandTask(taskName, projectDir, args, taskDescription)
+}
+
+registerRootCommandTask('acceptanceContract', ['bash', '-lc', 'cd client && dart run tool/acceptance_contract.dart guard --root .. --features e2e/features --mapping e2e/scenario_mappings.json'], 'Verify Gherkin scenario mappings and acceptance contracts.')
+registerCommandTask('clientCi', file('client'), ['make', 'offline-contract-test'], 'Run Flutter offline contract checks through the client Makefile.')
+registerCommandTask('serverCi', file('server'), ['./gradlew', 'test'], 'Run server checks through the existing server Gradle build.')
+registerCommandTask('adminCi', file('admin-console'), ['npm', 'run', 'ci'], 'Run admin console npm CI checks.')
+registerRootCommandTask('infraStatic', ['bash', '-lc', "find infra/weave-workspace/tests -maxdepth 1 -type f -name '*-test.sh' -print0 | sort -z | xargs -0 -n1 bash"], 'Run static infrastructure script checks.')
+registerRootCommandTask('docsBuild', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs build --strict'], 'Build the MkDocs site with strict validation.')
+registerRootCommandTask('docsStructureCheck', ['python3', 'tools/docs_check.py'], 'Run lightweight documentation structure checks.')
+registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs serve'], 'Serve the MkDocs site locally.')
+registerRootCommandTask('releaseNotesLabelCheck', ['python3', 'tools/release_notes_label_check.py'], 'Validate the current PR release-notes label set from PR_LABELS_JSON.')
+registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'python3 tools/docs_check.py --release-notes-only && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check'], 'Validate release notes structure, labels, and generator fixture evidence.')
+
+tasks.register('docsCheck') {
+    group = 'verification'
+    description = 'Run documentation structure checks and strict MkDocs build.'
+    dependsOn 'docsStructureCheck', 'docsBuild'
+}
+
+tasks.register('releaseNotesCheck') {
+    group = 'verification'
+    description = 'Compatibility alias for releaseEvidenceCheck.'
+    dependsOn 'releaseEvidenceCheck'
+}
+
+tasks.register('liveStackHelp') {
+    group = 'help'
+    description = 'Explain that live stack E2E is intentionally opt-in.'
+    doLast {
+        println 'Live stack E2E is intentionally opt-in. Use the GitHub workflow with I_HAVE_SOLAR_STORAGE_BUDGET when runner power/storage budget is available.'
+    }
+}
+
+tasks.register('doctor') {
+    group = 'verification'
+    description = 'Check required local build tools and pinned dependency files with actionable failures.'
+    doLast {
+        def failures = []
+        def checkCommand = { String label, List<String> args, String hint ->
+            def output = new ByteArrayOutputStream()
+            def result = exec {
+                commandLine execCommand(args)
+                standardOutput = output
+                errorOutput = output
+                ignoreExitValue = true
+            }
+            if (result.exitValue != 0) {
+                failures << "${label}: missing or unusable. ${hint}"
+            } else {
+                def firstLine = output.toString('UTF-8').readLines().find { it.trim() }
+                println "${label}: ${firstLine ?: 'ok'}"
+            }
+        }
+        def checkFile = { String label, String path, String hint ->
+            if (!file(path).exists()) {
+                failures << "${label}: ${path} not found. ${hint}"
+            } else {
+                println "${label}: ${path}"
+            }
+        }
+
+        println "Gradle: ${gradle.gradleVersion} via ${gradle.gradleHomeDir ?: 'wrapper/runtime'}"
+        println "JDK: ${System.getProperty('java.version')} (${System.getProperty('java.vendor')})"
+        if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+            failures << 'JDK: Java 21 or newer is required. Install Temurin 21+ or run with JAVA_HOME pointing at a supported JDK.'
+        }
+
+        checkFile('Gradle wrapper pin', 'gradle/wrapper/gradle-wrapper.properties', 'Restore the checked-in Gradle wrapper metadata.')
+        checkFile('Admin npm lockfile', 'admin-console/package-lock.json', 'Run npm install in admin-console only when intentionally updating dependencies, then commit the lockfile.')
+        checkFile('Admin npm dependencies', 'admin-console/node_modules/.bin/tsc', 'Run npm ci in admin-console before adminCi/ci.')
+        checkFile('Client Flutter lockfile', 'client/pubspec.lock', 'Run flutter pub get in client/ and commit the lockfile if dependencies intentionally changed.')
+        checkFile('Client Flutter dependencies', 'client/.dart_tool/package_config.json', 'Run flutter pub get in client before clientCi/ci.')
+        checkFile('MkDocs requirements pin', 'docs/requirements.txt', 'Restore pinned docs dependencies.')
+
+        checkCommand('git', ['git', '--version'], 'Install Git and ensure it is on PATH.')
+        checkCommand('bash', ['bash', '--version'], 'Install Bash and ensure it is on PATH.')
+        checkCommand('python3', ['python3', '--version'], 'Install Python 3 and ensure it is on PATH.')
+        checkCommand('flutter', ['flutter', '--version'], 'Install Flutter stable and ensure flutter is on PATH.')
+        checkCommand('dart', ['dart', '--version'], 'Install the Dart SDK or use the Dart bundled with Flutter.')
+        checkCommand('node', ['node', '--version'], 'Install Node matching the CI setup or the repo .nvm policy when added.')
+        checkCommand('npm', ['npm', '--version'], 'Install npm and run npm ci in admin-console when needed.')
+        checkCommand('mkdocs', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs --version'], 'Install pinned docs dependencies with: python3 -m pip install -r docs/requirements.txt (or use build/docs-venv).')
+
+        if (!failures.isEmpty()) {
+            throw new GradleException('Doctor found problems:\n - ' + failures.join('\n - '))
+        }
+    }
+}
 
 tasks.register('ci') {
     group = 'verification'
-    description = 'Run the monorepo CI orchestration checks. Requires the same local prerequisites as the delegated Make targets.'
-    dependsOn 'acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesCheck'
+    description = 'Run the canonical monorepo CI orchestration checks.'
+    dependsOn 'doctor', 'acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseEvidenceCheck'
+}
+
+['acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseEvidenceCheck'].each { taskName ->
+    tasks.named(taskName) {
+        mustRunAfter tasks.named('doctor')
+    }
 }
 
 tasks.named('check') {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 import org.gradle.internal.os.OperatingSystem
+import groovy.json.JsonOutput
 
 ext.execCommand = { List<String> args ->
     OperatingSystem.current().isWindows() ? ['cmd', '/c'] + args : args
@@ -52,6 +53,111 @@ tasks.register('liveStackHelp') {
         println 'Live stack E2E is intentionally opt-in. Use the GitHub workflow with I_HAVE_SOLAR_STORAGE_BUDGET when runner power/storage budget is available.'
     }
 }
+
+
+ext.ciEvidenceGates = [
+    'doctor',
+    'acceptanceContract',
+    'clientCi',
+    'serverCi',
+    'adminCi',
+    'infraStatic',
+    'docsCheck',
+    'releaseEvidenceCheck'
+]
+
+ext.safeCommandOutput = { List<String> args ->
+    def output = new ByteArrayOutputStream()
+    try {
+        def result = exec {
+            commandLine execCommand(args)
+            standardOutput = output
+            errorOutput = output
+            ignoreExitValue = true
+        }
+        if (result.exitValue != 0) {
+            return 'unavailable'
+        }
+        return output.toString('UTF-8').readLines().find { it.trim() }?.trim() ?: 'unavailable'
+    } catch (Exception ignored) {
+        return 'unavailable'
+    }
+}
+
+tasks.register('ciSummary') {
+    group = 'verification'
+    description = 'Write the sanitized CI evidence summary to build/evidence/ci-summary.json.'
+    doLast {
+        writeCiSummary(null)
+    }
+}
+
+void writeCiSummary(Throwable buildFailure) {
+    def evidenceDir = layout.buildDirectory.dir('evidence').get().asFile
+    evidenceDir.mkdirs()
+    def evidenceFile = new File(evidenceDir, 'ci-summary.json')
+    def gateSummaries = ciEvidenceGates.collect { gateName ->
+        def task = tasks.findByName(gateName)
+        def outcome = 'skipped'
+        if (task != null && task.state.executed) {
+            outcome = task.state.failure == null ? 'passed' : 'failed'
+        } else if (task != null && task.state.skipped) {
+            outcome = 'skipped'
+        }
+        [
+            name: gateName,
+            outcome: outcome,
+            artifactPaths: artifactPathsForGate(gateName)
+        ]
+    }
+    def summary = [
+        schemaVersion: 1,
+        generatedAtUtc: new Date().format("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone('UTC')),
+        commit: safeCommandOutput(['git', 'rev-parse', 'HEAD']),
+        branch: safeCommandOutput(['git', 'rev-parse', '--abbrev-ref', 'HEAD']),
+        build: [
+            result: buildFailure == null ? 'passed' : 'failed',
+            failureType: buildFailure == null ? null : buildFailure.class.name
+        ],
+        toolVersions: [
+            gradle: gradle.gradleVersion,
+            java: System.getProperty('java.version'),
+            python: safeCommandOutput(['python3', '--version']),
+            flutter: safeCommandOutput(['flutter', '--version']),
+            dart: safeCommandOutput(['dart', '--version']),
+            node: safeCommandOutput(['node', '--version']),
+            npm: safeCommandOutput(['npm', '--version'])
+        ],
+        gates: gateSummaries,
+        liveE2E: [
+            outcome: 'skipped',
+            reason: 'Live E2E is not part of default ci and requires explicit operator/budget confirmation.',
+            artifactPaths: []
+        ],
+        sanitized: true,
+        exclusions: [
+            'secrets',
+            'tokens',
+            'credential URLs',
+            'raw provider payloads',
+            'raw provider errors'
+        ]
+    ]
+    evidenceFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(summary)) + System.lineSeparator()
+    logger.lifecycle("Wrote sanitized CI evidence summary to ${project.relativePath(evidenceFile)}")
+}
+
+List<String> artifactPathsForGate(String gateName) {
+    switch (gateName) {
+        case 'docsCheck':
+            return ['build/docs-site']
+        case 'releaseEvidenceCheck':
+            return ['tools/fixtures/release_notes_unreleased.expected.md']
+        default:
+            return []
+    }
+}
+
 
 tasks.register('doctor') {
     group = 'verification'
@@ -118,6 +224,17 @@ tasks.register('ci') {
 ['acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseEvidenceCheck'].each { taskName ->
     tasks.named(taskName) {
         mustRunAfter tasks.named('doctor')
+    }
+}
+
+gradle.buildFinished { result ->
+    def evidenceRequested = gradle.startParameter.taskNames.any { requested ->
+        requested == 'ci' || requested == ':ci' || requested.endsWith(':ci') ||
+            requested == 'check' || requested == ':check' || requested.endsWith(':check')
+    }
+    def evidenceTaskPresent = gradle.taskGraph.allTasks.any { it.name == 'ci' }
+    if (evidenceRequested || evidenceTaskPresent) {
+        writeCiSummary(result.failure)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,28 +2,128 @@ plugins {
     id 'base'
 }
 
-ext.registerMakeTask = { String taskName, String makeTarget, String taskDescription ->
+import org.gradle.internal.os.OperatingSystem
+
+ext.execCommand = { List<String> args ->
+    OperatingSystem.current().isWindows() ? ['cmd', '/c'] + args : args
+}
+
+ext.registerCommandTask = { String taskName, Object taskWorkingDir, List<String> args, String taskDescription ->
     tasks.register(taskName, Exec) {
         group = 'verification'
         description = taskDescription
-        commandLine 'make', makeTarget
+        workingDir taskWorkingDir
+        commandLine execCommand(args)
         outputs.upToDateWhen { false }
     }
 }
 
-registerMakeTask('serverCi', 'server-ci', 'Run server checks through the existing server Gradle build.')
-registerMakeTask('clientCi', 'client-ci', 'Run Flutter offline contract checks through the existing client Makefile.')
-registerMakeTask('adminCi', 'admin-ci', 'Run admin console npm CI checks through the existing Makefile.')
-registerMakeTask('infraStatic', 'infra-static', 'Run static infrastructure script checks through the existing Makefile.')
-registerMakeTask('docsBuild', 'docs-build', 'Build the MkDocs site with strict validation.')
-registerMakeTask('docsCheck', 'docs-check', 'Run documentation structure checks and strict MkDocs build.')
-registerMakeTask('acceptanceContract', 'acceptance-contract', 'Verify Gherkin scenario mappings and acceptance contracts.')
-registerMakeTask('releaseNotesCheck', 'release-notes-check', 'Validate release notes structure, labels, and generator fixtures.')
+ext.registerRootCommandTask = { String taskName, List<String> args, String taskDescription ->
+    registerCommandTask(taskName, projectDir, args, taskDescription)
+}
+
+registerRootCommandTask('acceptanceContract', ['bash', '-lc', 'cd client && dart run tool/acceptance_contract.dart guard --root .. --features e2e/features --mapping e2e/scenario_mappings.json'], 'Verify Gherkin scenario mappings and acceptance contracts.')
+registerCommandTask('clientCi', file('client'), ['bash', '-lc', 'flutter gen-l10n && dart run build_runner build --delete-conflicting-outputs && dart format --output=none --set-exit-if-changed . && flutter analyze --fatal-infos && flutter test && make marketing-screenshots && git -C .. diff --exit-code -- client/lib client/test docs/assets/marketing docs/assets/roadmap && make offline-contract-test'], 'Run Flutter generated-code, format, analysis, tests, screenshots, and offline contract checks.')
+registerCommandTask('serverCi', file('server'), ['./gradlew', 'test'], 'Run server checks through the existing server Gradle build.')
+registerCommandTask('adminCi', file('admin-console'), ['npm', 'run', 'ci'], 'Run admin console npm CI checks.')
+registerRootCommandTask('infraStatic', ['bash', '-lc', "cd infra/weave-workspace/01-infrastructure && tofu fmt -check -recursive && tofu init -backend=false && tofu validate && cd ../02-keycloak-setup && tofu fmt -check -recursive && tofu init -backend=false && tofu validate && cd ../../.. && find infra/weave-workspace/tests -maxdepth 1 -type f -name '*-test.sh' -print0 | sort -z | xargs -0 -n1 bash"], 'Run OpenTofu format/validate and static infrastructure script checks.')
+registerRootCommandTask('docsBuild', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs build --strict'], 'Build the MkDocs site with strict validation.')
+registerRootCommandTask('docsStructureCheck', ['python3', 'tools/docs_check.py'], 'Run lightweight documentation structure checks.')
+registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs serve'], 'Serve the MkDocs site locally.')
+registerRootCommandTask('releaseNotesLabelCheck', ['python3', 'tools/release_notes_label_check.py'], 'Validate the current PR release-notes label set from PR_LABELS_JSON.')
+registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'python3 tools/docs_check.py --release-notes-only && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check'], 'Validate release notes structure, labels, and generator fixture evidence.')
+
+tasks.register('docsCheck') {
+    group = 'verification'
+    description = 'Run documentation structure checks and strict MkDocs build.'
+    dependsOn 'docsStructureCheck', 'docsBuild'
+}
+
+tasks.register('releaseNotesCheck') {
+    group = 'verification'
+    description = 'Compatibility alias for releaseEvidenceCheck.'
+    dependsOn 'releaseEvidenceCheck'
+}
+
+tasks.register('liveStackHelp') {
+    group = 'help'
+    description = 'Explain that live stack E2E is intentionally opt-in.'
+    doLast {
+        println 'Live stack E2E is intentionally opt-in. Use the GitHub workflow with I_HAVE_SOLAR_STORAGE_BUDGET when runner power/storage budget is available.'
+    }
+}
+
+tasks.register('doctor') {
+    group = 'verification'
+    description = 'Check required local build tools and pinned dependency files with actionable failures.'
+    doLast {
+        def failures = []
+        def checkCommand = { String label, List<String> args, String hint ->
+            def output = new ByteArrayOutputStream()
+            try {
+                def result = exec {
+                    commandLine execCommand(args)
+                    standardOutput = output
+                    errorOutput = output
+                    ignoreExitValue = true
+                }
+                if (result.exitValue != 0) {
+                    failures << "${label}: missing or unusable. ${hint}"
+                } else {
+                    def firstLine = output.toString('UTF-8').readLines().find { it.trim() }
+                    println "${label}: ${firstLine ?: 'ok'}"
+                }
+            } catch (Exception ignored) {
+                failures << "${label}: missing or unusable. ${hint}"
+            }
+        }
+        def checkFile = { String label, String path, String hint ->
+            if (!file(path).exists()) {
+                failures << "${label}: ${path} not found. ${hint}"
+            } else {
+                println "${label}: ${path}"
+            }
+        }
+
+        println "Gradle: ${gradle.gradleVersion} via ${gradle.gradleHomeDir ?: 'wrapper/runtime'}"
+        println "JDK: ${System.getProperty('java.version')} (${System.getProperty('java.vendor')})"
+        if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
+            failures << 'JDK: Java 21 or newer is required. Install Temurin 21+ or run with JAVA_HOME pointing at a supported JDK.'
+        }
+
+        checkFile('Gradle wrapper pin', 'gradle/wrapper/gradle-wrapper.properties', 'Restore the checked-in Gradle wrapper metadata.')
+        checkFile('Admin npm lockfile', 'admin-console/package-lock.json', 'Run npm install in admin-console only when intentionally updating dependencies, then commit the lockfile.')
+        checkFile('Admin npm dependencies', 'admin-console/node_modules/.bin/tsc', 'Run npm ci in admin-console before adminCi/ci.')
+        checkFile('Client Flutter lockfile', 'client/pubspec.lock', 'Run flutter pub get in client/ and commit the lockfile if dependencies intentionally changed.')
+        checkFile('Client Flutter dependencies', 'client/.dart_tool/package_config.json', 'Run flutter pub get in client before clientCi/ci.')
+        checkFile('MkDocs requirements pin', 'docs/requirements.txt', 'Restore pinned docs dependencies.')
+
+        checkCommand('git', ['git', '--version'], 'Install Git and ensure it is on PATH.')
+        checkCommand('bash', ['bash', '--version'], 'Install Bash and ensure it is on PATH.')
+        checkCommand('python3', ['python3', '--version'], 'Install Python 3 and ensure it is on PATH.')
+        checkCommand('flutter', ['flutter', '--version'], 'Install Flutter stable and ensure flutter is on PATH.')
+        checkCommand('dart', ['dart', '--version'], 'Install the Dart SDK or use the Dart bundled with Flutter.')
+        checkCommand('node', ['node', '--version'], 'Install Node matching the CI setup or the repo .nvm policy when added.')
+        checkCommand('npm', ['npm', '--version'], 'Install npm and run npm ci in admin-console when needed.')
+        checkCommand('tofu', ['tofu', '--version'], 'Install OpenTofu for infraStatic, matching the CI setup version.')
+        checkCommand('mkdocs', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs --version'], 'Install pinned docs dependencies with: python3 -m pip install -r docs/requirements.txt (or use build/docs-venv).')
+
+        if (!failures.isEmpty()) {
+            throw new GradleException('Doctor found problems:\n - ' + failures.join('\n - '))
+        }
+    }
+}
 
 tasks.register('ci') {
     group = 'verification'
-    description = 'Run the monorepo CI orchestration checks. Requires the same local prerequisites as the delegated Make targets.'
-    dependsOn 'acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesCheck'
+    description = 'Run the canonical monorepo CI orchestration checks.'
+    dependsOn 'doctor', 'acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseEvidenceCheck'
+}
+
+['acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseEvidenceCheck'].each { taskName ->
+    tasks.named(taskName) {
+        mustRunAfter tasks.named('doctor')
+    }
 }
 
 tasks.named('check') {

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -42,21 +42,23 @@ The app accepts local development service URLs such as `https://api.weave.local/
 
 ## Root Gradle orchestration
 
-The root `./gradlew` is a monorepo task runner, not a rewrite of the subproject build systems. It delegates to the existing Makefile targets and preserves current CI behavior while giving one discoverable command surface:
+The root `./gradlew` is the monorepo build/delivery source of truth. Make targets are temporary compatibility aliases that delegate to Gradle during the transition; do not add new root Make-only build logic.
 
-| Gradle task | Delegates to | Purpose |
-| --- | --- | --- |
-| `acceptanceContract` | `make acceptance-contract` | Gherkin mapping and acceptance contract guard. |
-| `clientCi` | `make client-ci` | Flutter offline contract path. |
-| `serverCi` | `make server-ci` | Existing server Gradle test path. |
-| `adminCi` | `make admin-ci` | Admin console npm CI path. |
-| `infraStatic` | `make infra-static` | Infrastructure script/static checks. |
-| `docsBuild` | `make docs-build` | Strict MkDocs build. |
-| `docsCheck` | `make docs-check` | Docs structure check plus strict MkDocs build. |
-| `releaseNotesCheck` | `make release-notes-check` | Release notes structure, label behavior, and generator fixture checks. |
-| `ci` | aggregate | Runs the delegated monorepo gate set. |
+| Gradle task | Purpose |
+| --- | --- |
+| `doctor` | Checks required tools and pinned dependency files with actionable failures. |
+| `acceptanceContract` | Gherkin mapping and acceptance contract guard. |
+| `clientCi` | Flutter generated-code, format, analysis, tests, screenshot drift, and offline contract path. |
+| `serverCi` | Existing server Gradle test path. |
+| `adminCi` | Admin console npm CI path. |
+| `infraStatic` | OpenTofu format/validate plus infrastructure script/static checks. |
+| `docsBuild` | Strict MkDocs build. |
+| `docsCheck` | Docs structure check plus strict MkDocs build. |
+| `releaseEvidenceCheck` | Release notes structure, label behavior, and generator fixture checks. |
+| `releaseNotesCheck` | Compatibility alias for `releaseEvidenceCheck`. |
+| `ci` | Canonical aggregate for the PR-safe monorepo gate set. |
 
-Each task requires the same tools and dependency setup as its delegated Make target; for example docs tasks need `python3 -m pip install -r docs/requirements.txt`, server checks need Java, client checks need Flutter, and admin checks need npm dependencies.
+Each task requires the same tools and dependency setup as the underlying ecosystem command; for example docs tasks need `python3 -m pip install -r docs/requirements.txt`, server checks need Java 21+, client checks need Flutter/Dart, and admin checks need Node/npm dependencies.
 
 ## Everyday Flutter workflow
 

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -42,21 +42,23 @@ The app accepts local development service URLs such as `https://api.weave.local/
 
 ## Root Gradle orchestration
 
-The root `./gradlew` is a monorepo task runner, not a rewrite of the subproject build systems. It delegates to the existing Makefile targets and preserves current CI behavior while giving one discoverable command surface:
+The root `./gradlew` is the monorepo build/delivery source of truth. Make targets are temporary compatibility aliases that delegate to Gradle during the transition; do not add new root Make-only build logic.
 
-| Gradle task | Delegates to | Purpose |
-| --- | --- | --- |
-| `acceptanceContract` | `make acceptance-contract` | Gherkin mapping and acceptance contract guard. |
-| `clientCi` | `make client-ci` | Flutter offline contract path. |
-| `serverCi` | `make server-ci` | Existing server Gradle test path. |
-| `adminCi` | `make admin-ci` | Admin console npm CI path. |
-| `infraStatic` | `make infra-static` | Infrastructure script/static checks. |
-| `docsBuild` | `make docs-build` | Strict MkDocs build. |
-| `docsCheck` | `make docs-check` | Docs structure check plus strict MkDocs build. |
-| `releaseNotesCheck` | `make release-notes-check` | Release notes structure, label behavior, and generator fixture checks. |
-| `ci` | aggregate | Runs the delegated monorepo gate set. |
+| Gradle task | Purpose |
+| --- | --- |
+| `doctor` | Checks required tools and pinned dependency files with actionable failures. |
+| `acceptanceContract` | Gherkin mapping and acceptance contract guard. |
+| `clientCi` | Flutter offline contract path. |
+| `serverCi` | Existing server Gradle test path. |
+| `adminCi` | Admin console npm CI path. |
+| `infraStatic` | Infrastructure script/static checks. |
+| `docsBuild` | Strict MkDocs build. |
+| `docsCheck` | Docs structure check plus strict MkDocs build. |
+| `releaseEvidenceCheck` | Release notes structure, label behavior, and generator fixture checks. |
+| `releaseNotesCheck` | Compatibility alias for `releaseEvidenceCheck`. |
+| `ci` | Canonical aggregate for the PR-safe monorepo gate set. |
 
-Each task requires the same tools and dependency setup as its delegated Make target; for example docs tasks need `python3 -m pip install -r docs/requirements.txt`, server checks need Java, client checks need Flutter, and admin checks need npm dependencies.
+Each task requires the same tools and dependency setup as the underlying ecosystem command; for example docs tasks need `python3 -m pip install -r docs/requirements.txt`, server checks need Java 21+, client checks need Flutter/Dart, and admin checks need Node/npm dependencies.
 
 ## Everyday Flutter workflow
 

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -12,6 +12,7 @@ Weave uses layered evidence so contributors can move quickly while release claim
 | Deterministic screenshots | README and roadmap SVG assets match the checked-in generator and do not drift silently. | `make marketing-screenshots`, `docs/assets/marketing/`, `docs/assets/roadmap/`, CI screenshot drift step. |
 | Acceptance contract guard | Gherkin acceptance scenarios stay mapped to executable frontend/live-stack tests. | [Acceptance contracts](acceptance-contracts.md), [Product acceptance flows](product-acceptance-flows.md), `test/live_stack_feature_mapping_test.dart`. |
 | Admin-provisioned first-use guard | Normal members stay out of OIDC/provider/infra setup and Workspace Health remains the admin/operator control plane. | [Admin-provisioned first use boundary](admin-provisioned-first-use.md), `client/test/architecture/admin_provisioned_first_use_contract_test.dart`, `client/test/features/settings/settings_screen_test.dart`, `client/test/features/onboarding/first_run_screen_test.dart`. |
+| CI summary artifact | The root Gradle task graph emitted a sanitized summary of commit, branch, tool versions, gate outcomes, artifact paths, and live-E2E skip reason. | `build/evidence/ci-summary.json` from `./gradlew ci` or `./gradlew ciSummary`. |
 | Live Stack E2E | A prepared self-hosted stack can boot the app-level journey and upload acceptance evidence artifacts. | `.github/workflows/live-stack-e2e.yml` workflow runs and their uploaded artifacts. |
 
 ## Default PR validation
@@ -35,6 +36,14 @@ make marketing-screenshots
 git diff --exit-code -- docs/assets/marketing docs/assets/roadmap
 ```
 
+The canonical cross-stack command is:
+
+```sh
+./gradlew ci
+```
+
+It writes `build/evidence/ci-summary.json` even when the Gradle build fails, so reviewers can inspect a sanitized task-graph summary without reconstructing evidence from chat or raw logs. Use `./gradlew ciSummary` when you only need to regenerate the summary shape for review.
+
 These checks are intentionally cheap enough for normal pull requests and do not require live credentials.
 
 ## Live-stack evidence
@@ -56,6 +65,7 @@ The workflow prepares an acceptance evidence directory, runs the app-level live-
 
 - Never commit live credentials, generated secret files, or raw logs that contain tokens/passwords.
 - Prefer redacted summaries in docs and PR bodies.
+- Use `build/evidence/ci-summary.json` for task outcomes; it must not include secrets, tokens, credential URLs, raw provider payloads, or raw provider errors.
 - Keep evidence explanations screen-reader friendly; do not make images or badge colors the only source of truth.
 - For permanent docs, link to workflow files and evidence procedures rather than transient artifact URLs.
 


### PR DESCRIPTION
## Summary
- adds a sanitized Gradle-generated CI summary artifact at `build/evidence/ci-summary.json`
- records commit, branch, tool versions, gate outcomes, artifact paths, and the default live-E2E skip reason
- updates the PR checklist and quality/evidence docs so reviewers cite generated evidence instead of reconstructing it from chat/logs

## Evidence
- `./gradlew ciSummary` ✅
- `./gradlew docsCheck releaseEvidenceCheck` ✅ (with pinned MkDocs deps installed in `build/docs-venv`)
- `./gradlew ci` ⚠️ intentionally failed locally via `doctor` on this host (JDK 17 / missing installed admin deps), and still wrote `build/evidence/ci-summary.json` with sanitized failed/skipped outcomes.

## Non-collected evidence
- Full local `./gradlew ci` parity was not collected on this host because `doctor` correctly requires Java 21+ and installed admin dependencies.
- Live E2E not run; summary records the opt-in skip reason.

## Stack note
This PR is stacked on #305 (`build/gradle-root-ssot`) because the evidence writer attaches to the new root Gradle task graph. Retarget to `main` after #305 merges.

## Release notes
- `release-notes-feature`