### PR TITLE
feat: close Workspace Health adapter readiness contract

### DIFF
--- a/client/lib/features/app/domain/entities/provider_stack_snapshot.dart
+++ b/client/lib/features/app/domain/entities/provider_stack_snapshot.dart
@@ -69,6 +69,7 @@ class ProviderCategoryStatusSnapshot {
     this.selectedByAdmin = false,
     this.bootstrapSuggestionOnly = true,
     this.lossyMappingNotes = const <String>[],
+    this.adapterEvidence = const <ProviderAdapterReadinessEvidenceSnapshot>[],
     required this.diagnostics,
   });
 
@@ -85,11 +86,34 @@ class ProviderCategoryStatusSnapshot {
   final bool selectedByAdmin;
   final bool bootstrapSuggestionOnly;
   final List<String> lossyMappingNotes;
+  final List<ProviderAdapterReadinessEvidenceSnapshot> adapterEvidence;
   final Map<String, Object?> diagnostics;
 
   bool get supportSafe =>
       diagnostics['secretsReturned'] == false &&
       diagnostics['rawProviderErrorsReturned'] == false;
+}
+
+class ProviderAdapterReadinessEvidenceSnapshot {
+  const ProviderAdapterReadinessEvidenceSnapshot({
+    required this.domain,
+    required this.adapterKey,
+    required this.configured,
+    required this.reachable,
+    required this.health,
+    required this.failClosed,
+    required this.supportSafeDiagnostics,
+    this.evidenceTimestamp,
+  });
+
+  final String domain;
+  final String adapterKey;
+  final bool configured;
+  final bool reachable;
+  final String health;
+  final bool failClosed;
+  final Map<String, Object?> supportSafeDiagnostics;
+  final DateTime? evidenceTimestamp;
 }
 
 class ProviderCategoryContractSnapshot {

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -1111,6 +1111,21 @@ class _ProviderStackReadinessSummary extends StatelessWidget {
                           _CompactStatusBadge(
                             label: l10n.settingsProviderStackRedacted,
                           ),
+                        for (final evidence in category.adapterEvidence) ...[
+                          _CompactStatusBadge(
+                            label:
+                                '${evidence.adapterKey}: ${evidence.configured ? l10n.settingsProviderStateConfigured : l10n.settingsProviderStateNotConfigured}',
+                          ),
+                          _CompactStatusBadge(
+                            label: evidence.reachable
+                                ? l10n.settingsProviderStateReady
+                                : l10n.settingsWorkspaceCapabilityUnavailable,
+                          ),
+                          if (evidence.failClosed)
+                            _CompactStatusBadge(
+                              label: l10n.settingsProviderStackFailClosedBadge,
+                            ),
+                        ],
                       ],
                     ),
                   ),

--- a/client/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
+++ b/client/lib/integrations/weave_api/data/dtos/provider_stack_response_dto.dart
@@ -84,6 +84,7 @@ class ProviderCategoryStatusResponseDto {
     required this.selectedByAdmin,
     required this.bootstrapSuggestionOnly,
     required this.lossyMappingNotes,
+    required this.adapterEvidence,
     required this.diagnostics,
   });
 
@@ -116,6 +117,9 @@ class ProviderCategoryStatusResponseDto {
           ? _bool(json['bootstrapSuggestionOnly'])
           : true,
       lossyMappingNotes: _safeStringList(json['lossyMappingNotes']),
+      adapterEvidence: _listOfMaps(json['adapterEvidence'])
+          .map(ProviderAdapterReadinessEvidenceResponseDto.fromJson)
+          .toList(growable: false),
       diagnostics: _safeDiagnostics(json['diagnostics']),
     );
   }
@@ -133,6 +137,7 @@ class ProviderCategoryStatusResponseDto {
   final bool selectedByAdmin;
   final bool bootstrapSuggestionOnly;
   final List<String> lossyMappingNotes;
+  final List<ProviderAdapterReadinessEvidenceResponseDto> adapterEvidence;
   final Map<String, Object?> diagnostics;
 
   ProviderCategoryStatusSnapshot toSnapshot() => ProviderCategoryStatusSnapshot(
@@ -149,8 +154,60 @@ class ProviderCategoryStatusResponseDto {
     selectedByAdmin: selectedByAdmin,
     bootstrapSuggestionOnly: bootstrapSuggestionOnly,
     lossyMappingNotes: lossyMappingNotes,
+    adapterEvidence: adapterEvidence
+        .map((evidence) => evidence.toSnapshot())
+        .toList(growable: false),
     diagnostics: diagnostics,
   );
+}
+
+class ProviderAdapterReadinessEvidenceResponseDto {
+  const ProviderAdapterReadinessEvidenceResponseDto({
+    required this.domain,
+    required this.adapterKey,
+    required this.configured,
+    required this.reachable,
+    required this.health,
+    required this.failClosed,
+    required this.supportSafeDiagnostics,
+    required this.evidenceTimestamp,
+  });
+
+  factory ProviderAdapterReadinessEvidenceResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return ProviderAdapterReadinessEvidenceResponseDto(
+      domain: _string(json['domain'], fallback: 'unknown'),
+      adapterKey: _safeProviderKey(json['adapterKey']),
+      configured: _bool(json['configured']),
+      reachable: _bool(json['reachable']),
+      health: _safeText(json['health']),
+      failClosed: _bool(json['failClosed']),
+      supportSafeDiagnostics: _safeDiagnostics(json['supportSafeDiagnostics']),
+      evidenceTimestamp: _dateTime(json['evidenceTimestamp']),
+    );
+  }
+
+  final String domain;
+  final String adapterKey;
+  final bool configured;
+  final bool reachable;
+  final String health;
+  final bool failClosed;
+  final Map<String, Object?> supportSafeDiagnostics;
+  final DateTime? evidenceTimestamp;
+
+  ProviderAdapterReadinessEvidenceSnapshot toSnapshot() =>
+      ProviderAdapterReadinessEvidenceSnapshot(
+        domain: domain,
+        adapterKey: adapterKey,
+        configured: configured,
+        reachable: reachable,
+        health: health,
+        failClosed: failClosed,
+        supportSafeDiagnostics: supportSafeDiagnostics,
+        evidenceTimestamp: evidenceTimestamp,
+      );
 }
 
 class ProviderCategoryContractResponseDto {

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -659,6 +659,20 @@ void main() {
                   memberImpact: 'Calendar is degraded.',
                   modules: ['calendar'],
                   providerCandidates: ['nextcloud-calendar'],
+                  adapterEvidence: [
+                    ProviderAdapterReadinessEvidenceSnapshot(
+                      domain: 'calendar',
+                      adapterKey: 'nextcloud-caldav',
+                      configured: false,
+                      reachable: false,
+                      health: 'admin_selected_pending_backend_configuration',
+                      failClosed: true,
+                      supportSafeDiagnostics: {
+                        'secretsReturned': false,
+                        'rawProviderErrorsReturned': false,
+                      },
+                    ),
+                  ],
                   diagnostics: {
                     'secretsReturned': false,
                     'rawProviderErrorsReturned': false,
@@ -768,6 +782,8 @@ void main() {
         findsOneWidget,
       );
       expect(find.text('calendar: degraded'), findsOneWidget);
+      expect(find.text('nextcloud-caldav: unconfigured'), findsOneWidget);
+      expect(find.text('Unavailable'), findsWidgets);
       expect(find.text('Weaver: Blocked'), findsOneWidget);
       expect(find.textContaining('provider-token-123'), findsNothing);
       expect(find.textContaining('https://gitlab.example.test'), findsNothing);

--- a/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -542,6 +542,25 @@ void main() {
                   'selectedByAdmin': true,
                   'bootstrapSuggestionOnly': false,
                   'lossyMappingNotes': [],
+                  'adapterEvidence': [
+                    {
+                      'domain': 'identity-idm',
+                      'adapterKey': 'keycloak-realm',
+                      'configured': true,
+                      'reachable': true,
+                      'health': 'ready',
+                      'failClosed': true,
+                      'supportSafeDiagnostics': {
+                        'providerState': 'ready',
+                        'supportSafe': true,
+                        'secretsReturned': false,
+                        'rawProviderErrorsReturned': false,
+                        'rawProviderError':
+                            'Authorization: Bearer should-not-render',
+                      },
+                      'evidenceTimestamp': '2026-05-25T18:00:00Z',
+                    },
+                  ],
                   'diagnostics': {
                     'providerCount': 2,
                     'allSupportSafe': true,
@@ -706,6 +725,27 @@ void main() {
         expect(snapshot.categories.first.selectedByAdmin, isTrue);
         expect(snapshot.categories.first.bootstrapSuggestionOnly, isFalse);
         expect(snapshot.categories.first.supportSafe, isTrue);
+        expect(
+          snapshot.categories.first.adapterEvidence.single.adapterKey,
+          'keycloak-realm',
+        );
+        expect(
+          snapshot.categories.first.adapterEvidence.single.configured,
+          isTrue,
+        );
+        expect(
+          snapshot.categories.first.adapterEvidence.single.reachable,
+          isTrue,
+        );
+        expect(
+          snapshot
+              .categories
+              .first
+              .adapterEvidence
+              .single
+              .supportSafeDiagnostics,
+          isNot(contains('rawProviderError')),
+        );
         expect(snapshot.categories.last.category, 'weaver');
         expect(
           snapshot.categories.last.readiness,

--- a/docs/admin-operator-handbook.md
+++ b/docs/admin-operator-handbook.md
@@ -68,7 +68,7 @@ Use the infra tree for local/single-host stack bootstrap, smoke checks, backup/r
 
 ## Support bundles
 
-Support bundles must redact secrets, tokens, cookies, private keys, raw provider errors, credential-bearing URLs, generated credentials, and unnecessary provider internals. Include enough sanitized readiness and audit evidence to diagnose operator issues without leaking user or provider data.
+Support bundles must redact secrets, tokens, cookies, private keys, raw provider errors, credential-bearing URLs, generated credentials, and unnecessary provider internals. Include enough sanitized readiness and audit evidence to diagnose operator issues without leaking user or provider data. Sprint 3 adapter readiness evidence is captured in [Sprint 3 Admin readiness evidence](sprint-3-admin-readiness-evidence.md).
 
 ## Validation gates
 

--- a/docs/sprint-3-admin-readiness-evidence.md
+++ b/docs/sprint-3-admin-readiness-evidence.md
@@ -1,0 +1,39 @@
+# Sprint 3 Admin readiness evidence
+
+This note records the support-safe readiness evidence added for Sprint 3 issues #250 and #315.
+
+## Contract
+
+Workspace Health/Admin Console consumes provider-neutral domain category readiness from `/providers/status`. Each category can include `adapterEvidence` entries with only:
+
+- `domain`
+- `adapterKey`
+- `configured`
+- `reachable`
+- `health`
+- `failClosed`
+- `supportSafeDiagnostics`
+- `evidenceTimestamp`
+
+`supportSafeDiagnostics` is limited to booleans, counts, and stable codes. It must not include provider endpoint URLs, bearer tokens, credential values, raw provider errors, stack traces, or room/user tokens.
+
+## Member/admin split
+
+- Normal member UX receives stable Weave capability/member-impact states only: ready/usable, disabled, degraded, policy-blocked, or admin setup required.
+- Admin/operator Workspace Health may show adapter keys, configured/reachable/fail-closed evidence, redacted support-safe error codes, and next setup action.
+- Provider endpoint rotation, SecretRefs, raw operational logs, and provider-specific remediation remain Admin/Operator-side.
+
+## Sanitized manual/live readiness note
+
+Current expensive live-stack proof remains operator/profile-gated. The safe evidence path is:
+
+```bash
+cd infra/weave-workspace
+WEAVE_SUPPORT_BUNDLE_RUN_CHECKS=false bash support-bundle.sh .generated/support-bundles
+bash tests/support-bundle-redaction-test.sh
+bash tests/acceptance-feature-mapping-test.sh
+```
+
+The generated support bundle now includes `checks/adapter-readiness-summary.json` with the same support-safe field names as `/providers/status`. The redaction test proves representative OpenProject/Nextcloud provider URLs and tokens are not present in the bundle; configured/provider-domain state is represented as booleans and stable adapter keys instead.
+
+Full enabled OpenProject provider proof should be attached only from an approved operator live-stack run. Do not substitute skipped or unconfirmed Live Stack E2E for this note.

--- a/infra/weave-workspace/support-bundle.sh
+++ b/infra/weave-workspace/support-bundle.sh
@@ -187,6 +187,7 @@ collect_public_env_from_file() {
   local source_file="$1"
   local target_file="$2"
   local key
+  local line
 
   if [[ ! -f "${source_file}" ]]; then
     printf 'Skipped: file not found: %s\n' "${source_file}" >>"${target_file}"
@@ -195,9 +196,40 @@ collect_public_env_from_file() {
 
   printf '# %s\n' "${source_file}" >>"${target_file}"
   for key in "${PUBLIC_ENV_KEYS[@]}"; do
-    grep -E "^(export[[:space:]]+)?${key}=" "${source_file}" >>"${target_file}" || true
+    while IFS= read -r line; do
+      write_support_safe_env_line "${key}" "${line}" >>"${target_file}"
+    done < <(grep -E "^(export[[:space:]]+)?${key}=" "${source_file}" || true)
   done
   printf '\n' >>"${target_file}"
+}
+
+is_provider_endpoint_key() {
+  local key="$1"
+  case "${key}" in
+    WEAVE_DEVOPS_GITLAB_BASE_URL|WEAVE_DEVOPS_FORGEJO_BASE_URL|WEAVE_OFFICE_ONLYOFFICE_DOCUMENT_SERVER_URL|WEAVE_PUBLIC_BASE_URL|WEAVE_OIDC_ISSUER_URL|WEAVE_NEXTCLOUD_BASE_URL|WEAVE_BOARDS_OPENPROJECT_BASE_URL|WEAVE_MATRIX_HOMESERVER_URL)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+write_support_safe_env_line() {
+  local key="$1"
+  local line="$2"
+  local value=""
+
+  if [[ "${line}" == export[[:space:]]* ]]; then
+    line="${line#export }"
+  fi
+  value="${line#*=}"
+
+  if is_provider_endpoint_key "${key}"; then
+    printf '%s_CONFIGURED=%s\n' "${key}" "$(if [[ -n "${value}" ]]; then printf true; else printf false; fi)"
+  else
+    printf '%s\n' "${line}"
+  fi
 }
 
 collect_public_env() {
@@ -213,13 +245,103 @@ collect_public_env() {
     local key
     for key in "${PUBLIC_ENV_KEYS[@]}"; do
       if [[ -n "${!key:-}" ]]; then
-        printf '%s=%q\n' "${key}" "${!key}"
+        if is_provider_endpoint_key "${key}"; then
+          printf '%s_CONFIGURED=true\n' "${key}"
+        else
+          printf '%s=%q\n' "${key}" "${!key}"
+        fi
       fi
     done
   } >>"${target}"
 
   redact_stream <"${target}" >"${target}.redacted"
   mv "${target}.redacted" "${target}"
+}
+
+bool_from_env_presence() {
+  local key="$1"
+  [[ -n "${!key:-}" ]]
+}
+
+bool_from_env_files() {
+  local key="$1"
+  grep -hE "^(export[[:space:]]+)?${key}=.+" \
+    "${ROOT_DIR}/.generated/bootstrap.env" \
+    "${ROOT_DIR}/.generated/app-config.env" 2>/dev/null | grep -q .
+}
+
+health_from_env() {
+  local configured="$1"
+  if [[ "${configured}" != "true" ]]; then
+    printf 'not_configured'
+    return
+  fi
+  case "${WEAVE_PROVIDER_STACK_READINESS:-${TF_VAR_provider_stack_readiness:-fail-closed}}" in
+    ready|configured|degraded|fail-closed|not_configured|disabled)
+      printf '%s' "${WEAVE_PROVIDER_STACK_READINESS:-${TF_VAR_provider_stack_readiness:-fail-closed}}"
+      ;;
+    *)
+      printf 'fail-closed'
+      ;;
+  esac
+}
+
+adapter_evidence_object() {
+  local comma="$1"
+  local domain="$2"
+  local adapter_key="$3"
+  local configured="$4"
+  local health
+  health="$(health_from_env "${configured}")"
+  local reachable="false"
+  local fail_closed="true"
+  if [[ "${health}" == "ready" || "${health}" == "configured" || "${health}" == "degraded" ]]; then
+    reachable="true"
+  fi
+  if [[ "${health}" == "ready" || "${health}" == "configured" ]]; then
+    fail_closed="false"
+  fi
+  cat <<JSON
+${comma}    {
+      "domain": "${domain}",
+      "adapterKey": "${adapter_key}",
+      "configured": ${configured},
+      "reachable": ${reachable},
+      "health": "${health}",
+      "failClosed": ${fail_closed},
+      "supportSafeDiagnostics": {
+        "secretsReturned": false,
+        "rawProviderErrorsReturned": false,
+        "diagnosticsRedacted": true
+      },
+      "evidenceTimestamp": "${CREATED_AT}"
+    }
+JSON
+}
+
+collect_adapter_readiness_evidence() {
+  local target="${WORK_DIR}/checks/adapter-readiness-summary.json"
+  mkdir -p "$(dirname -- "${target}")"
+  local identity_configured="false" chat_configured="false" files_configured="false" calendar_configured="false" boards_configured="false" meetings_configured="false"
+
+  (bool_from_env_presence WEAVE_OIDC_ISSUER_URL || bool_from_env_files WEAVE_OIDC_ISSUER_URL) && identity_configured="true"
+  (bool_from_env_presence WEAVE_MATRIX_HOMESERVER_URL || bool_from_env_files WEAVE_MATRIX_HOMESERVER_URL) && chat_configured="true"
+  (bool_from_env_presence WEAVE_NEXTCLOUD_BASE_URL || bool_from_env_files WEAVE_NEXTCLOUD_BASE_URL) && files_configured="true" && calendar_configured="true"
+  (bool_from_env_presence WEAVE_BOARDS_OPENPROJECT_BASE_URL || bool_from_env_files WEAVE_BOARDS_OPENPROJECT_BASE_URL) && boards_configured="true"
+  if [[ "${WEAVE_LIVEKIT_ENABLED:-false}" == "true" || "${WEAVE_LIVEKIT_TOKEN_ENDPOINT_CONFIGURED:-false}" == "true" ]]; then
+    meetings_configured="true"
+  fi
+
+  {
+    printf '{\n  "schema": "weave-support-safe-adapter-readiness-v1",\n  "generatedAt": "%s",\n  "adapterEvidence": [\n' "${CREATED_AT}"
+    adapter_evidence_object "" "identity-idm" "keycloak-realm" "${identity_configured}"
+    adapter_evidence_object "," "chat" "synapse-matrix" "${chat_configured}"
+    adapter_evidence_object "," "files" "nextcloud-files" "${files_configured}"
+    adapter_evidence_object "," "calendar" "nextcloud-caldav" "${calendar_configured}"
+    adapter_evidence_object "," "boards-tasks" "openproject-primary" "${boards_configured}"
+    adapter_evidence_object "," "meetings-calls" "livekit" "${meetings_configured}"
+    printf '  ]\n}\n'
+  } >"${target}"
 }
 
 collect_recent_artifacts() {
@@ -300,6 +422,7 @@ MSG
   collect_if_command_exists docker docker/system-df.txt docker system df
   collect_logs
   collect_optional_checks
+  collect_adapter_readiness_evidence
   collect_recent_artifacts
 
   scan_for_unredacted_secrets "${WORK_DIR}"

--- a/infra/weave-workspace/tests/acceptance-feature-mapping-test.sh
+++ b/infra/weave-workspace/tests/acceptance-feature-mapping-test.sh
@@ -72,7 +72,8 @@ assert_file_contains "docs/openproject-boards-runtime.md" "WEAVE_OPENPROJECT_LIV
 
 assert_file_contains "weave-workspace/tests/support-bundle-redaction-test.sh" "TF_VAR_boards_openproject_api_token=openproject-super-secret"
 assert_file_contains "weave-workspace/tests/support-bundle-redaction-test.sh" "support bundle leaked a test secret"
-assert_file_contains "weave-workspace/tests/support-bundle-redaction-test.sh" "WEAVE_BOARDS_OPENPROJECT_BASE_URL=https://openproject.example"
+assert_file_contains "weave-workspace/tests/support-bundle-redaction-test.sh" "WEAVE_BOARDS_OPENPROJECT_BASE_URL_CONFIGURED=true"
+assert_file_contains "weave-workspace/tests/support-bundle-redaction-test.sh" "weave-support-safe-adapter-readiness-v1"
 
 assert_file_contains "weave-workspace/operator-check.sh" "Checking public product, issuer, API, files, and matrix routes"
 assert_file_contains "weave-workspace/operator-check.sh" "WEAVE_BASE_URL:=\$("

--- a/infra/weave-workspace/tests/support-bundle-redaction-test.sh
+++ b/infra/weave-workspace/tests/support-bundle-redaction-test.sh
@@ -90,10 +90,16 @@ extracted="$(find "${output_dir}" -maxdepth 1 -type d -name 'weave-support-*' -p
 grep -Fq 'This bundle is for support-safe diagnostics only. It is not a backup' "${extracted}/README.txt"
 grep -Fq 'TF_VAR_tenant_domain=weave.local' "${extracted}/config/public-env-summary.env"
 grep -Fq 'WEAVE_API_BASE_URL=https://api.weave.local/api' "${extracted}/config/public-env-summary.env"
+grep -Fq 'WEAVE_NEXTCLOUD_BASE_URL_CONFIGURED=true' "${extracted}/config/public-env-summary.env"
+grep -Fq 'WEAVE_BOARDS_OPENPROJECT_BASE_URL_CONFIGURED=true' "${extracted}/config/public-env-summary.env"
+grep -Fq '"schema": "weave-support-safe-adapter-readiness-v1"' "${extracted}/checks/adapter-readiness-summary.json"
+grep -Fq '"domain": "boards-tasks"' "${extracted}/checks/adapter-readiness-summary.json"
+grep -Fq '"adapterKey": "openproject-primary"' "${extracted}/checks/adapter-readiness-summary.json"
+grep -Fq '"configured": true' "${extracted}/checks/adapter-readiness-summary.json"
 
-if grep -R -Fq 'super-secret' "${extracted}" || grep -R -Fq 'calendar-token' "${extracted}" || grep -R -Fq 'slack-signing-secret' "${extracted}" || grep -R -Fq 'slack-client-secret-ref' "${extracted}" || grep -R -Fq 'openproject-super-secret' "${extracted}" || grep -R -Fq 'openproject-secret-key-base' "${extracted}" || grep -R -Fq 'openproject-app-token' "${extracted}" || grep -R -Fq 'boards-provider-secret' "${extracted}" || grep -R -Fq 'boards-runtime-token' "${extracted}"; then
+if grep -R -Fq 'super-secret' "${extracted}" || grep -R -Fq 'calendar-token' "${extracted}" || grep -R -Fq 'slack-signing-secret' "${extracted}" || grep -R -Fq 'slack-client-secret-ref' "${extracted}" || grep -R -Fq 'openproject-super-secret' "${extracted}" || grep -R -Fq 'openproject-secret-key-base' "${extracted}" || grep -R -Fq 'openproject-app-token' "${extracted}" || grep -R -Fq 'boards-provider-secret' "${extracted}" || grep -R -Fq 'boards-runtime-token' "${extracted}" || grep -R -Fq 'openproject.example' "${extracted}" || grep -R -Fq 'files.weave.local' "${extracted}"; then
   echo "support bundle leaked a test secret" >&2
-  grep -R -n -E 'super-secret|calendar-token|slack-signing-secret|slack-client-secret-ref|openproject-super-secret|openproject-secret-key-base|openproject-app-token|boards-provider-secret|boards-runtime-token' "${extracted}" >&2 || true
+  grep -R -n -E 'super-secret|calendar-token|slack-signing-secret|slack-client-secret-ref|openproject-super-secret|openproject-secret-key-base|openproject-app-token|boards-provider-secret|boards-runtime-token|openproject\.example|files\.weave\.local' "${extracted}" >&2 || true
   exit 1
 fi
 

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderAdapterReadinessEvidenceResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderAdapterReadinessEvidenceResponse.java
@@ -1,0 +1,33 @@
+package com.massimotter.weave.backend.provider;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Schema(description = "Support-safe Admin Console evidence for one domain adapter candidate.")
+public record ProviderAdapterReadinessEvidenceResponse(
+        @Schema(description = "Provider-neutral Weave domain/category key.") String domain,
+        @Schema(description = "Support-safe adapter key; never an endpoint URL or credential.") String adapterKey,
+        @Schema(description = "True when backend/operator configuration is present for the selected adapter.") boolean configured,
+        @Schema(description = "True when the backend can infer a reachable adapter without exposing raw diagnostics.") boolean reachable,
+        @Schema(description = "Support-safe readiness/health state for this adapter.") String health,
+        @Schema(description = "True when unavailable provider access remains fail-closed behind Weave facades.") boolean failClosed,
+        @Schema(description = "Booleans/counts/stable codes only; no endpoints, secrets, tokens, or raw upstream errors.") Map<String, Object> supportSafeDiagnostics,
+        @Schema(description = "UTC timestamp for the evidence snapshot.") Instant evidenceTimestamp) {
+
+    public ProviderAdapterReadinessEvidenceResponse {
+        domain = requireText(domain, "domain");
+        adapterKey = requireText(adapterKey, "adapterKey");
+        health = requireText(health, "health");
+        supportSafeDiagnostics = supportSafeDiagnostics == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(supportSafeDiagnostics));
+        evidenceTimestamp = evidenceTimestamp == null ? Instant.EPOCH : evidenceTimestamp;
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryHealthMapper.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryHealthMapper.java
@@ -4,6 +4,7 @@ import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -20,8 +21,10 @@ final class ProviderCategoryHealthMapper {
     static List<ProviderCategoryStatusResponse> categories(
             List<ProviderStatusResponse> providers,
             WorkspaceCapabilitiesResponse capabilities,
-            ProviderSelectionRepository selections) {
+            ProviderSelectionRepository selections,
+            Instant generatedAt) {
         List<ProviderStatusResponse> safeProviders = providers == null ? List.of() : List.copyOf(providers);
+        Instant evidenceTimestamp = generatedAt == null ? Instant.EPOCH : generatedAt;
         return List.of(
                 capabilityCategory(
                         "identity-idm",
@@ -29,84 +32,96 @@ final class ProviderCategoryHealthMapper {
                         capabilities.shellAccess(),
                         safeProviders,
                         modules(ProviderModule.IDENTITY_REALM, ProviderModule.MATRIX_AUTH),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "chat",
                         "chat",
                         capabilities.chat(),
                         safeProviders,
                         modules(ProviderModule.MATRIX),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "files",
                         "files",
                         capabilities.files(),
                         safeProviders,
                         modules(ProviderModule.FILES),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "calendar",
                         "calendar",
                         capabilities.calendar(),
                         safeProviders,
                         modules(ProviderModule.CALENDAR),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "boards-tasks",
                         "boards/tasks",
                         capabilities.boards(),
                         safeProviders,
                         modules(ProviderModule.BOARDS),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 providerCategory(
                         "meetings-calls",
                         "meetings/calls",
                         "Meetings and calls are available only when the configured media provider is ready behind the backend token facade.",
                         safeProviders,
                         modules(ProviderModule.MEETINGS),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 providerCategory(
                         "documents-collaboration",
                         "documents/collaboration",
                         "Document collaboration is available only through backend-owned launch/capability facades.",
                         safeProviders,
                         modules(ProviderModule.OFFICE, ProviderModule.FORMS, ProviderModule.CONTACTS),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "decisions-evidence",
                         "decisions/evidence",
                         capabilities.decisionsEvidence(),
                         safeProviders,
                         Set.of(),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "manuals-help",
                         "manuals/help",
                         capabilities.manualsHelp(),
                         safeProviders,
                         Set.of(),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "release-evidence",
                         "release evidence",
                         capabilities.releaseEvidence(),
                         safeProviders,
                         modules(ProviderModule.RELEASE),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "admin-control-plane",
                         "admin control plane",
                         capabilities.adminControlPlane(),
                         safeProviders,
                         Set.of(),
-                        selections),
+                        selections,
+                        evidenceTimestamp),
                 capabilityCategory(
                         "weaver",
                         "Weaver",
                         capabilities.weaver(),
                         safeProviders,
                         Set.of(),
-                        selections));
+                        selections,
+                        evidenceTimestamp));
     }
 
     private static ProviderCategoryStatusResponse capabilityCategory(
@@ -115,7 +130,8 @@ final class ProviderCategoryHealthMapper {
             WorkspaceCapabilityStatusResponse capability,
             List<ProviderStatusResponse> providers,
             Set<ProviderModule> modules,
-            ProviderSelectionRepository selections) {
+            ProviderSelectionRepository selections,
+            Instant evidenceTimestamp) {
         SelectionView selection = selectionView(category, selections);
         ProviderCategoryReadiness readiness = selection.selectedByAdmin() || modules.isEmpty()
                 ? fromCapability(capability)
@@ -136,6 +152,7 @@ final class ProviderCategoryHealthMapper {
                 selection.selectedByAdmin(),
                 !selection.selectedByAdmin(),
                 selection.lossyMappingNotes(),
+                adapterEvidence(category, providers, modules, selection, readiness, evidenceTimestamp),
                 diagnostics(providers, modules, Map.of(
                         "capabilityEnabled", capability.enabled(),
                         "capabilityReadiness", capability.readiness().value(),
@@ -152,7 +169,8 @@ final class ProviderCategoryHealthMapper {
             String memberImpact,
             List<ProviderStatusResponse> providers,
             Set<ProviderModule> modules,
-            ProviderSelectionRepository selections) {
+            ProviderSelectionRepository selections,
+            Instant evidenceTimestamp) {
         List<ProviderStatusResponse> matching = matching(providers, modules);
         SelectionView selection = selectionView(category, selections);
         ProviderCategoryReadiness readiness = selection.selectedByAdmin()
@@ -177,6 +195,7 @@ final class ProviderCategoryHealthMapper {
                 selection.selectedByAdmin(),
                 !selection.selectedByAdmin(),
                 selection.lossyMappingNotes(),
+                adapterEvidence(category, providers, modules, selection, readiness, evidenceTimestamp),
                 diagnostics(providers, modules, Map.of(
                         "effectivePolicyState", policyState.value(),
                         "providerConfigSource", ProviderRegistry.PROVIDER_CONFIG_SOURCE,
@@ -214,6 +233,58 @@ final class ProviderCategoryHealthMapper {
             return ProviderCategoryReadiness.READY;
         }
         return ProviderCategoryReadiness.DEGRADED;
+    }
+
+    private static List<ProviderAdapterReadinessEvidenceResponse> adapterEvidence(
+            String category,
+            List<ProviderStatusResponse> providers,
+            Set<ProviderModule> modules,
+            SelectionView selection,
+            ProviderCategoryReadiness readiness,
+            Instant evidenceTimestamp) {
+        List<ProviderStatusResponse> matching = matching(providers, modules);
+        if (matching.isEmpty()) {
+            return List.of();
+        }
+        return matching.stream()
+                .map(provider -> new ProviderAdapterReadinessEvidenceResponse(
+                        category,
+                        provider.providerKey(),
+                        provider.configured(),
+                        reachable(provider),
+                        selection.selectedByAdmin() ? provider.readiness() : readiness.value(),
+                        provider.failClosed(),
+                        providerEvidenceDiagnostics(provider, selection),
+                        evidenceTimestamp))
+                .toList();
+    }
+
+    private static boolean reachable(ProviderStatusResponse provider) {
+        return provider.enabled()
+                && provider.configured()
+                && (provider.state() == ProviderState.READY
+                || provider.state() == ProviderState.CONFIGURED
+                || provider.state() == ProviderState.DEGRADED);
+    }
+
+    private static Map<String, Object> providerEvidenceDiagnostics(
+            ProviderStatusResponse provider,
+            SelectionView selection) {
+        Map<String, Object> diagnostics = new LinkedHashMap<>();
+        diagnostics.put("providerState", provider.state().contractName());
+        diagnostics.put("configured", provider.configured());
+        diagnostics.put("enabled", provider.enabled());
+        diagnostics.put("selectedByAdmin", selection.selectedByAdmin());
+        diagnostics.put("bootstrapSuggestionOnly", !selection.selectedByAdmin());
+        diagnostics.put("supportSafe", provider.supportSafe());
+        diagnostics.put("failClosed", provider.failClosed());
+        diagnostics.put("supportedCapabilityCount", provider.supportedCapabilities().size());
+        diagnostics.put("unsupportedOperationCount", provider.unsupportedOperations().size());
+        diagnostics.put("supportSafeErrorCodes", provider.supportSafeErrorCodes());
+        diagnostics.put("secretsReturned", false);
+        diagnostics.put("rawProviderErrorsReturned", false);
+        diagnostics.put("diagnosticsRedacted", true);
+        return diagnostics;
     }
 
     private static Map<String, Object> diagnostics(

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryStatusResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryStatusResponse.java
@@ -22,6 +22,7 @@ public record ProviderCategoryStatusResponse(
         @Schema(description = "True only after an admin has applied a provider mapping for this category.") boolean selectedByAdmin,
         @Schema(description = "True when defaults are being shown only as bootstrap/profile suggestions, not product truth.") boolean bootstrapSuggestionOnly,
         @Schema(description = "Support-safe notes for known lossy mappings across provider families.") List<String> lossyMappingNotes,
+        @Schema(description = "Support-safe infra/backend adapter readiness evidence for Admin Console and support bundles.") List<ProviderAdapterReadinessEvidenceResponse> adapterEvidence,
         @Schema(description = "Support-safe diagnostics. Values are booleans/counts/keys only; no endpoints, secrets, or raw upstream errors.") Map<String, Object> diagnostics) {
 
     public ProviderCategoryStatusResponse {
@@ -38,6 +39,7 @@ public record ProviderCategoryStatusResponse(
         selectedProviderKey = selectedProviderKey == null || selectedProviderKey.isBlank() ? "awaiting_admin_selection" : selectedProviderKey.trim();
         choiceModel = choiceModel == null || choiceModel.isBlank() ? "not_selected" : choiceModel.trim();
         lossyMappingNotes = lossyMappingNotes == null ? List.of() : List.copyOf(lossyMappingNotes);
+        adapterEvidence = adapterEvidence == null ? List.of() : List.copyOf(adapterEvidence);
         diagnostics = diagnostics == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(diagnostics));
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
@@ -41,7 +41,8 @@ public class ProviderRegistry {
         List<ProviderCategoryStatusResponse> categories = ProviderCategoryHealthMapper.categories(
                 statuses,
                 workspaceCapabilityService.snapshot(),
-                selectionRepository);
+                selectionRepository,
+                generatedAt);
         return new ProviderRegistryResponse(
                 "provider-stack-contract-v1",
                 PROVIDER_CONFIG_SOURCE,

--- a/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
@@ -95,6 +95,7 @@ class DomainAdapterRegistryMapperTest {
                 true,
                 false,
                 List.of(),
+                List.of(),
                 Map.of("allFailClosed", true, "secretsReturned", false, "rawProviderErrorsReturned", false));
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/provider/ProviderRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/ProviderRegistryTest.java
@@ -46,6 +46,16 @@ class ProviderRegistryTest {
         assertThat(chat.bootstrapSuggestionOnly()).isTrue();
         assertThat(chat.selectedProviderKey()).isEqualTo("awaiting_admin_selection");
         assertThat(chat.diagnostics()).containsEntry("selectionRequiredBeforeProviderUse", true);
+        assertThat(chat.adapterEvidence()).singleElement().satisfies(evidence -> {
+            assertThat(evidence.domain()).isEqualTo("chat");
+            assertThat(evidence.adapterKey()).isEqualTo("synapse-homeserver");
+            assertThat(evidence.configured()).isFalse();
+            assertThat(evidence.failClosed()).isTrue();
+            assertThat(evidence.supportSafeDiagnostics())
+                    .containsEntry("secretsReturned", false)
+                    .containsEntry("rawProviderErrorsReturned", false)
+                    .doesNotContainKeys("endpoint", "rawProviderError", "authorization");
+        });
         ProviderCategoryStatusResponse weaver = response.categories().stream()
                 .filter(category -> category.category().equals("weaver"))
                 .findFirst()


### PR DESCRIPTION
## Summary
- Adds support-safe Admin Console adapter readiness evidence to provider category status responses.
- Surfaces configured/reachable/fail-closed evidence only in Workspace Health for workspace admins.
- Extends support bundles with sanitized adapter readiness evidence while redacting provider endpoint URLs, tokens, secrets, and raw provider errors.
- Documents the Sprint 3 readiness evidence path and operator-gated live proof boundary.

Closes #250.
Closes #315.

## Evidence / gates
- `make acceptance-contract` ✅
- `make server-ci` ✅
- `make client-ci` ✅
- `make infra-static` ✅
- Targeted backend provider tests ✅
- Targeted Flutter Settings/API tests ✅
- `bash infra/weave-workspace/tests/support-bundle-redaction-test.sh` ✅
- Sanitized readiness note: `docs/sprint-3-admin-readiness-evidence.md`

## Privacy/safety
- No provider URLs, bearer tokens, secrets, raw provider errors, generated credentials, or credential-bearing URLs are rendered in member UX or support bundles.
- Full enabled OpenProject live proof remains operator/profile-gated; this PR records only support-safe readiness evidence and does not fake live provider writes.
