### PR TITLE
docs: finalize Sprint 3 report and seed Sprint 4 plan

### DIFF
--- a/docs/sprint-3-closure-report.md
+++ b/docs/sprint-3-closure-report.md
@@ -1,10 +1,19 @@
 # Sprint 3 closure report: provider-neutral domain adapter control plane
 
-Status: closure PR evidence, 2026-05-25.
+Status: final closure evidence, 2026-05-26.
 
 ## Closure scope
 
-Sprint 3 closes the provider-neutral domain adapter control plane. The closing state is Weave product-first: stable member domains, backend/admin-owned provider adapters, support-safe readiness, and explicit migration/audit boundaries. Default dogfood providers remain implementation choices for operators and admins, not the product identity presented to members.
+Sprint 3 closes the provider-neutral domain adapter control plane. The final state is Weave product-first: stable member domains, backend/admin-owned provider adapters, support-safe readiness, and explicit migration/audit boundaries. Default dogfood providers remain implementation choices for operators and admins, not the product identity presented to members.
+
+## Final closure status
+
+- Sprint 3 milestone: `Sprint 3 — Provider-neutral product maturity`, closed with `open_issues: 0` and `closed_issues: 12`.
+- Sprint 3 umbrella: #311, closed after final PR merge and post-merge CI.
+- Final closure PR: #322, `fix: align live E2E with member provider boundary`.
+- Final merge commit on `main`: `382676529c86d0da95156687e74cd862261e54ca`.
+- Final PR head before merge: `95b2bad7844e`.
+- Copilot review was requested and re-run. Its actionable Matrix-connect diagnostic was addressed before merge.
 
 ## Issue and PR graph
 
@@ -13,7 +22,8 @@ Sprint 3 closes the provider-neutral domain adapter control plane. The closing s
 | Live-stack dispatch guard | PR #300 closed issue #246 by making unconfirmed Live Stack E2E dispatch actionable instead of silently green. | Merged before closure. |
 | Workspace Health cockpit and support-safe readiness | PR #319 closed issues #250 and #315 by exposing adapter readiness evidence through Admin/Operator surfaces and support bundles without leaking raw provider data. | Merged before closure. |
 | Manuals, canonical models, diagrams, release workflow | PR #320 closed issues #289, #296, and #293 by publishing canonical feature models, embedded manual contracts, and generated/reviewable release-note workflow. | Merged before closure. |
-| Sprint 3 epic | Issue #311 is the final closure issue for the domain adapter control plane. | To close only after this PR is merged, current-main CI is green, and final-main Live Stack E2E is green. |
+| Live E2E member/provider boundary | PR #322 aligned live E2E, contract tests, feature mappings, and Matrix-connect diagnostics with the Sprint 3 member/admin boundary. | Merged as `382676529c86d0da95156687e74cd862261e54ca`. |
+| Sprint 3 epic | Issue #311 tracked the umbrella acceptance graph and final closure evidence. | Closed after #322 merge, Live Stack E2E, and post-merge `main` CI. |
 
 ## Frozen vocabulary and boundaries
 
@@ -39,7 +49,7 @@ The closing contract is:
 - Member UX renders stable Weave product capabilities and safe impact states. Members do not configure raw providers or receive provider-specific remediation details.
 - OpenProject is the first real Boards/Tasks provider validation path; it is not the visible product UX and is not proof of a broad provider marketplace.
 - Meetings use a backend token/readiness facade. LiveKit is the dogfood media provider path, but media encryption, recording, transcription, captions, and retention claims remain guarded until independently evidenced.
-- Weaver remains a future governed per-user PA runtime, disabled by default and later than admin portal, IDM/RBAC, readiness, and whitelisting.
+- Weaver remains a governed per-user PA/runtime direction. Sprint 4 may introduce read-only/proposal-first context assistance, but silent team-room writes remain out of scope until policy, consent, receipts, and audit evidence are mature.
 
 ## README and release evidence review
 
@@ -47,32 +57,37 @@ README.md was read as a whole public product document for this closure, not trea
 
 The README release-note tooling was changed accordingly: the previous special-phrase blacklist was removed. The remaining check is deterministic structure only: expected managed markers, marker ordering, required top-level sections, and release-note/release-evidence marker placement plus the existing round-trip comparison against generated managed blocks.
 
-## Evidence snapshot before closure PR
+## Final evidence snapshot
 
 | Evidence | Run / SHA | Result |
 | --- | --- | --- |
-| Current `main` | `5cdd7b57bd2e60ab52afbb9f0c97f72f18ff7574` | Clean baseline before closure PR branch. |
-| CI on current `main` | GitHub Actions run `26417215189` on `5cdd7b57bd2e60ab52afbb9f0c97f72f18ff7574` | `success`. |
-| Live Stack E2E on current `main` | GitHub Actions run `26419132246` on `5cdd7b57bd2e60ab52afbb9f0c97f72f18ff7574` | `failure`: operator-check still expected a member token to read `/providers/status`. This PR updates live/operator/smoke checks to the Sprint 3 boundary: provider registry diagnostics are Admin/Operator-only and member tokens receive `403`. Final closure evidence must use the post-merge run below. |
+| Final PR head | `95b2bad7844e` | PR #322 review-ready head after addressing Copilot's Matrix-connect diagnostic. |
+| PR CI on final head | GitHub Actions CI on `95b2bad7844e` | `success`; Gradle CI passed and Release Notes Label Check was skipped as expected for labeled PR context. |
+| Live Stack E2E on final head | GitHub Actions run `26433113444` on `95b2bad7844e` | `success`; `Bootstrap Stack And Run App E2E` completed in `11m14s`. |
+| Final merge commit | `382676529c86d0da95156687e74cd862261e54ca` | Squash merge of #322 into `main`. |
+| Post-merge `main` CI | GitHub Actions run `26433489753` on `382676529c86` | `success`; Gradle CI completed in `6m0s`. |
+| Sprint 3 umbrella | #311 | Closed with all checklist items completed. |
+| Sprint 3 milestone | Milestone #3 | Closed with `open_issues: 0`, `closed_issues: 12`. |
 
-## Local PR-C gates
+## Local PR gates used during closure
 
-Completed locally before opening the closure PR:
+Local gates used across the closure PR series included:
 
 ```bash
-make docs-check                         # pass
-make acceptance-contract                # pass
-./gradlew releaseEvidenceCheck          # pass
-python3 tools/readme_release_notes.py --check  # pass
-make infra-static                       # pass
-bash infra/weave-workspace/tests/infra-product-contract-test.sh  # pass
-bash infra/weave-workspace/tests/acceptance-feature-mapping-test.sh  # pass
+make docs-check
+make acceptance-contract
+./gradlew releaseEvidenceCheck
+python3 tools/readme_release_notes.py --check
+make infra-static
+bash infra/weave-workspace/tests/infra-product-contract-test.sh
+bash infra/weave-workspace/tests/acceptance-feature-mapping-test.sh
+flutter test test/live_stack_contract_test.dart test/live_stack_feature_mapping_test.dart test/release_1/v0_1_release_spine_contract_test.dart
 ```
 
-The PR must remain documentation/operator-tooling only and must not publish GitHub releases automatically.
+The final PR #322 remained a live-E2E/member-boundary fix and did not publish GitHub releases automatically.
 
 ## Residual risks and non-goals
 
-- Final closure still requires CI on the merged closure PR and a final-main Live Stack E2E run with `power_storage_confirmation=I_HAVE_SOLAR_STORAGE_BUDGET`.
-- No GitHub release is published by this closure work.
-- Broad provider marketplaces, Teams/Slack migration tooling, full generic provider swaps, media recording/transcription/caption claims, and Weaver runtime operation remain outside v0.1 unless promoted by later contracts and evidence.
+- No GitHub release was published by Sprint 3 closure work; release publication remains an explicit later action.
+- Broad provider marketplaces, Teams/Slack migration tooling, full generic provider swaps, media recording/transcription/caption claims, and Weaver runtime write operation remain outside the closed Sprint 3 scope unless promoted by later contracts and evidence.
+- Sprint 4 should start from this boundary: user-facing accessible work rooms and governed read-only/proposal-first Weaver context assistance, not another provider-specific expansion sprint.

--- a/docs/sprint-4-plan.md
+++ b/docs/sprint-4-plan.md
@@ -1,0 +1,144 @@
+# Sprint 4 plan: accessible work rooms and governed Weaver scout
+
+Status: planning draft, created after Sprint 3 closure.
+
+## Product intent
+
+Sprint 4 turns the Sprint 3 provider-neutral foundation into a usable work-room experience. A normal member should open Weave, find the right workspace/channel, understand active decisions and meetings, and ask a governed Weaver scout for read-only context without triggering silent writes.
+
+## Milestone and issue graph
+
+Milestone: `Sprint 4 — Accessible Work Rooms & governed Weaver scout`.
+
+Primary Sprint 4 issues:
+
+- #323 — Sprint 4 umbrella.
+- #324 — finalize Sprint 3 report and seed Sprint 4 plan.
+- #325 — Weave Home for DMs, favorites, channels, and AI chats.
+- #326 — accessible channel work-room tabs.
+- #327 — channel Decision Ledger MVP.
+- #328 — channel Meeting Capsule MVP.
+- #329 — read-only Weaver channel scout with approval receipts.
+- #330 — Sprint 4 ISO 9241 dogfood evidence gate.
+- #331 — release labels, required checks, and Gradle gate discipline.
+
+Existing epics and guardrails moved into the milestone:
+
+- #210, #211, #259.
+- #251, #219, #249.
+- #252, #214.
+- #253, #257, #51.
+- #288, #292.
+
+## Development handbook rules
+
+Sprint 4 follows the developer handbook:
+
+- Start short-lived PR branches from `main`.
+- Keep changes issue/spec-driven.
+- Every PR must choose exactly one release-notes label before review or merge:
+  - `release-notes-feature`
+  - `release-notes-bugfix`
+  - `release-notes-skip`
+- Request Copilot review on every review-ready PR.
+- Update product-facing Gherkin and scenario mappings when user journeys change.
+- Keep cross-layer contracts atomic across `client/`, `server/`, `infra/`, `e2e/`, docs, and release evidence when boundaries change.
+- Use root `./gradlew ci` as the monorepo aggregate gate; do not add new root Make-only build logic.
+
+## Track A — Weave Home and Channel Work Rooms
+
+Goal: make Weave feel like a real workspace, not a provider setup shell.
+
+Scope:
+
+- Weave Home groups DMs, favorites, channels, and AI/Weaver chats.
+- Channel Work Room exposes Chat, Files, Boards/Tasks, Calendar/Events, and future Decisions/Meetings/Weaver context through accessible tabs or sections.
+- Member UX uses Weave domain vocabulary and safe capability states, not provider setup copy.
+- Product acceptance flows and scenario mappings cover Home and channel navigation.
+
+Acceptance:
+
+- A normal member can enter Home and a channel work room without encountering preview/provider setup surfaces.
+- Keyboard and screenreader traversal is deterministic.
+- Empty, degraded, disabled, and policy-blocked states are concise, localizable, and support-safe.
+
+## Track B — Decision Ledger and Meeting Capsule
+
+Goal: create first-class work objects that preserve why work happened, not only chat messages.
+
+Scope:
+
+- Decision Ledger MVP with channel/source/author/time/status fields.
+- Decision states: proposed, accepted, superseded, rejected.
+- Meeting Capsule MVP tied to workspace/team/channel context with agenda, join/start state, participants/roles, and follow-up references.
+- Clear separation between Matrix chat E2EE and LiveKit/media protection claims.
+
+Acceptance:
+
+- Users can create/read decisions without visual-only affordances.
+- Meeting Capsule can be opened from a channel through backend-owned facades.
+- Decision and meeting objects can link to source/evidence references.
+- Screenreader flows expose state and actions clearly.
+
+## Track C — Governed Weaver scout
+
+Goal: introduce Weaver as useful read-only context assistance without agentic write risk.
+
+Scope:
+
+- Weaver can answer questions such as “what is open in this channel?” from allowed context.
+- Summaries cite source objects/messages/files/tasks/meetings.
+- Writes are drafts/proposals or require an explicit approval/receipt path.
+- Capability usage is visible in a screenreader-friendly way.
+
+Governance rule:
+
+- Sprint 4 uses the direction `user-rights, org-whitelisted tools`.
+- No silent team-room mutations.
+
+Acceptance:
+
+- Weaver can summarize allowed channel context with source references.
+- Weaver cannot mutate team-room data without policy and receipt path.
+- Receipts include actor, requested action, approved action, target, timestamp, and result category.
+- Failure output remains support-safe.
+
+## Track D — Accessibility and dogfood evidence
+
+Goal: make Sprint 4 strong enough for blind-user dogfood, not only “looks accessible”.
+
+Scope:
+
+- ISO 9241-style perceptibility/usefulness evidence for Home, Channel Work Rooms, Decisions, Meetings, and Weaver.
+- Keyboard-only and screenreader/Braille-first evidence shape.
+- No color-only state, drag-only task movement, or noisy live-region spam.
+- Document which checks are automated, manual, or review-artifact based.
+
+Acceptance:
+
+- Critical Sprint 4 flows have linked a11y evidence before review.
+- Status/empty/error/success states use concise, localizable copy.
+- Evidence artifacts are text-first and navigable.
+
+## Track E — DevOps and release discipline
+
+Goal: keep Sprint 4 evidence reliable and release notes reconstructable.
+
+Scope:
+
+- Confirm branch protection or rulesets require core CI and release-notes label checks.
+- Keep Release Notes Label Check non-bypassable for PRs.
+- Keep root Gradle as the source of truth for aggregate gates.
+- Ensure docs/report PRs use `release-notes-skip`; user-facing slices use `release-notes-feature` or `release-notes-bugfix` as appropriate.
+
+Acceptance:
+
+- `main` protection/ruleset status is documented or configured.
+- Release Notes Label Check cannot be accidentally bypassed.
+- CI evidence paths remain sanitized and uploaded.
+
+## Non-goals
+
+- Do not turn Sprint 4 into another provider-specific expansion sprint.
+- Do not claim broad provider marketplaces, Teams/Slack migration tooling, generic provider swaps, media recording/transcription/caption support, or autonomous Weaver writes without separate contracts and evidence.
+- Do not publish a GitHub release as part of Sprint 4 planning unless explicitly requested.

--- a/docs/sprint-4-plan.md
+++ b/docs/sprint-4-plan.md
@@ -1,6 +1,6 @@
 # Sprint 4 plan: accessible work rooms and governed Weaver scout
 
-Status: planning draft, created after Sprint 3 closure.
+Status: planning draft, 2026-05-26.
 
 ## Product intent
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,8 @@ nav:
       - Quality and evidence: quality-and-evidence.md
       - Build, evidence, and delivery system: build-evidence-delivery-system.md
       - Sprint 1 completion report: sprint-1-completion-report.md
+      - Sprint 3 closure report: sprint-3-closure-report.md
+      - Sprint 4 plan: sprint-4-plan.md
       - Accessibility release gate: accessibility-release-gate.md
       - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md
   - Product and Release Scope:


### PR DESCRIPTION
## Scope
- Finalize `docs/sprint-3-closure-report.md` with actual closure evidence from PR #322, Live Stack E2E, and post-merge `main` CI.
- Add `docs/sprint-4-plan.md` as the developer-handbook-aligned Sprint 4 kickoff plan.
- Link Sprint 3 closure and Sprint 4 plan from MkDocs navigation.

## Contract impact
- Documentation-only.
- No runtime, API, provider, auth, or infra contract change.

## Accessibility/localization notes
- Text-first documentation; no image-only information.
- No localization changes.

## Release notes
- Label: `release-notes-skip` because this is planning/report documentation only.

## Verification
- `make docs-check` passed locally using pinned docs dependencies in `build/docs-venv`.

Closes #324.
Refs #323, #331.
