### PR TITLE
docs(a11y): add Sprint 4 dogfood evidence gate

### DIFF
--- a/client/test/release_1/accessibility_gate_contract_test.dart
+++ b/client/test/release_1/accessibility_gate_contract_test.dart
@@ -16,6 +16,7 @@ void main() {
         'Manual assistive-technology evidence required before release sign-off',
         'Non-negotiable pass criteria',
         'Release accounting',
+        'Sprint 4 dogfood evidence gate',
       ]) {
         expect(
           markdown,
@@ -32,6 +33,11 @@ void main() {
         'Files list/upload/download/status/error',
         'Calendar list/create/delete/status/error',
         'Admin/status surfaces consumed by app',
+        'Weave Home',
+        'Channel Work Rooms',
+        'Decision Ledger',
+        'Meeting Capsule',
+        'Weaver Scout',
       ]) {
         expect(
           markdown,

--- a/docs/accessibility-release-gate.md
+++ b/docs/accessibility-release-gate.md
@@ -33,6 +33,18 @@ The automated suite must include widget or contract coverage for these accessibi
 | Shared controls | minimum target sizing and explicit semantic labels for reusable buttons | `test/core/a11y/semantic_button_test.dart`, `test/core/widgets/core_widgets_test.dart` |
 | v0.1 baseline journey | setup, sign-in, chat, files, settings recovery, and gated workspace surfaces remain coherent in one flow | `test/release_1/release_golden_paths_test.dart`, `test/release_1/v0_1_release_spine_contract_test.dart` |
 
+## Sprint 4 dogfood evidence gate
+
+Sprint 4 adds work-room surfaces that must be usable with a screen reader, Braille display, keyboard, and high text scaling before they are called dogfood-ready. Each PR that changes these flows links this section, records the automated evidence it touches, and notes which manual rows still need live assistive-technology sign-off.
+
+| Sprint 4 flow | Required evidence shape | Current automated anchor |
+| --- | --- | --- |
+| Weave Home | deterministic traversal across DMs, favorites, channels, and AI/Weaver areas; no raw provider setup copy in normal member paths | `test/features/chat/chat_screen_test.dart`, `test/release_1/ux_release_copy_contract_test.dart` |
+| Channel Work Rooms | tab labels and status semantics for chat, decisions, files, boards, calendar, meetings, and Weaver; no color-only state | `test/features/chat/channel_workspace_test.dart`, `test/release_1/v0_1_release_spine_contract_test.dart` |
+| Decision Ledger | text-first create/read flow with source references, lifecycle state, owner/time, and keyboard-reachable capture actions | `test/features/chat/decision_evidence_provider_test.dart`, `test/features/chat/chat_room_screen_test.dart` |
+| Meeting Capsule | fail-closed join/start controls, consent/evidence copy, and clear Matrix-chat vs media-protection boundaries | `test/features/chat/channel_workspace_test.dart`, `test/release_1/v0_1_release_spine_contract_test.dart` |
+| Weaver Scout | read-only/proposal-only status, citable source list, support-safe failure copy, and explicit approval-receipt requirement | `test/features/chat/channel_workspace_test.dart`, `test/release_1/ux_release_copy_contract_test.dart` |
+
 ## Manual assistive-technology evidence required before release sign-off
 
 Record the tester, date, platform, assistive technology, result, and evidence link in the release issue or runbook. Manual-only checks are a gate; they may not be inferred from green widget tests.
@@ -43,6 +55,8 @@ Record the tester, date, platform, assistive technology, result, and evidence li
 | Profile view/edit | Fields and validation errors are announced; save success/failure is announced | Tab order follows display name → locale → timezone → save | Long display names/locales do not clip critical controls | Pass or release-blocking bug |
 | Main navigation/settings | Bottom navigation labels are announced and current destination is clear | Navigation and settings actions are reachable by keyboard | Settings cards remain readable | Pass or release-blocking bug |
 | Chat room list/message list/composer | Room names, message authors/content, composer, and send are announced | Keyboard can open a room and send a message | Message list/composer remain usable | Pass or release-blocking bug |
+| Weave Home and Channel Work Rooms | Home sections, channel tabs, capability states, and active tab changes are announced without preview/provider setup vocabulary | Keyboard can move through Home sections and switch channel work-room tabs without pointer-only steps | Tabs and cards remain readable and do not hide critical status | Pass or release-blocking bug |
+| Decision Ledger, Meeting Capsule, and Weaver Scout | Decision records, meeting fail-closed controls, and Weaver source/receipt requirements are announced with enough context to act safely | Decision capture, meeting controls, and Weaver tab content are reachable in deterministic order | Ledger, capsule, and scout cards remain readable at 200% | Pass or release-blocking bug |
 | Files list/upload/download/status/error | File/folder rows, breadcrumbs, upload/download states, and errors are announced | Keyboard can navigate folders and trigger file actions | File rows and breadcrumbs remain usable | Pass or release-blocking bug |
 | Calendar list/create/delete/status/error | Calendar states/events/actions are announced without color-only status | Keyboard can reach event actions where enabled | Event rows/forms remain usable | Pass or release-blocking bug |
 | Admin/status/recovery copy | Degraded/offline states and recovery instructions are understandable | Recovery/status actions are keyboard reachable | Diagnostic copy remains readable | Pass or release-blocking bug |


### PR DESCRIPTION
## Summary
- Adds a Sprint 4 dogfood accessibility evidence gate for Weave Home, Channel Work Rooms, Decision Ledger, Meeting Capsule, and Weaver Scout.
- Extends manual assistive-technology sign-off rows for Sprint 4 screen-reader/Braille, keyboard, and 200% text-scaling evidence.
- Locks the new evidence shape with the release accessibility contract test.

## Evidence
- `cd client && flutter test test/release_1/accessibility_gate_contract_test.dart`
- `./gradlew acceptanceContract`
- `make docs-check`

## Sprint 4 links
- Part of #323
- Advances #330
