### PR TITLE
ci: run release label gate on every PR update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
   release-notes-label-check:
     name: Release Notes Label Check
-    if: github.event_name == 'pull_request' && (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -97,7 +97,7 @@ Use short-lived PR branches from `main`, keep changes issue/spec-driven, and req
 - `release-notes-bugfix`
 - `release-notes-skip`
 
-Release notes are generated from merged PR labels, not manually reconstructed later. The CI `Release Notes Label Check` fails PRs with zero or multiple release-notes labels. See [GitFlow and PR workflow](gitflow-pr-workflow.md) for the full chapter, label semantics, and merge rules.
+Release notes are generated from merged PR labels, not manually reconstructed later. The CI `Release Notes Label Check` runs on every pull-request update and fails PRs with zero or multiple release-notes labels; label-only changes run that lightweight check without re-running the full Gradle CI job. See [GitFlow and PR workflow](gitflow-pr-workflow.md) for the full chapter, label semantics, and merge rules.
 
 ## Documentation site
 


### PR DESCRIPTION
## Summary
- Runs `Release Notes Label Check` on every pull-request update, not only label/unlabel events.
- Keeps label-only events lightweight by preserving the existing full Gradle CI skip on label/unlabel events.
- Documents the Sprint 4 release-label gate behavior in the developer handbook.

## Evidence
- `./gradlew releaseEvidenceCheck`

## Sprint 4 links
- Part of #323
- Advances #331
