### PR TITLE
ci: run live E2E without power budget gate

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -7,10 +7,9 @@ on:
         description: "Backend image to boot inside the infra stack; ghcr.io/* is pulled, other refs are built from monorepo server/"
         required: false
         default: "weave-backend:live-stack-ci"
-      power_storage_confirmation:
-        description: "Type I_HAVE_SOLAR_STORAGE_BUDGET to confirm the self-hosted runner has enough power/storage budget for expensive live E2E"
-        required: true
-        default: ""
+  schedule:
+    # Nightly release-evidence run on the dedicated self-hosted live runner.
+    - cron: "17 2 * * *"
   workflow_call:
     inputs:
       weave_backend_image:
@@ -30,28 +29,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  live-stack-e2e-not-confirmed:
-    name: Explain missing manual dispatch confirmation
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.power_storage_confirmation != 'I_HAVE_SOLAR_STORAGE_BUDGET'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Explain why live-stack E2E did not start
-        run: |
-          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
-          # Live Stack E2E was not started
-
-          The expensive self-hosted live-stack run is gated behind an explicit
-          power/storage confirmation. Re-dispatch this workflow with
-          `power_storage_confirmation` set exactly to
-          `I_HAVE_SOLAR_STORAGE_BUDGET` when an operator has confirmed runner
-          power and storage budget.
-          EOF
-          echo "::error::Live Stack E2E not started: set power_storage_confirmation=I_HAVE_SOLAR_STORAGE_BUDGET after operator budget approval."
-          exit 1
-
   live-stack-e2e:
     name: Bootstrap Stack And Run App E2E
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.power_storage_confirmation == 'I_HAVE_SOLAR_STORAGE_BUDGET'
     runs-on:
       - self-hosted
       - macOS

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ tasks.register('releaseNotesCheck') {
 
 tasks.register('liveStackHelp') {
     group = 'help'
-    description = 'Explain that live stack E2E is intentionally opt-in.'
+    description = 'Explain how to run Live Stack E2E release evidence.'
     doLast {
-        println 'Live stack E2E is intentionally opt-in. Use the GitHub workflow with I_HAVE_SOLAR_STORAGE_BUDGET when runner power/storage budget is available.'
+        println 'Live Stack E2E is available by default on the dedicated self-hosted live runner. Use the GitHub workflow for manual release-candidate evidence; nightly runs also produce live-stack acceptance evidence when infrastructure is healthy.'
     }
 }
 
@@ -133,9 +133,9 @@ void writeCiSummary(Throwable buildFailure) {
         ],
         gates: gateSummaries,
         liveE2E: [
-            outcome: 'skipped',
-            reason: 'Live E2E is not part of default ci and requires explicit operator/budget confirmation.',
-            artifactPaths: []
+            outcome: 'separate-required-release-evidence',
+            reason: 'Live E2E runs on the dedicated self-hosted live runner by manual dispatch and nightly schedule; it is required for release-candidate evidence but remains outside default PR-safe ci.',
+            artifactPaths: ['weave-live-stack-acceptance-evidence']
         ],
         sanitized: true,
         exclusions: [

--- a/docs/acceptance-contracts.md
+++ b/docs/acceptance-contracts.md
@@ -32,7 +32,8 @@ For new product behavior:
 4. Keep live-stack E2E sparse. It proves critical end-to-end contracts only;
    lower-level tests carry the detailed technical coverage.
 5. Run `make offline-contract-test` before review. Use `make integration-test`
-   only for authorized live-stack runs with runner power/storage budget.
+   only on the dedicated live-stack runner or another explicitly prepared local
+   stack, keeping generated evidence sanitized.
 
 ## Feature-file language rules
 

--- a/docs/admin-operator-handbook.md
+++ b/docs/admin-operator-handbook.md
@@ -81,4 +81,4 @@ make server-ci
 make docs-check
 ```
 
-Use live-stack E2E only when explicitly authorized and runner power/storage budget is available.
+Live Stack E2E is available by default on the dedicated self-hosted live runner. Use the GitHub workflow for manual release-candidate evidence; nightly runs should produce acceptance evidence unless a concrete infrastructure blocker is recorded.

--- a/docs/build-evidence-delivery-system.md
+++ b/docs/build-evidence-delivery-system.md
@@ -13,7 +13,7 @@ Root Gradle is the build and delivery source of truth. `./gradlew ci` is the can
 - Default checks do not mutate tracked source; mutations happen only through explicit update tasks.
 - Default checks require no secrets, live services, nondeterministic GitHub API calls, or remote CDN assets.
 - Flutter/Dart and admin/npm checks are orchestrated through typed Gradle `Exec` tasks first; do not force Flutter Android into root Gradle prematurely.
-- Live E2E remains opt-in and preserves explicit operator/budget confirmation semantics.
+- Live E2E runs on the dedicated self-hosted live runner by default for scheduled/manual release evidence; concrete infrastructure blockers must be recorded instead of using power/storage budget as a standing gate.
 
 ## Stable Gradle command surface
 

--- a/docs/release-notes/v0.1.md
+++ b/docs/release-notes/v0.1.md
@@ -31,4 +31,4 @@ v0.1 is the dogfood-production release line. Entries below should reflect shippe
 
 ## Known Issues
 
-- Live-stack E2E remains opt-in because it requires explicit runner power/storage budget.
+- Live-stack E2E requires the dedicated self-hosted live runner and configured test credentials; power/storage budget is no longer a standing gate for scheduled or manual release evidence.

--- a/docs/release-v0.1-dogfood-plan.md
+++ b/docs/release-v0.1-dogfood-plan.md
@@ -44,7 +44,7 @@ Exit gate:
 - `make acceptance-contract`
 - `make infra-static`
 - client/server CI green in GitHub
-- Live Stack E2E manually green with explicit runner budget
+- Live Stack E2E green from the dedicated self-hosted live runner
 
 ## Phase 2 — OpenTofu-first infra
 

--- a/release/weave-stack.yaml
+++ b/release/weave-stack.yaml
@@ -30,7 +30,7 @@ components:
     path: e2e
     required_gates:
       - make acceptance-contract
-      - Live Stack E2E with explicit runner budget
+      - Live Stack E2E acceptance evidence from the dedicated self-hosted live runner
 scope:
   required:
     - weave-home


### PR DESCRIPTION
## Summary
- Removes the manual `I_HAVE_SOLAR_STORAGE_BUDGET` dispatch gate from Live Stack E2E.
- Adds a nightly scheduled Live Stack E2E run on the dedicated self-hosted live runner while keeping manual dispatch and reusable workflow support.
- Updates release/evidence docs so E2E is treated as available by default; only concrete infrastructure blockers should stop release evidence.

## Evidence
- `WEAVE_DOCS_VENV=build/docs-venv ./gradlew acceptanceContract releaseEvidenceCheck docsCheck`
- Workflow YAML parsed locally and contains `workflow_dispatch`, `schedule`, and `live-stack-e2e` job.

## Notes
- Does not invent or change live credentials/secrets.
- Offline contract behavior remains unchanged.
