### PR TITLE
docs: add v0.1 golden path readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,17 @@ Weave is an accessibility-first, self-hostable organization operating layer for 
 
 Weave is provider-neutral by design: an organization can keep its chosen identity, chat, file, calendar, collaboration, and project systems while exposing them through coherent Weave product concepts. The default dogfood stack can use Keycloak, Matrix, Nextcloud, OpenProject, and LiveKit, but those are adapter/admin/operator choices behind Weave-owned domain contracts, not the member-facing product identity. Provider swaps are governed admin/operator capabilities that ship only when a supported migration contract, readiness evidence, authorization, audit trail, and rollback path exist.
 
-This repository is the single source of truth for the product stack. Treat client, backend, infrastructure, acceptance evidence, documentation, and release metadata as one release unit. The active product-line reference is [Weave product line and Weaver integration plan](docs/product-line-and-weaver-plan.md). Documentation and README release-note embedding are tracked in [Manuals and release notes integration](docs/manuals-and-release-notes-integration.md).
+This repository is the single source of truth for the product stack. Treat client, backend, infrastructure, acceptance evidence, documentation, and release metadata as one release unit. The active product-line reference is [Weave product line and Weaver integration plan](docs/product-line-and-weaver-plan.md). For a fast professional-demo review, start with the [v0.1 Golden Path readiness](docs/v0.1-golden-path.md) page; it summarizes what is ready, admin-setup-required, disabled, degraded, hidden, and evidenced. Documentation and README release-note embedding are tracked in [Manuals and release notes integration](docs/manuals-and-release-notes-integration.md).
+
+## v0.1 Golden Path quick read
+
+- **What it is:** a provider-neutral organization operating layer, not a fixed bundle of provider screens.
+- **Member entry:** organization URL, invite link, or deep link after admin provisioning; no normal-member raw provider setup.
+- **Demo spine:** Weave Home, personal messages, channels/workspaces, chat, files, boards/tasks, calendar, meetings, decisions, and support-safe health impact.
+- **Admin/operator spine:** Workspace/Admin Health for provider categories, readiness, policy, backup/restore, smoke evidence, and support bundles.
+- **Evidence posture:** live E2E is a standard release-evidence path on the dedicated live runner when scheduled/manual, not a solar-budget exception.
+
+See [v0.1 Golden Path readiness](docs/v0.1-golden-path.md) for the concise status map and reviewer checklist.
 
 ## Product architecture
 

--- a/client/test/release_1/v0_1_release_spine_contract_test.dart
+++ b/client/test/release_1/v0_1_release_spine_contract_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('v0.1 release spine', () {
     final plan = File('../docs/release-v0.1-dogfood-plan.md');
+    final goldenPath = File('../docs/v0.1-golden-path.md');
     final productLine = File('../docs/product-line-and-weaver-plan.md');
     final firstUse = File('../docs/admin-provisioned-first-use.md');
     final canonicalModels = File('../docs/canonical-feature-models.md');
@@ -58,6 +59,39 @@ void main() {
         // ignore: avoid_print
         print(marker);
       }
+    });
+
+    test('documents professional demo golden path status', () {
+      expect(goldenPath.existsSync(), isTrue);
+      final markdown = goldenPath.readAsStringSync();
+      final readme = File('../README.md').readAsStringSync();
+
+      for (final required in <String>[
+        'professional demo review contract',
+        'provider-neutral organization operating layer',
+        'organization URL, invite link, or deep link',
+        'personal messages, channels/workspaces, upcoming work, decisions, and health impact',
+        'ready, admin-setup-required, disabled by policy, degraded, or hidden',
+        'Live E2E is standard release evidence on the dedicated self-hosted live runner',
+        'not gated by a solar or power-budget exception',
+        'exactly one release-notes label',
+        'no admin bypass',
+      ]) {
+        expect(markdown, contains(required));
+      }
+
+      for (final required in <String>[
+        'Product positioning',
+        'Weave Home and chat overview',
+        'Workspace/Admin Health',
+        'Governed Weaver runtime',
+        'Operator release path',
+      ]) {
+        expect(markdown, contains(required));
+      }
+
+      expect(readme, contains('v0.1 Golden Path quick read'));
+      expect(readme, contains('docs/v0.1-golden-path.md'));
     });
 
     test('documents provider-category admin foundation before Weaver runtime', () {

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,14 @@ Weave is a provider-neutral organization suite and integration layer for chat, f
 - [Admin/Operator Handbook](admin-operator-handbook.md) for organization setup, provider selection, policies, readiness, audit, infra, and support bundles.
 - [Developer Handbook](developer-handbook.md) and [GitFlow/PR workflow](gitflow-pr-workflow.md) for architecture, canonical models, facades/adapters, testing, release-note labels, release process, and contribution rules.
 - [Diagrams](diagrams/index.md) for Mermaid domain and facade architecture sources.
+- [v0.1 Golden Path readiness](v0.1-golden-path.md) for the professional-demo status map, evidence expectations, and reviewer checklist.
 - [Release Notes](release-notes/index.md) for unreleased notes, v0.1 notes, categories, and operator-impact tracking.
 
 ## Current product truth
 
 The active product direction is [Weave product line and Weaver integration plan](product-line-and-weaver-plan.md): Weave is product-first and provider-neutral. Admin/provider setup, IDM/RBAC, readiness, whitelisting, and support-safe diagnostics come before optional Weaver personal-assistant runtime work.
 
-v0.1 is a dogfood-production release, not a preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets.
+v0.1 is a dogfood-production release, not a preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets. The shortest status summary for reviewers is [v0.1 Golden Path readiness](v0.1-golden-path.md).
 
 ## Documentation stack
 

--- a/docs/v0.1-golden-path.md
+++ b/docs/v0.1-golden-path.md
@@ -1,0 +1,57 @@
+# v0.1 Golden Path readiness
+
+Status: professional demo review contract, source-backed by the monorepo and GitHub evidence.
+
+This page is the shortest review path for a prospective operator or reviewer. It summarizes what Weave v0.1 is, what can be demonstrated, what requires admin/operator setup, and what stays disabled or hidden until evidence exists.
+
+## What Weave is in the demo
+
+Weave is a provider-neutral organization operating layer. Members use Weave-owned product concepts for home, channels, chat, files, calendar, boards/tasks, meetings, decisions, and health. Admins/operators manage provider categories, readiness, policy, and support evidence. Concrete systems such as Keycloak, Matrix, Nextcloud, OpenProject, and LiveKit are current dogfood adapters behind Weave contracts; they are not the member-facing product identity.
+
+The demo order is intentionally:
+
+1. Weave provider-neutral organization suite.
+2. Admin portal, IDM/RBAC, readiness, and whitelisting.
+3. Optional governed Weaver runtime later.
+
+## Golden Path walkthrough
+
+1. A member opens an organization URL, invite link, or deep link after an admin has provisioned the organization.
+2. The member completes SSO and lands in Weave without raw provider setup.
+3. Weave Home communicates recent work, personal messages, channels/workspaces, upcoming work, decisions, and health impact.
+4. The member enters a channel workspace and uses Weave product surfaces: chat, files, boards/tasks, calendar, meetings, decisions, and read-only Weaver scout where policy allows.
+5. Admins/operators use Workspace/Admin Health for readiness, provider-category setup, degraded states, backup/restore, smoke evidence, and support bundles.
+6. Release evidence states whether a capability is ready, admin-setup-required, disabled by policy, degraded, or hidden.
+
+## Demo status map
+
+| Area | v0.1 demo state | Evidence/source |
+| --- | --- | --- |
+| Product positioning | Ready for review | `README.md`, `docs/product-line-and-weaver-plan.md` |
+| Member first entry | Admin-provisioned; no raw provider setup for normal members | `docs/admin-provisioned-first-use.md`, `client/test/release_1/ux_release_copy_contract_test.dart` |
+| Weave Home and chat overview | Ready for member review: favorites, personal messages, channels, and AI/Weaver area boundaries | `client/test/features/chat/chat_screen_test.dart`, `client/test/features/chat/chat_overview_test.dart` |
+| Channel workspace | Ready as a product spine with first-class work tabs and governed Weaver scout copy | `client/test/features/chat/channel_workspace_test.dart`, `e2e/features/v0_1_dogfood_release.feature` |
+| Files | Ready through Weave backend/product routes when the facade is healthy; degraded states stay support-safe | `client/test/release_1/release_golden_paths_test.dart`, live E2E file markers |
+| Calendar, boards/tasks, meetings, decisions | Release-scope surfaces with capability gates; user-visible behavior must stay ready, disabled, degraded, policy-blocked, or hidden according to evidence | `docs/release-v0.1-dogfood-plan.md`, `e2e/scenario_mappings.json` |
+| Workspace/Admin Health | Admin/operator readiness control plane; provider diagnostics stay out of member paths | `docs/admin-operator-handbook.md`, `client/test/features/settings/settings_screen_test.dart` |
+| Governed Weaver runtime | Disabled by default; read-only/proposal-first scout copy only where evidenced | `server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java`, `docs/product-line-and-weaver-plan.md` |
+| Operator release path | Install, update, backup, restore smoke, support bundle, and live E2E are release evidence paths | `infra/docs/operator-runbook.md`, `release/weave-stack.yaml`, GitHub Actions |
+
+## Release evidence expectations
+
+- Root Gradle remains the delivery orchestrator: `./gradlew acceptanceContract`, `./gradlew clientCi`, `./gradlew serverCi`, `./gradlew infraStatic`, or `./gradlew ci` for cross-stack changes.
+- Product-language Gherkin in `e2e/features/` must stay mapped in `e2e/scenario_mappings.json` to executable or documented evidence.
+- Live E2E is standard release evidence on the dedicated self-hosted live runner for scheduled/manual runs. It is not gated by a solar or power-budget exception; only concrete infrastructure blockers count.
+- Evidence artifacts must be sanitized: no secrets, tokens, cookies, private keys, credential-bearing URLs, raw provider bodies, or full private live logs.
+- A PR is not review-ready unless it has exactly one release-notes label, a filled evidence section, green required CI, resolved conversations, and no admin bypass.
+
+## Reviewer checklist
+
+A professional v0.1 demo is acceptable when a reviewer can answer yes to these questions from repo/CI evidence:
+
+- Does the README say what Weave is without making it a fixed provider bundle?
+- Can a normal member start from organization entry/SSO and avoid provider setup?
+- Does Home lead to useful daily work instead of roadmap or scaffold copy?
+- Are admin/operator readiness states actionable and support-safe?
+- Are disabled, degraded, hidden, and admin-setup-required capabilities honest?
+- Is live E2E treated as a normal release-evidence path when the live runner is available?

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -111,6 +111,13 @@
             "Upcoming events/meetings",
             "Recent decisions"
           ]
+        },
+        {
+          "path": "docs/v0.1-golden-path.md",
+          "fragments": [
+            "Weave Home communicates recent work, personal messages, channels/workspaces, upcoming work, decisions, and health impact.",
+            "Release evidence states whether a capability is ready, admin-setup-required, disabled by policy, degraded, or hidden."
+          ]
         }
       ]
     },
@@ -136,6 +143,13 @@
           "fragments": [
             "keeps provider diagnostics admin-only for members",
             "Provider stack readiness"
+          ]
+        },
+        {
+          "path": "docs/v0.1-golden-path.md",
+          "fragments": [
+            "A member opens an organization URL, invite link, or deep link after an admin has provisioned the organization.",
+            "The member completes SSO and lands in Weave without raw provider setup."
           ]
         }
       ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
       - Product line and Weaver plan: product-line-and-weaver-plan.md
       - Manuals and release notes integration: manuals-and-release-notes-integration.md
       - v0.1 dogfood plan: release-v0.1-dogfood-plan.md
+      - v0.1 Golden Path readiness: v0.1-golden-path.md
       - Admin-provisioned first use: admin-provisioned-first-use.md
       - Product acceptance flows: product-acceptance-flows.md
       - Product flow activity diagrams: product-flow-activity-diagrams.md


### PR DESCRIPTION
## Scope

Adds a concise v0.1 Golden Path readiness page for professional demo review and links it from README/docs navigation.

## User/operator/developer impact

- Prospective operators/reviewers get a short status map before reading detailed engineering docs.
- The page states member entry, admin/operator readiness, capability states, live E2E evidence policy, sanitized evidence expectations, and PR readiness constraints.
- Acceptance mapping now references the Golden Path page for the Home daily loop and user-ready organization flow.

## Evidence

- `./gradlew acceptanceContract docsCheck`
- `flutter test test/release_1/v0_1_release_spine_contract_test.dart`

## Review notes

Copilot unavailable due premium request exhaustion; fallback agent review + green CI required.

## Risks / boundaries

- Documentation and contract-test only; no runtime behavior changes.
- Exactly one release-notes label required: `release-notes-feature`.
- No admin bypass.
