### PR TITLE
feat: identity org bootstrap foundation

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
@@ -76,11 +76,19 @@ public class SecurityConfig {
             authorities.addAll(scopeAuthorities);
         }
 
-        for (String role : extractRealmRoles(jwt)) {
+        for (String role : extractRoles(jwt)) {
             authorities.add(new SimpleGrantedAuthority("ROLE_" + normalizeAuthoritySegment(role)));
         }
 
         return List.copyOf(authorities);
+    }
+
+    private List<String> extractRoles(Jwt jwt) {
+        LinkedHashSet<String> roles = new LinkedHashSet<>();
+        roles.addAll(extractStringClaims(jwt, "roles"));
+        roles.addAll(extractRealmRoles(jwt));
+        roles.addAll(extractClientRoles(jwt));
+        return List.copyOf(roles);
     }
 
     private List<String> extractRealmRoles(Jwt jwt) {
@@ -95,6 +103,44 @@ public class SecurityConfig {
         }
 
         return roleValues.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .map(String::trim)
+                .filter(role -> !role.isEmpty())
+                .toList();
+    }
+
+    private List<String> extractClientRoles(Jwt jwt) {
+        Map<String, Object> resourceAccess = jwt.getClaimAsMap("resource_access");
+        if (resourceAccess == null) {
+            return List.of();
+        }
+
+        for (String client : new String[] {"weave", "weave-app", jwt.getClaimAsString("azp"), jwt.getClaimAsString("client_id")}) {
+            if (client == null || client.isBlank() || !(resourceAccess.get(client) instanceof Map<?, ?> clientAccess)) {
+                continue;
+            }
+            Object roles = clientAccess.get("roles");
+            if (roles instanceof Collection<?> roleValues) {
+                return stringValues(roleValues);
+            }
+        }
+        return List.of();
+    }
+
+    private List<String> extractStringClaims(Jwt jwt, String claimName) {
+        Object claim = jwt.getClaims().get(claimName);
+        if (claim instanceof String value) {
+            return value.isBlank() ? List.of() : List.of(value.trim());
+        }
+        if (claim instanceof Collection<?> values) {
+            return stringValues(values);
+        }
+        return List.of();
+    }
+
+    private List<String> stringValues(Collection<?> values) {
+        return values.stream()
                 .filter(String.class::isInstance)
                 .map(String.class::cast)
                 .map(String::trim)

--- a/server/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
 
     private List<String> extractRoles(Jwt jwt) {
         LinkedHashSet<String> roles = new LinkedHashSet<>();
+        roles.addAll(extractStringClaims(jwt, "weave_roles"));
         roles.addAll(extractStringClaims(jwt, "roles"));
         roles.addAll(extractRealmRoles(jwt));
         roles.addAll(extractClientRoles(jwt));

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -6,6 +6,8 @@ import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
+import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
+import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
@@ -71,6 +73,17 @@ public class AdminControlPlaneController {
             content = @Content(schema = @Schema(implementation = EffectivePolicyResponse.class)))
     public EffectivePolicyResponse effectivePolicy(@AuthenticationPrincipal Jwt jwt) {
         return adminControlPlaneService.effectivePolicy(jwt);
+    }
+
+    @PostMapping({"/api/admin/organizations/bootstrap", "/api/v1/admin/organizations/bootstrap"})
+    @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
+    @Operation(summary = "Bootstrap or bind an organization with immutable identity recovery administrators")
+    @ApiResponse(responseCode = "200", description = "Support-safe organization bootstrap result.",
+            content = @Content(schema = @Schema(implementation = OrganizationBootstrapResponse.class)))
+    public OrganizationBootstrapResponse bootstrapOrganization(
+            @Valid @RequestBody OrganizationBootstrapRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.bootstrapOrganization(request, jwt);
     }
 
     @PatchMapping({"/api/admin/policies/capability-whitelist", "/api/v1/admin/policies/capability-whitelist"})

--- a/server/src/main/java/com/massimotter/weave/backend/model/AuthenticatedUserResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/AuthenticatedUserResponse.java
@@ -5,13 +5,13 @@ import java.util.List;
 
 @Schema(description = "Canonical Weave identity and product profile snapshot for the authenticated user.")
 public record AuthenticatedUserResponse(
-        @Schema(description = "Stable immutable Weave user identifier, backed by the Keycloak subject.")
+        @Schema(description = "Stable immutable Weave account identifier derived from issuer plus subject, never from email.")
         String userId,
         @Schema(description = "Stable login/workspace handle.")
         String username,
-        @Schema(description = "Verified email address when available.")
+        @Schema(description = "Verified email address when available; never the primary identity key.")
         String email,
-        @Schema(description = "Whether Keycloak reports the email address as verified.")
+        @Schema(description = "Whether the identity source reports the email address as verified.")
         boolean emailVerified,
         @Schema(description = "User-visible product display name.")
         String displayName,
@@ -19,7 +19,7 @@ public record AuthenticatedUserResponse(
         String locale,
         @Schema(description = "Preferred timezone.")
         String timezone,
-        @Schema(description = "MVP product roles.")
+        @Schema(description = "Canonical Weave organization roles mapped from identity-source claims.")
         List<String> roles,
         @Schema(description = "Workspace or module groups.")
         List<String> groups,
@@ -27,8 +27,22 @@ public record AuthenticatedUserResponse(
         String issuedFor,
         @Schema(description = "Token audience values.")
         List<String> audience,
-        @Schema(description = "Raw realm roles from Keycloak.")
-        List<String> realmRoles,
+        @Schema(description = "Organization identifier in Weave policy space.")
+        String organizationId,
+        @Schema(description = "Identity source issuer used to form the immutable primary identity key.")
+        String identityIssuer,
+        @Schema(description = "Identity source subject used to form the immutable primary identity key.")
+        String subject,
+        @Schema(description = "Documented immutable primary identity key: issuer plus subject.")
+        String primaryIdentityKey,
+        @Schema(description = "Support-safe account id derived from the primary identity key.")
+        String accountId,
+        @Schema(description = "Context-local roles for the current organization/session.")
+        List<String> contextRoles,
+        @Schema(description = "Support-safe role/group claim mapping evidence.")
+        List<String> providerRoleMappings,
+        @Schema(description = "Always false: email is an attribute, not the primary key.")
+        boolean emailPrimaryKey,
         @Schema(description = "Product profile sync status by module.")
         ModuleSyncStatusResponse moduleSyncStatus) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/IdentityKeyFormat.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/IdentityKeyFormat.java
@@ -1,0 +1,12 @@
+package com.massimotter.weave.backend.model;
+
+public final class IdentityKeyFormat {
+
+    public static final int MAX_ISSUER_LENGTH = 384;
+    public static final int MAX_SUBJECT_LENGTH = 128;
+    public static final int MAX_PRIMARY_IDENTITY_KEY_LENGTH = 528;
+    public static final String PRIMARY_IDENTITY_KEY_PATTERN = "issuer\\+subject:[^#\\s]{1,384}#[^#\\s]{1,128}";
+
+    private IdentityKeyFormat() {
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/ProductProfileResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/ProductProfileResponse.java
@@ -5,13 +5,13 @@ import java.util.Map;
 
 @Schema(description = "Product profile facade data for the authenticated Weave user.")
 public record ProductProfileResponse(
-        @Schema(description = "Stable immutable Weave user identifier, backed by the Keycloak subject.")
+        @Schema(description = "Stable immutable Weave account identifier derived from issuer plus subject, never from email.")
         String userId,
         @Schema(description = "Stable login/workspace handle.")
         String username,
         @Schema(description = "Email address from the identity authority when available.")
         String email,
-        @Schema(description = "Whether Keycloak reports the email address as verified.")
+        @Schema(description = "Whether the identity source reports the email address as verified.")
         boolean emailVerified,
         @Schema(description = "User-visible product display name.")
         String displayName,

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static com.massimotter.weave.backend.model.IdentityKeyFormat.MAX_PRIMARY_IDENTITY_KEY_LENGTH;
@@ -25,6 +27,6 @@ public record OrganizationBootstrapRequest(
         String reason) {
 
     public OrganizationBootstrapRequest {
-        adminSubjectKeys = adminSubjectKeys == null ? List.of() : List.copyOf(adminSubjectKeys);
+        adminSubjectKeys = adminSubjectKeys == null ? List.of() : Collections.unmodifiableList(new ArrayList<>(adminSubjectKeys));
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
@@ -15,7 +15,7 @@ public record OrganizationBootstrapRequest(
         String bootstrapMode,
         @Schema(description = "Immutable issuer+subject keys that retain owner/admin recovery access after bootstrap.")
         @Size(max = 25)
-        List<@NotBlank @Size(max = 512) @Pattern(
+        List<@NotBlank @Size(max = 528) @Pattern(
                 regexp = "issuer\\+subject:[^#\\s]{1,384}#[^#\\s]{1,128}",
                 message = "must be a support-safe issuer+subject key") String> adminSubjectKeys,
         @Schema(description = "Support-safe reason recorded in audit.")

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
+import static com.massimotter.weave.backend.model.IdentityKeyFormat.MAX_PRIMARY_IDENTITY_KEY_LENGTH;
+import static com.massimotter.weave.backend.model.IdentityKeyFormat.PRIMARY_IDENTITY_KEY_PATTERN;
+
 @Schema(description = "Admin-owned first-use organization bootstrap contract for existing or newly provisioned organizations.")
 public record OrganizationBootstrapRequest(
         @NotBlank
@@ -15,8 +18,8 @@ public record OrganizationBootstrapRequest(
         String bootstrapMode,
         @Schema(description = "Immutable issuer+subject keys that retain owner/admin recovery access after bootstrap.")
         @Size(max = 25)
-        List<@NotBlank @Size(max = 528) @Pattern(
-                regexp = "issuer\\+subject:[^#\\s]{1,384}#[^#\\s]{1,128}",
+        List<@NotBlank @Size(max = MAX_PRIMARY_IDENTITY_KEY_LENGTH) @Pattern(
+                regexp = PRIMARY_IDENTITY_KEY_PATTERN,
                 message = "must be a support-safe issuer+subject key") String> adminSubjectKeys,
         @Schema(description = "Support-safe reason recorded in audit.")
         String reason) {

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
@@ -2,6 +2,8 @@ package com.massimotter.weave.backend.model.admin;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 @Schema(description = "Admin-owned first-use organization bootstrap contract for existing or newly provisioned organizations.")
@@ -12,7 +14,8 @@ public record OrganizationBootstrapRequest(
         @Schema(description = "Existing organization binds an already-owned tenant; new organization provisions initial policy.")
         String bootstrapMode,
         @Schema(description = "Immutable issuer+subject keys that retain owner/admin recovery access after bootstrap.")
-        List<String> adminSubjectKeys,
+        @Size(max = 25)
+        List<@NotBlank @Size(max = 512) @Pattern(regexp = "issuer\\+subject:[A-Za-z][A-Za-z0-9+.-]*://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9._~:/-]*)?#[A-Za-z0-9._:-]{1,128}") String> adminSubjectKeys,
         @Schema(description = "Support-safe reason recorded in audit.")
         String reason) {
 

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
@@ -15,7 +15,9 @@ public record OrganizationBootstrapRequest(
         String bootstrapMode,
         @Schema(description = "Immutable issuer+subject keys that retain owner/admin recovery access after bootstrap.")
         @Size(max = 25)
-        List<@NotBlank @Size(max = 512) @Pattern(regexp = "issuer\\+subject:[A-Za-z][A-Za-z0-9+.-]*://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9._~:/-]*)?#[A-Za-z0-9._:-]{1,128}") String> adminSubjectKeys,
+        List<@NotBlank @Size(max = 512) @Pattern(
+                regexp = "issuer\\+subject:[^#\\s]{1,384}#[^#\\s]{1,128}",
+                message = "must be a support-safe issuer+subject key") String> adminSubjectKeys,
         @Schema(description = "Support-safe reason recorded in audit.")
         String reason) {
 

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
@@ -22,11 +22,11 @@ public record OrganizationBootstrapRequest(
         @Size(max = 25)
         List<@NotBlank @Size(max = MAX_PRIMARY_IDENTITY_KEY_LENGTH) @Pattern(
                 regexp = PRIMARY_IDENTITY_KEY_PATTERN,
-                message = "must be a support-safe issuer+subject key") String> adminSubjectKeys,
+                message = "must be a support-safe issuer+subject key") String> adminPrimaryIdentityKeys,
         @Schema(description = "Support-safe reason recorded in audit.")
         String reason) {
 
     public OrganizationBootstrapRequest {
-        adminSubjectKeys = adminSubjectKeys == null ? List.of() : Collections.unmodifiableList(new ArrayList<>(adminSubjectKeys));
+        adminPrimaryIdentityKeys = adminPrimaryIdentityKeys == null ? List.of() : Collections.unmodifiableList(new ArrayList<>(adminPrimaryIdentityKeys));
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapRequest.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+@Schema(description = "Admin-owned first-use organization bootstrap contract for existing or newly provisioned organizations.")
+public record OrganizationBootstrapRequest(
+        @NotBlank
+        @Schema(description = "Weave organization id to bootstrap or bind.", example = "acme-prod")
+        String organizationId,
+        @Schema(description = "Existing organization binds an already-owned tenant; new organization provisions initial policy.")
+        String bootstrapMode,
+        @Schema(description = "Immutable issuer+subject keys that retain owner/admin recovery access after bootstrap.")
+        List<String> adminSubjectKeys,
+        @Schema(description = "Support-safe reason recorded in audit.")
+        String reason) {
+
+    public OrganizationBootstrapRequest {
+        adminSubjectKeys = adminSubjectKeys == null ? List.of() : List.copyOf(adminSubjectKeys);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapResponse.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+
+@Schema(description = "Support-safe organization bootstrap result.")
+public record OrganizationBootstrapResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String organizationId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String bootstrapMode,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String actorPrimaryIdentityKey,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> retainedAdminSubjectKeys,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean lastAdminGuardPassed,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean supportSafe,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Instant bootstrappedAt,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> auditRefs) {
+
+    public OrganizationBootstrapResponse {
+        retainedAdminSubjectKeys = retainedAdminSubjectKeys == null ? List.of() : List.copyOf(retainedAdminSubjectKeys);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/OrganizationBootstrapResponse.java
@@ -9,14 +9,14 @@ public record OrganizationBootstrapResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String organizationId,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String bootstrapMode,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String actorPrimaryIdentityKey,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> retainedAdminSubjectKeys,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> retainedAdminPrimaryIdentityKeys,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean lastAdminGuardPassed,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean supportSafe,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Instant bootstrappedAt,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) List<String> auditRefs) {
 
     public OrganizationBootstrapResponse {
-        retainedAdminSubjectKeys = retainedAdminSubjectKeys == null ? List.of() : List.copyOf(retainedAdminSubjectKeys);
+        retainedAdminPrimaryIdentityKeys = retainedAdminPrimaryIdentityKeys == null ? List.of() : List.copyOf(retainedAdminPrimaryIdentityKeys);
         auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -47,6 +47,10 @@ public class AdminControlPlaneService {
             "disabled",
             "degraded",
             "policy-blocked");
+    private static final int MAX_BOOTSTRAP_ADMIN_KEYS = 25;
+    private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = 512;
+    private static final String PRIMARY_IDENTITY_KEY_PATTERN =
+            "issuer\\+subject:[A-Za-z][A-Za-z0-9+.-]*://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9._~:/-]*)?#[A-Za-z0-9._:-]{1,128}";
 
     private final ProviderRegistry providerRegistry;
     private final WorkspaceCapabilityService workspaceCapabilityService;
@@ -339,7 +343,7 @@ public class AdminControlPlaneService {
             return;
         }
         List<String> capabilities = safeCapabilities(request.capabilityKeys());
-        if (capabilities.isEmpty() || capabilities.contains("admin.policy.edit")) {
+        if (capabilities.contains("admin.policy.edit")) {
             return;
         }
         throw new ApiErrorException(
@@ -386,6 +390,17 @@ public class AdminControlPlaneService {
                 .distinct()
                 .sorted()
                 .toList();
+        if (retained.size() > MAX_BOOTSTRAP_ADMIN_KEYS || retained.stream().anyMatch(this::unsafeBootstrapAdminKey)) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "organization-bootstrap-admin-key-invalid",
+                    "Organization bootstrap admin keys must be support-safe immutable issuer+subject keys.",
+                    Map.of(
+                            "requiredFormat", "issuer+subject:<issuer>#<subject>",
+                            "maxCount", MAX_BOOTSTRAP_ADMIN_KEYS,
+                            "maxLength", MAX_BOOTSTRAP_ADMIN_KEY_LENGTH,
+                            "supportSafe", true));
+        }
         if (!retained.contains(actorPrimaryIdentityKey)) {
             throw new ApiErrorException(
                     HttpStatus.BAD_REQUEST,
@@ -394,6 +409,10 @@ public class AdminControlPlaneService {
                     Map.of("supportSafe", true));
         }
         return retained;
+    }
+
+    private boolean unsafeBootstrapAdminKey(String value) {
+        return value.length() > MAX_BOOTSTRAP_ADMIN_KEY_LENGTH || !value.matches(PRIMARY_IDENTITY_KEY_PATTERN);
     }
 
     private boolean providerMatchesCategory(String providerKey, String category) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -39,6 +39,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
+import static com.massimotter.weave.backend.model.IdentityKeyFormat.MAX_PRIMARY_IDENTITY_KEY_LENGTH;
+import static com.massimotter.weave.backend.model.IdentityKeyFormat.PRIMARY_IDENTITY_KEY_PATTERN;
+
 @Service
 public class AdminControlPlaneService {
 
@@ -48,9 +51,7 @@ public class AdminControlPlaneService {
             "degraded",
             "policy-blocked");
     private static final int MAX_BOOTSTRAP_ADMIN_KEYS = 25;
-    private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = 528;
-    private static final String PRIMARY_IDENTITY_KEY_PATTERN =
-            "issuer\\+subject:[^#\\s]{1,384}#[^#\\s]{1,128}";
+    private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = MAX_PRIMARY_IDENTITY_KEY_LENGTH;
 
     private final ProviderRegistry providerRegistry;
     private final WorkspaceCapabilityService workspaceCapabilityService;
@@ -358,7 +359,7 @@ public class AdminControlPlaneService {
 
     private String safeOrganizationId(String value) {
         String trimmed = value.trim().toLowerCase(Locale.ROOT);
-        if (!trimmed.matches("[a-z0-9][a-z0-9-]{1,62}")) {
+        if (!trimmed.matches("[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")) {
             throw new ApiErrorException(
                     HttpStatus.BAD_REQUEST,
                     "organization-id-invalid",
@@ -384,13 +385,14 @@ public class AdminControlPlaneService {
     }
 
     private List<String> retainedAdminSubjectKeys(List<String> suppliedKeys, String actorPrimaryIdentityKey) {
-        List<String> retained = Stream.concat(suppliedKeys.stream(), Stream.of(actorPrimaryIdentityKey))
+        List<String> supplied = suppliedKeys == null ? List.of() : suppliedKeys;
+        List<String> retained = Stream.concat(supplied.stream(), Stream.of(actorPrimaryIdentityKey))
                 .filter(value -> value != null && !value.isBlank())
                 .map(String::trim)
                 .distinct()
                 .sorted()
                 .toList();
-        if (suppliedKeys.size() > MAX_BOOTSTRAP_ADMIN_KEYS || retained.stream().anyMatch(this::unsafeBootstrapAdminKey)) {
+        if (supplied.size() > MAX_BOOTSTRAP_ADMIN_KEYS || retained.stream().anyMatch(this::unsafeBootstrapAdminKey)) {
             throw new ApiErrorException(
                     HttpStatus.BAD_REQUEST,
                     "organization-bootstrap-admin-key-invalid",

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -171,6 +171,7 @@ public class AdminControlPlaneService {
                     "Capability whitelist update requires a profile key.",
                     Map.of("reason", "profileKey is required"));
         }
+        String profileKey = request.profileKey().trim().toLowerCase(Locale.ROOT);
         enforceLastAdminGuard(request);
         auditEventPublisher.publish(new AuditEvent(
                 organizationId(jwt),
@@ -182,7 +183,7 @@ public class AdminControlPlaneService {
                 "admin-policy-" + Instant.now(clock).toEpochMilli(),
                 AuditRedactionLevel.SECRET_REDACTED,
                 Map.of(
-                        "profileKey", request.profileKey().trim(),
+                        "profileKey", profileKey,
                         "capabilityKeys", safeCapabilities(request.capabilityKeys()),
                         "reason", safeText(request.reason()),
                         "denyByDefault", true,
@@ -340,7 +341,7 @@ public class AdminControlPlaneService {
     }
 
     private void enforceLastAdminGuard(CapabilityWhitelistUpdateRequest request) {
-        if (!"workspace-admin".equals(request.profileKey().trim())) {
+        if (!"workspace-admin".equals(request.profileKey().trim().toLowerCase(Locale.ROOT))) {
             return;
         }
         List<String> capabilities = safeCapabilities(request.capabilityKeys());

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -52,6 +53,7 @@ public class AdminControlPlaneService {
             "policy-blocked");
     private static final int MAX_BOOTSTRAP_ADMIN_KEYS = 25;
     private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = MAX_PRIMARY_IDENTITY_KEY_LENGTH;
+    private static final Pattern PRIMARY_IDENTITY_KEY_REGEX = Pattern.compile(PRIMARY_IDENTITY_KEY_PATTERN);
 
     private final ProviderRegistry providerRegistry;
     private final WorkspaceCapabilityService workspaceCapabilityService;
@@ -415,7 +417,7 @@ public class AdminControlPlaneService {
     }
 
     private boolean unsafeBootstrapAdminKey(String value) {
-        return value.length() > MAX_BOOTSTRAP_ADMIN_KEY_LENGTH || !value.matches(PRIMARY_IDENTITY_KEY_PATTERN);
+        return value.length() > MAX_BOOTSTRAP_ADMIN_KEY_LENGTH || !PRIMARY_IDENTITY_KEY_REGEX.matcher(value).matches();
     }
 
     private boolean providerMatchesCategory(String providerKey, String category) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -48,7 +48,7 @@ public class AdminControlPlaneService {
             "degraded",
             "policy-blocked");
     private static final int MAX_BOOTSTRAP_ADMIN_KEYS = 25;
-    private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = 512;
+    private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = 528;
     private static final String PRIMARY_IDENTITY_KEY_PATTERN =
             "issuer\\+subject:[^#\\s]{1,384}#[^#\\s]{1,128}";
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -390,14 +390,14 @@ public class AdminControlPlaneService {
                 .distinct()
                 .sorted()
                 .toList();
-        if (retained.size() > MAX_BOOTSTRAP_ADMIN_KEYS || retained.stream().anyMatch(this::unsafeBootstrapAdminKey)) {
+        if (suppliedKeys.size() > MAX_BOOTSTRAP_ADMIN_KEYS || retained.stream().anyMatch(this::unsafeBootstrapAdminKey)) {
             throw new ApiErrorException(
                     HttpStatus.BAD_REQUEST,
                     "organization-bootstrap-admin-key-invalid",
                     "Organization bootstrap admin keys must be support-safe immutable issuer+subject keys.",
                     Map.of(
                             "requiredFormat", "issuer+subject:<issuer>#<subject>",
-                            "maxCount", MAX_BOOTSTRAP_ADMIN_KEYS,
+                            "maxSuppliedCount", MAX_BOOTSTRAP_ADMIN_KEYS,
                             "maxLength", MAX_BOOTSTRAP_ADMIN_KEY_LENGTH,
                             "supportSafe", true));
         }

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -58,6 +58,7 @@ public class AdminControlPlaneService {
     private final ProviderRegistry providerRegistry;
     private final WorkspaceCapabilityService workspaceCapabilityService;
     private final ProviderSelectionRepository providerSelectionRepository;
+    private final OrganizationBootstrapRepository organizationBootstrapRepository;
     private final AuditEventPublisher auditEventPublisher;
     private final Clock clock;
 
@@ -66,19 +67,22 @@ public class AdminControlPlaneService {
             ProviderRegistry providerRegistry,
             WorkspaceCapabilityService workspaceCapabilityService,
             ProviderSelectionRepository providerSelectionRepository,
+            OrganizationBootstrapRepository organizationBootstrapRepository,
             AuditEventPublisher auditEventPublisher) {
-        this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, auditEventPublisher, Clock.systemUTC());
+        this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher, Clock.systemUTC());
     }
 
     AdminControlPlaneService(
             ProviderRegistry providerRegistry,
             WorkspaceCapabilityService workspaceCapabilityService,
             ProviderSelectionRepository providerSelectionRepository,
+            OrganizationBootstrapRepository organizationBootstrapRepository,
             AuditEventPublisher auditEventPublisher,
             Clock clock) {
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
         this.providerSelectionRepository = providerSelectionRepository;
+        this.organizationBootstrapRepository = organizationBootstrapRepository;
         this.auditEventPublisher = auditEventPublisher;
         this.clock = clock;
     }
@@ -206,32 +210,39 @@ public class AdminControlPlaneService {
         String organizationId = safeOrganizationId(request.organizationId());
         String bootstrapMode = bootstrapMode(request.bootstrapMode());
         List<String> retainedAdmins = retainedAdminSubjectKeys(request.adminSubjectKeys(), identity.primaryIdentityKey());
-        String auditRef = "organization-bootstrap-" + organizationId + "-" + Instant.now(clock).toEpochMilli();
-        auditEventPublisher.publish(new AuditEvent(
+        Instant bootstrappedAt = Instant.now(clock);
+        OrganizationBootstrapRecord record = organizationBootstrapRepository.save(new OrganizationBootstrapRecord(
                 organizationId,
+                bootstrapMode,
+                identity.primaryIdentityKey(),
+                retainedAdmins,
+                bootstrappedAt));
+        String auditRef = "organization-bootstrap-" + record.organizationId() + "-" + bootstrappedAt.toEpochMilli();
+        auditEventPublisher.publish(new AuditEvent(
+                record.organizationId(),
                 "admin-control-plane",
                 actorRef(jwt),
                 "organization-bootstrap",
                 AuditAction.ADMIN_POLICY_UPDATED,
-                Instant.now(clock),
+                bootstrappedAt,
                 auditRef,
                 AuditRedactionLevel.SECRET_REDACTED,
                 Map.of(
-                        "bootstrapMode", bootstrapMode,
-                        "actorPrimaryIdentityKey", identity.primaryIdentityKey(),
-                        "retainedAdminSubjectKeyCount", retainedAdmins.size(),
+                        "bootstrapMode", record.bootstrapMode(),
+                        "actorPrimaryIdentityKey", record.actorPrimaryIdentityKey(),
+                        "retainedAdminSubjectKeyCount", record.retainedAdminSubjectKeys().size(),
                         "lastAdminGuardPassed", true,
                         "supportSafe", true,
                         "emailPrimaryKey", false,
                         "reason", safeText(request.reason()))));
         return new OrganizationBootstrapResponse(
-                organizationId,
-                bootstrapMode,
-                identity.primaryIdentityKey(),
-                retainedAdmins,
+                record.organizationId(),
+                record.bootstrapMode(),
+                record.actorPrimaryIdentityKey(),
+                record.retainedAdminSubjectKeys(),
                 true,
                 true,
-                Instant.now(clock),
+                record.bootstrappedAt(),
                 List.of(auditRef));
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -50,7 +50,7 @@ public class AdminControlPlaneService {
     private static final int MAX_BOOTSTRAP_ADMIN_KEYS = 25;
     private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = 512;
     private static final String PRIMARY_IDENTITY_KEY_PATTERN =
-            "issuer\\+subject:[A-Za-z][A-Za-z0-9+.-]*://[A-Za-z0-9.-]+(?::[0-9]+)?(?:/[A-Za-z0-9._~:/-]*)?#[A-Za-z0-9._:-]{1,128}";
+            "issuer\\+subject:[^#\\s]{1,384}#[^#\\s]{1,128}";
 
     private final ProviderRegistry providerRegistry;
     private final WorkspaceCapabilityService workspaceCapabilityService;

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -12,6 +12,8 @@ import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
+import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
+import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -79,7 +82,7 @@ public class AdminControlPlaneService {
                 "admin-control-plane-v1",
                 organizationId(jwt),
                 organizationName(jwt),
-                "keycloak",
+                "OIDC/SAML selected IDM",
                 registry.providerConfigSource(),
                 registry.bootstrapDefaultsAreSuggestionsOnly(),
                 registry.backendOwnedFacades(),
@@ -163,6 +166,7 @@ public class AdminControlPlaneService {
                     "Capability whitelist update requires a profile key.",
                     Map.of("reason", "profileKey is required"));
         }
+        enforceLastAdminGuard(request);
         auditEventPublisher.publish(new AuditEvent(
                 organizationId(jwt),
                 "admin-control-plane",
@@ -180,6 +184,47 @@ public class AdminControlPlaneService {
                         "rawProviderError", "redacted before audit",
                         "token", "not-stored")));
         return whitelist(jwt);
+    }
+
+    public OrganizationBootstrapResponse bootstrapOrganization(OrganizationBootstrapRequest request, Jwt jwt) {
+        OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
+        if (request == null || request.organizationId() == null || request.organizationId().isBlank()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "organization-bootstrap-invalid",
+                    "Organization bootstrap requires an organization id.",
+                    Map.of("reason", "organizationId is required"));
+        }
+        String organizationId = safeOrganizationId(request.organizationId());
+        String bootstrapMode = bootstrapMode(request.bootstrapMode());
+        List<String> retainedAdmins = retainedAdminSubjectKeys(request.adminSubjectKeys(), identity.primaryIdentityKey());
+        String auditRef = "organization-bootstrap-" + organizationId + "-" + Instant.now(clock).toEpochMilli();
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId,
+                "admin-control-plane",
+                actorRef(jwt),
+                "organization-bootstrap",
+                AuditAction.ADMIN_POLICY_UPDATED,
+                Instant.now(clock),
+                auditRef,
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.of(
+                        "bootstrapMode", bootstrapMode,
+                        "actorPrimaryIdentityKey", identity.primaryIdentityKey(),
+                        "retainedAdminSubjectKeyCount", retainedAdmins.size(),
+                        "lastAdminGuardPassed", true,
+                        "supportSafe", true,
+                        "emailPrimaryKey", false,
+                        "reason", safeText(request.reason()))));
+        return new OrganizationBootstrapResponse(
+                organizationId,
+                bootstrapMode,
+                identity.primaryIdentityKey(),
+                retainedAdmins,
+                true,
+                true,
+                Instant.now(clock),
+                List.of(auditRef));
     }
 
     public ProviderReadinessTestResponse testProviderReadiness(ProviderReadinessTestRequest request, Jwt jwt) {
@@ -287,6 +332,68 @@ public class AdminControlPlaneService {
                 true,
                 requiresMigrationDryRun(request),
                 safeLossyMappingNotes(request.lossyMappingNotes()));
+    }
+
+    private void enforceLastAdminGuard(CapabilityWhitelistUpdateRequest request) {
+        if (!"workspace-admin".equals(request.profileKey().trim())) {
+            return;
+        }
+        List<String> capabilities = safeCapabilities(request.capabilityKeys());
+        if (capabilities.isEmpty() || capabilities.contains("admin.policy.edit")) {
+            return;
+        }
+        throw new ApiErrorException(
+                HttpStatus.BAD_REQUEST,
+                "last-admin-guard",
+                "Workspace admin policy updates must retain at least one admin policy editor.",
+                Map.of(
+                        "profileKey", "workspace-admin",
+                        "requiredCapability", "admin.policy.edit",
+                        "supportSafe", true));
+    }
+
+    private String safeOrganizationId(String value) {
+        String trimmed = value.trim().toLowerCase(Locale.ROOT);
+        if (!trimmed.matches("[a-z0-9][a-z0-9-]{1,62}")) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "organization-id-invalid",
+                    "Organization id must be a support-safe slug.",
+                    Map.of("organizationId", "invalid-organization-id-redacted"));
+        }
+        return trimmed;
+    }
+
+    private String bootstrapMode(String value) {
+        if (value == null || value.isBlank()) {
+            return "existing_org";
+        }
+        String trimmed = value.trim();
+        if (trimmed.equals("existing_org") || trimmed.equals("new_org")) {
+            return trimmed;
+        }
+        throw new ApiErrorException(
+                HttpStatus.BAD_REQUEST,
+                "organization-bootstrap-mode-invalid",
+                "Organization bootstrap mode must be existing_org or new_org.",
+                Map.of("bootstrapMode", "invalid-bootstrap-mode-redacted"));
+    }
+
+    private List<String> retainedAdminSubjectKeys(List<String> suppliedKeys, String actorPrimaryIdentityKey) {
+        List<String> retained = Stream.concat(suppliedKeys.stream(), Stream.of(actorPrimaryIdentityKey))
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .distinct()
+                .sorted()
+                .toList();
+        if (!retained.contains(actorPrimaryIdentityKey)) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "last-admin-guard",
+                    "Organization bootstrap must retain the current owner/admin as a recovery administrator.",
+                    Map.of("supportSafe", true));
+        }
+        return retained;
     }
 
     private boolean providerMatchesCategory(String providerKey, String category) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -209,7 +209,7 @@ public class AdminControlPlaneService {
         }
         String organizationId = safeOrganizationId(request.organizationId());
         String bootstrapMode = bootstrapMode(request.bootstrapMode());
-        List<String> retainedAdmins = retainedAdminSubjectKeys(request.adminSubjectKeys(), identity.primaryIdentityKey());
+        List<String> retainedAdmins = retainedAdminPrimaryIdentityKeys(request.adminPrimaryIdentityKeys(), identity.primaryIdentityKey());
         Instant bootstrappedAt = Instant.now(clock);
         OrganizationBootstrapRecord record = organizationBootstrapRepository.save(new OrganizationBootstrapRecord(
                 organizationId,
@@ -230,7 +230,7 @@ public class AdminControlPlaneService {
                 Map.of(
                         "bootstrapMode", record.bootstrapMode(),
                         "actorPrimaryIdentityKey", record.actorPrimaryIdentityKey(),
-                        "retainedAdminSubjectKeyCount", record.retainedAdminSubjectKeys().size(),
+                        "retainedAdminPrimaryIdentityKeyCount", record.retainedAdminPrimaryIdentityKeys().size(),
                         "lastAdminGuardPassed", true,
                         "supportSafe", true,
                         "emailPrimaryKey", false,
@@ -239,7 +239,7 @@ public class AdminControlPlaneService {
                 record.organizationId(),
                 record.bootstrapMode(),
                 record.actorPrimaryIdentityKey(),
-                record.retainedAdminSubjectKeys(),
+                record.retainedAdminPrimaryIdentityKeys(),
                 true,
                 true,
                 record.bootstrappedAt(),
@@ -398,7 +398,7 @@ public class AdminControlPlaneService {
                 Map.of("bootstrapMode", "invalid-bootstrap-mode-redacted"));
     }
 
-    private List<String> retainedAdminSubjectKeys(List<String> suppliedKeys, String actorPrimaryIdentityKey) {
+    private List<String> retainedAdminPrimaryIdentityKeys(List<String> suppliedKeys, String actorPrimaryIdentityKey) {
         List<String> supplied = suppliedKeys == null ? List.of() : suppliedKeys;
         List<String> retained = Stream.concat(supplied.stream(), Stream.of(actorPrimaryIdentityKey))
                 .filter(value -> value != null && !value.isBlank())

--- a/server/src/main/java/com/massimotter/weave/backend/service/FileOrganizationBootstrapRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/FileOrganizationBootstrapRepository.java
@@ -1,0 +1,100 @@
+package com.massimotter.weave.backend.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class FileOrganizationBootstrapRepository implements OrganizationBootstrapRepository {
+
+    private static final TypeReference<Map<String, OrganizationBootstrapRecord>> BOOTSTRAP_MAP = new TypeReference<>() {
+    };
+
+    private final ObjectMapper objectMapper;
+    private final Path storagePath;
+    private final Map<String, OrganizationBootstrapRecord> records = new ConcurrentHashMap<>();
+    private final Object persistenceLock = new Object();
+
+    @Autowired
+    public FileOrganizationBootstrapRepository(
+            ObjectMapper objectMapper,
+            @Value("${weave.organization.bootstrap.storage.path:./data/organization-bootstrap.json}") String storagePath) {
+        this(objectMapper, Path.of(storagePath));
+    }
+
+    FileOrganizationBootstrapRepository(ObjectMapper objectMapper, Path storagePath) {
+        this.objectMapper = objectMapper;
+        this.storagePath = storagePath;
+        load();
+    }
+
+    @Override
+    public Optional<OrganizationBootstrapRecord> findByOrganizationId(String organizationId) {
+        if (organizationId == null || organizationId.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(records.get(normalizeOrganizationId(organizationId)));
+    }
+
+    @Override
+    public OrganizationBootstrapRecord save(OrganizationBootstrapRecord record) {
+        if (record == null || record.organizationId() == null || record.organizationId().isBlank()) {
+            throw new IllegalArgumentException("Organization bootstrap record requires a non-blank organization id.");
+        }
+        synchronized (persistenceLock) {
+            records.put(normalizeOrganizationId(record.organizationId()), record);
+            persist();
+            return record;
+        }
+    }
+
+    private void load() {
+        if (!Files.exists(storagePath)) {
+            return;
+        }
+        try {
+            Map<String, OrganizationBootstrapRecord> loaded = objectMapper.readValue(storagePath.toFile(), BOOTSTRAP_MAP);
+            records.clear();
+            if (loaded != null) {
+                loaded.values().forEach(record -> records.put(normalizeOrganizationId(record.organizationId()), record));
+            }
+        } catch (IOException exception) {
+            throw new OrganizationBootstrapStoreException(
+                    "Failed to load organization bootstrap records from " + storagePath, exception);
+        }
+    }
+
+    private void persist() {
+        try {
+            Path parent = storagePath.toAbsolutePath().getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            Path tempFile = Files.createTempFile(parent, storagePath.getFileName().toString(), ".tmp");
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(tempFile.toFile(), new TreeMap<>(records));
+            try {
+                Files.move(tempFile, storagePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException atomicMoveFailure) {
+                Files.move(tempFile, storagePath, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException exception) {
+            throw new OrganizationBootstrapStoreException(
+                    "Failed to persist organization bootstrap records to " + storagePath, exception);
+        }
+    }
+
+    private String normalizeOrganizationId(String organizationId) {
+        return organizationId.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/FileProductProfileOverrideRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/FileProductProfileOverrideRepository.java
@@ -2,6 +2,7 @@ package com.massimotter.weave.backend.service;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.massimotter.weave.backend.model.IdentityKeyFormat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,7 +40,11 @@ public class FileProductProfileOverrideRepository implements ProductProfileOverr
 
     @Override
     public ProductProfileOverride findByPrimaryIdentityKey(String primaryIdentityKey) {
-        return profiles.get(primaryIdentityKey);
+        ProductProfileOverride profile = profiles.get(primaryIdentityKey);
+        if (profile != null) {
+            return profile;
+        }
+        return migrateLegacySubjectProfile(primaryIdentityKey);
     }
 
     @Override
@@ -64,6 +69,30 @@ public class FileProductProfileOverrideRepository implements ProductProfileOverr
         } catch (IOException exception) {
             throw new ProductProfileStoreException(
                     "Failed to load product profile overrides from " + storagePath, exception);
+        }
+    }
+
+    private ProductProfileOverride migrateLegacySubjectProfile(String primaryIdentityKey) {
+        if (primaryIdentityKey == null || !primaryIdentityKey.matches(IdentityKeyFormat.PRIMARY_IDENTITY_KEY_PATTERN)) {
+            return null;
+        }
+        String legacySubjectKey = primaryIdentityKey.substring(primaryIdentityKey.lastIndexOf('#') + 1);
+        ProductProfileOverride legacyProfile = profiles.get(legacySubjectKey);
+        if (legacyProfile == null) {
+            return null;
+        }
+        synchronized (persistenceLock) {
+            ProductProfileOverride current = profiles.get(primaryIdentityKey);
+            if (current != null) {
+                return current;
+            }
+            ProductProfileOverride migrated = profiles.remove(legacySubjectKey);
+            if (migrated == null) {
+                return null;
+            }
+            profiles.put(primaryIdentityKey, migrated);
+            persist();
+            return migrated;
         }
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/FileProductProfileOverrideRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/FileProductProfileOverrideRepository.java
@@ -10,6 +10,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
@@ -19,6 +20,7 @@ public class FileProductProfileOverrideRepository implements ProductProfileOverr
 
     private static final TypeReference<Map<String, ProductProfileOverride>> PROFILE_MAP = new TypeReference<>() {
     };
+    private static final Pattern PRIMARY_IDENTITY_KEY_PATTERN = Pattern.compile(IdentityKeyFormat.PRIMARY_IDENTITY_KEY_PATTERN);
 
     private final ObjectMapper objectMapper;
     private final Path storagePath;
@@ -73,7 +75,7 @@ public class FileProductProfileOverrideRepository implements ProductProfileOverr
     }
 
     private ProductProfileOverride migrateLegacySubjectProfile(String primaryIdentityKey) {
-        if (primaryIdentityKey == null || !primaryIdentityKey.matches(IdentityKeyFormat.PRIMARY_IDENTITY_KEY_PATTERN)) {
+        if (primaryIdentityKey == null || !PRIMARY_IDENTITY_KEY_PATTERN.matcher(primaryIdentityKey).matches()) {
             return null;
         }
         String legacySubjectKey = primaryIdentityKey.substring(primaryIdentityKey.lastIndexOf('#') + 1);

--- a/server/src/main/java/com/massimotter/weave/backend/service/FileProductProfileOverrideRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/FileProductProfileOverrideRepository.java
@@ -42,6 +42,9 @@ public class FileProductProfileOverrideRepository implements ProductProfileOverr
 
     @Override
     public ProductProfileOverride findByPrimaryIdentityKey(String primaryIdentityKey) {
+        if (primaryIdentityKey == null || primaryIdentityKey.isBlank()) {
+            return null;
+        }
         ProductProfileOverride profile = profiles.get(primaryIdentityKey);
         if (profile != null) {
             return profile;
@@ -51,6 +54,9 @@ public class FileProductProfileOverrideRepository implements ProductProfileOverr
 
     @Override
     public ProductProfileOverride saveForPrimaryIdentityKey(String primaryIdentityKey, ProductProfileOverride profile) {
+        if (primaryIdentityKey == null || primaryIdentityKey.isBlank()) {
+            throw new IllegalArgumentException("Product profile override key must be a non-blank primary identity key.");
+        }
         synchronized (persistenceLock) {
             profiles.put(primaryIdentityKey, profile);
             persist();

--- a/server/src/main/java/com/massimotter/weave/backend/service/FileProductProfileOverrideRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/FileProductProfileOverrideRepository.java
@@ -38,14 +38,14 @@ public class FileProductProfileOverrideRepository implements ProductProfileOverr
     }
 
     @Override
-    public ProductProfileOverride findBySubject(String subject) {
-        return profiles.get(subject);
+    public ProductProfileOverride findByPrimaryIdentityKey(String primaryIdentityKey) {
+        return profiles.get(primaryIdentityKey);
     }
 
     @Override
-    public ProductProfileOverride save(String subject, ProductProfileOverride profile) {
+    public ProductProfileOverride saveForPrimaryIdentityKey(String primaryIdentityKey, ProductProfileOverride profile) {
         synchronized (persistenceLock) {
-            profiles.put(subject, profile);
+            profiles.put(primaryIdentityKey, profile);
             persist();
             return profile;
         }

--- a/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
@@ -3,6 +3,7 @@ package com.massimotter.weave.backend.service;
 import java.util.Optional;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
+
 public class InMemoryOrganizationBootstrapRepository implements OrganizationBootstrapRepository {
 
     private final ConcurrentHashMap<String, OrganizationBootstrapRecord> records = new ConcurrentHashMap<>();
@@ -17,6 +18,9 @@ public class InMemoryOrganizationBootstrapRepository implements OrganizationBoot
 
     @Override
     public OrganizationBootstrapRecord save(OrganizationBootstrapRecord record) {
+        if (record == null || record.organizationId() == null || record.organizationId().isBlank()) {
+            throw new IllegalArgumentException("Organization bootstrap record requires a non-blank organization id.");
+        }
         records.put(normalizeOrganizationId(record.organizationId()), record);
         return record;
     }

--- a/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
@@ -1,0 +1,29 @@
+package com.massimotter.weave.backend.service;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class InMemoryOrganizationBootstrapRepository implements OrganizationBootstrapRepository {
+
+    private final ConcurrentHashMap<String, OrganizationBootstrapRecord> records = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<OrganizationBootstrapRecord> findByOrganizationId(String organizationId) {
+        if (organizationId == null || organizationId.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(records.get(organizationId.trim().toLowerCase()));
+    }
+
+    @Override
+    public OrganizationBootstrapRecord save(OrganizationBootstrapRecord record) {
+        records.put(record.organizationId(), record);
+        return record;
+    }
+
+    public void clear() {
+        records.clear();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
@@ -1,6 +1,7 @@
 package com.massimotter.weave.backend.service;
 
 import java.util.Optional;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Repository;
 
@@ -24,7 +25,7 @@ public class InMemoryOrganizationBootstrapRepository implements OrganizationBoot
     }
 
     private String normalizeOrganizationId(String organizationId) {
-        return organizationId.trim().toLowerCase();
+        return organizationId.trim().toLowerCase(Locale.ROOT);
     }
 
     public void clear() {

--- a/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
@@ -14,13 +14,17 @@ public class InMemoryOrganizationBootstrapRepository implements OrganizationBoot
         if (organizationId == null || organizationId.isBlank()) {
             return Optional.empty();
         }
-        return Optional.ofNullable(records.get(organizationId.trim().toLowerCase()));
+        return Optional.ofNullable(records.get(normalizeOrganizationId(organizationId)));
     }
 
     @Override
     public OrganizationBootstrapRecord save(OrganizationBootstrapRecord record) {
-        records.put(record.organizationId(), record);
+        records.put(normalizeOrganizationId(record.organizationId()), record);
         return record;
+    }
+
+    private String normalizeOrganizationId(String organizationId) {
+        return organizationId.trim().toLowerCase();
     }
 
     public void clear() {

--- a/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/InMemoryOrganizationBootstrapRepository.java
@@ -3,9 +3,6 @@ package com.massimotter.weave.backend.service;
 import java.util.Optional;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
-import org.springframework.stereotype.Repository;
-
-@Repository
 public class InMemoryOrganizationBootstrapRepository implements OrganizationBootstrapRepository {
 
     private final ConcurrentHashMap<String, OrganizationBootstrapRecord> records = new ConcurrentHashMap<>();

--- a/server/src/main/java/com/massimotter/weave/backend/service/OnboardingStatusService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OnboardingStatusService.java
@@ -8,11 +8,8 @@ import com.massimotter.weave.backend.model.OnboardingProvisioningState;
 import com.massimotter.weave.backend.model.OnboardingStatusResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
@@ -22,7 +19,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class OnboardingStatusService {
 
-    private static final List<String> ROLE_PRIORITY = List.of("owner", "admin", "member", "guest");
+    private static final List<String> ROLE_PRIORITY = List.of("owner", "admin", "operator", "member", "guest");
     private static final Set<String> INVITE_STATUSES = Set.of("active", "pending", "disabled");
 
     private final OAuth2ResourceServerProperties resourceServerProperties;
@@ -45,18 +42,18 @@ public class OnboardingStatusService {
     }
 
     public OnboardingStatusResponse status(Jwt jwt) {
-        String subject = jwt.getSubject();
-        String username = firstText(jwt.getClaimAsString("preferred_username"), subject);
+        OrganizationIdentityContext organizationIdentity = OrganizationIdentityContextFactory.fromJwt(jwt);
+        String username = firstText(jwt.getClaimAsString("preferred_username"), organizationIdentity.subject());
         String email = jwt.getClaimAsString("email");
         boolean emailVerified = emailVerified(jwt);
         String displayName = firstText(jwt.getClaimAsString("name"), username);
         String locale = firstText(jwt.getClaimAsString("locale"), "en");
         String timezone = firstText(jwt.getClaimAsString("timezone"), "UTC");
-        List<String> roles = productRoles(extractRealmRoles(jwt));
-        List<String> groups = extractStringList(jwt, "groups");
+        List<String> roles = organizationIdentity.roles();
+        List<String> groups = organizationIdentity.groups();
 
         OnboardingStatusResponse.Identity identity = new OnboardingStatusResponse.Identity(
-                subject,
+                organizationIdentity.accountId(),
                 username,
                 email,
                 emailVerified,
@@ -187,7 +184,7 @@ public class OnboardingStatusService {
             OnboardingStatusResponse.ProfileStatus profile) {
         OnboardingStatusResponse.ModuleStatus identity = new OnboardingStatusResponse.ModuleStatus(
                 OnboardingProvisioningState.READY,
-                "Identity is available from the authenticated Keycloak-backed session.",
+                "Identity is available from the authenticated OIDC/SAML session.",
                 null);
         OnboardingProvisioningState profileState = "ready".equals(profile.status())
                 ? OnboardingProvisioningState.READY
@@ -291,51 +288,6 @@ public class OnboardingStatusService {
                         modules.nextcloud().action())
                 .filter(this::hasText)
                 .distinct()
-                .toList();
-    }
-
-    private List<String> extractRealmRoles(Jwt jwt) {
-        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
-        if (realmAccess == null) {
-            return List.of();
-        }
-        Object roles = realmAccess.get("roles");
-        if (!(roles instanceof Collection<?> roleValues)) {
-            return List.of();
-        }
-        return roleValues.stream()
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .map(String::trim)
-                .filter(role -> !role.isEmpty())
-                .sorted()
-                .toList();
-    }
-
-    private List<String> extractStringList(Jwt jwt, String claimName) {
-        Object claim = jwt.getClaims().get(claimName);
-        if (!(claim instanceof Collection<?> values)) {
-            return List.of();
-        }
-        return values.stream()
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .map(String::trim)
-                .filter(value -> !value.isEmpty())
-                .sorted()
-                .toList();
-    }
-
-    private List<String> productRoles(List<String> realmRoles) {
-        LinkedHashSet<String> roles = new LinkedHashSet<>();
-        for (String role : realmRoles) {
-            String normalized = role.toLowerCase(Locale.ROOT);
-            if (ROLE_PRIORITY.contains(normalized)) {
-                roles.add(normalized);
-            }
-        }
-        return ROLE_PRIORITY.stream()
-                .filter(roles::contains)
                 .toList();
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationBootstrapRecord.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationBootstrapRecord.java
@@ -7,10 +7,10 @@ public record OrganizationBootstrapRecord(
         String organizationId,
         String bootstrapMode,
         String actorPrimaryIdentityKey,
-        List<String> retainedAdminSubjectKeys,
+        List<String> retainedAdminPrimaryIdentityKeys,
         Instant bootstrappedAt) {
 
     public OrganizationBootstrapRecord {
-        retainedAdminSubjectKeys = retainedAdminSubjectKeys == null ? List.of() : List.copyOf(retainedAdminSubjectKeys);
+        retainedAdminPrimaryIdentityKeys = retainedAdminPrimaryIdentityKeys == null ? List.of() : List.copyOf(retainedAdminPrimaryIdentityKeys);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationBootstrapRecord.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationBootstrapRecord.java
@@ -1,0 +1,16 @@
+package com.massimotter.weave.backend.service;
+
+import java.time.Instant;
+import java.util.List;
+
+public record OrganizationBootstrapRecord(
+        String organizationId,
+        String bootstrapMode,
+        String actorPrimaryIdentityKey,
+        List<String> retainedAdminSubjectKeys,
+        Instant bootstrappedAt) {
+
+    public OrganizationBootstrapRecord {
+        retainedAdminSubjectKeys = retainedAdminSubjectKeys == null ? List.of() : List.copyOf(retainedAdminSubjectKeys);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationBootstrapRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationBootstrapRepository.java
@@ -1,0 +1,10 @@
+package com.massimotter.weave.backend.service;
+
+import java.util.Optional;
+
+public interface OrganizationBootstrapRepository {
+
+    Optional<OrganizationBootstrapRecord> findByOrganizationId(String organizationId);
+
+    OrganizationBootstrapRecord save(OrganizationBootstrapRecord record);
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationBootstrapStoreException.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationBootstrapStoreException.java
@@ -1,0 +1,8 @@
+package com.massimotter.weave.backend.service;
+
+public class OrganizationBootstrapStoreException extends RuntimeException {
+
+    public OrganizationBootstrapStoreException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContext.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContext.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.service;
+
+import java.util.List;
+
+public record OrganizationIdentityContext(
+        String organizationId,
+        String issuer,
+        String subject,
+        String primaryIdentityKey,
+        String accountId,
+        List<String> roles,
+        List<String> groups,
+        List<String> contextRoles,
+        List<String> providerRoleMappings) {
+
+    public OrganizationIdentityContext {
+        roles = roles == null ? List.of() : List.copyOf(roles);
+        groups = groups == null ? List.of() : List.copyOf(groups);
+        contextRoles = contextRoles == null ? List.of() : List.copyOf(contextRoles);
+        providerRoleMappings = providerRoleMappings == null ? List.of() : List.copyOf(providerRoleMappings);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
@@ -41,7 +41,6 @@ final class OrganizationIdentityContextFactory {
         List<String> roles = canonicalRoles(jwt);
         List<String> groups = stringClaims(jwt, "weave_groups", "groups");
         List<String> contextRoles = stringClaims(jwt, "weave_context_roles").stream()
-                .map(String::trim)
                 .map(role -> role.toLowerCase(Locale.ROOT))
                 .distinct()
                 .sorted()

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
@@ -2,6 +2,7 @@ package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.exception.ApiErrorException;
 import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
@@ -17,8 +18,9 @@ import org.springframework.security.oauth2.jwt.Jwt;
 final class OrganizationIdentityContextFactory {
 
     private static final List<String> WEAVE_ORG_ROLES = List.of("owner", "admin", "operator", "member", "guest");
-    private static final int MAX_IDENTITY_ISSUER_LENGTH = 384;
-    private static final int MAX_IDENTITY_SUBJECT_LENGTH = 128;
+
+    private static final int MAX_IDENTITY_ISSUER_LENGTH = com.massimotter.weave.backend.model.IdentityKeyFormat.MAX_ISSUER_LENGTH;
+    private static final int MAX_IDENTITY_SUBJECT_LENGTH = com.massimotter.weave.backend.model.IdentityKeyFormat.MAX_SUBJECT_LENGTH;
 
     private OrganizationIdentityContextFactory() {
     }
@@ -203,11 +205,7 @@ final class OrganizationIdentityContextFactory {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(primaryIdentityKey.getBytes(StandardCharsets.UTF_8));
-            StringBuilder builder = new StringBuilder("acct_");
-            for (int index = 0; index < 16; index++) {
-                builder.append(String.format("%02x", hash[index]));
-            }
-            return builder.toString();
+            return "acct_" + HexFormat.of().formatHex(hash, 0, 16);
         } catch (NoSuchAlgorithmException exception) {
             throw new IllegalStateException("SHA-256 digest is required for stable account identifiers", exception);
         }

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
@@ -41,7 +41,9 @@ final class OrganizationIdentityContextFactory {
         List<String> roles = canonicalRoles(jwt);
         List<String> groups = stringClaims(jwt, "weave_groups", "groups");
         List<String> contextRoles = stringClaims(jwt, "weave_context_roles").stream()
+                .map(String::trim)
                 .map(role -> role.toLowerCase(Locale.ROOT))
+                .distinct()
                 .sorted()
                 .toList();
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
@@ -35,10 +35,7 @@ final class OrganizationIdentityContextFactory {
                 claim(jwt, "org_id"),
                 "weave-dogfood");
         String primaryIdentityKey = "issuer+subject:" + issuer + "#" + subject;
-        String accountId = firstText(
-                claim(jwt, "weave_account_id"),
-                claim(jwt, "account_id"),
-                stableAccountId(primaryIdentityKey));
+        String accountId = stableAccountId(primaryIdentityKey);
         List<String> roles = canonicalRoles(jwt);
         List<String> groups = stringClaims(jwt, "weave_groups", "groups");
         List<String> contextRoles = stringClaims(jwt, "weave_context_roles").stream()

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
@@ -129,20 +129,17 @@ final class OrganizationIdentityContextFactory {
         if (resourceAccess == null) {
             return List.of();
         }
-        Object weaveClient = Stream.of("weave", "weave-app", claim(jwt, "azp"), claim(jwt, "client_id"))
+        return Stream.of("weave", "weave-app", claim(jwt, "azp"), claim(jwt, "client_id"))
                 .filter(OrganizationIdentityContextFactory::hasText)
                 .map(resourceAccess::get)
                 .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .map(clientAccess -> clientAccess.get("roles"))
+                .filter(Collection.class::isInstance)
+                .map(Collection.class::cast)
                 .findFirst()
-                .orElse(null);
-        if (!(weaveClient instanceof Map<?, ?> clientAccess)) {
-            return List.of();
-        }
-        Object roles = clientAccess.get("roles");
-        if (!(roles instanceof Collection<?> roleValues)) {
-            return List.of();
-        }
-        return stringValues(roleValues);
+                .map(OrganizationIdentityContextFactory::stringValues)
+                .orElse(List.of());
     }
 
     private static List<String> providerRoleMappings(List<String> roles, List<String> groups) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
@@ -17,6 +17,8 @@ import org.springframework.security.oauth2.jwt.Jwt;
 final class OrganizationIdentityContextFactory {
 
     private static final List<String> WEAVE_ORG_ROLES = List.of("owner", "admin", "operator", "member", "guest");
+    private static final int MAX_IDENTITY_ISSUER_LENGTH = 384;
+    private static final int MAX_IDENTITY_SUBJECT_LENGTH = 128;
 
     private OrganizationIdentityContextFactory() {
     }
@@ -26,7 +28,9 @@ final class OrganizationIdentityContextFactory {
         String issuer = issuer(jwt);
         String organizationId = firstText(
                 claim(jwt, "weave_tenant"),
+                claim(jwt, "weave_tenant_id"),
                 claim(jwt, "tenant"),
+                claim(jwt, "tenant_id"),
                 claim(jwt, "tid"),
                 claim(jwt, "org_id"),
                 "weave-dogfood");
@@ -62,19 +66,35 @@ final class OrganizationIdentityContextFactory {
                     "Authenticated token is missing a stable subject.",
                     Map.of("claim", "sub"));
         }
-        return jwt.getSubject().trim();
+        String subject = jwt.getSubject().trim();
+        validateIdentitySegment(subject, "sub", MAX_IDENTITY_SUBJECT_LENGTH);
+        return subject;
     }
 
     private static String issuer(Jwt jwt) {
         if (jwt != null && jwt.getIssuer() != null && hasText(jwt.getIssuer().toString())) {
-            return jwt.getIssuer().toString().trim();
+            String issuer = jwt.getIssuer().toString().trim();
+            validateIdentitySegment(issuer, "iss", MAX_IDENTITY_ISSUER_LENGTH);
+            return issuer;
         }
-        return Optional.ofNullable(claim(jwt, "iss"))
+        String issuer = Optional.ofNullable(claim(jwt, "iss"))
                 .orElseThrow(() -> new ApiErrorException(
                         HttpStatus.BAD_REQUEST,
                         "missing-issuer",
                         "Authenticated token is missing a stable issuer.",
                         Map.of("claim", "iss")));
+        validateIdentitySegment(issuer, "iss", MAX_IDENTITY_ISSUER_LENGTH);
+        return issuer;
+    }
+
+    private static void validateIdentitySegment(String value, String claim, int maxLength) {
+        if (value.length() > maxLength || value.indexOf('#') >= 0 || value.chars().anyMatch(Character::isWhitespace)) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "invalid-identity-claim",
+                    "Authenticated token identity claims are not support-safe issuer+subject components.",
+                    Map.of("claim", claim));
+        }
     }
 
     private static List<String> canonicalRoles(Jwt jwt) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
@@ -1,0 +1,193 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+final class OrganizationIdentityContextFactory {
+
+    private static final List<String> WEAVE_ORG_ROLES = List.of("owner", "admin", "operator", "member", "guest");
+
+    private OrganizationIdentityContextFactory() {
+    }
+
+    static OrganizationIdentityContext fromJwt(Jwt jwt) {
+        String subject = requireSubject(jwt);
+        String issuer = issuer(jwt);
+        String organizationId = firstText(
+                claim(jwt, "weave_tenant"),
+                claim(jwt, "tenant"),
+                claim(jwt, "tid"),
+                claim(jwt, "org_id"),
+                "weave-dogfood");
+        String primaryIdentityKey = "issuer+subject:" + issuer + "#" + subject;
+        String accountId = firstText(
+                claim(jwt, "weave_account_id"),
+                claim(jwt, "account_id"),
+                stableAccountId(primaryIdentityKey));
+        List<String> roles = canonicalRoles(jwt);
+        List<String> groups = stringClaims(jwt, "weave_groups", "groups");
+        List<String> contextRoles = stringClaims(jwt, "weave_context_roles").stream()
+                .map(role -> role.toLowerCase(Locale.ROOT))
+                .sorted()
+                .toList();
+
+        return new OrganizationIdentityContext(
+                organizationId,
+                issuer,
+                subject,
+                primaryIdentityKey,
+                accountId,
+                roles,
+                groups,
+                contextRoles,
+                providerRoleMappings(roles, groups));
+    }
+
+    private static String requireSubject(Jwt jwt) {
+        if (jwt == null || !hasText(jwt.getSubject())) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "missing-subject",
+                    "Authenticated token is missing a stable subject.",
+                    Map.of("claim", "sub"));
+        }
+        return jwt.getSubject().trim();
+    }
+
+    private static String issuer(Jwt jwt) {
+        if (jwt != null && jwt.getIssuer() != null && hasText(jwt.getIssuer().toString())) {
+            return jwt.getIssuer().toString().trim();
+        }
+        return Optional.ofNullable(claim(jwt, "iss")).orElse("unknown-issuer");
+    }
+
+    private static List<String> canonicalRoles(Jwt jwt) {
+        return Stream.of(
+                        stringClaims(jwt, "weave_roles"),
+                        stringClaims(jwt, "roles"),
+                        realmRoles(jwt),
+                        clientRoles(jwt))
+                .flatMap(Collection::stream)
+                .map(role -> role.toLowerCase(Locale.ROOT))
+                .filter(WEAVE_ORG_ROLES::contains)
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private static List<String> realmRoles(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt == null ? null : jwt.getClaimAsMap("realm_access");
+        if (realmAccess == null) {
+            return List.of();
+        }
+        Object roles = realmAccess.get("roles");
+        if (!(roles instanceof Collection<?> roleValues)) {
+            return List.of();
+        }
+        return stringValues(roleValues);
+    }
+
+    private static List<String> clientRoles(Jwt jwt) {
+        Map<String, Object> resourceAccess = jwt == null ? null : jwt.getClaimAsMap("resource_access");
+        if (resourceAccess == null) {
+            return List.of();
+        }
+        Object weaveClient = Stream.of("weave", "weave-app", claim(jwt, "azp"), claim(jwt, "client_id"))
+                .filter(OrganizationIdentityContextFactory::hasText)
+                .map(resourceAccess::get)
+                .filter(Map.class::isInstance)
+                .findFirst()
+                .orElse(null);
+        if (!(weaveClient instanceof Map<?, ?> clientAccess)) {
+            return List.of();
+        }
+        Object roles = clientAccess.get("roles");
+        if (!(roles instanceof Collection<?> roleValues)) {
+            return List.of();
+        }
+        return stringValues(roleValues);
+    }
+
+    private static List<String> providerRoleMappings(List<String> roles, List<String> groups) {
+        return Stream.concat(
+                        roles.stream().map(role -> "role_claim:" + role),
+                        groups.stream().map(group -> "group_claim:" + group))
+                .sorted()
+                .toList();
+    }
+
+    private static List<String> stringClaims(Jwt jwt, String... claimNames) {
+        LinkedHashSet<String> values = new LinkedHashSet<>();
+        if (jwt == null) {
+            return List.of();
+        }
+        for (String claimName : claimNames) {
+            Object claim = jwt.getClaims().get(claimName);
+            if (claim instanceof Collection<?> collection) {
+                values.addAll(stringValues(collection));
+            } else if (claim instanceof String text && hasText(text)) {
+                values.add(text.trim());
+            }
+        }
+        return values.stream()
+                .filter(OrganizationIdentityContextFactory::hasText)
+                .map(String::trim)
+                .sorted()
+                .toList();
+    }
+
+    private static List<String> stringValues(Collection<?> values) {
+        return values.stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .map(String::trim)
+                .filter(OrganizationIdentityContextFactory::hasText)
+                .toList();
+    }
+
+    private static String claim(Jwt jwt, String claimName) {
+        if (jwt == null) {
+            return null;
+        }
+        Object value = jwt.getClaims().get(claimName);
+        return value instanceof String text && hasText(text) ? text.trim() : null;
+    }
+
+    private static String firstText(String... values) {
+        for (String value : values) {
+            if (hasText(value)) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String stableAccountId(String primaryIdentityKey) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(primaryIdentityKey.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder("acct_");
+            for (int index = 0; index < 16; index++) {
+                builder.append(String.format("%02x", hash[index]));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 digest is required for stable account identifiers", exception);
+        }
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationIdentityContextFactory.java
@@ -69,7 +69,12 @@ final class OrganizationIdentityContextFactory {
         if (jwt != null && jwt.getIssuer() != null && hasText(jwt.getIssuer().toString())) {
             return jwt.getIssuer().toString().trim();
         }
-        return Optional.ofNullable(claim(jwt, "iss")).orElse("unknown-issuer");
+        return Optional.ofNullable(claim(jwt, "iss"))
+                .orElseThrow(() -> new ApiErrorException(
+                        HttpStatus.BAD_REQUEST,
+                        "missing-issuer",
+                        "Authenticated token is missing a stable issuer.",
+                        Map.of("claim", "iss")));
     }
 
     private static List<String> canonicalRoles(Jwt jwt) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileOverrideRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileOverrideRepository.java
@@ -2,7 +2,7 @@ package com.massimotter.weave.backend.service;
 
 public interface ProductProfileOverrideRepository {
 
-    ProductProfileOverride findBySubject(String subject);
+    ProductProfileOverride findByPrimaryIdentityKey(String primaryIdentityKey);
 
-    ProductProfileOverride save(String subject, ProductProfileOverride profile);
+    ProductProfileOverride saveForPrimaryIdentityKey(String primaryIdentityKey, ProductProfileOverride profile);
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
@@ -78,7 +78,9 @@ public class ProductProfileService {
         OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
         validateRequest(request);
         try {
-            profileRepository.save(identity.primaryIdentityKey(), merge(profileRepository.findBySubject(identity.primaryIdentityKey()), request));
+            profileRepository.saveForPrimaryIdentityKey(
+                    identity.primaryIdentityKey(),
+                    merge(profileRepository.findByPrimaryIdentityKey(identity.primaryIdentityKey()), request));
         } catch (ProductProfileStoreException exception) {
             throw new ApiErrorException(
                     HttpStatus.INTERNAL_SERVER_ERROR,
@@ -97,7 +99,7 @@ public class ProductProfileService {
     private ProductProfileSnapshot snapshot(Jwt jwt) {
         OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
         String username = firstText(jwt.getClaimAsString("preferred_username"), identity.subject());
-        ProductProfileOverride stored = profileRepository.findBySubject(identity.primaryIdentityKey());
+        ProductProfileOverride stored = profileRepository.findByPrimaryIdentityKey(identity.primaryIdentityKey());
         String displayName = stored != null && hasText(stored.displayName())
                 ? stored.displayName()
                 : firstText(jwt.getClaimAsString("name"), username);

--- a/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
@@ -8,10 +8,8 @@ import com.massimotter.weave.backend.model.ProductProfileResponse;
 import com.massimotter.weave.backend.model.UpdateProductProfileRequest;
 import java.time.DateTimeException;
 import java.time.ZoneId;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.springframework.http.HttpStatus;
@@ -21,7 +19,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class ProductProfileService {
 
-    private static final List<String> MVP_ROLES = List.of("owner", "admin", "operator", "member", "guest");
     private static final ModuleSyncStatusResponse NOT_CONFIGURED_SYNC =
             new ModuleSyncStatusResponse("not_configured", "not_configured");
 
@@ -33,19 +30,27 @@ public class ProductProfileService {
 
     public AuthenticatedUserResponse authenticatedUser(Jwt jwt) {
         ProductProfileSnapshot snapshot = snapshot(jwt);
+        OrganizationIdentityContext identity = snapshot.identity();
         return new AuthenticatedUserResponse(
-                snapshot.userId(),
+                identity.accountId(),
                 snapshot.username(),
                 snapshot.email(),
                 snapshot.emailVerified(),
                 snapshot.displayName(),
                 snapshot.locale(),
                 snapshot.timezone(),
-                productRoles(snapshot.realmRoles()),
-                snapshot.groups(),
+                identity.roles(),
+                identity.groups(),
                 issuedFor(jwt),
                 jwt.getAudience(),
-                snapshot.realmRoles(),
+                identity.organizationId(),
+                identity.issuer(),
+                identity.subject(),
+                identity.primaryIdentityKey(),
+                identity.accountId(),
+                identity.contextRoles(),
+                identity.providerRoleMappings(),
+                false,
                 snapshot.moduleSyncStatus());
     }
 
@@ -70,10 +75,10 @@ public class ProductProfileService {
     }
 
     public ProductProfileResponse update(Jwt jwt, UpdateProductProfileRequest request) {
-        String subject = requireSubject(jwt);
+        OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
         validateRequest(request);
         try {
-            profileRepository.save(subject, merge(profileRepository.findBySubject(subject), request));
+            profileRepository.save(identity.primaryIdentityKey(), merge(profileRepository.findBySubject(identity.primaryIdentityKey()), request));
         } catch (ProductProfileStoreException exception) {
             throw new ApiErrorException(
                     HttpStatus.INTERNAL_SERVER_ERROR,
@@ -90,9 +95,9 @@ public class ProductProfileService {
     }
 
     private ProductProfileSnapshot snapshot(Jwt jwt) {
-        String subject = requireSubject(jwt);
-        String username = firstText(jwt.getClaimAsString("preferred_username"), subject);
-        ProductProfileOverride stored = profileRepository.findBySubject(subject);
+        OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
+        String username = firstText(jwt.getClaimAsString("preferred_username"), identity.subject());
+        ProductProfileOverride stored = profileRepository.findBySubject(identity.primaryIdentityKey());
         String displayName = stored != null && hasText(stored.displayName())
                 ? stored.displayName()
                 : firstText(jwt.getClaimAsString("name"), username);
@@ -113,7 +118,7 @@ public class ProductProfileService {
                 : "workspace";
 
         return new ProductProfileSnapshot(
-                subject,
+                identity,
                 username,
                 jwt.getClaimAsString("email"),
                 emailVerified(jwt),
@@ -123,8 +128,6 @@ public class ProductProfileService {
                 timezone,
                 accessibilityPreferences,
                 profileVisibility,
-                extractStringList(jwt, "groups"),
-                extractRealmRoles(jwt),
                 NOT_CONFIGURED_SYNC);
     }
 
@@ -215,53 +218,9 @@ public class ProductProfileService {
                 .orElse(null);
     }
 
-    private List<String> extractRealmRoles(Jwt jwt) {
-        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
-        if (realmAccess == null) {
-            return List.of();
-        }
-
-        Object roles = realmAccess.get("roles");
-        if (!(roles instanceof Collection<?> roleValues)) {
-            return List.of();
-        }
-
-        return roleValues.stream()
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .map(String::trim)
-                .filter(role -> !role.isEmpty())
-                .sorted()
-                .toList();
-    }
-
-    private List<String> extractStringList(Jwt jwt, String claimName) {
-        Object claim = jwt.getClaims().get(claimName);
-        if (!(claim instanceof Collection<?> values)) {
-            return List.of();
-        }
-
-        return values.stream()
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .map(String::trim)
-                .filter(value -> !value.isEmpty())
-                .sorted()
-                .toList();
-    }
-
     private boolean emailVerified(Jwt jwt) {
         Object value = jwt.getClaims().get("email_verified");
         return value instanceof Boolean verified && verified;
-    }
-
-    private List<String> productRoles(List<String> realmRoles) {
-        return realmRoles.stream()
-                .map(role -> role.toLowerCase(Locale.ROOT))
-                .filter(MVP_ROLES::contains)
-                .distinct()
-                .sorted()
-                .toList();
     }
 
     private String valueOrExisting(String supplied, String existing) {
@@ -280,7 +239,7 @@ public class ProductProfileService {
     }
 
     private record ProductProfileSnapshot(
-            String userId,
+            OrganizationIdentityContext identity,
             String username,
             String email,
             boolean emailVerified,
@@ -290,13 +249,11 @@ public class ProductProfileService {
             String timezone,
             Map<String, String> accessibilityPreferences,
             String profileVisibility,
-            List<String> groups,
-            List<String> realmRoles,
             ModuleSyncStatusResponse moduleSyncStatus) {
 
         ProductProfileResponse toResponse() {
             return new ProductProfileResponse(
-                    userId,
+                    identity.accountId(),
                     username,
                     email,
                     emailVerified,

--- a/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
@@ -92,7 +92,7 @@ public class ProductProfileService {
     }
 
     public ModuleSyncStatusResponse syncStatus(Jwt jwt) {
-        requireSubject(jwt);
+        OrganizationIdentityContextFactory.fromJwt(jwt);
         return NOT_CONFIGURED_SYNC;
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
@@ -88,7 +88,7 @@ public class ProductProfileService {
                     "Product profile update could not be persisted.",
                     Map.of("store", "profile-overrides"));
         }
-        return profile(jwt);
+        return snapshot(jwt, identity).toResponse();
     }
 
     public ModuleSyncStatusResponse syncStatus(Jwt jwt) {
@@ -97,7 +97,10 @@ public class ProductProfileService {
     }
 
     private ProductProfileSnapshot snapshot(Jwt jwt) {
-        OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
+        return snapshot(jwt, OrganizationIdentityContextFactory.fromJwt(jwt));
+    }
+
+    private ProductProfileSnapshot snapshot(Jwt jwt, OrganizationIdentityContext identity) {
         String username = firstText(jwt.getClaimAsString("preferred_username"), identity.subject());
         ProductProfileOverride stored = profileRepository.findByPrimaryIdentityKey(identity.primaryIdentityKey());
         String displayName = stored != null && hasText(stored.displayName())

--- a/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ProductProfileService.java
@@ -59,7 +59,7 @@ public class ProductProfileService {
     }
 
     public ProfileReadinessResponse readiness(Jwt jwt) {
-        requireSubject(jwt);
+        OrganizationIdentityContextFactory.fromJwt(jwt);
         return new ProfileReadinessResponse(
                 "CEFACADE",
                 "/profile/readiness",
@@ -201,18 +201,6 @@ public class ProductProfileService {
                 .sorted(Map.Entry.comparingByKey())
                 .forEach(entry -> sanitized.put(entry.getKey().trim(), entry.getValue().trim()));
         return Map.copyOf(sanitized);
-    }
-
-    private String requireSubject(Jwt jwt) {
-        String subject = jwt.getSubject();
-        if (!hasText(subject)) {
-            throw new ApiErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "missing-subject",
-                    "Authenticated token is missing a stable subject.",
-                    Map.of("claim", "sub"));
-        }
-        return subject;
     }
 
     private String issuedFor(Jwt jwt) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -11,10 +11,8 @@ import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyDenyResponse;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
 import com.massimotter.weave.backend.exception.ApiErrorException;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -202,9 +200,9 @@ public class WorkspaceCapabilityService {
         EffectivePolicy policy = effectivePolicy(jwt);
         return new WorkspaceCapabilityPolicyResponse(
                 "identity/IDM",
-                "Keycloak",
-                "OIDC/SAML adapter contract; Keycloak is the self-hosted default, not a product lock-in",
-                "JWT realm roles plus groups claims from the selected IDM",
+                "OIDC/SAML selected IDM",
+                "OIDC/SAML adapter contract; Keycloak is only the dogfood default, not product truth",
+                "OIDC role claims plus group claims from the selected IDM",
                 policy.roles(),
                 policy.groups(),
                 policy.profileKeys(),
@@ -222,12 +220,11 @@ public class WorkspaceCapabilityService {
 
     public EffectivePolicyResponse effectivePolicySnapshot(Jwt jwt, String context) {
         EffectivePolicy policy = effectivePolicy(jwt);
-        String subject = jwt == null || jwt.getSubject() == null || jwt.getSubject().isBlank()
-                ? "system"
-                : jwt.getSubject();
-        String organization = firstText(claim(jwt, "weave_tenant"), claim(jwt, "tenant"), claim(jwt, "tid"), "weave-dogfood");
-        String issuer = jwt == null || jwt.getIssuer() == null ? "unknown-issuer" : jwt.getIssuer().toString();
-        String primaryIdentityKey = "issuer+subject:" + issuer + "#" + subject;
+        OrganizationIdentityContext identity = jwt == null ? null : OrganizationIdentityContextFactory.fromJwt(jwt);
+        String subject = identity == null ? "system" : identity.subject();
+        String organization = identity == null ? "weave-dogfood" : identity.organizationId();
+        String issuer = identity == null ? "unknown-issuer" : identity.issuer();
+        String primaryIdentityKey = identity == null ? "issuer+subject:unknown-issuer#system" : identity.primaryIdentityKey();
         List<String> denies = List.of(
                 "admin.policy.edit",
                 "admin.provider.configure",
@@ -241,7 +238,7 @@ public class WorkspaceCapabilityService {
                 List.of(issuer),
                 policy.groups(),
                 policy.roles(),
-                contextRoles(jwt),
+                identity == null ? List.of() : identity.contextRoles(),
                 policy.providerRoleMappings(),
                 policy.capabilities().stream().sorted().toList(),
                 denies.stream()
@@ -385,8 +382,9 @@ public class WorkspaceCapabilityService {
                     Set.copyOf(systemCapabilities),
                     List.of("system:internal-readiness"));
         }
-        List<String> roles = extractRealmRoles(jwt);
-        List<String> groups = extractStringList(jwt, "groups");
+        OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
+        List<String> roles = identity.roles();
+        List<String> groups = identity.groups();
         LinkedHashSet<String> capabilities = new LinkedHashSet<>();
         LinkedHashSet<String> profileKeys = new LinkedHashSet<>();
 
@@ -431,22 +429,7 @@ public class WorkspaceCapabilityService {
                 groups,
                 List.copyOf(profileKeys),
                 Set.copyOf(capabilities),
-                providerRoleMappings(roles, groups));
-    }
-
-    private List<String> providerRoleMappings(List<String> roles, List<String> groups) {
-        return Stream.concat(
-                        roles.stream().map(role -> "realm_role:" + role),
-                        groups.stream().map(group -> "group_claim:" + group))
-                .sorted()
-                .toList();
-    }
-
-    private List<String> contextRoles(Jwt jwt) {
-        return extractStringList(jwt, "weave_context_roles").stream()
-                .map(role -> role.toLowerCase(Locale.ROOT))
-                .sorted()
-                .toList();
+                identity.providerRoleMappings());
     }
 
     private List<String> readinessImpact(EffectivePolicy policy) {
@@ -467,58 +450,6 @@ public class WorkspaceCapabilityService {
             return "operator role does not automatically grant user, provider, or policy administration";
         }
         return "missing mapped org role, context role, or group capability";
-    }
-
-    private List<String> extractRealmRoles(Jwt jwt) {
-        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
-        if (realmAccess == null) {
-            return List.of();
-        }
-
-        Object roles = realmAccess.get("roles");
-        if (!(roles instanceof Collection<?> roleValues)) {
-            return List.of();
-        }
-
-        return roleValues.stream()
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .map(role -> role.trim().toLowerCase(Locale.ROOT))
-                .filter(role -> !role.isEmpty())
-                .sorted()
-                .toList();
-    }
-
-    private List<String> extractStringList(Jwt jwt, String claimName) {
-        Object claim = jwt.getClaims().get(claimName);
-        if (!(claim instanceof Collection<?> values)) {
-            return List.of();
-        }
-
-        return values.stream()
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .map(String::trim)
-                .filter(value -> !value.isEmpty())
-                .sorted()
-                .toList();
-    }
-
-    private String claim(Jwt jwt, String claimName) {
-        if (jwt == null) {
-            return null;
-        }
-        Object value = jwt.getClaims().get(claimName);
-        return value instanceof String text && hasText(text) ? text.trim() : null;
-    }
-
-    private String firstText(String... values) {
-        for (String value : values) {
-            if (hasText(value)) {
-                return value.trim();
-            }
-        }
-        return null;
     }
 
     private boolean hasText(String value) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -219,8 +219,8 @@ public class WorkspaceCapabilityService {
     }
 
     public EffectivePolicyResponse effectivePolicySnapshot(Jwt jwt, String context) {
-        EffectivePolicy policy = effectivePolicy(jwt);
         OrganizationIdentityContext identity = jwt == null ? null : OrganizationIdentityContextFactory.fromJwt(jwt);
+        EffectivePolicy policy = effectivePolicy(identity);
         String subject = identity == null ? "system" : identity.subject();
         String organization = identity == null ? "weave-dogfood" : identity.organizationId();
         String issuer = identity == null ? "unknown-issuer" : identity.issuer();
@@ -372,7 +372,11 @@ public class WorkspaceCapabilityService {
     }
 
     private EffectivePolicy effectivePolicy(Jwt jwt) {
-        if (jwt == null) {
+        return effectivePolicy(jwt == null ? null : OrganizationIdentityContextFactory.fromJwt(jwt));
+    }
+
+    private EffectivePolicy effectivePolicy(OrganizationIdentityContext identity) {
+        if (identity == null) {
             LinkedHashSet<String> systemCapabilities = new LinkedHashSet<>(OWNER_ADMIN_CAPABILITIES);
             systemCapabilities.remove("weaver.enabled");
             return new EffectivePolicy(
@@ -382,7 +386,6 @@ public class WorkspaceCapabilityService {
                     Set.copyOf(systemCapabilities),
                     List.of("system:internal-readiness"));
         }
-        OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
         List<String> roles = identity.roles();
         List<String> groups = identity.groups();
         LinkedHashSet<String> capabilities = new LinkedHashSet<>();

--- a/server/src/test/java/com/massimotter/weave/backend/bdd/ProviderStackReadinessStepDefinitions.java
+++ b/server/src/test/java/com/massimotter/weave/backend/bdd/ProviderStackReadinessStepDefinitions.java
@@ -67,6 +67,7 @@ public class ProviderStackReadinessStepDefinitions {
     public void aWorkspaceScopedProductCaller() {
         caller = jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.weave.local/realms/weave")
                         .claim("aud", List.of("weave-app")))
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
     }
@@ -75,6 +76,7 @@ public class ProviderStackReadinessStepDefinitions {
     public void aWorkspaceScopedAdminProductCaller() {
         caller = jwt().jwt(jwt -> jwt
                         .subject("admin-123")
+                        .claim("iss", "https://auth.weave.local/realms/weave")
                         .claim("aud", List.of("weave-app"))
                         .claim("realm_access", Map.of("roles", List.of("admin"))))
                 .authorities(

--- a/server/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -114,6 +114,14 @@ class FirstPartyIdentityContractTest {
     }
 
     @Test
+    void grantsMethodSecurityRolesFromClientResourceAccess() throws Exception {
+        mockMvc.perform(get("/api/admin/policies/effective")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer client-admin-role"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.orgRoles[0]").value("admin"));
+    }
+
+    @Test
     void normalizesIssuedForFromClientIdWhenAzpIsAbsent() throws Exception {
         mockMvc.perform(get("/api/me")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer client-id-only"))
@@ -145,6 +153,10 @@ class FirstPartyIdentityContractTest {
                     Map.of("azp", FIRST_PARTY_CLIENT_ID));
             case "client-id-only" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace",
                     Map.of("client_id", FIRST_PARTY_CLIENT_ID));
+            case "client-admin-role" -> jwt(tokenValue, List.of(REQUIRED_AUDIENCE), "weave:workspace",
+                    Map.of(
+                            "azp", FIRST_PARTY_CLIENT_ID,
+                            "resource_access", Map.of(FIRST_PARTY_CLIENT_ID, Map.of("roles", List.of("admin")))));
             case "wrong-audience" -> jwt(tokenValue, List.of("other-api"), "weave:workspace",
                     Map.of("azp", FIRST_PARTY_CLIENT_ID));
             case "missing-audience" -> jwt(tokenValue, null, "weave:workspace",

--- a/server/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -118,21 +119,24 @@ class FirstPartyIdentityContractTest {
                         .header(HttpHeaders.AUTHORIZATION, "Bearer client-id-only"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.issuedFor").value(FIRST_PARTY_CLIENT_ID))
-                .andExpect(jsonPath("$.userId").value("user-123"));
+                .andExpect(jsonPath("$.userId", startsWith("acct_")))
+                .andExpect(jsonPath("$.subject").value("user-123"));
     }
 
     @Test
     void acceptsValidFullFirstPartyToken() throws Exception {
         mockMvc.perform(get("/api/me")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-full-token"))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer valid-full-token"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userId").value("user-123"))
+                .andExpect(jsonPath("$.userId", startsWith("acct_")))
                 .andExpect(jsonPath("$.username").value("alice"))
                 .andExpect(jsonPath("$.emailVerified").value(false))
                 .andExpect(jsonPath("$.displayName").value("Alice Example"))
                 .andExpect(jsonPath("$.issuedFor").value(FIRST_PARTY_CLIENT_ID))
                 .andExpect(jsonPath("$.audience[0]").value(REQUIRED_AUDIENCE))
-                .andExpect(jsonPath("$.realmRoles[0]").value("member"));
+                .andExpect(jsonPath("$.subject").value("user-123"))
+                .andExpect(jsonPath("$.primaryIdentityKey").value("issuer+subject:https://auth.weave.local/realms/weave#user-123"))
+                .andExpect(jsonPath("$.providerRoleMappings[0]").value("role_claim:member"));
     }
 
     private Jwt decode(String tokenValue) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -270,7 +270,7 @@ class AdminControlPlaneControllerTest {
         mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"profileKey\":\"workspace-admin\",\"capabilityKeys\":[\"chat.read\"]}"))
+                        .content("{\"profileKey\":\"Workspace-Admin\",\"capabilityKeys\":[\"chat.read\"]}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("last-admin-guard"))
                 .andExpect(content().string(not(containsString("alice@example.com"))));

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -254,6 +254,18 @@ class AdminControlPlaneControllerTest {
     }
 
     @Test
+    void bootstrapRejectsUnsafeAdminRecoveryKeys() throws Exception {
+        mockMvc.perform(post("/api/admin/organizations/bootstrap")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminSubjectKeys\":[\"alice@example.com\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("organization-bootstrap-admin-key-invalid"))
+                .andExpect(content().string(not(containsString("alice@example.com"))))
+                .andExpect(content().string(containsString("issuer+subject:<issuer>#<subject>")));
+    }
+
+    @Test
     void lastAdminGuardRejectsWorkspaceAdminPolicyThatRemovesPolicyEdit() throws Exception {
         mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
                         .with(adminJwt())
@@ -262,6 +274,16 @@ class AdminControlPlaneControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("last-admin-guard"))
                 .andExpect(content().string(not(containsString("alice@example.com"))));
+    }
+
+    @Test
+    void lastAdminGuardRejectsEmptyWorkspaceAdminPolicy() throws Exception {
+        mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"profileKey\":\"workspace-admin\",\"capabilityKeys\":[]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("last-admin-guard"));
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -23,6 +23,8 @@ import com.massimotter.weave.backend.provider.ProviderSelection;
 import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import java.time.Instant;
 import com.massimotter.weave.backend.service.AdminControlPlaneService;
+import com.massimotter.weave.backend.service.InMemoryOrganizationBootstrapRepository;
+import com.massimotter.weave.backend.service.OrganizationBootstrapRepository;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -434,6 +436,11 @@ class AdminControlPlaneControllerTest {
         @Bean
         ProviderSelectionRepository providerSelectionRepository() {
             return new InMemoryProviderSelectionRepository();
+        }
+
+        @Bean
+        OrganizationBootstrapRepository organizationBootstrapRepository() {
+            return new InMemoryOrganizationBootstrapRepository();
         }
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -266,6 +266,17 @@ class AdminControlPlaneControllerTest {
     }
 
     @Test
+    void bootstrapRejectsNullAdminRecoveryKeysAsValidationError() throws Exception {
+        mockMvc.perform(post("/api/admin/organizations/bootstrap")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminSubjectKeys\":[null]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("validation-error"))
+                .andExpect(content().string(containsString("adminSubjectKeys")));
+    }
+
+    @Test
     void lastAdminGuardRejectsWorkspaceAdminPolicyThatRemovesPolicyEdit() throws Exception {
         mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
                         .with(adminJwt())

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -236,19 +236,19 @@ class AdminControlPlaneControllerTest {
         mockMvc.perform(post("/api/admin/organizations/bootstrap")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminSubjectKeys\":[]}"))
+                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminPrimaryIdentityKeys\":[]}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.organizationId").value("acme-prod"))
                 .andExpect(jsonPath("$.bootstrapMode").value("existing_org"))
                 .andExpect(jsonPath("$.actorPrimaryIdentityKey").value("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"))
-                .andExpect(jsonPath("$.retainedAdminSubjectKeys[*]", hasItems("issuer+subject:https://auth.example.invalid/realms/weave#admin-123")))
+                .andExpect(jsonPath("$.retainedAdminPrimaryIdentityKeys[*]", hasItems("issuer+subject:https://auth.example.invalid/realms/weave#admin-123")))
                 .andExpect(jsonPath("$.lastAdminGuardPassed").value(true))
                 .andExpect(jsonPath("$.supportSafe").value(true));
 
         mockMvc.perform(post("/api/admin/organizations/bootstrap")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"organizationId\":\"newco\",\"bootstrapMode\":\"new_org\",\"adminSubjectKeys\":[\"issuer+subject:https://auth.example.invalid/realms/weave#admin-123\"]}"))
+                        .content("{\"organizationId\":\"newco\",\"bootstrapMode\":\"new_org\",\"adminPrimaryIdentityKeys\":[\"issuer+subject:https://auth.example.invalid/realms/weave#admin-123\"]}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.organizationId").value("newco"))
                 .andExpect(jsonPath("$.bootstrapMode").value("new_org"))
@@ -260,11 +260,11 @@ class AdminControlPlaneControllerTest {
         mockMvc.perform(post("/api/admin/organizations/bootstrap")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminSubjectKeys\":[\"alice@example.com\"]}"))
+                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminPrimaryIdentityKeys\":[\"alice@example.com\"]}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("validation-error"))
                 .andExpect(content().string(not(containsString("alice@example.com"))))
-                .andExpect(content().string(containsString("adminSubjectKeys")));
+                .andExpect(content().string(containsString("adminPrimaryIdentityKeys")));
     }
 
     @Test
@@ -272,10 +272,10 @@ class AdminControlPlaneControllerTest {
         mockMvc.perform(post("/api/admin/organizations/bootstrap")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminSubjectKeys\":[null]}"))
+                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminPrimaryIdentityKeys\":[null]}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("validation-error"))
-                .andExpect(content().string(containsString("adminSubjectKeys")));
+                .andExpect(content().string(containsString("adminPrimaryIdentityKeys")));
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -260,9 +260,9 @@ class AdminControlPlaneControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminSubjectKeys\":[\"alice@example.com\"]}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("organization-bootstrap-admin-key-invalid"))
+                .andExpect(jsonPath("$.code").value("validation-error"))
                 .andExpect(content().string(not(containsString("alice@example.com"))))
-                .andExpect(content().string(containsString("issuer+subject:<issuer>#<subject>")));
+                .andExpect(content().string(containsString("adminSubjectKeys")));
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -103,9 +103,9 @@ class AdminControlPlaneControllerTest {
         when(workspaceCapabilityService.snapshot()).thenReturn(capabilities);
         when(workspaceCapabilityService.policySnapshot(org.mockito.ArgumentMatchers.any())).thenReturn(new WorkspaceCapabilityPolicyResponse(
                 "identity/IDM",
-                "Keycloak",
-                "OIDC/SAML adapter contract; Keycloak is the self-hosted default, not a product lock-in",
-                "JWT realm roles plus groups claims from the selected IDM",
+                "OIDC/SAML selected IDM",
+                "OIDC/SAML adapter contract; Keycloak is only the dogfood default, not product truth",
+                "OIDC role claims plus group claims from the selected IDM",
                 List.of("admin"),
                 List.of("weave-board-editors"),
                 List.of("workspace-admin", "group:weave-board-editors"),
@@ -121,7 +121,7 @@ class AdminControlPlaneControllerTest {
                 List.of("weave-board-editors"),
                 List.of("admin"),
                 List.of("context_admin"),
-                List.of("realm_role:admin", "group_claim:weave-board-editors"),
+                List.of("role_claim:admin", "group_claim:weave-board-editors"),
                 List.of("chat.read", "files.read", "boards.update_task", "admin.policy.edit", "admin.provider.configure", "weaver.exec_disabled"),
                 List.of(new EffectivePolicyDenyResponse("weaver.enabled", "weaver runtime is disabled unless an organization policy group explicitly grants it", "deny-by-default-capability-policy")),
                 List.of("member-visible states remain ready, disabled, degraded, or policy-blocked"),
@@ -171,7 +171,7 @@ class AdminControlPlaneControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.contractVersion").value("admin-control-plane-v1"))
                 .andExpect(jsonPath("$.organizationId").value("weave-dogfood"))
-                .andExpect(jsonPath("$.recommendedIdentityBroker").value("keycloak"))
+                .andExpect(jsonPath("$.recommendedIdentityBroker").value("OIDC/SAML selected IDM"))
                 .andExpect(jsonPath("$.providerConfigSource").value("admin-control-plane-selected-provider-mappings"))
                 .andExpect(jsonPath("$.bootstrapDefaultsAreSuggestionsOnly").value(true))
                 .andExpect(jsonPath("$.backendOwnedFacades").value(true))
@@ -202,7 +202,7 @@ class AdminControlPlaneControllerTest {
                 .andExpect(jsonPath("$.subject").value("admin-123"))
                 .andExpect(jsonPath("$.organization").value("weave-dogfood"))
                 .andExpect(jsonPath("$.capabilityGrants[*]", hasItems("admin.policy.edit", "admin.provider.configure")))
-                .andExpect(jsonPath("$.providerRoleMappings[*]", hasItems("realm_role:admin", "group_claim:weave-board-editors")))
+                .andExpect(jsonPath("$.providerRoleMappings[*]", hasItems("role_claim:admin", "group_claim:weave-board-editors")))
                 .andExpect(jsonPath("$.denies[0].capability").value("weaver.enabled"))
                 .andExpect(jsonPath("$.denyByDefault").value(true))
                 .andExpect(jsonPath("$.supportSafe").value(true))
@@ -227,6 +227,41 @@ class AdminControlPlaneControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"category\":\"chat\",\"providerKey\":\"slack\",\"choiceModel\":\"external_existing_provider\",\"secretRef\":\"secretref://weave/provider/slack\"}"))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void adminsCanBootstrapExistingAndNewOrganizationsWithLastAdminRecoveryKey() throws Exception {
+        mockMvc.perform(post("/api/admin/organizations/bootstrap")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"organizationId\":\"acme-prod\",\"bootstrapMode\":\"existing_org\",\"adminSubjectKeys\":[]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.organizationId").value("acme-prod"))
+                .andExpect(jsonPath("$.bootstrapMode").value("existing_org"))
+                .andExpect(jsonPath("$.actorPrimaryIdentityKey").value("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"))
+                .andExpect(jsonPath("$.retainedAdminSubjectKeys[*]", hasItems("issuer+subject:https://auth.example.invalid/realms/weave#admin-123")))
+                .andExpect(jsonPath("$.lastAdminGuardPassed").value(true))
+                .andExpect(jsonPath("$.supportSafe").value(true));
+
+        mockMvc.perform(post("/api/admin/organizations/bootstrap")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"organizationId\":\"newco\",\"bootstrapMode\":\"new_org\",\"adminSubjectKeys\":[\"issuer+subject:https://auth.example.invalid/realms/weave#admin-123\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.organizationId").value("newco"))
+                .andExpect(jsonPath("$.bootstrapMode").value("new_org"))
+                .andExpect(jsonPath("$.emailPrimaryKey").doesNotExist());
+    }
+
+    @Test
+    void lastAdminGuardRejectsWorkspaceAdminPolicyThatRemovesPolicyEdit() throws Exception {
+        mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"profileKey\":\"workspace-admin\",\"capabilityKeys\":[\"chat.read\"]}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("last-admin-guard"))
+                .andExpect(content().string(not(containsString("alice@example.com"))));
     }
 
     @Test
@@ -275,7 +310,7 @@ class AdminControlPlaneControllerTest {
         mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"profileKey\":\"workspace-admin\",\"capabilityKeys\":[\"chat.read\",\"calendar.manage_events\"],\"reason\":\"grant through Admin Console\"}"))
+                        .content("{\"profileKey\":\"workspace-admin\",\"capabilityKeys\":[\"admin.policy.edit\",\"chat.read\",\"calendar.manage_events\"],\"reason\":\"grant through Admin Console\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.denyByDefault").value(true));
 
@@ -326,6 +361,7 @@ class AdminControlPlaneControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor adminJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("admin-123")
+                        .claim("iss", "https://auth.example.invalid/realms/weave")
                         .claim("aud", java.util.List.of("weave-app"))
                         .claim("weave_tenant", "weave-dogfood")
                         .claim("realm_access", java.util.Map.of("roles", java.util.List.of("admin"))))
@@ -337,6 +373,7 @@ class AdminControlPlaneControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor operatorJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("operator-123")
+                        .claim("iss", "https://auth.example.invalid/realms/weave")
                         .claim("aud", java.util.List.of("weave-app"))
                         .claim("weave_tenant", "weave-dogfood")
                         .claim("realm_access", java.util.Map.of("roles", java.util.List.of("operator"))))
@@ -348,6 +385,7 @@ class AdminControlPlaneControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor memberJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/weave")
                         .claim("aud", java.util.List.of("weave-app"))
                         .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member"))))
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ChatControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ChatControllerTest.java
@@ -471,6 +471,7 @@ class ChatControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor workspaceJwt(String role) {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("preferred_username", "test")
                         .claim("weave_tenant_id", "tenant-default")
                         .claim("realm_access", Map.of("roles", List.of(role)))
@@ -481,12 +482,16 @@ class ChatControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor memberJwt() {
         return jwt()
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"), new SimpleGrantedAuthority("ROLE_MEMBER"))
-                .jwt(jwt -> jwt.subject("member-123"));
+                .jwt(jwt -> jwt
+                        .subject("member-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme"));
     }
 
     private org.springframework.test.web.servlet.request.RequestPostProcessor adminJwt() {
         return jwt()
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"), new SimpleGrantedAuthority("ROLE_ADMIN"))
-                .jwt(jwt -> jwt.subject("admin-123"));
+                .jwt(jwt -> jwt
+                        .subject("admin-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme"));
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/FilesCalendarFacadeControllerTest.java
@@ -326,6 +326,7 @@ class FilesCalendarFacadeControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor workspaceJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("aud", java.util.List.of("weave-app"))
                         .claim("weave_tenant_id", "tenant-default")
                 .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
@@ -336,6 +337,7 @@ class FilesCalendarFacadeControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor memberJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("aud", java.util.List.of("weave-app"))
                         .claim("weave_tenant_id", "tenant-default")
                         .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))

--- a/server/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
@@ -18,6 +18,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -45,6 +47,8 @@ class IdentityControllerTest {
     void returnsAuthenticatedPrincipalDetails() throws Exception {
         mockMvc.perform(get("/api/me").with(jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
+                        .claim("weave_tenant", "acme-prod")
                         .claim("preferred_username", "alice")
                         .claim("name", "Alice Example")
                         .claim("email", "alice@example.com")
@@ -54,10 +58,11 @@ class IdentityControllerTest {
                         .claim("azp", "weave-app")
                         .claim("aud", List.of("weave-app", "account"))
                         .claim("realm_access", Map.of("roles", List.of("member", "admin")))
-                        .claim("groups", List.of("team-alpha", "team-beta")))
+                        .claim("groups", List.of("team-alpha", "team-beta"))
+                        .claim("weave_context_roles", List.of("channel-admin")))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userId").value("user-123"))
+                .andExpect(jsonPath("$.userId", startsWith("acct_")))
                 .andExpect(jsonPath("$.username").value("alice"))
                 .andExpect(jsonPath("$.displayName").value("Alice Example"))
                 .andExpect(jsonPath("$.emailVerified").value(true))
@@ -66,7 +71,12 @@ class IdentityControllerTest {
                 .andExpect(jsonPath("$.moduleSyncStatus.matrix").value("not_configured"))
                 .andExpect(jsonPath("$.issuedFor").value("weave-app"))
                 .andExpect(jsonPath("$.audience[0]").value("weave-app"))
-                .andExpect(jsonPath("$.realmRoles[0]").value("admin"))
+                .andExpect(jsonPath("$.organizationId").value("acme-prod"))
+                .andExpect(jsonPath("$.subject").value("user-123"))
+                .andExpect(jsonPath("$.primaryIdentityKey").value("issuer+subject:https://auth.example.invalid/realms/acme#user-123"))
+                .andExpect(jsonPath("$.emailPrimaryKey").value(false))
+                .andExpect(jsonPath("$.providerRoleMappings[0]").value("group_claim:team-alpha"))
+                .andExpect(jsonPath("$.contextRoles[0]").value("channel-admin"))
                 .andExpect(jsonPath("$.groups[1]").value("team-beta"));
     }
 
@@ -80,7 +90,7 @@ class IdentityControllerTest {
                         .claim("aud", List.of("weave-app")))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userId").value("user-123"))
+                .andExpect(jsonPath("$.userId", startsWith("acct_")))
                 .andExpect(jsonPath("$.username").value("alice"))
                 .andExpect(jsonPath("$.email").value("alice@example.com"))
                 .andExpect(jsonPath("$.displayName").value("Alice Example"));
@@ -96,7 +106,24 @@ class IdentityControllerTest {
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.roles[0]").value("operator"))
-                .andExpect(jsonPath("$.realmRoles[0]").value("operator"));
+                .andExpect(jsonPath("$.providerRoleMappings[0]").value("role_claim:operator"));
+    }
+
+    @Test
+    void emailRenameDoesNotChangePrimaryIdentity() throws Exception {
+        mockMvc.perform(get("/api/me").with(jwt().jwt(jwt -> jwt
+                        .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
+                        .claim("email", "alice.renamed@example.com")
+                        .claim("preferred_username", "alice")
+                        .claim("realm_access", Map.of("roles", List.of("member")))
+                        .claim("aud", List.of("weave-app")))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.primaryIdentityKey").value("issuer+subject:https://auth.example.invalid/realms/acme#user-123"))
+                .andExpect(jsonPath("$.userId", startsWith("acct_")))
+                .andExpect(jsonPath("$.userId", not("alice.renamed@example.com")))
+                .andExpect(jsonPath("$.emailPrimaryKey").value(false));
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/IdentityControllerTest.java
@@ -84,6 +84,7 @@ class IdentityControllerTest {
     void exposesCanonicalMeEndpoint() throws Exception {
         mockMvc.perform(get("/api/me").with(jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("preferred_username", "alice")
                         .claim("name", "Alice Example")
                         .claim("email", "alice@example.com")
@@ -100,6 +101,7 @@ class IdentityControllerTest {
     void includesOperatorAsAProductRole() throws Exception {
         mockMvc.perform(get("/api/me").with(jwt().jwt(jwt -> jwt
                         .subject("operator-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("preferred_username", "ops")
                         .claim("realm_access", Map.of("roles", List.of("operator")))
                         .claim("aud", List.of("weave-app")))
@@ -136,6 +138,7 @@ class IdentityControllerTest {
     void fallsBackToClientIdWhenAzpIsAbsent() throws Exception {
         mockMvc.perform(get("/api/me").with(jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("client_id", "weave-app")
                         .claim("aud", List.of("weave-app")))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))

--- a/server/src/test/java/com/massimotter/weave/backend/controller/OnboardingControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/OnboardingControllerTest.java
@@ -28,6 +28,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -78,7 +79,7 @@ class OnboardingControllerTest {
                         .claim("groups", List.of("workspace-default")))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.identity.userId").value("user-123"))
+                .andExpect(jsonPath("$.identity.userId", startsWith("acct_")))
                 .andExpect(jsonPath("$.identity.username").value("alice"))
                 .andExpect(jsonPath("$.identity.groups[0]").value("workspace-default"))
                 .andExpect(jsonPath("$.invite.status").value("active"))
@@ -143,6 +144,7 @@ class OnboardingControllerTest {
         return Stream.of(
                 Arguments.of("owner", true, true, true),
                 Arguments.of("admin", true, true, true),
+                Arguments.of("operator", false, false, false),
                 Arguments.of("member", false, false, true),
                 Arguments.of("guest", false, false, false));
     }

--- a/server/src/test/java/com/massimotter/weave/backend/controller/OnboardingControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/OnboardingControllerTest.java
@@ -68,6 +68,7 @@ class OnboardingControllerTest {
     void returnsFirstRunStatusForAuthenticatedUser() throws Exception {
         mockMvc.perform(get("/api/onboarding/status").with(jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("preferred_username", "alice")
                         .claim("name", "Alice Example")
                         .claim("email", "alice@example.com")
@@ -99,6 +100,7 @@ class OnboardingControllerTest {
             boolean canUseModules) throws Exception {
         mockMvc.perform(get("/api/onboarding/status").with(jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("preferred_username", realmRole + "-user")
                         .claim("name", "Role User")
                         .claim("email", realmRole + "@example.com")
@@ -117,6 +119,7 @@ class OnboardingControllerTest {
     void returnsPendingInviteAndProfileStatusWithoutRawDownstreamErrors() throws Exception {
         mockMvc.perform(get("/api/onboarding/status").with(jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("preferred_username", "alice")
                         .claim("name", "Alice Example")
                         .claim("email", "alice@example.com")

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ProfileControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ProfileControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -74,7 +75,7 @@ class ProfileControllerTest {
     void returnsProfileDerivedFromAuthenticatedPrincipal() throws Exception {
         mockMvc.perform(get("/api/profile").with(profileJwt()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userId").value("user-123"))
+                .andExpect(jsonPath("$.userId", startsWith("acct_")))
                 .andExpect(jsonPath("$.username").value("alice"))
                 .andExpect(jsonPath("$.displayName").value("Alice Example"))
                 .andExpect(jsonPath("$.avatar").value("https://example.test/alice.png"))

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ProfileControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ProfileControllerTest.java
@@ -166,6 +166,7 @@ class ProfileControllerTest {
                         .content("{\"displayName\":\"Alice Weave\"}")
                         .with(jwt().jwt(jwt -> jwt
                                 .subject("user-123")
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
                                 .claim("preferred_username", "alice")
                                 .claim("aud", List.of("weave-app")))))
                 .andExpect(status().isForbidden());
@@ -174,6 +175,7 @@ class ProfileControllerTest {
     private static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.JwtRequestPostProcessor profileJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
                         .claim("preferred_username", "alice")
                         .claim("name", "Alice Example")
                         .claim("email", "alice@example.com")

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ProfileControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ProfileControllerTest.java
@@ -64,8 +64,8 @@ class ProfileControllerTest {
     @BeforeEach
     void setUpProfileRepository() {
         profileOverrides.clear();
-        when(profileRepository.findBySubject(anyString())).thenAnswer(invocation -> profileOverrides.get(invocation.getArgument(0)));
-        when(profileRepository.save(anyString(), any(ProductProfileOverride.class))).thenAnswer(invocation -> {
+        when(profileRepository.findByPrimaryIdentityKey(anyString())).thenAnswer(invocation -> profileOverrides.get(invocation.getArgument(0)));
+        when(profileRepository.saveForPrimaryIdentityKey(anyString(), any(ProductProfileOverride.class))).thenAnswer(invocation -> {
             profileOverrides.put(invocation.getArgument(0), invocation.getArgument(1));
             return invocation.getArgument(1);
         });

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -84,6 +84,7 @@ class WorkspaceControllerTest {
         mockMvc.perform(get("/api/v1/organization/manifest").with(jwt()
                         .jwt(jwt -> jwt
                                 .subject("calendar-editor@example.invalid")
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
                                 .claim("weave_tenant_id", "weave-dogfood")
                                 .claim("weave_organization_name", "Weave Dogfood")
                                 .claim("realm_access", Map.of("roles", List.of()))
@@ -132,6 +133,7 @@ class WorkspaceControllerTest {
             mockMvc.perform(get("/api/v1/organization/manifest").with(jwt()
                             .jwt(jwt -> jwt
                                     .subject("calendar-editor@example.invalid")
+                                    .claim("iss", "https://auth.example.invalid/realms/acme")
                                     .claim("weave_tenant_id", "weave-dogfood")
                                     .claim("realm_access", Map.of("roles", List.of()))
                                     .claim("groups", List.of("weave-calendar-editors")))
@@ -151,6 +153,7 @@ class WorkspaceControllerTest {
             mockMvc.perform(get("/api/v1/organization/manifest").with(jwt()
                             .jwt(jwt -> jwt
                                     .subject("calendar-editor@example.invalid")
+                                    .claim("iss", "https://auth.example.invalid/realms/acme")
                                     .claim("weave_tenant_id", "weave-dogfood")
                                     .claim("realm_access", Map.of("roles", List.of()))
                                     .claim("groups", List.of("weave-calendar-editors")))
@@ -167,6 +170,7 @@ class WorkspaceControllerTest {
         mockMvc.perform(get("/api/v1/organization/manifest").with(jwt()
                         .jwt(jwt -> jwt
                                 .subject("calendar-editor@example.invalid")
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
                                 .claim("realm_access", Map.of("roles", List.of()))
                                 .claim("groups", List.of("weave-calendar-editors")))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
@@ -197,6 +201,7 @@ class WorkspaceControllerTest {
         mockMvc.perform(get("/api/v1/workspace/weaver/runtime-profile").with(jwt()
                         .jwt(jwt -> jwt
                                 .subject("member@example.invalid")
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
                                 .claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
@@ -213,6 +218,7 @@ class WorkspaceControllerTest {
     void returnsAdminCapabilityPolicySnapshot() throws Exception {
         mockMvc.perform(get("/api/v1/workspace/capability-policy").with(jwt()
                         .jwt(jwt -> jwt
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
                                 .claim("realm_access", Map.of("roles", List.of("admin")))
                                 .claim("groups", List.of("weave-board-editors")))
                         .authorities(
@@ -229,7 +235,9 @@ class WorkspaceControllerTest {
     @Test
     void rejectsCapabilityPolicyForMembers() throws Exception {
         mockMvc.perform(get("/api/v1/workspace/capability-policy").with(jwt()
-                        .jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("member"))))
+                        .jwt(jwt -> jwt
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
+                                .claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isForbidden());
     }
@@ -260,7 +268,9 @@ class WorkspaceControllerTest {
 
     private void assertConfiguredWorkspaceCapabilities(String path) throws Exception {
         mockMvc.perform(get(path).with(jwt()
-                        .jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("member"))))
+                        .jwt(jwt -> jwt
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
+                                .claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.shellAccess.enabled").value(true))
@@ -277,7 +287,9 @@ class WorkspaceControllerTest {
 
     private void assertReleaseReadinessSnapshot(String path) throws Exception {
         mockMvc.perform(get(path).with(jwt()
-                        .jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("member"))))
+                        .jwt(jwt -> jwt
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
+                                .claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.readiness").value("ready"))
@@ -289,7 +301,9 @@ class WorkspaceControllerTest {
 
     private void assertWeaveHomeSnapshot(String path) throws Exception {
         mockMvc.perform(get(path).with(jwt()
-                        .jwt(jwt -> jwt.claim("realm_access", Map.of("roles", List.of("member"))))
+                        .jwt(jwt -> jwt
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
+                                .claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.version").value(1))

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -219,7 +219,7 @@ class WorkspaceControllerTest {
                                 new SimpleGrantedAuthority("SCOPE_weave:workspace"),
                                 new SimpleGrantedAuthority("ROLE_ADMIN"))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.defaultIdmProvider").value("Keycloak"))
+                .andExpect(jsonPath("$.defaultIdmProvider").value("OIDC/SAML selected IDM"))
                 .andExpect(jsonPath("$.denyByDefault").value(true))
                 .andExpect(jsonPath("$.supportSafe").value(true))
                 .andExpect(jsonPath("$.grantedCapabilities").isArray())

--- a/server/src/test/java/com/massimotter/weave/backend/service/OnboardingStatusServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/OnboardingStatusServiceTest.java
@@ -75,6 +75,7 @@ class OnboardingStatusServiceTest {
         return Jwt.withTokenValue("token")
                 .header("alg", "none")
                 .subject("user-123")
+                .issuer("https://auth.example.invalid/realms/acme")
                 .issuedAt(now)
                 .expiresAt(now.plusSeconds(600))
                 .claim("preferred_username", "alice")

--- a/server/src/test/java/com/massimotter/weave/backend/service/ProductProfileServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ProductProfileServiceTest.java
@@ -68,6 +68,27 @@ class ProductProfileServiceTest {
         assertThat(service.authenticatedUser(renamedEmail).emailPrimaryKey()).isFalse();
     }
 
+    @Test
+    void migratesLegacySubjectProfileOverrideToPrimaryIdentityKey() throws Exception {
+        Path storagePath = tempDir.resolve("profile-overrides.json");
+        new ObjectMapper().writerWithDefaultPrettyPrinter().writeValue(storagePath.toFile(), Map.of(
+                "user-123", new ProductProfileOverride(
+                        "Alice Legacy",
+                        null,
+                        "fr-FR",
+                        "Europe/Paris",
+                        Map.of(),
+                        "workspace")));
+
+        ProductProfileService service = new ProductProfileService(
+                new FileProductProfileOverrideRepository(new ObjectMapper(), storagePath));
+
+        assertThat(service.profile(profileJwt()).displayName()).isEqualTo("Alice Legacy");
+        String persisted = java.nio.file.Files.readString(storagePath);
+        assertThat(persisted).contains("issuer+subject:https://auth.weave.local/realms/weave#user-123");
+        assertThat(persisted).doesNotContain("\"user-123\"");
+    }
+
     private static Jwt profileJwt() {
         return profileJwt("alice@example.com");
     }

--- a/server/src/test/java/com/massimotter/weave/backend/service/ProductProfileServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ProductProfileServiceTest.java
@@ -45,13 +45,41 @@ class ProductProfileServiceTest {
         assertThat(recreatedService.authenticatedUser(jwt).displayName()).isEqualTo("Alice Durable");
     }
 
+    @Test
+    void emailRenameKeepsStableAccountAndProfileKey() {
+        ProductProfileService service = new ProductProfileService(
+                new FileProductProfileOverrideRepository(new ObjectMapper(), tempDir.resolve("profile-overrides.json")));
+        Jwt original = profileJwt("alice@example.com");
+        Jwt renamedEmail = profileJwt("alice.renamed@example.com");
+
+        service.update(original, new UpdateProductProfileRequest(
+                "Alice Stable",
+                null,
+                null,
+                null,
+                null,
+                null));
+
+        assertThat(service.authenticatedUser(renamedEmail).userId())
+                .isEqualTo(service.authenticatedUser(original).userId());
+        assertThat(service.authenticatedUser(renamedEmail).primaryIdentityKey())
+                .isEqualTo("issuer+subject:https://auth.weave.local/realms/weave#user-123");
+        assertThat(service.authenticatedUser(renamedEmail).displayName()).isEqualTo("Alice Stable");
+        assertThat(service.authenticatedUser(renamedEmail).emailPrimaryKey()).isFalse();
+    }
+
     private static Jwt profileJwt() {
+        return profileJwt("alice@example.com");
+    }
+
+    private static Jwt profileJwt(String email) {
         return Jwt.withTokenValue("token")
                 .header("alg", "none")
                 .subject("user-123")
+                .claim("iss", "https://auth.weave.local/realms/weave")
                 .claim("preferred_username", "alice")
                 .claim("name", "Alice Example")
-                .claim("email", "alice@example.com")
+                .claim("email", email)
                 .claim("email_verified", true)
                 .claim("locale", "en")
                 .claim("timezone", "UTC")

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -127,6 +127,7 @@ class WeaverRuntimeServiceTest {
                 Map.of("alg", "none"),
                 Map.of(
                         "sub", subject,
+                        "iss", "https://auth.example.invalid/realms/acme",
                         "realm_access", Map.of("roles", roles),
                         "groups", groups));
     }

--- a/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -202,6 +202,7 @@ class WorkspaceCapabilityServiceTest {
         return Jwt.withTokenValue("token")
                 .header("alg", "none")
                 .subject("user-1")
+                .issuer("https://auth.example.invalid/realms/acme")
                 .claim("realm_access", Map.of("roles", roles))
                 .claim("groups", groups)
                 .build();

--- a/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -128,7 +128,7 @@ class WorkspaceCapabilityServiceTest {
 
         var policy = service.policySnapshot(jwt(List.of("admin"), List.of("weave-board-editors")));
 
-        assertThat(policy.defaultIdmProvider()).isEqualTo("Keycloak");
+        assertThat(policy.defaultIdmProvider()).isEqualTo("OIDC/SAML selected IDM");
         assertThat(policy.adapterContract()).contains("OIDC/SAML");
         assertThat(policy.roles()).containsExactly("admin");
         assertThat(policy.groups()).containsExactly("weave-board-editors");


### PR DESCRIPTION
## Linked issue
- Closes #346

## Goal
Implement the Identity-first organization bootstrap slice that turns the merged organization-embedding strategy into executable backend behavior.

## Sprint 5 acceptance slice
- Immutable provider-neutral identity key is enforced (`issuer + subject` or documented stable provider equivalent).
- Existing organizations and newly provisioned organizations can both bootstrap into Weave.
- OIDC/SAML roles and groups map into Weave org/context roles without making Keycloak product truth.
- Email/display name remain mutable attributes, not primary keys.
- Last-owner/last-admin guard prevents policy changes that strand an organization.
- Member UX remains provider-neutral; admin/operator surfaces stay support-safe.

## Required tasks
- [x] Confirm current identity/auth codepaths and existing `/api/me` contract.
- [x] Add/confirm backend org identity context model.
- [x] Implement immutable primary identity key derivation.
- [x] Implement existing-org and new-org bootstrap path.
- [x] Add last-owner/last-admin guard.
- [x] Add tests for email rename preserving identity.
- [x] Add tests for guest/member/operator/admin/owner mappings.
- [x] Update implementation docs only where semantics change. (No docs change needed; API/OpenAPI annotations updated in code.)

## Evidence
- [x] `./gradlew serverCi` — passed locally on `c5f612c`.
- [x] `./gradlew acceptanceContract` — passed locally on `c5f612c`; runtime evidence not collected by this gate.
- [x] PR remains focused on #346; no provider replacement UX or Boards feature implementation.

## Notes for review
- `/api/me` now exposes `organizationId`, `identityIssuer`, `subject`, `primaryIdentityKey`, `accountId`, `contextRoles`, `providerRoleMappings`, and `emailPrimaryKey=false`.
- Profile overrides and account id are keyed by immutable `issuer+subject`, so email rename does not change primary identity.
- Admin bootstrap supports `existing_org` and `new_org`; responses/audit payloads are support-safe and include last-admin guard evidence.
- Effective policy uses mapped org roles/groups for owner/admin/operator/member/guest capability boundaries.

## Draft status
Implementation, Copilot follow-up fixes (including stable issuer and aligned identity-key and canonical policy and bootstrap key-count and account-id derivation and centralized guardrail and derived-context reuse and profile readiness and in-memory bootstrap validation alignment), and local evidence are recorded. Keep draft until GitHub checks are green on the pushed head and Integration-Gate review confirms merge readiness.




















