### PR TITLE
feat: enforce effective workspace policy

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/chat/ChatDomainFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/chat/ChatDomainFacadeService.java
@@ -72,6 +72,7 @@ public class ChatDomainFacadeService {
     }
 
     public ChatReadiness adminReadiness(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "chat", "admin-readiness");
         return readiness(jwt, true);
     }
 
@@ -94,6 +95,7 @@ public class ChatDomainFacadeService {
     }
 
     public ChatMigrationPreflightReport preflight(ChatMigrationPreflightRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "chat", "migration-preflight");
         ChatMigrationPreflightRequest safeRequest = request == null
                 ? new ChatMigrationPreflightRequest(null, null, true, Map.of(), List.of(), List.of(), null)
                 : request;

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -37,7 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 @ApiResponses({
         @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
                 content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or is not an owner/admin/operator.",
+        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or effective workspace capability policy denies the operation.",
                 content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
 })
 public class AdminControlPlaneController {
@@ -49,7 +49,7 @@ public class AdminControlPlaneController {
     }
 
     @GetMapping({"/api/admin/control-plane", "/api/v1/admin/control-plane"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Read the support-safe organization control-plane overview")
     @ApiResponse(responseCode = "200", description = "Admin control-plane snapshot.",
             content = @Content(schema = @Schema(implementation = AdminControlPlaneResponse.class)))
@@ -58,7 +58,7 @@ public class AdminControlPlaneController {
     }
 
     @GetMapping({"/api/admin/policies/capability-whitelist", "/api/v1/admin/policies/capability-whitelist"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Read deny-by-default capability whitelist policy")
     @ApiResponse(responseCode = "200", description = "Capability whitelist snapshot.",
             content = @Content(schema = @Schema(implementation = CapabilityWhitelistResponse.class)))
@@ -67,7 +67,7 @@ public class AdminControlPlaneController {
     }
 
     @GetMapping({"/api/admin/policies/effective", "/api/v1/admin/policies/effective"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Explain the effective capability policy for the authenticated subject")
     @ApiResponse(responseCode = "200", description = "Support-safe effective policy explanation.",
             content = @Content(schema = @Schema(implementation = EffectivePolicyResponse.class)))
@@ -76,7 +76,7 @@ public class AdminControlPlaneController {
     }
 
     @PostMapping({"/api/admin/organizations/bootstrap", "/api/v1/admin/organizations/bootstrap"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Bootstrap or bind an organization with immutable identity recovery administrators")
     @ApiResponse(responseCode = "200", description = "Support-safe organization bootstrap result.",
             content = @Content(schema = @Schema(implementation = OrganizationBootstrapResponse.class)))
@@ -87,7 +87,7 @@ public class AdminControlPlaneController {
     }
 
     @PatchMapping({"/api/admin/policies/capability-whitelist", "/api/v1/admin/policies/capability-whitelist"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Record a support-safe capability whitelist policy update")
     @ApiResponse(responseCode = "200", description = "Updated capability whitelist snapshot.",
             content = @Content(schema = @Schema(implementation = CapabilityWhitelistResponse.class)))
@@ -98,7 +98,7 @@ public class AdminControlPlaneController {
     }
 
     @PostMapping({"/api/admin/providers/selections", "/api/v1/admin/providers/selections"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Apply or dry-run an Admin Console selected provider mapping")
     @ApiResponse(responseCode = "200", description = "Support-safe selected provider mapping.",
             content = @Content(schema = @Schema(implementation = ProviderSelectionResponse.class)))
@@ -109,7 +109,7 @@ public class AdminControlPlaneController {
     }
 
     @PostMapping({"/api/admin/providers/readiness-tests", "/api/v1/admin/providers/readiness-tests"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Run a backend-owned support-safe provider readiness test contract")
     @ApiResponse(responseCode = "200", description = "Support-safe provider readiness test result.",
             content = @Content(schema = @Schema(implementation = ProviderReadinessTestResponse.class)))
@@ -120,7 +120,7 @@ public class AdminControlPlaneController {
     }
 
     @GetMapping({"/api/admin/audit/events", "/api/v1/admin/audit/events"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Read support-safe admin/provider audit events")
     @ApiResponse(responseCode = "200", description = "Audit event list.")
     public List<AdminAuditEventResponse> auditEvents(@AuthenticationPrincipal Jwt jwt) {

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -123,7 +123,7 @@ public class AdminControlPlaneController {
     @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
     @Operation(summary = "Read support-safe admin/provider audit events")
     @ApiResponse(responseCode = "200", description = "Audit event list.")
-    public List<AdminAuditEventResponse> auditEvents() {
-        return adminControlPlaneService.auditEvents();
+    public List<AdminAuditEventResponse> auditEvents(@AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.auditEvents(jwt);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/controller/OfficeController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/OfficeController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @ApiResponses({
         @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
                 content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
+        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or document capability policy denies Office access.",
                 content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
 })
 public class OfficeController {

--- a/server/src/main/java/com/massimotter/weave/backend/controller/OfficeController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/OfficeController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,8 +41,8 @@ public class OfficeController {
     @Operation(summary = "Read Office provider-neutral capabilities")
     @ApiResponse(responseCode = "200", description = "Secret-free Office capability metadata.",
             content = @Content(schema = @Schema(implementation = OfficeCapabilitiesResponse.class)))
-    public OfficeCapabilitiesResponse capabilities() {
-        return officeFacadeService.capabilities();
+    public OfficeCapabilitiesResponse capabilities(@AuthenticationPrincipal Jwt jwt) {
+        return officeFacadeService.capabilities(jwt);
     }
 
     @PostMapping("/api/office/launch")
@@ -49,7 +51,9 @@ public class OfficeController {
             content = @Content(schema = @Schema(implementation = OfficeLaunchResponse.class)))
     @ApiResponse(responseCode = "503", description = "Office provider is not configured or unavailable.",
             content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
-    public OfficeLaunchResponse launch(@Valid @RequestBody OfficeLaunchRequest request) {
-        return officeFacadeService.launch(request);
+    public OfficeLaunchResponse launch(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody OfficeLaunchRequest request) {
+        return officeFacadeService.launch(jwt, request);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/controller/ProviderRegistryController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/ProviderRegistryController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @ApiResponses({
         @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
                 content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or is not an owner/admin/operator.",
+        @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or effective workspace capability policy denies provider readiness access.",
                 content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
 })
 public class ProviderRegistryController {
@@ -38,7 +38,7 @@ public class ProviderRegistryController {
     }
 
     @GetMapping("/api/providers/status")
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(summary = "Read support-safe admin/provider category capability and readiness status")
     @ApiResponse(responseCode = "200", description = "Provider registry snapshot.",
             content = @Content(schema = @Schema(implementation = ProviderRegistryResponse.class)))

--- a/server/src/main/java/com/massimotter/weave/backend/controller/ProviderRegistryController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/ProviderRegistryController.java
@@ -3,6 +3,7 @@ package com.massimotter.weave.backend.controller;
 import com.massimotter.weave.backend.model.ApiErrorResponse;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
 import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,9 +29,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class ProviderRegistryController {
 
     private final ProviderRegistry providerRegistry;
+    private final WorkspaceCapabilityService workspaceCapabilityService;
 
-    public ProviderRegistryController(ProviderRegistry providerRegistry) {
+    public ProviderRegistryController(ProviderRegistry providerRegistry,
+            WorkspaceCapabilityService workspaceCapabilityService) {
         this.providerRegistry = providerRegistry;
+        this.workspaceCapabilityService = workspaceCapabilityService;
     }
 
     @GetMapping("/api/providers/status")
@@ -36,7 +42,8 @@ public class ProviderRegistryController {
     @Operation(summary = "Read support-safe admin/provider category capability and readiness status")
     @ApiResponse(responseCode = "200", description = "Provider registry snapshot.",
             content = @Content(schema = @Schema(implementation = ProviderRegistryResponse.class)))
-    public ProviderRegistryResponse status() {
+    public ProviderRegistryResponse status(@AuthenticationPrincipal Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "provider-registry", "status");
         return providerRegistry.status();
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -142,8 +142,8 @@ public class WorkspaceController {
             @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
-    public WorkspaceReleaseReadinessResponse releaseReadiness() {
-        return workspaceReleaseReadinessService.snapshot();
+    public WorkspaceReleaseReadinessResponse releaseReadiness(@AuthenticationPrincipal Jwt jwt) {
+        return workspaceReleaseReadinessService.snapshot(jwt);
     }
 
     @GetMapping({"/api/workspace/home", "/api/v1/workspace/home"})

--- a/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -89,7 +89,7 @@ public class WorkspaceController {
     }
 
     @GetMapping({"/api/workspace/capability-policy", "/api/v1/workspace/capability-policy"})
-    @PreAuthorize("hasAnyRole('OWNER','ADMIN','OPERATOR')")
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
     @Operation(
             summary = "Get workspace capability policy",
             description = "Returns an admin/operator support-safe snapshot of IDM role/group intake, profile mapping, deny-by-default posture, and Weaver-disabled-by-default policy state.",
@@ -101,7 +101,7 @@ public class WorkspaceController {
                     content = @Content(schema = @Schema(implementation = WorkspaceCapabilityPolicyResponse.class))),
             @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "Bearer token is not an owner/admin/operator or is missing the weave:workspace scope.",
+            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or effective policy denies capability-policy access.",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     public WorkspaceCapabilityPolicyResponse capabilityPolicy(@AuthenticationPrincipal Jwt jwt) {
@@ -139,7 +139,7 @@ public class WorkspaceController {
                     content = @Content(schema = @Schema(implementation = WorkspaceReleaseReadinessResponse.class))),
             @ApiResponse(responseCode = "401", description = "Missing or invalid bearer token.",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope.",
+            @ApiResponse(responseCode = "403", description = "Bearer token is missing the weave:workspace scope or effective policy denies operator readiness access.",
                     content = @Content(schema = @Schema(implementation = ApiErrorResponse.class)))
     })
     public WorkspaceReleaseReadinessResponse releaseReadiness(@AuthenticationPrincipal Jwt jwt) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -88,6 +88,7 @@ public class AdminControlPlaneService {
     }
 
     public AdminControlPlaneResponse overview(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "overview");
         ProviderRegistryResponse registry = providerRegistry.status();
         return new AdminControlPlaneResponse(
                 "admin-control-plane-v1",
@@ -116,6 +117,7 @@ public class AdminControlPlaneService {
     }
 
     public ProviderSelectionResponse selectProvider(ProviderSelectionRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin.provider.configure", "admin-control-plane", "select-provider");
         ProviderSelection selection = validateProviderSelection(request, jwt);
         boolean dryRun = request.dryRun();
         ProviderSelection applied = dryRun ? selection : providerSelectionRepository.save(selection);
@@ -144,10 +146,12 @@ public class AdminControlPlaneService {
     }
 
     public EffectivePolicyResponse effectivePolicy(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "effective-policy");
         return workspaceCapabilityService.effectivePolicySnapshot(jwt, "organization");
     }
 
     public CapabilityWhitelistResponse whitelist(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "read-capability-whitelist");
         WorkspaceCapabilityPolicyResponse policy = workspaceCapabilityService.policySnapshot(jwt);
         Map<String, List<String>> profileCapabilities = new LinkedHashMap<>();
         profileCapabilities.put("workspace-admin", List.of(
@@ -170,6 +174,7 @@ public class AdminControlPlaneService {
     }
 
     public CapabilityWhitelistResponse updateWhitelist(CapabilityWhitelistUpdateRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin.policy.edit", "admin-control-plane", "update-capability-whitelist");
         if (request == null || request.profileKey() == null || request.profileKey().isBlank()) {
             throw new ApiErrorException(
                     HttpStatus.BAD_REQUEST,
@@ -199,6 +204,7 @@ public class AdminControlPlaneService {
     }
 
     public OrganizationBootstrapResponse bootstrapOrganization(OrganizationBootstrapRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin.policy.edit", "admin-control-plane", "bootstrap-organization");
         OrganizationIdentityContext identity = OrganizationIdentityContextFactory.fromJwt(jwt);
         if (request == null || request.organizationId() == null || request.organizationId().isBlank()) {
             throw new ApiErrorException(
@@ -247,6 +253,7 @@ public class AdminControlPlaneService {
     }
 
     public ProviderReadinessTestResponse testProviderReadiness(ProviderReadinessTestRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "provider-readiness-test");
         if (request == null || request.providerKey() == null || request.providerKey().isBlank()) {
             throw new ApiErrorException(
                     HttpStatus.BAD_REQUEST,
@@ -298,7 +305,8 @@ public class AdminControlPlaneService {
                         "secretRef", safeSecretRef(request.secretRef())));
     }
 
-    public List<AdminAuditEventResponse> auditEvents() {
+    public List<AdminAuditEventResponse> auditEvents(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "read-audit-events");
         if (auditEventPublisher instanceof InMemoryAuditEventPublisher memoryAudit) {
             return memoryAudit.events().stream()
                     .map(event -> new AdminAuditEventResponse(

--- a/server/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
@@ -51,14 +51,16 @@ public class BoardsFacadeService {
     private final BoardsRepository boardsRepository;
     private final ContextAuthorizationPort contextAuthorizationPort;
     private final ContextAuthorizationProperties contextAuthorizationProperties;
+    private final WorkspaceCapabilityService workspaceCapabilityService;
     private final AuditEventPublisher auditEventPublisher;
 
     public BoardsFacadeService(
             BoardsRuntimeGuard runtimeGuard,
             BoardsRepository boardsRepository,
             ContextAuthorizationPort contextAuthorizationPort,
-            ContextAuthorizationProperties contextAuthorizationProperties) {
-        this(runtimeGuard, boardsRepository, contextAuthorizationPort, contextAuthorizationProperties, new InMemoryAuditEventPublisher());
+            ContextAuthorizationProperties contextAuthorizationProperties,
+            WorkspaceCapabilityService workspaceCapabilityService) {
+        this(runtimeGuard, boardsRepository, contextAuthorizationPort, contextAuthorizationProperties, workspaceCapabilityService, new InMemoryAuditEventPublisher());
     }
 
     @Autowired
@@ -67,11 +69,13 @@ public class BoardsFacadeService {
             BoardsRepository boardsRepository,
             ContextAuthorizationPort contextAuthorizationPort,
             ContextAuthorizationProperties contextAuthorizationProperties,
+            WorkspaceCapabilityService workspaceCapabilityService,
             AuditEventPublisher auditEventPublisher) {
         this.runtimeGuard = runtimeGuard;
         this.boardsRepository = boardsRepository;
         this.contextAuthorizationPort = contextAuthorizationPort;
         this.contextAuthorizationProperties = contextAuthorizationProperties;
+        this.workspaceCapabilityService = workspaceCapabilityService;
         this.auditEventPublisher = auditEventPublisher;
     }
 
@@ -193,6 +197,7 @@ public class BoardsFacadeService {
 
     private PrincipalContext requireContextPermission(Jwt jwt, ContextPermission permission) {
         requireEnabled();
+        workspaceCapabilityService.requireCapability(jwt, capabilityFor(permission), "boards", operationFor(permission));
         PrincipalContext principalContext = principalContext(jwt);
         var decision = contextAuthorizationPort.check(new ContextAuthorizationRequest(
                 principalContext.tenantId(),
@@ -259,6 +264,14 @@ public class BoardsFacadeService {
                 BoardsErrorCode.UNAUTHORIZED,
                 "Boards access requires an authenticated principal.",
                 Map.of("reason", reason)));
+    }
+
+    private String capabilityFor(ContextPermission permission) {
+        return permission == ContextPermission.VIEW ? "boards.read" : "boards.update_task";
+    }
+
+    private String operationFor(ContextPermission permission) {
+        return permission == ContextPermission.VIEW ? "read-workspace" : "mutate-task";
     }
 
     private record PrincipalContext(String tenantId, String contextId, String principalRef) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
@@ -38,7 +38,6 @@ import com.massimotter.weave.backend.model.chat.WeaverScoutSummaryRequest;
 import com.massimotter.weave.backend.model.chat.WeaverScoutSummaryResponse;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -492,39 +491,11 @@ public class ChatFacadeService {
     }
 
     private void requireAdminRole(Jwt jwt) {
-        List<String> roles = extractRealmRoles(jwt);
-        if (roles.stream().noneMatch(role -> role.equals("owner") || role.equals("admin") || role.equals("operator"))) {
-            throw new ApiErrorException(
-                    HttpStatus.FORBIDDEN,
-                    "admin-policy-blocked",
-                    "This Chat provider replacement action requires an owner, admin, or operator role.",
-                    Map.of(
-                            "module", DOMAIN,
-                            "operation", "provider_replacement_dry_run",
-                            "policyState", "policy-blocked",
-                            "diagnosticsRedacted", true));
-        }
-    }
-
-    private List<String> extractRealmRoles(Jwt jwt) {
-        if (jwt == null) {
-            return List.of();
-        }
-        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
-        if (realmAccess == null) {
-            return List.of();
-        }
-        Object roles = realmAccess.get("roles");
-        if (!(roles instanceof Collection<?> roleValues)) {
-            return List.of();
-        }
-        return roleValues.stream()
-                .filter(String.class::isInstance)
-                .map(String.class::cast)
-                .map(role -> role.trim().toLowerCase(Locale.ROOT))
-                .filter(role -> !role.isEmpty())
-                .sorted()
-                .toList();
+        workspaceCapabilityService.requireCapability(
+                jwt,
+                "admin_control_plane.readiness_read",
+                DOMAIN,
+                "provider_replacement_dry_run");
     }
 
     private List<String> grantedChatCapabilities(Jwt jwt) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
@@ -314,7 +314,7 @@ public class ChatFacadeService {
             ChatProviderReplacementDryRunRequest request) {
         requireChatReady(jwt, "chat.read", "provider_replacement_dry_run");
         PrincipalContext principal = requireContextPermission(jwt, ContextPermission.ADMIN);
-        requireAdminRole(jwt);
+        requireAdminReadinessCapability(jwt);
         String sourceAdapter = sanitizeAdapterKey(request.sourceAdapter());
         String targetAdapter = sanitizeAdapterKey(request.targetAdapter());
         Instant timestamp = Instant.now();
@@ -490,7 +490,7 @@ public class ChatFacadeService {
                         "diagnosticsRedacted", true));
     }
 
-    private void requireAdminRole(Jwt jwt) {
+    private void requireAdminReadinessCapability(Jwt jwt) {
         workspaceCapabilityService.requireCapability(
                 jwt,
                 "admin_control_plane.readiness_read",

--- a/server/src/main/java/com/massimotter/weave/backend/service/FilesFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/FilesFacadeService.java
@@ -28,14 +28,17 @@ public class FilesFacadeService {
     private final FilesStorageAdapter filesStorageAdapter;
     private final ContextAuthorizationPort contextAuthorizationPort;
     private final ContextAuthorizationProperties contextAuthorizationProperties;
+    private final WorkspaceCapabilityService workspaceCapabilityService;
 
     public FilesFacadeService(
             ObjectProvider<FilesStorageAdapter> filesStorageAdapterProvider,
             ContextAuthorizationPort contextAuthorizationPort,
-            ContextAuthorizationProperties contextAuthorizationProperties) {
+            ContextAuthorizationProperties contextAuthorizationProperties,
+            WorkspaceCapabilityService workspaceCapabilityService) {
         this.filesStorageAdapter = filesStorageAdapterProvider.getIfAvailable();
         this.contextAuthorizationPort = contextAuthorizationPort;
         this.contextAuthorizationProperties = contextAuthorizationProperties;
+        this.workspaceCapabilityService = workspaceCapabilityService;
     }
 
     public FileListResponse list(String path) {
@@ -72,6 +75,8 @@ public class FilesFacadeService {
                     "Authentication is required.",
                     Map.of("module", "files", "operation", operation));
         }
+        Jwt jwt = jwtPrincipal(authentication, operation);
+        workspaceCapabilityService.requireCapability(jwt, capabilityFor(permission), "files", operation);
         PrincipalContext principalContext = principalContext(authentication, operation);
         var decision = contextAuthorizationPort.check(new ContextAuthorizationRequest(
                 principalContext.tenantId(),
@@ -90,6 +95,17 @@ public class FilesFacadeService {
                             "contextId", DEFAULT_CONTEXT_ID,
                             "permission", permission.name().toLowerCase()));
         }
+    }
+
+    private Jwt jwtPrincipal(Authentication authentication, String operation) {
+        if (authentication.getPrincipal() instanceof Jwt jwt) {
+            return jwt;
+        }
+        throw invalidAuthentication(operation, "JWT principal is required");
+    }
+
+    private String capabilityFor(ContextPermission permission) {
+        return permission == ContextPermission.VIEW ? "files.read" : "files.upload";
     }
 
     private PrincipalContext principalContext(Authentication authentication, String operation) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/FilesFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/FilesFacadeService.java
@@ -77,7 +77,7 @@ public class FilesFacadeService {
         }
         Jwt jwt = jwtPrincipal(authentication, operation);
         workspaceCapabilityService.requireCapability(jwt, capabilityFor(permission), "files", operation);
-        PrincipalContext principalContext = principalContext(authentication, operation);
+        PrincipalContext principalContext = principalContext(jwt, operation);
         var decision = contextAuthorizationPort.check(new ContextAuthorizationRequest(
                 principalContext.tenantId(),
                 DEFAULT_CONTEXT_ID,
@@ -108,15 +108,8 @@ public class FilesFacadeService {
         return permission == ContextPermission.VIEW ? "files.read" : "files.upload";
     }
 
-    private PrincipalContext principalContext(Authentication authentication, String operation) {
-        if (authentication.getPrincipal() instanceof Jwt jwt) {
-            return new PrincipalContext(jwtTenantId(jwt, operation), jwtPrincipalRef(jwt, operation));
-        }
-        String principalRef = contextAuthorizationProperties.principalRef(authentication.getName());
-        if (principalRef == null) {
-            throw invalidAuthentication(operation, "principal claim is missing");
-        }
-        return new PrincipalContext(contextAuthorizationProperties.defaultTenantId(), principalRef);
+    private PrincipalContext principalContext(Jwt jwt, String operation) {
+        return new PrincipalContext(jwtTenantId(jwt, operation), jwtPrincipalRef(jwt, operation));
     }
 
     private String jwtTenantId(Jwt jwt, String operation) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/OfficeFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OfficeFacadeService.java
@@ -4,22 +4,27 @@ import com.massimotter.weave.backend.model.office.OfficeCapabilitiesResponse;
 import com.massimotter.weave.backend.model.office.OfficeLaunchRequest;
 import com.massimotter.weave.backend.model.office.OfficeLaunchResponse;
 import com.massimotter.weave.backend.office.port.OfficeProvider;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
 @Service
 public class OfficeFacadeService {
 
     private final OfficeProvider officeProvider;
+    private final WorkspaceCapabilityService workspaceCapabilityService;
 
-    public OfficeFacadeService(OfficeProvider officeProvider) {
+    public OfficeFacadeService(OfficeProvider officeProvider, WorkspaceCapabilityService workspaceCapabilityService) {
         this.officeProvider = officeProvider;
+        this.workspaceCapabilityService = workspaceCapabilityService;
     }
 
-    public OfficeCapabilitiesResponse capabilities() {
+    public OfficeCapabilitiesResponse capabilities(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "documents.view", "office", "capabilities");
         return officeProvider.capabilities();
     }
 
-    public OfficeLaunchResponse launch(OfficeLaunchRequest request) {
+    public OfficeLaunchResponse launch(Jwt jwt, OfficeLaunchRequest request) {
+        workspaceCapabilityService.requireCapability(jwt, "documents.edit", "office", "launch");
         return officeProvider.launch(request);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -199,6 +199,7 @@ public class WorkspaceCapabilityService {
     }
 
     public WorkspaceCapabilityPolicyResponse policySnapshot(Jwt jwt) {
+        requireCapability(jwt, "admin_control_plane.readiness_read", "workspace-capability-policy", "read");
         EffectivePolicy policy = effectivePolicy(jwt);
         return new WorkspaceCapabilityPolicyResponse(
                 "identity/IDM",
@@ -395,8 +396,6 @@ public class WorkspaceCapabilityService {
 
         if (roles.stream().anyMatch(role -> role.equals("owner") || role.equals("admin"))) {
             capabilities.addAll(OWNER_ADMIN_CAPABILITIES);
-            capabilities.add("admin.provider.configure");
-            capabilities.add("admin.policy.edit");
             profileKeys.add("workspace-admin");
         }
         if (roles.contains("operator")) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -45,6 +45,8 @@ public class WorkspaceCapabilityService {
             "release_evidence.read",
             "release_evidence.manage",
             "admin_control_plane.readiness_read",
+            "admin.policy.edit",
+            "admin.provider.configure",
             "weaver.exec_disabled");
     private static final List<String> OPERATOR_CAPABILITIES = List.of(
             "admin_control_plane.readiness_read",

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceHomeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceHomeService.java
@@ -26,7 +26,7 @@ public class WorkspaceHomeService {
 
     public WorkspaceHomeResponse snapshot() {
         WorkspaceCapabilitiesResponse capabilities = workspaceCapabilityService.snapshot();
-        WorkspaceReleaseReadinessResponse releaseReadiness = workspaceReleaseReadinessService.snapshot();
+        WorkspaceReleaseReadinessResponse releaseReadiness = workspaceReleaseReadinessService.supportSafeSnapshot();
 
         List<WorkspaceHomeSectionResponse> sections = List.of(
                 section(

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
@@ -33,10 +33,10 @@ public class WorkspaceReleaseReadinessService {
 
     public WorkspaceReleaseReadinessResponse snapshot(Jwt jwt) {
         workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "workspace-release-readiness", "read");
-        return snapshot();
+        return supportSafeSnapshot();
     }
 
-    public WorkspaceReleaseReadinessResponse snapshot() {
+    WorkspaceReleaseReadinessResponse supportSafeSnapshot() {
         WorkspaceCapabilitiesResponse capabilities = workspaceCapabilityService.snapshot();
 
         List<WorkspaceReleaseReadinessCheckResponse> checks = List.of(

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessService.java
@@ -9,6 +9,7 @@ import com.massimotter.weave.backend.model.WorkspaceReleaseReadinessResponse;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -28,6 +29,11 @@ public class WorkspaceReleaseReadinessService {
         this.weaveSecurityProperties = weaveSecurityProperties;
         this.workspaceCapabilityProperties = workspaceCapabilityProperties;
         this.workspaceCapabilityService = workspaceCapabilityService;
+    }
+
+    public WorkspaceReleaseReadinessResponse snapshot(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "workspace-release-readiness", "read");
+        return snapshot();
     }
 
     public WorkspaceReleaseReadinessResponse snapshot() {

--- a/server/src/test/java/com/massimotter/weave/backend/bdd/OpenProjectBoardsStepDefinitions.java
+++ b/server/src/test/java/com/massimotter/weave/backend/bdd/OpenProjectBoardsStepDefinitions.java
@@ -19,10 +19,13 @@ import com.massimotter.weave.backend.boards.port.CreateTaskCommand;
 import com.massimotter.weave.backend.boards.support.BoardsErrorCode;
 import com.massimotter.weave.backend.boards.support.BoardsException;
 import com.massimotter.weave.backend.config.ContextAuthorizationProperties;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.context.authz.ContextAuthorizationDecision;
 import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.model.boards.BoardsWorkspaceResponse;
 import com.massimotter.weave.backend.service.BoardsFacadeService;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -32,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Map;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -250,7 +254,8 @@ public class OpenProjectBoardsStepDefinitions {
                 request -> denyContext
                         ? ContextAuthorizationDecision.deny("no matching context membership")
                         : ContextAuthorizationDecision.allow("context membership matched"),
-                new ContextAuthorizationProperties(null, null, null, null, null, null, null, null));
+                new ContextAuthorizationProperties(null, null, null, null, null, null, null, null),
+                workspaceCapabilityService());
     }
 
     private void ensureScenarioState() {
@@ -297,13 +302,25 @@ public class OpenProjectBoardsStepDefinitions {
                 .encodeToString(("apikey:" + API_TOKEN).getBytes(StandardCharsets.UTF_8));
     }
 
+    private WorkspaceCapabilityService workspaceCapabilityService() {
+        OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+        properties.getJwt().setIssuerUri("https://auth.weave.local/realms/weave");
+        return new WorkspaceCapabilityService(
+                properties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+    }
+
     private Jwt jwt() {
         Instant now = Instant.parse("2026-05-20T18:00:00Z");
         return Jwt.withTokenValue("token")
                 .header("alg", "none")
                 .subject("user-123")
+                .issuer("https://auth.example.invalid/realms/acme")
                 .claim("weave_tenant_id", "tenant-acme")
                 .claim("weave_context_id", "ctx-product-channel")
+                .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                .claim("groups", java.util.List.of("weave-board-editors"))
                 .issuedAt(now)
                 .expiresAt(now.plusSeconds(300))
                 .build();

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -8,6 +8,7 @@ import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.DevopsProviderConfiguration;
 import com.massimotter.weave.backend.config.ProviderCoreConfiguration;
 import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.exception.ApiExceptionHandler;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
@@ -27,6 +28,7 @@ import com.massimotter.weave.backend.service.InMemoryOrganizationBootstrapReposi
 import com.massimotter.weave.backend.service.OrganizationBootstrapRepository;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +38,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -45,6 +48,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -95,6 +101,7 @@ class AdminControlPlaneControllerTest {
     @BeforeEach
     void setUpWorkspaceCapabilitySnapshot() {
         selectDefaultProviders();
+        enforceEffectiveCapabilityPolicy();
         WorkspaceCapabilitiesResponse capabilities = new WorkspaceCapabilitiesResponse(
                 capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "SSO ready."),
                 capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Chat ready."),
@@ -134,6 +141,32 @@ class AdminControlPlaneControllerTest {
                 false));
     }
 
+    private void enforceEffectiveCapabilityPolicy() {
+        doAnswer(invocation -> {
+            org.springframework.security.oauth2.jwt.Jwt jwt = invocation.getArgument(0);
+            String capability = invocation.getArgument(1);
+            List<String> roles = jwt == null
+                    ? List.of()
+                    : ((Map<String, Object>) jwt.getClaimAsMap("realm_access"))
+                            .getOrDefault("roles", List.of()) instanceof List<?> roleValues
+                                    ? roleValues.stream().filter(String.class::isInstance).map(String.class::cast).toList()
+                                    : List.of();
+            boolean allowed = switch (capability) {
+                case "admin_control_plane.readiness_read" -> roles.stream().anyMatch(role -> role.equals("owner") || role.equals("admin") || role.equals("operator"));
+                case "admin.policy.edit", "admin.provider.configure" -> roles.stream().anyMatch(role -> role.equals("owner") || role.equals("admin"));
+                default -> false;
+            };
+            if (!allowed) {
+                throw new ApiErrorException(
+                        HttpStatus.FORBIDDEN,
+                        "capability-policy-blocked",
+                        "This action is blocked by workspace role or group policy.",
+                        Map.of("requiredCapability", capability, "policyState", "policy_blocked", "diagnosticsRedacted", true));
+            }
+            return null;
+        }).when(workspaceCapabilityService).requireCapability(any(), anyString(), anyString(), anyString());
+    }
+
     private void selectDefaultProviders() {
         if (providerSelectionRepository instanceof InMemoryProviderSelectionRepository memoryRepository) {
             memoryRepository.clear();
@@ -164,7 +197,10 @@ class AdminControlPlaneControllerTest {
     @Test
     void adminControlPlaneRejectsMembers() throws Exception {
         mockMvc.perform(get("/api/admin/control-plane").with(memberJwt()))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"))
+                .andExpect(jsonPath("$.details.diagnosticsRedacted").value(true));
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/controller/BoardsControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/BoardsControllerTest.java
@@ -6,13 +6,17 @@ import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.BoardsRuntimeConfiguration;
 import com.massimotter.weave.backend.config.ContextAuthorizationProperties;
 import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.context.authz.ContextAuthorizationDecision;
 import com.massimotter.weave.backend.context.authz.ContextAuthorizationPort;
 import com.massimotter.weave.backend.context.authz.ContextPermission;
 import com.massimotter.weave.backend.exception.ApiExceptionHandler;
 import com.massimotter.weave.backend.service.BoardsFacadeService;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -44,14 +48,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         ApiErrorResponseWriter.class,
         ApiExceptionHandler.class,
         BoardsRuntimeConfiguration.class,
-        BoardsFacadeService.class
+        BoardsFacadeService.class,
+        WorkspaceCapabilityService.class
 })
 @TestPropertySource(properties = {
         "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave",
         "weave.boards.workspace.runtime-enabled=true",
         "weave.context.authorization.principal-claim=preferred_username"
 })
-@EnableConfigurationProperties(ContextAuthorizationProperties.class)
+@EnableConfigurationProperties({
+        ContextAuthorizationProperties.class,
+        WorkspaceCapabilityProperties.class,
+        WeaveSecurityProperties.class,
+        OAuth2ResourceServerProperties.class
+})
 class BoardsControllerTest {
 
     @Autowired
@@ -203,9 +213,12 @@ class BoardsControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor workspaceJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
+                        .claim("iss", "https://auth.example.invalid/realms/weave")
                         .claim("preferred_username", "test")
                         .claim("weave_tenant_id", "tenant-default")
-                        .claim("aud", java.util.List.of("weave-app")))
+                        .claim("aud", java.util.List.of("weave-app"))
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                        .claim("groups", java.util.List.of("weave-board-editors")))
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/controller/OfficeControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/OfficeControllerTest.java
@@ -4,14 +4,19 @@ import com.massimotter.weave.backend.config.ApiAccessDeniedHandler;
 import com.massimotter.weave.backend.config.ApiAuthenticationEntryPoint;
 import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.exception.ApiExceptionHandler;
 import com.massimotter.weave.backend.office.port.DisabledOfficeProvider;
 import com.massimotter.weave.backend.service.OfficeFacadeService;
+import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -39,9 +44,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         ApiErrorResponseWriter.class,
         ApiExceptionHandler.class,
         DisabledOfficeProvider.class,
-        OfficeFacadeService.class
+        OfficeFacadeService.class,
+        WorkspaceCapabilityService.class
 })
 @TestPropertySource(properties = "spring.security.oauth2.resourceserver.jwt.issuer-uri=https://auth.example.invalid/realms/weave")
+@EnableConfigurationProperties({
+        WorkspaceCapabilityProperties.class,
+        WeaveSecurityProperties.class,
+        OAuth2ResourceServerProperties.class
+})
 class OfficeControllerTest {
 
     @Autowired
@@ -92,7 +103,10 @@ class OfficeControllerTest {
     private org.springframework.test.web.servlet.request.RequestPostProcessor workspaceJwt() {
         return jwt().jwt(jwt -> jwt
                         .subject("user-123")
-                        .claim("aud", java.util.List.of("weave-app")))
+                        .claim("iss", "https://auth.example.invalid/realms/weave")
+                        .claim("aud", java.util.List.of("weave-app"))
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                        .claim("groups", java.util.List.of("weave-document-editors")))
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
@@ -6,6 +6,7 @@ import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.DevopsProviderConfiguration;
 import com.massimotter.weave.backend.config.ProviderCoreConfiguration;
 import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.exception.ApiExceptionHandler;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
@@ -19,6 +20,7 @@ import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import java.time.Instant;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +28,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.O
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.context.TestPropertySource;
@@ -34,6 +37,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -83,6 +89,7 @@ class ProviderRegistryControllerTest {
     @BeforeEach
     void setUpWorkspaceCapabilitySnapshot() {
         selectDefaultProviders();
+        enforceEffectiveCapabilityPolicy();
         when(workspaceCapabilityService.snapshot()).thenReturn(new WorkspaceCapabilitiesResponse(
                 capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Weave SSO shell access is available."),
                 capability(WorkspaceCapabilityReadiness.READY, WorkspaceCapabilityPolicyState.ALLOWED, "Chat is available through Weave."),
@@ -90,6 +97,26 @@ class ProviderRegistryControllerTest {
                 capability(WorkspaceCapabilityReadiness.DEGRADED, WorkspaceCapabilityPolicyState.ALLOWED, "Calendar is degraded. Ask an admin to inspect Workspace Health."),
                 capability(WorkspaceCapabilityReadiness.BLOCKED, WorkspaceCapabilityPolicyState.POLICY_BLOCKED, "Boards/tasks are blocked by your role or group policy."),
                 capability(WorkspaceCapabilityReadiness.UNAVAILABLE, WorkspaceCapabilityPolicyState.DISABLED, "Weaver is disabled by workspace policy.")));
+    }
+
+    private void enforceEffectiveCapabilityPolicy() {
+        doAnswer(invocation -> {
+            org.springframework.security.oauth2.jwt.Jwt jwt = invocation.getArgument(0);
+            List<String> roles = jwt == null
+                    ? List.of()
+                    : jwt.getClaimAsMap("realm_access").getOrDefault("roles", List.of()) instanceof List<?> roleValues
+                            ? roleValues.stream().filter(String.class::isInstance).map(String.class::cast).toList()
+                            : List.of();
+            boolean allowed = roles.stream().anyMatch(role -> role.equals("owner") || role.equals("admin") || role.equals("operator"));
+            if (!allowed) {
+                throw new ApiErrorException(
+                        HttpStatus.FORBIDDEN,
+                        "capability-policy-blocked",
+                        "This action is blocked by workspace role or group policy.",
+                        Map.of("requiredCapability", "admin_control_plane.readiness_read", "policyState", "policy_blocked", "diagnosticsRedacted", true));
+            }
+            return null;
+        }).when(workspaceCapabilityService).requireCapability(any(), anyString(), anyString(), anyString());
     }
 
     private void selectDefaultProviders() {
@@ -126,7 +153,10 @@ class ProviderRegistryControllerTest {
     @Test
     void providerStatusRejectsMembers() throws Exception {
         mockMvc.perform(get("/api/providers/status").with(memberJwt()))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"))
+                .andExpect(jsonPath("$.details.diagnosticsRedacted").value(true));
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -252,7 +252,10 @@ class WorkspaceControllerTest {
                                 .claim("iss", "https://auth.example.invalid/realms/acme")
                                 .claim("realm_access", Map.of("roles", List.of("member"))))
                         .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"))
+                .andExpect(jsonPath("$.details.diagnosticsRedacted").value(true));
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -185,9 +185,22 @@ class WorkspaceControllerTest {
     }
 
     @Test
-    void returnsReleaseReadinessSnapshot() throws Exception {
+    void operatorCanReadReleaseReadinessSnapshot() throws Exception {
         assertReleaseReadinessSnapshot("/api/workspace/release-readiness");
         assertReleaseReadinessSnapshot("/api/v1/workspace/release-readiness");
+    }
+
+    @Test
+    void releaseReadinessRejectsMembersWithoutAdminReadinessCapability() throws Exception {
+        mockMvc.perform(get("/api/v1/workspace/release-readiness").with(jwt()
+                        .jwt(jwt -> jwt
+                                .claim("iss", "https://auth.example.invalid/realms/acme")
+                                .claim("realm_access", Map.of("roles", List.of("member"))))
+                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"))
+                .andExpect(jsonPath("$.details.diagnosticsRedacted").value(true));
     }
 
     @Test
@@ -289,8 +302,10 @@ class WorkspaceControllerTest {
         mockMvc.perform(get(path).with(jwt()
                         .jwt(jwt -> jwt
                                 .claim("iss", "https://auth.example.invalid/realms/acme")
-                                .claim("realm_access", Map.of("roles", List.of("member"))))
-                        .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                                .claim("realm_access", Map.of("roles", List.of("operator"))))
+                        .authorities(
+                                new SimpleGrantedAuthority("SCOPE_weave:workspace"),
+                                new SimpleGrantedAuthority("ROLE_OPERATOR"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.readiness").value("ready"))
                 .andExpect(jsonPath("$.checks[0].key").value("auth-contract"))

--- a/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
@@ -1,0 +1,84 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
+import com.massimotter.weave.backend.provider.InMemoryProviderSelectionRepository;
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class AdminControlPlaneServiceTest {
+
+    @Test
+    void providerAndPolicyMutationsRequireEffectiveOwnerOrAdminPolicyServerSide() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        AdminControlPlaneService service = new AdminControlPlaneService(
+                mock(ProviderRegistry.class),
+                workspaceCapabilityService(),
+                new InMemoryProviderSelectionRepository(),
+                new InMemoryOrganizationBootstrapRepository(),
+                auditPublisher,
+                Clock.fixed(Instant.parse("2026-05-27T01:03:39Z"), ZoneOffset.UTC));
+        CapabilityWhitelistUpdateRequest request = new CapabilityWhitelistUpdateRequest(
+                "workspace-admin",
+                List.of("admin.policy.edit", "admin.provider.configure"),
+                "maintain recovery admin policy");
+
+        assertThatThrownBy(() -> service.updateWhitelist(request, jwt("operator")))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.status().value()).isEqualTo(403);
+                    assertThat(exception.code()).isEqualTo("capability-policy-blocked");
+                    assertThat(exception.details()).containsEntry("requiredCapability", "admin.policy.edit");
+                    assertThat(exception.details()).containsEntry("diagnosticsRedacted", true);
+                });
+        assertThatThrownBy(() -> service.updateWhitelist(request, jwt("member")))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.status().value()).isEqualTo(403);
+                    assertThat(exception.code()).isEqualTo("capability-policy-blocked");
+                });
+
+        var response = service.updateWhitelist(request, jwt("admin"));
+
+        assertThat(response.denyByDefault()).isTrue();
+        assertThat(auditPublisher.events())
+                .extracting(event -> event.action())
+                .containsExactly(AuditAction.ADMIN_POLICY_UPDATED);
+        assertThat(auditPublisher.events().get(0).payload())
+                .containsEntry("profileKey", "workspace-admin")
+                .containsEntry("denyByDefault", true);
+    }
+
+    private WorkspaceCapabilityService workspaceCapabilityService() {
+        OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+        properties.getJwt().setIssuerUri("https://auth.weave.local/realms/weave");
+        return new WorkspaceCapabilityService(
+                properties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+    }
+
+    private Jwt jwt(String role) {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject(role + "-123")
+                .issuer("https://auth.example.invalid/realms/acme")
+                .claim("weave_tenant", "weave-dogfood")
+                .claim("realm_access", Map.of("roles", List.of(role)))
+                .claim("groups", List.of())
+                .build();
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
@@ -21,6 +21,8 @@ import com.massimotter.weave.backend.boards.port.CreateTaskCommand;
 import com.massimotter.weave.backend.boards.port.MoveTaskCommand;
 import com.massimotter.weave.backend.boards.port.TaskQuery;
 import com.massimotter.weave.backend.config.ContextAuthorizationProperties;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.context.authz.ContextAuthorizationDecision;
 import com.massimotter.weave.backend.exception.ApiErrorException;
 import java.time.Instant;
@@ -28,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +44,8 @@ class BoardsFacadeServiceTest {
                 new BoardsRuntimeGuard(false),
                 new LocalWorkspaceBoardsRepository(),
                 request -> ContextAuthorizationDecision.allow("test allow"),
-                contextAuthorizationProperties());
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
 
         assertThatThrownBy(() -> service.workspace(jwt()))
                 .isInstanceOfSatisfying(ApiErrorException.class, error -> {
@@ -59,7 +63,8 @@ class BoardsFacadeServiceTest {
                 new BoardsRuntimeGuard(true),
                 new LocalWorkspaceBoardsRepository(),
                 request -> ContextAuthorizationDecision.deny("no matching context membership"),
-                contextAuthorizationProperties());
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
 
         assertThatThrownBy(() -> service.workspace(jwt()))
                 .isInstanceOfSatisfying(ApiErrorException.class, error -> {
@@ -84,7 +89,8 @@ class BoardsFacadeServiceTest {
                     captured.set(request);
                     return ContextAuthorizationDecision.allow("context membership matched");
                 },
-                contextAuthorizationProperties());
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
 
         service.workspace(jwtWithContext("tenant-acme", "ctx-product-channel"));
 
@@ -105,7 +111,8 @@ class BoardsFacadeServiceTest {
                     captured.set(request);
                     return ContextAuthorizationDecision.deny("edit denied");
                 },
-                contextAuthorizationProperties());
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
 
         var createRequest = new com.massimotter.weave.backend.model.boards.BoardsCreateTaskRequest(
                 "local-column-todo",
@@ -128,6 +135,37 @@ class BoardsFacadeServiceTest {
 
 
     @Test
+    void createTaskRequiresEffectivePolicyGrantBeforeContextAuthorization() {
+        java.util.concurrent.atomic.AtomicBoolean contextChecked = new java.util.concurrent.atomic.AtomicBoolean(false);
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsRuntimeGuard(true),
+                new LocalWorkspaceBoardsRepository(),
+                request -> {
+                    contextChecked.set(true);
+                    return ContextAuthorizationDecision.allow("context would allow");
+                },
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
+
+        var createRequest = new com.massimotter.weave.backend.model.boards.BoardsCreateTaskRequest(
+                "local-column-todo",
+                "Write acceptance evidence",
+                null,
+                java.util.List.of(),
+                java.util.List.of(),
+                null);
+
+        assertThatThrownBy(() -> service.createTask(jwtWithoutGroups(), "local-board-1", createRequest))
+                .isInstanceOfSatisfying(ApiErrorException.class, error -> {
+                    assertThat(error.status().value()).isEqualTo(403);
+                    assertThat(error.code()).isEqualTo("capability-policy-blocked");
+                    assertThat(error.details()).containsEntry("requiredCapability", "boards.update_task");
+                    assertThat(error.details()).containsEntry("diagnosticsRedacted", true);
+                });
+        assertThat(contextChecked).isFalse();
+    }
+
+    @Test
     void taskWritesPublishSupportSafeWorkspaceAuditEvents() {
         var auditPublisher = new InMemoryAuditEventPublisher();
         BoardsFacadeService service = new BoardsFacadeService(
@@ -135,6 +173,7 @@ class BoardsFacadeServiceTest {
                 new LocalWorkspaceBoardsRepository(),
                 request -> ContextAuthorizationDecision.allow("edit allowed"),
                 contextAuthorizationProperties(),
+                workspaceCapabilityService(),
                 auditPublisher);
 
         var created = service.createTask(jwt(), "local-board-1",
@@ -170,7 +209,8 @@ class BoardsFacadeServiceTest {
                 new BoardsRuntimeGuard(true),
                 new EmptyBoardsRepository(ProviderKind.OPEN_PROJECT),
                 request -> ContextAuthorizationDecision.allow("test allow"),
-                contextAuthorizationProperties());
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
 
         var response = service.workspace(jwt());
 
@@ -192,7 +232,8 @@ class BoardsFacadeServiceTest {
                 new BoardsRuntimeGuard(true),
                 new EmptyBoardsRepository(ProviderKind.OPEN_PROJECT, "op:v1:c3VwcG9ydC1zYWZl"),
                 request -> ContextAuthorizationDecision.allow("test allow"),
-                contextAuthorizationProperties());
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
 
         var response = service.workspace(jwt());
 
@@ -210,7 +251,8 @@ class BoardsFacadeServiceTest {
                 new BoardsRuntimeGuard(true),
                 new EmptyBoardsRepository(ProviderKind.OPEN_PROJECT, "https://openproject.example.test/page?token=secret"),
                 request -> ContextAuthorizationDecision.allow("test allow"),
-                contextAuthorizationProperties());
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
 
         assertThatThrownBy(() -> service.workspace(jwt()))
                 .isInstanceOfSatisfying(ApiErrorException.class, error -> {
@@ -228,12 +270,38 @@ class BoardsFacadeServiceTest {
         return new ContextAuthorizationProperties(null, null, null, null, null, null, null, null);
     }
 
+    private WorkspaceCapabilityService workspaceCapabilityService() {
+        OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+        properties.getJwt().setIssuerUri("https://auth.weave.local/realms/weave");
+        return new WorkspaceCapabilityService(
+                properties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+    }
+
     private Jwt jwt() {
         Instant now = Instant.parse("2026-05-19T05:00:00Z");
         return Jwt.withTokenValue("token")
                 .header("alg", "none")
                 .subject("user-123")
+                .issuer("https://auth.example.invalid/realms/acme")
                 .claim("weave_tenant_id", "tenant-default")
+                .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                .claim("groups", java.util.List.of("weave-board-editors"))
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .build();
+    }
+
+    private Jwt jwtWithoutGroups() {
+        Instant now = Instant.parse("2026-05-19T05:00:00Z");
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("user-123")
+                .issuer("https://auth.example.invalid/realms/acme")
+                .claim("weave_tenant_id", "tenant-default")
+                .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                .claim("groups", java.util.List.of())
                 .issuedAt(now)
                 .expiresAt(now.plusSeconds(300))
                 .build();
@@ -244,8 +312,11 @@ class BoardsFacadeServiceTest {
         return Jwt.withTokenValue("token")
                 .header("alg", "none")
                 .subject("user-123")
+                .issuer("https://auth.example.invalid/realms/acme")
                 .claim("weave_tenant_id", tenantId)
                 .claim("weave_context_id", contextId)
+                .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                .claim("groups", java.util.List.of("weave-board-editors"))
                 .issuedAt(now)
                 .expiresAt(now.plusSeconds(300))
                 .build();

--- a/server/src/test/java/com/massimotter/weave/backend/service/FilesFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/FilesFacadeServiceTest.java
@@ -2,6 +2,8 @@ package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.config.ContextAuthorizationConfiguration;
 import com.massimotter.weave.backend.config.ContextAuthorizationProperties;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.context.authz.ContextAuthorizationDecision;
 import com.massimotter.weave.backend.context.authz.ContextAuthorizationPort;
@@ -20,6 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Configuration;
@@ -113,6 +116,27 @@ class FilesFacadeServiceTest {
     }
 
     @Test
+    void guestFileAccessRequiresEffectivePolicyGrantBeforeContextAuthorization() {
+        java.util.concurrent.atomic.AtomicBoolean contextChecked = new java.util.concurrent.atomic.AtomicBoolean(false);
+        SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken(jwtWithRolesAndGroups(List.of("guest"), List.of()), null));
+
+        assertThatThrownBy(() -> service(
+                        new StubAdapter(true),
+                        request -> {
+                            contextChecked.set(true);
+                            return ContextAuthorizationDecision.allow("context would allow");
+                        })
+                        .upload("/Team", null))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.status()).isEqualTo(HttpStatus.FORBIDDEN);
+                    assertThat(exception.code()).isEqualTo("capability-policy-blocked");
+                    assertThat(exception.details()).containsEntry("requiredCapability", "files.upload");
+                    assertThat(exception.details()).containsEntry("diagnosticsRedacted", true);
+                });
+        assertThat(contextChecked).isFalse();
+    }
+
+    @Test
     void configurationPropertiesBindSeededMembershipsIntoAuthorizationPort() {
         contextRunner
                 .withPropertyValues(
@@ -145,6 +169,8 @@ class FilesFacadeServiceTest {
                 Jwt.withTokenValue("token")
                         .header("alg", "none")
                         .subject("user-123")
+                        .issuer("https://auth.example.invalid/realms/acme")
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
                         .build(),
                 null));
 
@@ -162,8 +188,10 @@ class FilesFacadeServiceTest {
                 Jwt.withTokenValue("token")
                         .header("alg", "none")
                         .subject("opaque-keycloak-subject")
+                        .issuer("https://auth.example.invalid/realms/acme")
                         .claim("preferred_username", "test")
                         .claim("weave_tenant_id", "tenant-default")
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
                         .build(),
                 null));
 
@@ -199,18 +227,34 @@ class FilesFacadeServiceTest {
             FilesStorageAdapter adapter,
             ContextAuthorizationPort contextAuthorizationPort,
             ContextAuthorizationProperties contextAuthorizationProperties) {
-        return new FilesFacadeService(provider(adapter), contextAuthorizationPort, contextAuthorizationProperties);
+        return new FilesFacadeService(provider(adapter), contextAuthorizationPort, contextAuthorizationProperties, workspaceCapabilityService());
     }
 
     private ContextAuthorizationProperties defaultContextAuthorizationProperties() {
         return new ContextAuthorizationProperties(null, null, null, null, null, List.of(), List.of(), List.of());
     }
 
+    private WorkspaceCapabilityService workspaceCapabilityService() {
+        OAuth2ResourceServerProperties properties = new OAuth2ResourceServerProperties();
+        properties.getJwt().setIssuerUri("https://auth.weave.local/realms/weave");
+        return new WorkspaceCapabilityService(
+                properties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+    }
+
     private Jwt jwt() {
+        return jwtWithRolesAndGroups(List.of("member"), List.of("weave-file-uploaders"));
+    }
+
+    private Jwt jwtWithRolesAndGroups(List<String> roles, List<String> groups) {
         return Jwt.withTokenValue("token")
                 .header("alg", "none")
                 .subject("user-123")
+                .issuer("https://auth.example.invalid/realms/acme")
                 .claim("weave_tenant_id", "tenant-default")
+                .claim("realm_access", java.util.Map.of("roles", roles))
+                .claim("groups", groups)
                 .build();
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -157,6 +157,56 @@ class WorkspaceCapabilityServiceTest {
     }
 
     @Test
+    void ownerAndAdminCanConfigureProvidersAndPolicyButOperatorCannotMutate() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.weave.local/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+
+        service.requireCapability(jwt(List.of("owner"), List.of()), "admin.provider.configure", "admin-control-plane", "select-provider");
+        service.requireCapability(jwt(List.of("admin"), List.of()), "admin.policy.edit", "admin-control-plane", "update-capability-whitelist");
+
+        assertThatThrownBy(() -> service.requireCapability(
+                jwt(List.of("operator"), List.of()),
+                "admin.provider.configure",
+                "admin-control-plane",
+                "select-provider"))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.status().value()).isEqualTo(403);
+                    assertThat(exception.code()).isEqualTo("capability-policy-blocked");
+                    assertThat(exception.details()).containsEntry("requiredCapability", "admin.provider.configure");
+                    assertThat(exception.details()).containsEntry("diagnosticsRedacted", true);
+                });
+    }
+
+    @Test
+    void guestsUnknownRolesAndUnmappedGroupsFailClosedForRepresentativeAdminReads() {
+        WorkspaceCapabilityService service = new WorkspaceCapabilityService(
+                resourceServerProperties("https://auth.weave.local/realms/weave"),
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+
+        List<Jwt> deniedIdentities = List.of(
+                jwt(List.of("guest"), List.of()),
+                jwt(List.of("unknown"), List.of("unmapped-group")),
+                jwt(List.of(), List.of("unmapped-group")));
+
+        for (Jwt deniedIdentity : deniedIdentities) {
+            assertThatThrownBy(() -> service.requireCapability(
+                    deniedIdentity,
+                    "admin_control_plane.readiness_read",
+                    "admin-control-plane",
+                    "overview"))
+                    .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                        assertThat(exception.status().value()).isEqualTo(403);
+                        assertThat(exception.code()).isEqualTo("capability-policy-blocked");
+                        assertThat(exception.details()).containsEntry("policyState", "policy_blocked");
+                        assertThat(exception.details()).containsEntry("diagnosticsRedacted", true);
+                    });
+        }
+    }
+
+    @Test
     void requireCapabilityAllowsExplicitGroupGrants() {
         WorkspaceCapabilityService service = new WorkspaceCapabilityService(
                 resourceServerProperties("https://auth.weave.local/realms/weave"),

--- a/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceReleaseReadinessServiceTest.java
@@ -4,7 +4,10 @@ import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import org.junit.jupiter.api.Test;
+import java.util.List;
+import java.util.Map;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,7 +38,7 @@ class WorkspaceReleaseReadinessServiceTest {
                         null),
                 capabilityService);
 
-        var snapshot = service.snapshot();
+        var snapshot = service.snapshot(jwt("operator"));
 
         assertThat(snapshot.readiness()).isEqualTo(WorkspaceCapabilityReadiness.READY);
         assertThat(snapshot.actions()).isEmpty();
@@ -61,7 +64,7 @@ class WorkspaceReleaseReadinessServiceTest {
                 properties,
                 capabilityService);
 
-        var snapshot = service.snapshot();
+        var snapshot = service.snapshot(jwt("operator"));
 
         assertThat(snapshot.readiness()).isEqualTo(WorkspaceCapabilityReadiness.BLOCKED);
         assertThat(snapshot.actions()).contains("Provide the missing auth runtime inputs for the backend: WEAVE_OIDC_ISSUER_URI.");
@@ -89,12 +92,22 @@ class WorkspaceReleaseReadinessServiceTest {
                 properties,
                 capabilityService);
 
-        var snapshot = service.snapshot();
+        var snapshot = service.snapshot(jwt("operator"));
 
         assertThat(snapshot.readiness()).isEqualTo(WorkspaceCapabilityReadiness.DEGRADED);
         assertThat(snapshot.actions()).containsExactly(
                 "Set WEAVE_MATRIX_HOMESERVER_URL to the public Matrix base URL, for example https://matrix.weave.local.",
                 "Set WEAVE_NEXTCLOUD_BASE_URL to the canonical Nextcloud URL, for example https://files.weave.local.");
+    }
+
+    private Jwt jwt(String role) {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject(role + "-123")
+                .issuer("https://auth.example.invalid/realms/acme")
+                .claim("realm_access", Map.of("roles", List.of(role)))
+                .claim("groups", List.of())
+                .build();
     }
 
     private OAuth2ResourceServerProperties resourceServerProperties(String issuerUri) {


### PR DESCRIPTION
## Summary
- Enforces effective workspace capabilities inside backend domain/admin facades instead of relying only on route annotations or implicit allow behavior.
- Gates admin/provider/policy/readiness surfaces through `WorkspaceCapabilityService.requireCapability(...)`, including owner/admin-only provider and policy mutations, operator read-only support scope, and member/guest/unknown fail-closed responses.
- Adds representative tests for admin/operator/member/guest/unknown/unmapped identities across admin control plane, provider/readiness, boards, files, office, chat, and release-readiness paths with support-safe `capability-policy-blocked` details.

## Testing
- `./gradlew test --tests '*WorkspaceCapabilityServiceTest' --tests '*BoardsFacadeServiceTest' --tests '*FilesFacadeServiceTest'`
- `./gradlew test --tests '*AdminControlPlaneServiceTest' --tests '*WorkspaceCapabilityServiceTest' --tests '*WorkspaceReleaseReadinessServiceTest' --tests '*BoardsFacadeServiceTest' --tests '*FilesFacadeServiceTest' --tests '*WorkspaceControllerTest' --tests '*AdminControlPlaneControllerTest' --tests '*ProviderRegistryControllerTest' --tests '*Chat*Test'`
- `./gradlew test --tests '*OpenProjectBoardsAcceptanceSuiteTest'`
- `./gradlew test --tests '*ProviderStackReadinessAcceptanceSuiteTest' --tests '*ProviderStack*'`
- `./gradlew serverCi`

Closes #347
