### PR TITLE
test: enforce core domain adapter fit contracts

### DIFF
--- a/client/test/release_1/v0_1_release_spine_contract_test.dart
+++ b/client/test/release_1/v0_1_release_spine_contract_test.dart
@@ -195,7 +195,7 @@ void main() {
         'Policy is deny-by-default.',
         'Space, Conversation, Message, Thread, Reaction, Attachment, Membership, and Presence',
         'Drive, Node, Folder, File, Version, Share, Permission, Lock, and EditSession',
-        'Calendar, Event, Attendee, Recurrence, Availability, Resource, Meeting, Participant, Recording, and Captions',
+        'Calendar, Event, Attendee, Recurrence, Availability, Resource, Meeting, Participant, Recording, Captions, and MediaSession',
         'Board, List, Task, Status, Assignee, Comment, Attachment, Dependency, and CustomField',
         'Organization, User, Group, Role, ProviderConfig, CapabilityPolicy, Whitelist, SecretRef, Readiness, and AuditEvent',
         'Identity/Keycloak plus Boards/Tasks/OpenProject and a Planner-like placeholder',

--- a/docs/canonical-feature-models.md
+++ b/docs/canonical-feature-models.md
@@ -71,7 +71,7 @@ Diagram: [`docs/diagrams/er_files_docs.mmd`](diagrams/er_files_docs.mmd).
 
 Entities: `Calendar`, `Event`, `Attendee`, `Recurrence`, `Availability`, `Resource`, `Meeting`, `Participant`, `Recording`, and `Captions`.
 
-The calendar/meetings canonical set is Calendar, Event, Attendee, Recurrence, Availability, Resource, Meeting, Participant, Recording, and Captions.
+The calendar/meetings canonical set is Calendar, Event, Attendee, Recurrence, Availability, Resource, Meeting, Participant, Recording, Captions, and MediaSession.
 
 The calendar/meetings facade maps CalDAV/iCalendar, Microsoft Graph calendar/onlineMeeting, and LiveKit rooms/participants/egress into stable scheduling and meeting records. RRULE/time-zone semantics are normalized before client use. Meeting tokens, media provider secrets, room SIDs, egress IDs, and webhook payloads remain backend-only mapping data.
 

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -57,7 +57,7 @@ Feature: Weave v0.1 dogfood production release
 
   @weave-v01-canonical-provider-neutral-models
   Scenario: Self-hosted and external providers map to the same Weave feature models
-    Given an organization compares the recommended self-hosted defaults with external providers for chat, files, calendar, meetings, boards/tasks, and identity
+    Given an organization compares self-hosted identity with Teams or Slack chat, SharePoint files, and OpenProject or Planner boards
     When the backend provider registry maps each selected provider into Weave feature facades
     Then Matrix or Slack-like chat maps to the same Space, Conversation, Message, Thread, Reaction, Attachment, Membership, and Presence model
     And Nextcloud or SharePoint-like files map to the same Drive, Node, Folder, File, Version, Share, Permission, Lock, and EditSession model

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -61,7 +61,7 @@ Feature: Weave v0.1 dogfood production release
     When the backend provider registry maps each selected provider into Weave feature facades
     Then Matrix or Slack-like chat maps to the same Space, Conversation, Message, Thread, Reaction, Attachment, Membership, and Presence model
     And Nextcloud or SharePoint-like files map to the same Drive, Node, Folder, File, Version, Share, Permission, Lock, and EditSession model
-    And CalDAV or Microsoft Graph-like calendar and LiveKit or Teams-like meetings map to the same Calendar, Event, Attendee, Recurrence, Availability, Resource, Meeting, Participant, Recording, and Captions model
+    And CalDAV or Microsoft Graph-like calendar and LiveKit or Teams-like meetings map to the same Calendar, Event, Attendee, Recurrence, Availability, Resource, Meeting, Participant, Recording, Captions, and MediaSession model
     And OpenProject or Planner-like tasks map to the same Board, List, Task, Status, Assignee, Comment, Attachment, Dependency, and CustomField model
     And Keycloak or Entra-like identity maps to the same Organization, User, Group, Role, ProviderConfig, CapabilityPolicy, Whitelist, SecretRef, Readiness, and AuditEvent model
 

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -378,7 +378,7 @@
             "Canonical feature models come before control-plane",
             "Space, Conversation, Message, Thread, Reaction, Attachment, Membership, and Presence",
             "Drive, Node, Folder, File, Version, Share, Permission, Lock, and EditSession",
-            "Calendar, Event, Attendee, Recurrence, Availability, Resource, Meeting, Participant, Recording, and Captions",
+            "Calendar, Event, Attendee, Recurrence, Availability, Resource, Meeting, Participant, Recording, Captions, and MediaSession",
             "Board, List, Task, Status, Assignee, Comment, Attachment, Dependency, and CustomField",
             "Organization, User, Group, Role, ProviderConfig, CapabilityPolicy, Whitelist, SecretRef, Readiness, and AuditEvent"
           ]

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -384,6 +384,18 @@
           ]
         },
         {
+          "path": "server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java",
+          "fragments": [
+            "coreProductDomainsCarryExecutableAdapterFitContracts",
+            "providerRegistryAdapterFitSupportsMixedProviderPostureWithoutMemberProviderIds",
+            "microsoft-teams",
+            "slack",
+            "sharepoint",
+            "openproject-primary",
+            "microsoft-planner"
+          ]
+        },
+        {
           "path": "docs/diagrams/architecture_facade.mmd",
           "fragments": [
             "Canonical feature APIs",

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
@@ -29,7 +29,7 @@ public final class ProviderCapabilityContracts {
                     List.of("Space", "Conversation", "Message", "Thread", "Reaction", "Attachment", "Membership", "Presence"),
                     "selected chat provider owns message history unless an admin migrates or declares Weave-owned retention",
                     List.of("Slack broadcast/thread semantics", "Teams channel permissions", "Matrix E2EE recovery", "rich cards/adaptive blocks", "attachment retention"),
-                    "export conversation/message/attachment provenance or document provider export boundary",
+                    "export conversation/message/attachment provenance or document provider export boundary; delete/deprovision follows provider and retention policy",
                     "chat replacement requires preflight, dry-run, membership/history/attachment loss report, and rollback/retention note")),
             Map.entry("files", new Definition(
                     List.of("files.read", "files.upload", "files.download", "files.delete"),

--- a/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
@@ -10,6 +10,19 @@ import org.junit.jupiter.api.Test;
 
 class DomainAdapterRegistryMapperTest {
 
+    private static final Map<String, List<String>> CORE_DOMAIN_OBJECTS = Map.of(
+            "chat", List.of("Conversation", "Message", "Thread", "Membership", "Attachment"),
+            "files", List.of("Drive", "Node", "Version", "Share", "Permission", "Lock"),
+            "calendar", List.of("Calendar", "Event", "Attendee", "Recurrence", "Resource"),
+            "boards-tasks", List.of("Board", "List", "Task", "Status", "Assignee", "Comment", "Dependency", "CustomField"),
+            "meetings-calls", List.of("Meeting", "Participant", "Recording", "Captions", "MediaSession"));
+
+    private static final Map<String, List<String>> MIXED_PROVIDER_POSTURE = Map.of(
+            "identity-idm", List.of("keycloak-realm", "entra-id", "generic-oidc", "generic-saml"),
+            "chat", List.of("synapse-homeserver", "microsoft-teams", "slack"),
+            "files", List.of("nextcloud-files", "sharepoint"),
+            "boards-tasks", List.of("openproject-primary", "microsoft-planner"));
+
     @Test
     void enabledDomainWithMultipleActiveAdaptersIsInvalidAndFailClosed() {
         var status = new DomainAdapterStatusResponse(
@@ -78,6 +91,57 @@ class DomainAdapterRegistryMapperTest {
     }
 
     @Test
+    void coreProductDomainsCarryExecutableAdapterFitContracts() {
+        CORE_DOMAIN_OBJECTS.forEach((category, canonicalObjects) -> {
+            var contract = ProviderCapabilityContracts.contract(category, modulesFor(category));
+
+            assertThat(contract.stableMemberImpactStates()).containsExactly("usable", "disabled", "degraded", "policy-blocked");
+            assertThat(contract.canonicalObjects()).containsAll(canonicalObjects);
+            assertThat(contract.sourceOfTruth()).isNotBlank();
+            assertThat(contract.lossyMappingRisks()).isNotEmpty();
+            assertThat(contract.exportDeleteExpectation()).containsIgnoringCase("export");
+            assertThat(contract.exportDeleteExpectation()).containsPattern("(?i)delete|deletion|retention|archive");
+            assertThat(contract.replacementRequirement()).containsIgnoringCase("dry-run");
+            assertThat(contract.choiceModels())
+                    .extracting(ProviderChoiceModelResponse::choiceModel)
+                    .contains("recommended_self_hosted_default", "external_existing_provider", "managed_cloud_provider", "hybrid_composite");
+            assertThat(contract.adminSelectable()).isTrue();
+            assertThat(contract.normalMembersConfigureProviders()).isFalse();
+        });
+    }
+
+    @Test
+    void providerRegistryAdapterFitSupportsMixedProviderPostureWithoutMemberProviderIds() {
+        var domains = DomainAdapterRegistryMapper.fromCategories(List.of(
+                category("identity-idm", ProviderCategoryReadiness.READY, ProviderModule.IDENTITY_REALM),
+                category("chat", ProviderCategoryReadiness.READY, ProviderModule.MATRIX),
+                category("files", ProviderCategoryReadiness.READY, ProviderModule.FILES),
+                category("calendar", ProviderCategoryReadiness.READY, ProviderModule.CALENDAR),
+                category("boards-tasks", ProviderCategoryReadiness.READY, ProviderModule.BOARDS),
+                category("meetings-calls", ProviderCategoryReadiness.READY, ProviderModule.MEETINGS)), null).domains();
+
+        assertThat(domains).extracting(DomainAdapterStatusResponse::domain)
+                .contains("chat", "files", "calendar", "boards-tasks", "meetings-calls");
+        assertThat(domains).allSatisfy(domain -> {
+            assertThat(domain.singleActiveAdapterValid()).isTrue();
+            assertThat(domain.supportSafe()).isTrue();
+            assertThat(domain.candidates()).allSatisfy(candidate -> {
+                assertThat(candidate.supportSafe()).isTrue();
+                assertThat(candidate.diagnostics())
+                        .containsEntry("secretsReturned", false)
+                        .containsEntry("rawProviderErrorsReturned", false);
+            });
+        });
+        MIXED_PROVIDER_POSTURE.forEach((category, adapterKeys) -> assertThat(domains)
+                .filteredOn(domain -> domain.domain().equals(category))
+                .singleElement()
+                .satisfies(domain -> assertThat(domain.candidates())
+                        .extracting(DomainAdapterCandidateResponse::adapterKey)
+                        .containsAll(adapterKeys)));
+        assertThat(domains.toString()).doesNotContain("Bearer ", "access_token", "secretref://", "https://tenant");
+    }
+
+    @Test
     void mapperDoesNotMarkMisconfiguredActiveAdapterAsConfigured() {
         var category = category("files", ProviderCategoryReadiness.MISCONFIGURED);
 
@@ -94,10 +158,14 @@ class DomainAdapterRegistryMapperTest {
     }
 
     private ProviderCategoryStatusResponse category(String category, ProviderCategoryReadiness readiness) {
+        return category(category, readiness, ProviderModule.FILES);
+    }
+
+    private ProviderCategoryStatusResponse category(String category, ProviderCategoryReadiness readiness, ProviderModule module) {
         return new ProviderCategoryStatusResponse(
                 category,
                 category,
-                ProviderCapabilityContracts.contract(category, Set.of(ProviderModule.FILES)),
+                ProviderCapabilityContracts.contract(category, Set.of(module)),
                 readiness,
                 WorkspaceCapabilityPolicyState.ALLOWED,
                 "Files are available through Weave.",
@@ -110,6 +178,17 @@ class DomainAdapterRegistryMapperTest {
                 List.of(),
                 List.of(),
                 Map.of("allFailClosed", true, "secretsReturned", false, "rawProviderErrorsReturned", false));
+    }
+
+    private Set<ProviderModule> modulesFor(String category) {
+        return switch (category) {
+            case "chat" -> Set.of(ProviderModule.MATRIX);
+            case "files" -> Set.of(ProviderModule.FILES);
+            case "calendar" -> Set.of(ProviderModule.CALENDAR);
+            case "boards-tasks" -> Set.of(ProviderModule.BOARDS);
+            case "meetings-calls" -> Set.of(ProviderModule.MEETINGS);
+            default -> Set.of();
+        };
     }
 
     private DomainAdapterCandidateResponse candidate(

--- a/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 class DomainAdapterRegistryMapperTest {
 
     private static final Map<String, List<String>> CORE_DOMAIN_OBJECTS = Map.of(
-            "chat", List.of("Conversation", "Message", "Thread", "Membership", "Attachment"),
-            "files", List.of("Drive", "Node", "Version", "Share", "Permission", "Lock"),
-            "calendar", List.of("Calendar", "Event", "Attendee", "Recurrence", "Resource"),
-            "boards-tasks", List.of("Board", "List", "Task", "Status", "Assignee", "Comment", "Dependency", "CustomField"),
+            "chat", List.of("Space", "Conversation", "Message", "Thread", "Reaction", "Attachment", "Membership", "Presence"),
+            "files", List.of("Drive", "Node", "Folder", "File", "Version", "Share", "Permission", "Lock", "EditSession"),
+            "calendar", List.of("Calendar", "Event", "Attendee", "Recurrence", "Availability", "Resource"),
+            "boards-tasks", List.of("Board", "List", "Task", "Status", "Assignee", "Comment", "Attachment", "Dependency", "CustomField"),
             "meetings-calls", List.of("Meeting", "Participant", "Recording", "Captions", "MediaSession"));
 
     private static final Map<String, List<String>> MIXED_PROVIDER_POSTURE = Map.of(
@@ -96,7 +96,7 @@ class DomainAdapterRegistryMapperTest {
             var contract = ProviderCapabilityContracts.contract(category, modulesFor(category));
 
             assertThat(contract.stableMemberImpactStates()).containsExactly("usable", "disabled", "degraded", "policy-blocked");
-            assertThat(contract.canonicalObjects()).containsAll(canonicalObjects);
+            assertThat(contract.canonicalObjects()).containsExactlyInAnyOrderElementsOf(canonicalObjects);
             assertThat(contract.sourceOfTruth()).isNotBlank();
             assertThat(contract.lossyMappingRisks()).isNotEmpty();
             assertThat(contract.exportDeleteExpectation()).containsIgnoringCase("export");


### PR DESCRIPTION
## Summary
- Enforces executable adapter-fit contracts for Chat, Files, Calendar, Boards/Tasks, and Meetings.
- Proves mixed-provider posture coverage for self-hosted identity, Teams/Slack chat, SharePoint files, and OpenProject/Planner boards.
- Maps the mixed-provider acceptance posture to the existing canonical provider-neutral scenario.

## Changed behavior
- Provider category contracts must declare canonical objects, source-of-truth, lossy mapping risks, export/delete expectations, replacement dry-run requirements, and stable member impact states.
- Provider registry adapter-fit output remains support-safe and does not expose secrets/raw provider diagnostics.

## Tests / evidence
- `cd server && ./gradlew test --tests com.massimotter.weave.backend.provider.DomainAdapterRegistryMapperTest`
- `./gradlew acceptanceContract`
- `./gradlew serverCi`

Closes #348
