### PR TITLE
feat: add provider replacement dry-run contract

### DIFF
--- a/docs/provider-replacement-and-anti-silo-contract.md
+++ b/docs/provider-replacement-and-anti-silo-contract.md
@@ -87,6 +87,8 @@ Preflight checks:
 
 No data is mutated during preflight.
 
+The backend exposes this as an Admin Console contract at `POST /api/admin/providers/replacements/dry-run`. The request carries `category`, `currentAdapter`, `targetAdapter`, `choiceModel`, `secretRef`, and a source-of-truth declaration. The response is support-safe: it reports canonical objects, lossy mapping risks, export/delete/deprovision expectations, readiness before activation, cutover gates, and audit references without returning raw secrets, tenant URLs, bearer tokens, or downstream provider bodies.
+
 ### 2. Dry-run mapping
 
 Dry-run maps source provider objects to canonical Weave objects and target-provider capabilities.

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -615,6 +615,13 @@
             "chat.read",
             "chat.send"
           ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/controller/PlatformProductContractControllerTest.java",
+          "fragments": [
+            "providerReplacementDryRunReportsAntiSiloEvidenceAndRedactsDiagnostics",
+            "providerReplacementDryRunRejectsRawSecretsAndUnsupportedAdapterCombinations"
+          ]
         }
       ]
     },

--- a/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
+++ b/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
@@ -15,6 +15,7 @@ public enum AuditAction {
     CONSENT_REVOKED("consent.revoked"),
     ADMIN_POLICY_UPDATED("admin.policy.updated"),
     PROVIDER_READINESS_TESTED("provider.readiness.tested"),
+    PROVIDER_REPLACEMENT_DRY_RUN("provider.replacement.dry_run"),
     CHAT_MIGRATION_PREFLIGHTED("chat.migration.preflighted"),
     WEAVER_RUNTIME_PROFILE_GENERATED("weaver.runtime_profile.generated"),
     TASK_CREATED("task.created"),

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -10,6 +10,8 @@ import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
+import com.massimotter.weave.backend.model.admin.ProviderReplacementDryRunRequest;
+import com.massimotter.weave.backend.model.admin.ProviderReplacementDryRunResponse;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionResponse;
 import com.massimotter.weave.backend.service.AdminControlPlaneService;
@@ -117,6 +119,17 @@ public class AdminControlPlaneController {
             @Valid @RequestBody ProviderReadinessTestRequest request,
             @AuthenticationPrincipal Jwt jwt) {
         return adminControlPlaneService.testProviderReadiness(request, jwt);
+    }
+
+    @PostMapping({"/api/admin/providers/replacements/dry-run", "/api/v1/admin/providers/replacements/dry-run"})
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
+    @Operation(summary = "Dry-run a provider replacement before activation")
+    @ApiResponse(responseCode = "200", description = "Support-safe provider replacement dry-run report.",
+            content = @Content(schema = @Schema(implementation = ProviderReplacementDryRunResponse.class)))
+    public ProviderReplacementDryRunResponse dryRunProviderReplacement(
+            @Valid @RequestBody ProviderReplacementDryRunRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.dryRunProviderReplacement(request, jwt);
     }
 
     @GetMapping({"/api/admin/audit/events", "/api/v1/admin/audit/events"})

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunRequest.java
@@ -1,0 +1,20 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+@Schema(description = "Support-safe provider replacement preflight. This validates an adapter swap without applying provider state.")
+public record ProviderReplacementDryRunRequest(
+        @NotBlank String category,
+        @NotBlank String currentAdapter,
+        @NotBlank String targetAdapter,
+        String choiceModel,
+        @NotBlank String secretRef,
+        @NotBlank String sourceOfTruth,
+        List<String> lossyMappingNotes,
+        String reason) {
+    public ProviderReplacementDryRunRequest {
+        lossyMappingNotes = lossyMappingNotes == null ? List.of() : List.copyOf(lossyMappingNotes);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunResponse.java
@@ -1,0 +1,53 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Support-safe provider replacement dry-run report for Admin Console review.")
+public record ProviderReplacementDryRunResponse(
+        String dryRunId,
+        String status,
+        String mode,
+        String category,
+        String currentAdapter,
+        String targetAdapter,
+        String choiceModel,
+        String declaredSourceOfTruth,
+        boolean secretRefPresent,
+        String readinessState,
+        boolean migrationDryRunRequired,
+        LossyMappingReport lossyMappingReport,
+        LifecycleExpectations lifecycleExpectations,
+        List<String> cutoverGates,
+        List<String> memberImpactStates,
+        boolean supportSafe,
+        boolean providerDiagnosticsRedacted,
+        List<String> auditRefs) {
+    public ProviderReplacementDryRunResponse {
+        cutoverGates = cutoverGates == null ? List.of() : List.copyOf(cutoverGates);
+        memberImpactStates = memberImpactStates == null ? List.of() : List.copyOf(memberImpactStates);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+    }
+
+    public record LossyMappingReport(
+            List<String> canonicalObjects,
+            List<String> contractRisks,
+            List<String> adminNotes,
+            List<String> conflicts,
+            String replacementRequirement) {
+        public LossyMappingReport {
+            canonicalObjects = canonicalObjects == null ? List.of() : List.copyOf(canonicalObjects);
+            contractRisks = contractRisks == null ? List.of() : List.copyOf(contractRisks);
+            adminNotes = adminNotes == null ? List.of() : List.copyOf(adminNotes);
+            conflicts = conflicts == null ? List.of() : List.copyOf(conflicts);
+        }
+    }
+
+    public record LifecycleExpectations(
+            String sourceOfTruthPolicy,
+            String exportExpectation,
+            String deleteExpectation,
+            String deprovisionExpectation,
+            String rollbackSupportBoundary) {
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
@@ -152,6 +152,26 @@ public final class ProviderCapabilityContracts {
                 .toList();
     }
 
+    public static List<String> canonicalObjects(String category) {
+        return List.copyOf(definition(category).canonicalObjects());
+    }
+
+    public static String sourceOfTruth(String category) {
+        return definition(category).sourceOfTruth();
+    }
+
+    public static List<String> lossyMappingRisks(String category) {
+        return List.copyOf(definition(category).lossyMappingRisks());
+    }
+
+    public static String exportDeleteExpectation(String category) {
+        return definition(category).exportDeleteExpectation();
+    }
+
+    public static String replacementRequirement(String category) {
+        return definition(category).replacementRequirement();
+    }
+
     private static Definition definition(String category) {
         Definition definition = DEFINITIONS.get(category);
         if (definition == null) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -16,6 +16,8 @@ import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestResponse;
+import com.massimotter.weave.backend.model.admin.ProviderReplacementDryRunRequest;
+import com.massimotter.weave.backend.model.admin.ProviderReplacementDryRunResponse;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionResponse;
 import com.massimotter.weave.backend.model.admin.SecretRefResponse;
@@ -113,6 +115,7 @@ public class AdminControlPlaneService {
                         "policy", "/api/admin/policies/capability-whitelist",
                         "audit", "/api/admin/audit/events",
                         "readinessTest", "/api/admin/providers/readiness-tests",
+                        "providerReplacementDryRun", "/api/admin/providers/replacements/dry-run",
                         "providerSelections", "/api/admin/providers/selections"));
     }
 
@@ -131,18 +134,114 @@ public class AdminControlPlaneService {
                     Instant.now(clock),
                     "provider-selection-" + selection.category() + "-" + Instant.now(clock).toEpochMilli(),
                     AuditRedactionLevel.SECRET_REDACTED,
-                    Map.of(
-                            "category", selection.category(),
-                            "providerKey", selection.providerKey(),
-                            "choiceModel", selection.choiceModel(),
-                            "secretRef", safeSecretRef(selection.secretRef()),
-                            "reason", safeText(request.reason()),
-                            "providerConfigSource", ProviderRegistry.PROVIDER_CONFIG_SOURCE,
-                            "migrationDryRunRequired", selection.migrationDryRunRequired(),
-                            "lossyMappingNoteCount", selection.lossyMappingNotes().size(),
-                            "token", "not-stored")));
+                    Map.ofEntries(
+                            Map.entry("category", selection.category()),
+                            Map.entry("providerKey", selection.providerKey()),
+                            Map.entry("choiceModel", selection.choiceModel()),
+                            Map.entry("secretRef", safeSecretRef(selection.secretRef())),
+                            Map.entry("reason", safeText(request.reason())),
+                            Map.entry("providerConfigSource", ProviderRegistry.PROVIDER_CONFIG_SOURCE),
+                            Map.entry("migrationDryRunRequired", selection.migrationDryRunRequired()),
+                            Map.entry("lossyMappingNoteCount", selection.lossyMappingNotes().size()),
+                            Map.entry("replacementApplyAttempt", true),
+                            Map.entry("dryRunEvidenceRequired", selection.migrationDryRunRequired()),
+                            Map.entry("token", "not-stored"))));
         }
         return toSelectionResponse(applied, dryRun, dryRun ? "dry_run_valid" : "admin_selected_pending_readiness");
+    }
+
+    public ProviderReplacementDryRunResponse dryRunProviderReplacement(ProviderReplacementDryRunRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin.provider.configure", "admin-control-plane", "provider-replacement-dry-run");
+        if (request == null || request.category() == null || request.category().isBlank()
+                || request.currentAdapter() == null || request.currentAdapter().isBlank()
+                || request.targetAdapter() == null || request.targetAdapter().isBlank()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-replacement-invalid",
+                    "Provider replacement dry-run requires category, current adapter, and target adapter.",
+                    Map.of("reason", "category/currentAdapter/targetAdapter are required"));
+        }
+        String category = request.category().trim();
+        String currentAdapter = request.currentAdapter().trim();
+        String targetAdapter = request.targetAdapter().trim();
+        if (ProviderCategoryCatalog.category(category).isEmpty()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-category-unknown",
+                    "Provider category is not part of the Weave canonical control-plane contract.",
+                    Map.of("category", category));
+        }
+        if (!providerMatchesCategory(currentAdapter, category) || !providerMatchesCategory(targetAdapter, category)) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-replacement-category-mismatch",
+                    "Provider replacement adapters must both be registered as support-safe candidates for the selected category.",
+                    Map.of("category", category, "adapters", "unsupported-adapter-redacted"));
+        }
+        String choiceModel = selectionChoiceModel(request.choiceModel());
+        requiredSecretRef(request.secretRef());
+        String declaredSourceOfTruth = safeSourceOfTruth(request.sourceOfTruth());
+        List<String> adminNotes = safeLossyMappingNotes(request.lossyMappingNotes());
+        List<String> conflicts = currentAdapter.equalsIgnoreCase(targetAdapter)
+                ? List.of("Current and target adapters are identical; record no-op or choose a distinct target before activation.")
+                : List.of();
+        boolean migrationRequired = true;
+        String status = conflicts.isEmpty() ? "dry-run-ready" : "requires-admin-review";
+        String dryRunId = "provider-replacement-dry-run-" + category + "-" + Instant.now(clock).toEpochMilli();
+        String auditRef = "provider-replacement-dry-run-" + category + "-" + Instant.now(clock).toEpochMilli();
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef(jwt),
+                "provider-replacement-dry-run",
+                AuditAction.PROVIDER_REPLACEMENT_DRY_RUN,
+                Instant.now(clock),
+                auditRef,
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.ofEntries(
+                        Map.entry("category", category),
+                        Map.entry("currentAdapter", currentAdapter),
+                        Map.entry("targetAdapter", targetAdapter),
+                        Map.entry("choiceModel", choiceModel),
+                        Map.entry("sourceOfTruth", declaredSourceOfTruth),
+                        Map.entry("secretRefPresent", true),
+                        Map.entry("secretRef", safeSecretRef(request.secretRef())),
+                        Map.entry("migrationDryRunRequired", migrationRequired),
+                        Map.entry("lossyMappingNoteCount", adminNotes.size()),
+                        Map.entry("rawProviderError", "redacted before audit"),
+                        Map.entry("token", "not-stored"))));
+        return new ProviderReplacementDryRunResponse(
+                dryRunId,
+                status,
+                "dry-run",
+                category,
+                currentAdapter,
+                targetAdapter,
+                choiceModel,
+                declaredSourceOfTruth,
+                true,
+                conflicts.isEmpty() ? "ready-for-admin-review" : "blocked-until-conflicts-resolved",
+                migrationRequired,
+                new ProviderReplacementDryRunResponse.LossyMappingReport(
+                        ProviderCapabilityContracts.canonicalObjects(category),
+                        ProviderCapabilityContracts.lossyMappingRisks(category),
+                        adminNotes,
+                        conflicts,
+                        ProviderCapabilityContracts.replacementRequirement(category)),
+                new ProviderReplacementDryRunResponse.LifecycleExpectations(
+                        ProviderCapabilityContracts.sourceOfTruth(category),
+                        ProviderCapabilityContracts.exportDeleteExpectation(category),
+                        ProviderCapabilityContracts.exportDeleteExpectation(category),
+                        "deprovision source identities, groups, memberships, grants, and service principals through the authoritative provider before capability cutover",
+                        "rollback is an admin decision boundary; dry-run does not mutate provider state and apply must preserve mapping history"),
+                List.of(
+                        "SecretRef exists and remains backend-only; raw credentials are never returned.",
+                        "Admin confirms source-of-truth, export/delete, lossy mapping, and rollback/support notes.",
+                        "Readiness test and migration dry-run evidence are reviewed before activation."),
+                List.of("usable", "disabled", "degraded", "policy-blocked"),
+                true,
+                true,
+                List.of(auditRef));
     }
 
     public EffectivePolicyResponse effectivePolicy(Jwt jwt) {
@@ -480,15 +579,50 @@ public class AdminControlPlaneService {
         if (value == null || value.isBlank()) {
             return null;
         }
+        return validateSecretRef(value, "provider-selection-secretref-invalid", "Provider selections may reference credentials only through SecretRef URIs.");
+    }
+
+    private String requiredSecretRef(String value) {
+        if (value == null || value.isBlank()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-replacement-secretref-invalid",
+                    "Provider replacement dry-run requires a backend SecretRef before activation can be evaluated.",
+                    Map.of("secretRef", "invalid-secret-ref-redacted"));
+        }
+        return validateSecretRef(value, "provider-replacement-secretref-invalid", "Provider replacement dry-run may reference credentials only through SecretRef URIs.");
+    }
+
+    private String validateSecretRef(String value, String code, String message) {
         String trimmed = value.trim();
         if (trimmed.toLowerCase(Locale.ROOT).startsWith("secretref://")) {
             return trimmed;
         }
         throw new ApiErrorException(
                 HttpStatus.BAD_REQUEST,
-                "provider-selection-secretref-invalid",
-                "Provider selections may reference credentials only through SecretRef URIs.",
+                code,
+                message,
                 Map.of("secretRef", "invalid-secret-ref-redacted"));
+    }
+
+    private String safeSourceOfTruth(String value) {
+        if (value == null || value.isBlank()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-replacement-source-of-truth-invalid",
+                    "Provider replacement dry-run requires a support-safe source-of-truth declaration.",
+                    Map.of("sourceOfTruth", "invalid-source-of-truth-redacted"));
+        }
+        String trimmed = value.trim();
+        String redacted = safeText(trimmed);
+        if (!redacted.equals(trimmed) || trimmed.length() > 160) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-replacement-source-of-truth-invalid",
+                    "Provider replacement source-of-truth declaration must not contain URLs, bearer tokens, or secret material.",
+                    Map.of("sourceOfTruth", "invalid-source-of-truth-redacted"));
+        }
+        return trimmed;
     }
 
     private boolean requiresMigrationDryRun(ProviderSelectionRequest request) {
@@ -580,7 +714,11 @@ public class AdminControlPlaneService {
         if (value == null || value.isBlank()) {
             return "not-provided";
         }
-        return value.trim().replaceAll("(?i)bearer\\s+[^\\s]+", "Bearer [redacted]");
+        return value.trim()
+                .replaceAll("(?i)bearer\\s+[^\\s]+", "Bearer [redacted]")
+                .replaceAll("(?i)xox[baprs]-[A-Za-z0-9-]+", "slack-token-[redacted]")
+                .replaceAll("(?i)https?://[^\\s]+", "url-[redacted]")
+                .replaceAll("(?i)secret(ref)?://[^\\s]+", "secret-ref-[redacted]");
     }
 
     private String organizationId(Jwt jwt) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -68,6 +68,7 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.paths['/api/guest/access-contract']").exists())
                 .andExpect(jsonPath("$.paths['/api/guest/invitations']").exists())
                 .andExpect(jsonPath("$.paths['/api/migration/dry-runs']").exists())
+                .andExpect(jsonPath("$.paths['/api/admin/providers/replacements/dry-run']").exists())
                 .andExpect(jsonPath("$.paths['/api/connectors/boundary']").exists())
                 .andExpect(jsonPath("$.paths['/api/connectors/manifest/validate']").exists())
                 .andExpect(jsonPath("$.components.schemas.BoardsWorkspaceResponse.properties.syncMetadata").exists())

--- a/server/src/test/java/com/massimotter/weave/backend/controller/PlatformProductContractControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/PlatformProductContractControllerTest.java
@@ -159,6 +159,88 @@ class PlatformProductContractControllerTest {
     }
 
     @Test
+    void providerReplacementDryRunReportsAntiSiloEvidenceAndRedactsDiagnostics() throws Exception {
+        mockMvc.perform(post("/api/admin/providers/replacements/dry-run")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "category": "chat",
+                                  "currentAdapter": "synapse-homeserver",
+                                  "targetAdapter": "slack",
+                                  "choiceModel": "external_existing_provider",
+                                  "secretRef": "secretref://weave/provider/slack",
+                                  "sourceOfTruth": "selected chat provider owns message history",
+                                  "lossyMappingNotes": ["Slack rich cards need review", "Bearer raw-token is redacted", "https://tenant.example.invalid/private is redacted"],
+                                  "reason": "evaluate provider swap before activation"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mode").value("dry-run"))
+                .andExpect(jsonPath("$.status").value("dry-run-ready"))
+                .andExpect(jsonPath("$.category").value("chat"))
+                .andExpect(jsonPath("$.currentAdapter").value("synapse-homeserver"))
+                .andExpect(jsonPath("$.targetAdapter").value("slack"))
+                .andExpect(jsonPath("$.secretRefPresent").value(true))
+                .andExpect(jsonPath("$.migrationDryRunRequired").value(true))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.providerDiagnosticsRedacted").value(true))
+                .andExpect(jsonPath("$.lossyMappingReport.canonicalObjects", hasItem("Message")))
+                .andExpect(jsonPath("$.lossyMappingReport.contractRisks", hasItem(containsString("Slack"))))
+                .andExpect(jsonPath("$.lifecycleExpectations.exportExpectation", containsString("export")))
+                .andExpect(jsonPath("$.lifecycleExpectations.deprovisionExpectation", containsString("deprovision")))
+                .andExpect(jsonPath("$.memberImpactStates", hasItem("policy-blocked")))
+                .andExpect(jsonPath("$.auditRefs[0]", containsString("provider-replacement-dry-run-chat")))
+                .andExpect(content().string(not(containsString("raw-token"))))
+                .andExpect(content().string(not(containsString("tenant.example.invalid"))))
+                .andExpect(content().string(not(containsString("Authorization: Bearer"))));
+
+        mockMvc.perform(get("/api/admin/audit/events").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("provider.replacement.dry_run")))
+                .andExpect(content().string(not(containsString("raw-token"))))
+                .andExpect(content().string(not(containsString("tenant.example.invalid"))));
+    }
+
+    @Test
+    void providerReplacementDryRunRejectsRawSecretsAndUnsupportedAdapterCombinations() throws Exception {
+        mockMvc.perform(post("/api/admin/providers/replacements/dry-run")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "category": "chat",
+                                  "currentAdapter": "synapse-homeserver",
+                                  "targetAdapter": "slack",
+                                  "choiceModel": "external_existing_provider",
+                                  "secretRef": "xoxb-raw-token",
+                                  "sourceOfTruth": "selected chat provider owns message history"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("provider-replacement-secretref-invalid"))
+                .andExpect(jsonPath("$.details.secretRef").value("invalid-secret-ref-redacted"))
+                .andExpect(content().string(not(containsString("xoxb-raw-token"))));
+
+        mockMvc.perform(post("/api/admin/providers/replacements/dry-run")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "category": "chat",
+                                  "currentAdapter": "synapse-homeserver",
+                                  "targetAdapter": "sharepoint",
+                                  "choiceModel": "external_existing_provider",
+                                  "secretRef": "secretref://weave/provider/sharepoint",
+                                  "sourceOfTruth": "selected chat provider owns message history"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("provider-replacement-category-mismatch"))
+                .andExpect(content().string(not(containsString("sharepoint.example"))));
+    }
+
+    @Test
     void calendarAccessPolicyAndSetupCredentialsAreRevocableWithoutSecretOutput() throws Exception {
         mockMvc.perform(get("/api/calendar/access-policy").with(workspaceJwt()))
                 .andExpect(status().isOk())
@@ -196,5 +278,18 @@ class PlatformProductContractControllerTest {
                         .claim("weave_tenant_id", "tenant-default")
                         .claim("aud", java.util.List.of("weave-app")))
                 .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"));
+    }
+
+    private org.springframework.test.web.servlet.request.RequestPostProcessor adminJwt() {
+        return jwt().jwt(jwt -> jwt
+                        .subject("admin-123")
+                        .issuer("https://auth.example.invalid/realms/weave")
+                        .claim("preferred_username", "admin")
+                        .claim("weave_tenant_id", "tenant-default")
+                        .claim("aud", java.util.List.of("weave-app"))
+                        .claim("realm_access", java.util.Map.of("roles", java.util.List.of("admin"))))
+                .authorities(
+                        new SimpleGrantedAuthority("SCOPE_weave:workspace"),
+                        new SimpleGrantedAuthority("ROLE_ADMIN"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds Admin Console provider replacement dry-run API for category/current/target adapter preflight without applying state.
- Returns support-safe anti-silo evidence: lossy mapping risks, canonical objects, source-of-truth/export/delete/deprovision expectations, readiness state, cutover gates, and audit refs.
- Rejects raw credential values and unsupported category/adapter combinations; dry-run/apply attempt audit payloads stay redacted.

## Tests
- `cd server && ./gradlew test --tests com.massimotter.weave.backend.controller.PlatformProductContractControllerTest --tests com.massimotter.weave.backend.controller.OpenApiDocumentationTest`
- `./gradlew serverCi acceptanceContract`

Closes #349
