### PR TITLE
feat: show admin policy readiness boundaries

### DIFF
--- a/admin-console/README.md
+++ b/admin-console/README.md
@@ -6,8 +6,10 @@ Separate React + MUI admin surface for organization owners, admins, and operator
 
 - Talks only to Weave backend admin APIs (`/api/admin/...`).
 - Uses OIDC/Keycloak as the default self-hosted identity broker contract through `weave-admin-console`.
-- Shows organization overview, provider category readiness, provider detail/readiness actions, deny-by-default whitelist policy, and redacted audit events.
+- Shows organization overview, effective policy explanation, provider category readiness, replacement dry-run results, provider detail/readiness actions, deny-by-default whitelist policy, and redacted audit events.
+- Renders owner/admin, operator, and member boundaries distinctly: owners/admins configure, operators inspect support-safe readiness, and members see only usable/disabled/degraded/policy-blocked capability states.
 - Never calls raw providers directly and never renders raw provider secrets.
+- New user-visible Admin Console copy is kept in `src/copy.ts` so localization entries stay reviewable even before additional locales are enabled.
 - The Weave member client remains provider-agnostic and is not the admin portal.
 
 ## Local commands

--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -4,8 +4,11 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
 import { AdminControlPlaneApi, sampleControlPlane } from './api';
+import { adminConsoleMessages } from './copy';
 
-function mockApi(overrides: Partial<AdminControlPlaneApi> = {}): AdminControlPlaneApi {
+function mockApi(
+  overrides: Partial<AdminControlPlaneApi> = {},
+): AdminControlPlaneApi {
   return {
     getControlPlane: vi.fn().mockResolvedValue(sampleControlPlane),
     updateWhitelistPolicy: vi.fn().mockResolvedValue({
@@ -13,7 +16,39 @@ function mockApi(overrides: Partial<AdminControlPlaneApi> = {}): AdminControlPla
       allowedCapabilities: ['files.read'],
     }),
     selectProvider: vi.fn().mockResolvedValue(undefined),
-    testProviderReadiness: vi.fn().mockResolvedValue({ providerKey: 'keycloak-realm', state: 'ready', summary: 'Ready' }),
+    dryRunProviderReplacement: vi.fn().mockResolvedValue({
+      dryRunId: 'chat-slack-dry-run',
+      status: 'dry_run_ready',
+      category: 'identity-idm',
+      currentAdapter: 'keycloak-realm',
+      targetAdapter: 'keycloak-realm',
+      readinessState: 'ready',
+      migrationDryRunRequired: true,
+      memberImpactStates: ['usable', 'degraded', 'policy-blocked'],
+      supportSafe: true,
+      providerDiagnosticsRedacted: true,
+      cutoverGates: ['Run backend migration dry-run before apply'],
+      lossyMappingReport: {
+        canonicalObjects: ['IdentitySubject', 'GroupMembership'],
+        contractRisks: ['External claims need mapping review'],
+        adminNotes: ['Support-safe dry-run'],
+        conflicts: [],
+        replacementRequirement: 'Review before apply',
+      },
+      lifecycleExpectations: {
+        sourceOfTruthPolicy: 'Weave effective policy remains source of truth',
+        exportExpectation: 'Export evidence is required before cutover.',
+        deleteExpectation:
+          'Delete/deprovision evidence is required after cutover.',
+        deprovisionExpectation: 'Deactivate old adapter after verification.',
+        rollbackSupportBoundary: 'Rollback bounded by provider export support.',
+      },
+    }),
+    testProviderReadiness: vi.fn().mockResolvedValue({
+      providerKey: 'keycloak-realm',
+      state: 'ready',
+      summary: 'Ready',
+    }),
     listAuditEvents: vi.fn().mockResolvedValue(sampleControlPlane.auditEvents),
     ...overrides,
   } as unknown as AdminControlPlaneApi;
@@ -29,25 +64,68 @@ describe('Admin Console MVP', () => {
   it('renders organization, provider, policy, and audit sections from backend control-plane data', async () => {
     render(<App api={mockApi()} />);
 
-    expect(await screen.findByRole('heading', { name: /weave organization admin console/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /organization overview/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /provider categories/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /provider selection and readiness/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /policy and whitelist/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /secretref inventory/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /audit trail/i })).toBeInTheDocument();
-    expect(screen.getByLabelText(/identity \/ idm status is ready/i)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', {
+        name: /weave organization admin console/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /organization overview/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /provider categories/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: /provider selection and readiness/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /effective policy explanation/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /member capability preview/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: /provider replacement dry-run results/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /policy and whitelist/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /secretref inventory/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /audit trail/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/identity \/ idm status is ready/i),
+    ).toBeInTheDocument();
     expect(screen.getByText(/provider source of truth/i)).toBeInTheDocument();
-    expect(screen.getByText(/policy is deny-by-default/i)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/policy is deny-by-default/i).length,
+    ).toBeGreaterThan(0);
   });
 
   it('keeps admin/provider setup separate from the member client and direct providers', async () => {
     render(<App api={mockApi()} />);
 
-    expect(await screen.findByText(/calls only Weave backend admin APIs/i)).toBeInTheDocument();
-    expect(screen.getByText(/it does not call Keycloak, Nextcloud, Matrix, Microsoft Graph, Slack, Teams/i)).toBeInTheDocument();
-    expect(screen.getByText(/Secrets stay as SecretRef handles/i)).toBeInTheDocument();
-    expect(screen.getByText(/use the provider-agnostic weave client/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/calls only Weave backend admin APIs/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /it does not call Keycloak, Nextcloud, Matrix, Microsoft Graph, Slack, Teams/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Secrets stay as SecretRef handles/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/use the provider-agnostic weave client/i),
+    ).toBeInTheDocument();
   });
 
   it('saves whitelist policy through the backend API and announces the result', async () => {
@@ -55,13 +133,21 @@ describe('Admin Console MVP', () => {
     const user = userEvent.setup();
     render(<App api={api} />);
 
-    const policyField = await screen.findByRole('textbox', { name: /allowed capabilities/i });
+    const policyField = await screen.findByRole('textbox', {
+      name: /allowed capabilities/i,
+    });
     await user.clear(policyField);
     await user.type(policyField, 'files.read');
-    await user.click(screen.getByRole('button', { name: /save whitelist policy/i }));
+    await user.click(
+      screen.getByRole('button', { name: /save whitelist policy/i }),
+    );
 
-    await waitFor(() => expect(api.updateWhitelistPolicy).toHaveBeenCalledWith(['files.read']));
-    expect(await screen.findByRole('status')).toHaveTextContent(/whitelist policy saved/i);
+    await waitFor(() =>
+      expect(api.updateWhitelistPolicy).toHaveBeenCalledWith(['files.read']),
+    );
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /whitelist policy saved/i,
+    );
   });
 
   it('applies selected providers as Admin Console source of truth through the backend API', async () => {
@@ -69,10 +155,21 @@ describe('Admin Console MVP', () => {
     const user = userEvent.setup();
     render(<App api={api} />);
 
-    await user.click(await screen.findByRole('button', { name: /apply selected provider/i }));
+    await user.click(
+      await screen.findByRole('button', { name: /apply selected provider/i }),
+    );
 
-    await waitFor(() => expect(api.selectProvider).toHaveBeenCalledWith('identity-idm', 'keycloak-realm', 'recommended_self_hosted_default', false));
-    expect(await screen.findByRole('status')).toHaveTextContent(/provider selection applied/i);
+    await waitFor(() =>
+      expect(api.selectProvider).toHaveBeenCalledWith(
+        'identity-idm',
+        'keycloak-realm',
+        'recommended_self_hosted_default',
+        false,
+      ),
+    );
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /provider selection applied/i,
+    );
   });
 
   it('dry-runs selected providers through the backend API before applying', async () => {
@@ -80,10 +177,108 @@ describe('Admin Console MVP', () => {
     const user = userEvent.setup();
     render(<App api={api} />);
 
-    await user.click(await screen.findByRole('button', { name: /dry-run provider selection/i }));
+    await user.click(
+      await screen.findByRole('button', {
+        name: /dry-run provider selection/i,
+      }),
+    );
 
-    await waitFor(() => expect(api.selectProvider).toHaveBeenCalledWith('identity-idm', 'keycloak-realm', 'recommended_self_hosted_default', true));
-    expect(await screen.findByRole('status')).toHaveTextContent(/dry-run validated/i);
+    await waitFor(() =>
+      expect(api.selectProvider).toHaveBeenCalledWith(
+        'identity-idm',
+        'keycloak-realm',
+        'recommended_self_hosted_default',
+        true,
+      ),
+    );
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /dry-run validated/i,
+    );
+  });
+
+  it('renders support-safe provider replacement dry-run evidence', async () => {
+    const api = mockApi();
+    const user = userEvent.setup();
+    render(<App api={api} />);
+
+    await user.click(
+      await screen.findByRole('button', {
+        name: /dry-run replacement contract/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(api.dryRunProviderReplacement).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'identity-idm' }),
+        'keycloak-realm',
+        'recommended_self_hosted_default',
+      ),
+    );
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /replacement dry-run completed/i,
+    );
+    expect(screen.getByText(/support-safe: yes/i)).toBeInTheDocument();
+    expect(screen.getByText(/diagnostics redacted: yes/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /member impact states: usable, degraded, policy-blocked/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('shows distinct owner, operator, and member boundaries without provider-admin controls in member preview', async () => {
+    const { unmount } = render(<App api={mockApi()} />);
+
+    expect(
+      await screen.findByText(
+        /configure provider categories, replacement dry-runs/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /inspect readiness, audit evidence, and support-safe diagnostics/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /use weave product capabilities with only usable, disabled, degraded, or policy-blocked states/i,
+      ),
+    ).toBeInTheDocument();
+    unmount();
+
+    render(<App api={mockApi()} viewerRole="member" />);
+    const memberPreview = await screen.findByLabelText(
+      /member-visible capability states/i,
+    );
+    expect(memberPreview).toHaveTextContent(/Member state: usable/i);
+    expect(memberPreview).not.toHaveTextContent(/secretref:\/\//i);
+    expect(document.body).not.toHaveTextContent(/secretref:\/\//i);
+    expect(document.body).not.toHaveTextContent(
+      /keycloak|nextcloud|matrix|microsoft graph|slack|teams|livekit/i,
+    );
+    expect(
+      screen.queryByRole('heading', {
+        name: /provider selection and readiness/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /apply selected provider/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps new Admin Console copy in the localization catalog', () => {
+    expect(adminConsoleMessages.en.effectivePolicyHeading).toBe(
+      'Effective policy explanation',
+    );
+    expect(adminConsoleMessages.en.replacementButton).toBe(
+      'Dry-run replacement contract',
+    );
+    expect(adminConsoleMessages.en.memberPreviewDescription).toContain(
+      'hides provider adapters',
+    );
+    expect(adminConsoleMessages.en.memberStateDescription).toContain(
+      'stable capability state',
+    );
   });
 
   it('queues provider readiness tests through the backend API', async () => {
@@ -91,9 +286,17 @@ describe('Admin Console MVP', () => {
     const user = userEvent.setup();
     render(<App api={api} />);
 
-    await user.click(await screen.findByRole('button', { name: /test readiness through backend/i }));
+    await user.click(
+      await screen.findByRole('button', {
+        name: /test readiness through backend/i,
+      }),
+    );
 
-    await waitFor(() => expect(api.testProviderReadiness).toHaveBeenCalledWith('keycloak-realm'));
-    expect(await screen.findByRole('status')).toHaveTextContent(/readiness test queued/i);
+    await waitFor(() =>
+      expect(api.testProviderReadiness).toHaveBeenCalledWith('keycloak-realm'),
+    );
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      /readiness test queued/i,
+    );
   });
 });

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -24,9 +24,24 @@ import {
   Toolbar,
   Typography,
 } from '@mui/material';
-import { AdminControlPlaneApi, adminConsoleConfig, CapabilityState, ControlPlaneResponse, ProviderCategory, sampleControlPlane } from './api';
+import {
+  AdminControlPlaneApi,
+  adminConsoleConfig,
+  CapabilityState,
+  ControlPlaneResponse,
+  ProviderCategory,
+  ProviderReplacementDryRunReport,
+  sampleControlPlane,
+} from './api';
+import { AdminConsoleLocale, adminCopy } from './copy';
 
-const stateColor: Record<CapabilityState, 'success' | 'default' | 'warning' | 'error' | 'info'> = {
+type ViewerRole = 'owner' | 'admin' | 'operator' | 'member';
+type MemberStableState = 'usable' | 'disabled' | 'degraded' | 'policy-blocked';
+
+const stateColor: Record<
+  CapabilityState,
+  'success' | 'default' | 'warning' | 'error' | 'info'
+> = {
   ready: 'success',
   disabled: 'default',
   degraded: 'warning',
@@ -41,24 +56,68 @@ function readableState(state: string): string {
   return state.replace(/[-_]/g, ' ');
 }
 
+function memberStableState(state: CapabilityState): MemberStableState {
+  switch (state) {
+    case 'ready':
+    case 'configured':
+      return 'usable';
+    case 'policy-blocked':
+      return 'policy-blocked';
+    case 'disabled':
+    case 'unsupported':
+    case 'not_configured':
+      return 'disabled';
+    case 'degraded':
+    case 'misconfigured':
+    default:
+      return 'degraded';
+  }
+}
+
 function defaultProviderKey(category?: ProviderCategory): string {
   if (!category) return '';
-  return category.selectedAdapter === 'awaiting_admin_selection' ? category.providerCandidates[0] ?? '' : category.selectedAdapter;
+  return category.selectedAdapter === 'awaiting_admin_selection'
+    ? (category.providerCandidates[0] ?? '')
+    : category.selectedAdapter;
 }
 
 interface AppProps {
   api?: AdminControlPlaneApi;
+  viewerRole?: ViewerRole;
+  locale?: AdminConsoleLocale;
 }
 
-export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
-  const [controlPlane, setControlPlane] = useState<ControlPlaneResponse>(sampleControlPlane);
-  const [loadState, setLoadState] = useState<'loading' | 'loaded' | 'offline-sample'>('loading');
+export default function App({
+  api = new AdminControlPlaneApi(),
+  viewerRole = 'owner',
+  locale = 'en',
+}: AppProps) {
+  const copy = adminCopy(locale);
+  const canConfigure = viewerRole === 'owner' || viewerRole === 'admin';
+  const canInspectReadiness = canConfigure || viewerRole === 'operator';
+  const [controlPlane, setControlPlane] =
+    useState<ControlPlaneResponse>(sampleControlPlane);
+  const [loadState, setLoadState] = useState<
+    'loading' | 'loaded' | 'offline-sample'
+  >('loading');
   const [error, setError] = useState<string | null>(null);
-  const [selectedCategory, setSelectedCategory] = useState(sampleControlPlane.providerCategories[0]?.key ?? '');
-  const [providerDraft, setProviderDraft] = useState(defaultProviderKey(sampleControlPlane.providerCategories[0]));
-  const [choiceModelDraft, setChoiceModelDraft] = useState('recommended_self_hosted_default');
-  const [policyDraft, setPolicyDraft] = useState(sampleControlPlane.whitelistPolicy.allowedCapabilities.join('\n'));
-  const [statusMessage, setStatusMessage] = useState('Admin Console is loading backend control-plane data.');
+  const [selectedCategory, setSelectedCategory] = useState(
+    sampleControlPlane.providerCategories[0]?.key ?? '',
+  );
+  const [providerDraft, setProviderDraft] = useState(
+    defaultProviderKey(sampleControlPlane.providerCategories[0]),
+  );
+  const [choiceModelDraft, setChoiceModelDraft] = useState(
+    'recommended_self_hosted_default',
+  );
+  const [policyDraft, setPolicyDraft] = useState(
+    sampleControlPlane.whitelistPolicy.allowedCapabilities.join('\n'),
+  );
+  const [dryRunReport, setDryRunReport] =
+    useState<ProviderReplacementDryRunReport | null>(null);
+  const [statusMessage, setStatusMessage] = useState(
+    'Admin Console is loading backend control-plane data.',
+  );
 
   useEffect(() => {
     let alive = true;
@@ -71,15 +130,25 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
         setPolicyDraft(response.whitelistPolicy.allowedCapabilities.join('\n'));
         setSelectedCategory(firstCategory?.key ?? '');
         setProviderDraft(defaultProviderKey(firstCategory));
-        setChoiceModelDraft(firstCategory?.choiceModel === 'not_selected' ? 'recommended_self_hosted_default' : firstCategory?.choiceModel ?? 'recommended_self_hosted_default');
+        setChoiceModelDraft(
+          firstCategory?.choiceModel === 'not_selected'
+            ? 'recommended_self_hosted_default'
+            : (firstCategory?.choiceModel ?? 'recommended_self_hosted_default'),
+        );
         setLoadState('loaded');
         setStatusMessage('Backend control-plane data loaded.');
       })
       .catch((cause: unknown) => {
         if (!alive) return;
         setLoadState('offline-sample');
-        setError(cause instanceof Error ? cause.message : 'Admin API is unavailable; showing the contract-backed sample state.');
-        setStatusMessage('Admin API unavailable. Showing support-safe sample data only.');
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : 'Admin API is unavailable; showing the contract-backed sample state.',
+        );
+        setStatusMessage(
+          'Admin API unavailable. Showing support-safe sample data only.',
+        );
       });
     return () => {
       alive = false;
@@ -87,42 +156,80 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
   }, [api]);
 
   const selectedCategoryDetails = useMemo(
-    () => controlPlane.providerCategories.find((category) => category.key === selectedCategory) ?? controlPlane.providerCategories[0],
+    () =>
+      controlPlane.providerCategories.find(
+        (category) => category.key === selectedCategory,
+      ) ?? controlPlane.providerCategories[0],
     [controlPlane.providerCategories, selectedCategory],
   );
 
   function changeCategory(categoryKey: string) {
-    const category = controlPlane.providerCategories.find((candidate) => candidate.key === categoryKey);
+    const category = controlPlane.providerCategories.find(
+      (candidate) => candidate.key === categoryKey,
+    );
     setSelectedCategory(categoryKey);
     setProviderDraft(defaultProviderKey(category));
-    setChoiceModelDraft(category?.choiceModel === 'not_selected' ? 'recommended_self_hosted_default' : category?.choiceModel ?? 'recommended_self_hosted_default');
+    setChoiceModelDraft(
+      category?.choiceModel === 'not_selected'
+        ? 'recommended_self_hosted_default'
+        : (category?.choiceModel ?? 'recommended_self_hosted_default'),
+    );
+    setDryRunReport(null);
   }
 
   async function savePolicy() {
+    if (!canConfigure) return;
     const allowedCapabilities = policyDraft
       .split('\n')
       .map((capability) => capability.trim())
       .filter(Boolean);
     const response = await api.updateWhitelistPolicy(allowedCapabilities);
     setControlPlane((current) => ({ ...current, whitelistPolicy: response }));
-    setStatusMessage(`Whitelist policy saved with ${allowedCapabilities.length} requested capabilities.`);
+    setStatusMessage(
+      `Whitelist policy saved with ${allowedCapabilities.length} requested capabilities.`,
+    );
   }
 
   async function selectProvider(dryRun: boolean) {
-    if (!selectedCategoryDetails || !providerDraft) return;
-    await api.selectProvider(selectedCategoryDetails.key, providerDraft, choiceModelDraft, dryRun);
+    if (!canConfigure || !selectedCategoryDetails || !providerDraft) return;
+    await api.selectProvider(
+      selectedCategoryDetails.key,
+      providerDraft,
+      choiceModelDraft,
+      dryRun,
+    );
     if (dryRun) {
-      setStatusMessage(`Dry-run validated for ${selectedCategoryDetails.key}: ${providerDraft}.`);
+      setStatusMessage(
+        `Dry-run validated for ${selectedCategoryDetails.key}: ${providerDraft}.`,
+      );
       return;
     }
     const refreshed = await api.getControlPlane();
     setControlPlane(refreshed);
-    setStatusMessage(`Provider selection applied for ${selectedCategoryDetails.key}: ${providerDraft}. Backend control plane refreshed as source of truth.`);
+    setStatusMessage(
+      `Provider selection applied for ${selectedCategoryDetails.key}: ${providerDraft}. Backend control plane refreshed as source of truth.`,
+    );
+  }
+
+  async function dryRunReplacement() {
+    if (!canConfigure || !selectedCategoryDetails || !providerDraft) return;
+    const report = await api.dryRunProviderReplacement(
+      selectedCategoryDetails,
+      providerDraft,
+      choiceModelDraft,
+    );
+    setDryRunReport(report);
+    setStatusMessage(
+      `${copy.replacementStatusSuccess} for ${report.category}: ${report.currentAdapter} → ${report.targetAdapter}.`,
+    );
   }
 
   async function testReadiness(providerKey: string) {
+    if (!canInspectReadiness || !providerKey) return;
     const result = await api.testProviderReadiness(providerKey);
-    setStatusMessage(`Readiness test queued for ${result.providerKey}: ${readableState(result.state)}.`);
+    setStatusMessage(
+      `Readiness test queued for ${result.providerKey}: ${readableState(result.state)}.`,
+    );
   }
 
   return (
@@ -130,195 +237,525 @@ export default function App({ api = new AdminControlPlaneApi() }: AppProps) {
       <CssBaseline />
       <AppBar position="static" color="primary">
         <Toolbar>
-          <Typography variant="h1" component="h1" sx={{ fontSize: { xs: '1.35rem', md: '1.7rem' }, fontWeight: 700 }}>
+          <Typography
+            variant="h1"
+            component="h1"
+            sx={{ fontSize: { xs: '1.35rem', md: '1.7rem' }, fontWeight: 700 }}
+          >
             Weave Organization Admin Console
           </Typography>
         </Toolbar>
       </AppBar>
       <Container component="main" maxWidth="lg" sx={{ py: 4 }}>
         <Stack spacing={3}>
-          <Alert severity={loadState === 'loaded' ? 'success' : loadState === 'loading' ? 'info' : 'warning'} role="status">
+          <Alert
+            severity={
+              loadState === 'loaded'
+                ? 'success'
+                : loadState === 'loading'
+                  ? 'info'
+                  : 'warning'
+            }
+            role="status"
+          >
             {statusMessage}
           </Alert>
           {error ? <Alert severity="warning">{error}</Alert> : null}
 
-          <Card component="section" aria-labelledby="oidc-heading">
+          <Card component="section" aria-labelledby="effective-policy-heading">
             <CardContent>
-              <Typography id="oidc-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 1 }}>
-                Admin sign-in contract
+              <Typography
+                id="effective-policy-heading"
+                variant="h2"
+                sx={{ fontSize: '1.35rem', mb: 1 }}
+              >
+                {copy.effectivePolicyHeading}
               </Typography>
-              <Typography>
-                Sign in through OIDC/Keycloak client <strong>{adminConsoleConfig.oidcClientId}</strong>. This console calls only Weave backend admin APIs;
-                it does not call Keycloak, Nextcloud, Matrix, Microsoft Graph, Slack, Teams, or other providers directly.
-              </Typography>
-              <Typography sx={{ mt: 1 }}>
-                Issuer: <code>{adminConsoleConfig.oidcIssuerUrl}</code>
-              </Typography>
-              <Button variant="outlined" sx={{ mt: 2 }} href={`${adminConsoleConfig.oidcIssuerUrl}/protocol/openid-connect/auth`}>
-                Open identity broker
-              </Button>
-            </CardContent>
-          </Card>
-
-          <Card component="section" aria-labelledby="org-heading">
-            <CardContent>
-              <Typography id="org-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 1 }}>
-                Organization overview
-              </Typography>
-              <Stack spacing={1}>
-                <Typography>
-                  <strong>{controlPlane.organization.displayName}</strong> ({controlPlane.organization.id})
-                </Typography>
-                <Typography>
-                  Provider source of truth: <code>{controlPlane.providerConfigSource}</code>
-                </Typography>
-                <Typography>
-                  Bootstrap defaults are suggestions only: <strong>{controlPlane.bootstrapDefaultsAreSuggestionsOnly ? 'yes' : 'no'}</strong>
-                </Typography>
-                <Typography>Member clients may configure providers: <strong>no</strong></Typography>
+              <Typography>{copy.effectivePolicySummary}</Typography>
+              <Stack
+                direction={{ xs: 'column', md: 'row' }}
+                spacing={2}
+                sx={{ mt: 2 }}
+              >
+                <Card variant="outlined" sx={{ flex: 1 }}>
+                  <CardContent>
+                    <Typography variant="h3" sx={{ fontSize: '1.05rem' }}>
+                      {copy.ownerAdminRole}
+                    </Typography>
+                    <Typography>{copy.ownerAdminDescription}</Typography>
+                  </CardContent>
+                </Card>
+                <Card variant="outlined" sx={{ flex: 1 }}>
+                  <CardContent>
+                    <Typography variant="h3" sx={{ fontSize: '1.05rem' }}>
+                      {copy.operatorRole}
+                    </Typography>
+                    <Typography>{copy.operatorDescription}</Typography>
+                  </CardContent>
+                </Card>
+                <Card variant="outlined" sx={{ flex: 1 }}>
+                  <CardContent>
+                    <Typography variant="h3" sx={{ fontSize: '1.05rem' }}>
+                      {copy.memberRole}
+                    </Typography>
+                    <Typography>{copy.memberDescription}</Typography>
+                  </CardContent>
+                </Card>
               </Stack>
             </CardContent>
           </Card>
 
-          <Card component="section" aria-labelledby="providers-heading">
+          <Card component="section" aria-labelledby="member-preview-heading">
             <CardContent>
-              <Typography id="providers-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 2 }}>
-                Provider categories
-              </Typography>
-              <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ flexWrap: 'wrap' }} useFlexGap>
-                {controlPlane.providerCategories.map((category) => (
-                  <Card key={category.key} variant="outlined" sx={{ flex: '1 1 260px' }}>
-                    <CardContent>
-                      <Typography variant="h3" sx={{ fontSize: '1.05rem' }}>
-                        {category.label}
-                      </Typography>
-                      <Chip
-                        sx={{ mt: 1 }}
-                        color={stateColor[category.state]}
-                        label={`Status: ${readableState(category.state)}`}
-                        aria-label={`${category.label} status is ${readableState(category.state)}`}
-                      />
-                      <Typography sx={{ mt: 1 }}>{category.summary}</Typography>
-                      <Typography variant="body2" sx={{ mt: 1 }}>
-                        Selected: {category.selectedAdapter}; candidates: {category.providerCandidates.join(', ')}
-                      </Typography>
-                    </CardContent>
-                  </Card>
-                ))}
-              </Stack>
-            </CardContent>
-          </Card>
-
-          <Card component="section" aria-labelledby="provider-selection-heading">
-            <CardContent>
-              <Typography id="provider-selection-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 2 }}>
-                Provider selection and readiness
+              <Typography
+                id="member-preview-heading"
+                variant="h2"
+                sx={{ fontSize: '1.35rem', mb: 1 }}
+              >
+                {copy.memberPreviewHeading}
               </Typography>
               <Alert severity="info" sx={{ mb: 2 }}>
-                Admin Console-selected mappings are the source of truth. Secrets stay as SecretRef handles; readiness tests run only through backend admin APIs.
+                {copy.memberPreviewDescription}
               </Alert>
-              <Stack spacing={2}>
-                <FormControl fullWidth>
-                  <InputLabel id="provider-category-select-label">Provider category</InputLabel>
-                  <Select labelId="provider-category-select-label" id="provider-category-select" value={selectedCategory} label="Provider category" onChange={(event) => changeCategory(event.target.value)}>
-                    {controlPlane.providerCategories.map((category) => (
-                      <MenuItem key={category.key} value={category.key}>
-                        {category.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                  <FormHelperText>Category-first canonical Weave contracts stay separate from adapter choices.</FormHelperText>
-                </FormControl>
+              <List aria-label="Member-visible capability states">
+                {controlPlane.providerCategories.map((category) => (
+                  <ListItem key={`member-${category.key}`}>
+                    <ListItemText
+                      primary={category.label}
+                      secondary={`${copy.memberStateLabel}: ${memberStableState(category.state)}. ${copy.memberStateDescription}`}
+                    />
+                  </ListItem>
+                ))}
+              </List>
+            </CardContent>
+          </Card>
 
-                {selectedCategoryDetails ? (
-                  <>
+          {viewerRole !== 'member' ? (
+            <>
+              <Card component="section" aria-labelledby="oidc-heading">
+                <CardContent>
+                  <Typography
+                    id="oidc-heading"
+                    variant="h2"
+                    sx={{ fontSize: '1.35rem', mb: 1 }}
+                  >
+                    Admin sign-in contract
+                  </Typography>
+                  <Typography>
+                    Sign in through OIDC/Keycloak client{' '}
+                    <strong>{adminConsoleConfig.oidcClientId}</strong>. This
+                    console calls only Weave backend admin APIs; it does not
+                    call Keycloak, Nextcloud, Matrix, Microsoft Graph, Slack,
+                    Teams, or other providers directly.
+                  </Typography>
+                  <Typography sx={{ mt: 1 }}>
+                    Issuer: <code>{adminConsoleConfig.oidcIssuerUrl}</code>
+                  </Typography>
+                  <Button
+                    variant="outlined"
+                    sx={{ mt: 2 }}
+                    href={`${adminConsoleConfig.oidcIssuerUrl}/protocol/openid-connect/auth`}
+                  >
+                    Open identity broker
+                  </Button>
+                </CardContent>
+              </Card>
+
+              <Card component="section" aria-labelledby="org-heading">
+                <CardContent>
+                  <Typography
+                    id="org-heading"
+                    variant="h2"
+                    sx={{ fontSize: '1.35rem', mb: 1 }}
+                  >
+                    Organization overview
+                  </Typography>
+                  <Stack spacing={1}>
+                    <Typography>
+                      <strong>{controlPlane.organization.displayName}</strong> (
+                      {controlPlane.organization.id})
+                    </Typography>
+                    <Typography>
+                      Provider source of truth:{' '}
+                      <code>{controlPlane.providerConfigSource}</code>
+                    </Typography>
+                    <Typography>
+                      Bootstrap defaults are suggestions only:{' '}
+                      <strong>
+                        {controlPlane.bootstrapDefaultsAreSuggestionsOnly
+                          ? 'yes'
+                          : 'no'}
+                      </strong>
+                    </Typography>
+                    <Typography>
+                      Current viewer role: <strong>{viewerRole}</strong>
+                    </Typography>
+                    <Typography>
+                      Member clients may configure providers:{' '}
+                      <strong>no</strong>
+                    </Typography>
+                  </Stack>
+                </CardContent>
+              </Card>
+
+              <Card component="section" aria-labelledby="providers-heading">
+                <CardContent>
+                  <Typography
+                    id="providers-heading"
+                    variant="h2"
+                    sx={{ fontSize: '1.35rem', mb: 2 }}
+                  >
+                    Provider categories
+                  </Typography>
+                  <Stack
+                    direction={{ xs: 'column', md: 'row' }}
+                    spacing={2}
+                    sx={{ flexWrap: 'wrap' }}
+                    useFlexGap
+                  >
+                    {controlPlane.providerCategories.map((category) => (
+                      <Card
+                        key={category.key}
+                        variant="outlined"
+                        sx={{ flex: '1 1 260px' }}
+                      >
+                        <CardContent>
+                          <Typography variant="h3" sx={{ fontSize: '1.05rem' }}>
+                            {category.label}
+                          </Typography>
+                          <Chip
+                            sx={{ mt: 1 }}
+                            color={stateColor[category.state]}
+                            label={`Status: ${readableState(category.state)}`}
+                            aria-label={`${category.label} status is ${readableState(category.state)}`}
+                          />
+                          <Typography sx={{ mt: 1 }}>
+                            {category.summary}
+                          </Typography>
+                          {canConfigure ? (
+                            <Typography variant="body2" sx={{ mt: 1 }}>
+                              Selected: {category.selectedAdapter}; candidates:{' '}
+                              {category.providerCandidates.join(', ')}
+                            </Typography>
+                          ) : null}
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </Stack>
+                </CardContent>
+              </Card>
+
+              <Card
+                component="section"
+                aria-labelledby="provider-selection-heading"
+              >
+                <CardContent>
+                  <Typography
+                    id="provider-selection-heading"
+                    variant="h2"
+                    sx={{ fontSize: '1.35rem', mb: 2 }}
+                  >
+                    Provider selection and readiness
+                  </Typography>
+                  <Alert severity="info" sx={{ mb: 2 }}>
+                    Admin Console-selected mappings are the source of truth.
+                    Secrets stay as SecretRef handles; readiness tests run only
+                    through backend admin APIs.
+                  </Alert>
+                  <Stack spacing={2}>
                     <FormControl fullWidth>
-                      <InputLabel id="provider-candidate-select-label">Selected provider adapter</InputLabel>
-                      <Select labelId="provider-candidate-select-label" id="provider-candidate-select" value={providerDraft} label="Selected provider adapter" onChange={(event) => setProviderDraft(event.target.value)}>
-                        {selectedCategoryDetails.providerCandidates.map((candidate) => (
-                          <MenuItem key={candidate} value={candidate}>
-                            {candidate}
+                      <InputLabel id="provider-category-select-label">
+                        Provider category
+                      </InputLabel>
+                      <Select
+                        labelId="provider-category-select-label"
+                        id="provider-category-select"
+                        value={selectedCategory}
+                        label="Provider category"
+                        onChange={(event) => changeCategory(event.target.value)}
+                      >
+                        {controlPlane.providerCategories.map((category) => (
+                          <MenuItem key={category.key} value={category.key}>
+                            {category.label}
                           </MenuItem>
                         ))}
                       </Select>
+                      <FormHelperText>
+                        Category-first canonical Weave contracts stay separate
+                        from adapter choices.
+                      </FormHelperText>
                     </FormControl>
-                    <FormControl fullWidth>
-                      <InputLabel id="choice-model-select-label">Choice model</InputLabel>
-                      <Select labelId="choice-model-select-label" id="choice-model-select" value={choiceModelDraft} label="Choice model" onChange={(event) => setChoiceModelDraft(event.target.value)}>
-                        <MenuItem value="recommended_self_hosted_default">recommended self-hosted default</MenuItem>
-                        <MenuItem value="external_existing_provider">external existing provider</MenuItem>
-                        <MenuItem value="managed_cloud_provider">managed cloud provider</MenuItem>
-                      </Select>
-                    </FormControl>
-                    <Typography>SecretRefs: {selectedCategoryDetails.secretRefs.join(', ') || `secretref://weave/provider/${providerDraft}`}</Typography>
-                    <Typography>Never paste raw secrets, bearer tokens, provider URLs with credentials, or downstream diagnostics.</Typography>
-                    <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
-                      <Button variant="outlined" onClick={() => void selectProvider(true)}>
-                        Dry-run provider selection
-                      </Button>
-                      <Button variant="contained" onClick={() => void selectProvider(false)}>
-                        Apply selected provider
-                      </Button>
-                      <Button variant="contained" color="secondary" onClick={() => void testReadiness(providerDraft)}>
-                        Test readiness through backend
-                      </Button>
+
+                    {selectedCategoryDetails ? (
+                      <>
+                        <FormControl fullWidth disabled={!canConfigure}>
+                          <InputLabel id="provider-candidate-select-label">
+                            Selected provider adapter
+                          </InputLabel>
+                          <Select
+                            labelId="provider-candidate-select-label"
+                            id="provider-candidate-select"
+                            value={providerDraft}
+                            label="Selected provider adapter"
+                            onChange={(event) =>
+                              setProviderDraft(event.target.value)
+                            }
+                          >
+                            {selectedCategoryDetails.providerCandidates.map(
+                              (candidate) => (
+                                <MenuItem key={candidate} value={candidate}>
+                                  {candidate}
+                                </MenuItem>
+                              ),
+                            )}
+                          </Select>
+                        </FormControl>
+                        <FormControl fullWidth disabled={!canConfigure}>
+                          <InputLabel id="choice-model-select-label">
+                            Choice model
+                          </InputLabel>
+                          <Select
+                            labelId="choice-model-select-label"
+                            id="choice-model-select"
+                            value={choiceModelDraft}
+                            label="Choice model"
+                            onChange={(event) =>
+                              setChoiceModelDraft(event.target.value)
+                            }
+                          >
+                            <MenuItem value="recommended_self_hosted_default">
+                              recommended self-hosted default
+                            </MenuItem>
+                            <MenuItem value="external_existing_provider">
+                              external existing provider
+                            </MenuItem>
+                            <MenuItem value="managed_cloud_provider">
+                              managed cloud provider
+                            </MenuItem>
+                          </Select>
+                        </FormControl>
+                        {canConfigure ? (
+                          <Typography>
+                            SecretRefs:{' '}
+                            {selectedCategoryDetails.secretRefs.join(', ') ||
+                              `secretref://weave/provider/${providerDraft}`}
+                          </Typography>
+                        ) : null}
+                        <Typography>
+                          Never paste raw secrets, bearer tokens, provider URLs
+                          with credentials, or downstream diagnostics.
+                        </Typography>
+                        <Stack
+                          direction={{ xs: 'column', sm: 'row' }}
+                          spacing={2}
+                        >
+                          {canConfigure ? (
+                            <>
+                              <Button
+                                variant="outlined"
+                                onClick={() => void selectProvider(true)}
+                              >
+                                Dry-run provider selection
+                              </Button>
+                              <Button
+                                variant="outlined"
+                                color="secondary"
+                                onClick={() => void dryRunReplacement()}
+                              >
+                                {copy.replacementButton}
+                              </Button>
+                              <Button
+                                variant="contained"
+                                onClick={() => void selectProvider(false)}
+                              >
+                                Apply selected provider
+                              </Button>
+                            </>
+                          ) : null}
+                          <Button
+                            variant="contained"
+                            color="secondary"
+                            onClick={() => void testReadiness(providerDraft)}
+                          >
+                            Test readiness through backend
+                          </Button>
+                        </Stack>
+                      </>
+                    ) : null}
+                  </Stack>
+                </CardContent>
+              </Card>
+
+              <Card component="section" aria-labelledby="replacement-heading">
+                <CardContent>
+                  <Typography
+                    id="replacement-heading"
+                    variant="h2"
+                    sx={{ fontSize: '1.35rem', mb: 1 }}
+                  >
+                    {copy.replacementHeading}
+                  </Typography>
+                  <Typography>{copy.replacementSummary}</Typography>
+                  {dryRunReport ? (
+                    <Stack spacing={1} sx={{ mt: 2 }}>
+                      <Alert
+                        severity={
+                          dryRunReport.supportSafe &&
+                          dryRunReport.providerDiagnosticsRedacted
+                            ? 'success'
+                            : 'warning'
+                        }
+                      >
+                        {dryRunReport.status}; support-safe:{' '}
+                        {dryRunReport.supportSafe ? 'yes' : 'no'}; diagnostics
+                        redacted:{' '}
+                        {dryRunReport.providerDiagnosticsRedacted
+                          ? 'yes'
+                          : 'no'}
+                        .
+                      </Alert>
+                      <Typography>
+                        {dryRunReport.category}: {dryRunReport.currentAdapter} →{' '}
+                        {dryRunReport.targetAdapter}; readiness{' '}
+                        {readableState(dryRunReport.readinessState)}.
+                      </Typography>
+                      <Typography>
+                        Member impact states:{' '}
+                        {dryRunReport.memberImpactStates.join(', ')}
+                      </Typography>
+                      <Typography>
+                        Canonical objects:{' '}
+                        {dryRunReport.lossyMappingReport.canonicalObjects.join(
+                          ', ',
+                        ) || 'reported by backend contract'}
+                      </Typography>
+                      <Typography>
+                        Cutover gates:{' '}
+                        {dryRunReport.cutoverGates.join('; ') ||
+                          'backend migration dry-run before apply'}
+                      </Typography>
+                      <Typography>
+                        {dryRunReport.lifecycleExpectations.exportExpectation}
+                      </Typography>
+                      <Typography>
+                        {dryRunReport.lifecycleExpectations.deleteExpectation}
+                      </Typography>
                     </Stack>
-                  </>
-                ) : null}
-              </Stack>
-            </CardContent>
-          </Card>
+                  ) : (
+                    <Alert severity="info" sx={{ mt: 2 }}>
+                      {copy.replacementEmpty}
+                    </Alert>
+                  )}
+                </CardContent>
+              </Card>
 
-          <Card component="section" aria-labelledby="policy-heading">
-            <CardContent>
-              <Typography id="policy-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 1 }}>
-                Policy and whitelist
-              </Typography>
-              <Alert severity="info" sx={{ mb: 2 }}>
-                Policy is deny-by-default. Add one canonical Weave capability per line only after the organization has approved it.
-              </Alert>
-              <TextField label="Allowed capabilities" value={policyDraft} onChange={(event) => setPolicyDraft(event.target.value)} fullWidth multiline minRows={5} helperText="Example: files.read. Do not paste secrets, provider tokens, raw diagnostics, or provider-specific payloads here." />
-              <Button sx={{ mt: 2 }} variant="contained" onClick={() => void savePolicy()}>
-                Save whitelist policy
-              </Button>
-              <Divider sx={{ my: 2 }} />
-              <Typography>Blocked examples: {controlPlane.whitelistPolicy.blockedCapabilities.join(', ')}</Typography>
-            </CardContent>
-          </Card>
+              {canConfigure ? (
+                <Card component="section" aria-labelledby="policy-heading">
+                  <CardContent>
+                    <Typography
+                      id="policy-heading"
+                      variant="h2"
+                      sx={{ fontSize: '1.35rem', mb: 1 }}
+                    >
+                      Policy and whitelist
+                    </Typography>
+                    <Alert severity="info" sx={{ mb: 2 }}>
+                      Policy is deny-by-default. Add one canonical Weave
+                      capability per line only after the organization has
+                      approved it.
+                    </Alert>
+                    <TextField
+                      label="Allowed capabilities"
+                      value={policyDraft}
+                      onChange={(event) => setPolicyDraft(event.target.value)}
+                      fullWidth
+                      multiline
+                      minRows={5}
+                      helperText="Example: files.read. Do not paste secrets, provider tokens, raw diagnostics, or provider-specific payloads here."
+                    />
+                    <Button
+                      sx={{ mt: 2 }}
+                      variant="contained"
+                      onClick={() => void savePolicy()}
+                    >
+                      Save whitelist policy
+                    </Button>
+                    <Divider sx={{ my: 2 }} />
+                    <Typography>
+                      Blocked examples:{' '}
+                      {controlPlane.whitelistPolicy.blockedCapabilities.join(
+                        ', ',
+                      )}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              ) : null}
 
-          <Card component="section" aria-labelledby="secrets-heading">
-            <CardContent>
-              <Typography id="secrets-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 1 }}>
-                SecretRef inventory
-              </Typography>
-              <List aria-label="Support-safe SecretRef handles">
-                {controlPlane.providerCategories.flatMap((category) => category.secretRefs.map((secretRef) => ({ category, secretRef }))).map(({ category, secretRef }) => (
-                  <ListItem key={`${category.key}-${secretRef}`} alignItems="flex-start">
-                    <ListItemText primary={`${category.label}: SecretRef handle`} secondary={`${secretRef} — raw secret exposed: no`} />
-                  </ListItem>
-                ))}
-              </List>
-            </CardContent>
-          </Card>
+              {canConfigure ? (
+                <Card component="section" aria-labelledby="secrets-heading">
+                  <CardContent>
+                    <Typography
+                      id="secrets-heading"
+                      variant="h2"
+                      sx={{ fontSize: '1.35rem', mb: 1 }}
+                    >
+                      SecretRef inventory
+                    </Typography>
+                    <List aria-label="Support-safe SecretRef handles">
+                      {controlPlane.providerCategories
+                        .flatMap((category) =>
+                          category.secretRefs.map((secretRef) => ({
+                            category,
+                            secretRef,
+                          })),
+                        )
+                        .map(({ category, secretRef }) => (
+                          <ListItem
+                            key={`${category.key}-${secretRef}`}
+                            alignItems="flex-start"
+                          >
+                            <ListItemText
+                              primary={`${category.label}: SecretRef handle`}
+                              secondary={`${secretRef} — raw secret exposed: no`}
+                            />
+                          </ListItem>
+                        ))}
+                    </List>
+                  </CardContent>
+                </Card>
+              ) : null}
 
-          <Card component="section" aria-labelledby="audit-heading">
-            <CardContent>
-              <Typography id="audit-heading" variant="h2" sx={{ fontSize: '1.35rem', mb: 1 }}>
-                Audit trail
-              </Typography>
-              <List aria-label="Recent admin audit events">
-                {controlPlane.auditEvents.map((event) => (
-                  <ListItem key={event.id} alignItems="flex-start">
-                    <ListItemText primary={`${event.action} by ${event.actor}`} secondary={`${event.createdAt} — ${event.summary}`} />
-                  </ListItem>
-                ))}
-              </List>
-            </CardContent>
-          </Card>
+              <Card component="section" aria-labelledby="audit-heading">
+                <CardContent>
+                  <Typography
+                    id="audit-heading"
+                    variant="h2"
+                    sx={{ fontSize: '1.35rem', mb: 1 }}
+                  >
+                    Audit trail
+                  </Typography>
+                  <List aria-label="Recent admin audit events">
+                    {controlPlane.auditEvents.map((event) => (
+                      <ListItem key={event.id} alignItems="flex-start">
+                        <ListItemText
+                          primary={`${event.action} by ${event.actor}`}
+                          secondary={`${event.createdAt} — ${event.summary}`}
+                        />
+                      </ListItem>
+                    ))}
+                  </List>
+                </CardContent>
+              </Card>
+            </>
+          ) : null}
 
           <Box component="footer">
             <Typography variant="body2">
-              Need member behavior? Use the provider-agnostic Weave Client. Admin/provider setup belongs here and in backend policy. <Link href="/api/organization/manifest">Organization manifest</Link>
+              Need member behavior? Use the provider-agnostic Weave Client.
+              Admin/provider setup belongs here and in backend policy.{' '}
+              <Link href="/api/organization/manifest">
+                Organization manifest
+              </Link>
             </Typography>
           </Box>
         </Stack>

--- a/admin-console/src/api.test.ts
+++ b/admin-console/src/api.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AdminControlPlaneApi, sampleControlPlane } from './api';
+
+// V01_ADMIN_CONSOLE_MVP: Admin Console may call only Weave backend admin APIs, not optional provider APIs.
+describe('AdminControlPlaneApi provider boundary', () => {
+  it('uses backend admin endpoints for provider selection, readiness, and replacement dry-runs', async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      const path = String(input);
+      const body = path.includes('/replacements/dry-run')
+        ? {
+            status: 'dry_run_ready',
+            category: 'chat',
+            currentAdapter: 'synapse-homeserver',
+            targetAdapter: 'slack',
+            readinessState: 'degraded',
+            memberImpactStates: [
+              'usable',
+              'disabled',
+              'degraded',
+              'policy-blocked',
+            ],
+            supportSafe: true,
+            providerDiagnosticsRedacted: true,
+            lossyMappingReport: {
+              canonicalObjects: ['Conversation'],
+              contractRisks: [],
+              adminNotes: [],
+              conflicts: [],
+            },
+            lifecycleExpectations: {
+              exportExpectation: 'export first',
+              deleteExpectation: 'delete after cutover',
+            },
+          }
+        : path.includes('/readiness-tests')
+          ? { providerKey: 'slack', state: 'ready', readiness: 'ready' }
+          : {};
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const api = new AdminControlPlaneApi(
+      {
+        apiBaseUrl: 'https://api.example.invalid/api',
+        oidcIssuerUrl: 'https://auth.example.invalid',
+        oidcClientId: 'weave-admin-console',
+      },
+      fetchImpl as typeof fetch,
+    );
+    const category = {
+      ...sampleControlPlane.providerCategories[1],
+      selectedAdapter: 'synapse-homeserver',
+    };
+
+    await api.selectProvider('chat', 'slack');
+    await api.testProviderReadiness('slack');
+    const report = await api.dryRunProviderReplacement(category, 'slack');
+
+    expect(report.supportSafe).toBe(true);
+    expect(report.memberImpactStates).toEqual([
+      'usable',
+      'disabled',
+      'degraded',
+      'policy-blocked',
+    ]);
+    expect(calls).toEqual([
+      'https://api.example.invalid/api/admin/providers/selections',
+      'https://api.example.invalid/api/admin/providers/readiness-tests',
+      'https://api.example.invalid/api/admin/providers/replacements/dry-run',
+    ]);
+    expect(calls.join('\n')).not.toMatch(
+      /slack\.com|graph\.microsoft\.com|nextcloud|matrix|livekit/i,
+    );
+  });
+});

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -1,4 +1,12 @@
-export type CapabilityState = 'ready' | 'disabled' | 'degraded' | 'policy-blocked' | 'misconfigured' | 'unsupported' | 'not_configured' | 'configured';
+export type CapabilityState =
+  | 'ready'
+  | 'disabled'
+  | 'degraded'
+  | 'policy-blocked'
+  | 'misconfigured'
+  | 'unsupported'
+  | 'not_configured'
+  | 'configured';
 
 export interface ProviderCategory {
   key: string;
@@ -29,6 +37,56 @@ export interface AuditEvent {
   summary: string;
 }
 
+export interface ProviderReplacementDryRunReport {
+  dryRunId: string;
+  status: string;
+  category: string;
+  currentAdapter: string;
+  targetAdapter: string;
+  readinessState: CapabilityState;
+  migrationDryRunRequired: boolean;
+  memberImpactStates: Array<
+    'usable' | 'disabled' | 'degraded' | 'policy-blocked'
+  >;
+  supportSafe: boolean;
+  providerDiagnosticsRedacted: boolean;
+  cutoverGates: string[];
+  lossyMappingReport: {
+    canonicalObjects: string[];
+    contractRisks: string[];
+    adminNotes: string[];
+    conflicts: string[];
+    replacementRequirement: string;
+  };
+  lifecycleExpectations: {
+    sourceOfTruthPolicy: string;
+    exportExpectation: string;
+    deleteExpectation: string;
+    deprovisionExpectation: string;
+    rollbackSupportBoundary: string;
+  };
+}
+
+interface ServerProviderReplacementDryRunReport {
+  dryRunId?: string;
+  status?: string;
+  category?: string;
+  currentAdapter?: string;
+  targetAdapter?: string;
+  readinessState?: string;
+  migrationDryRunRequired?: boolean;
+  memberImpactStates?: string[];
+  supportSafe?: boolean;
+  providerDiagnosticsRedacted?: boolean;
+  cutoverGates?: string[];
+  lossyMappingReport?: Partial<
+    ProviderReplacementDryRunReport['lossyMappingReport']
+  >;
+  lifecycleExpectations?: Partial<
+    ProviderReplacementDryRunReport['lifecycleExpectations']
+  >;
+}
+
 export interface ControlPlaneResponse {
   organization: {
     id: string;
@@ -49,14 +107,27 @@ export interface AdminConsoleConfig {
   oidcClientId: string;
 }
 
-type RuntimeEnv = Partial<Record<'VITE_WEAVE_API_BASE_URL' | 'VITE_WEAVE_OIDC_ISSUER_URL' | 'VITE_WEAVE_ADMIN_OIDC_CLIENT_ID', string>>;
+type RuntimeEnv = Partial<
+  Record<
+    | 'VITE_WEAVE_API_BASE_URL'
+    | 'VITE_WEAVE_OIDC_ISSUER_URL'
+    | 'VITE_WEAVE_ADMIN_OIDC_CLIENT_ID',
+    string
+  >
+>;
 
-const runtimeEnv: RuntimeEnv = (import.meta as ImportMeta & { env?: RuntimeEnv }).env ?? {};
+const runtimeEnv: RuntimeEnv =
+  (import.meta as ImportMeta & { env?: RuntimeEnv }).env ?? {};
 
 export const adminConsoleConfig: AdminConsoleConfig = {
-  apiBaseUrl: (runtimeEnv.VITE_WEAVE_API_BASE_URL ?? 'https://api.weave.local:44443/api').replace(/\/$/, ''),
-  oidcIssuerUrl: runtimeEnv.VITE_WEAVE_OIDC_ISSUER_URL ?? 'https://auth.weave.local:44443/realms/weave',
-  oidcClientId: runtimeEnv.VITE_WEAVE_ADMIN_OIDC_CLIENT_ID ?? 'weave-admin-console',
+  apiBaseUrl: (
+    runtimeEnv.VITE_WEAVE_API_BASE_URL ?? 'https://api.weave.local:44443/api'
+  ).replace(/\/$/, ''),
+  oidcIssuerUrl:
+    runtimeEnv.VITE_WEAVE_OIDC_ISSUER_URL ??
+    'https://auth.weave.local:44443/realms/weave',
+  oidcClientId:
+    runtimeEnv.VITE_WEAVE_ADMIN_OIDC_CLIENT_ID ?? 'weave-admin-console',
 };
 
 export class AdminApiError extends Error {
@@ -75,7 +146,11 @@ interface ServerControlPlaneResponse {
   bootstrapDefaultsAreSuggestionsOnly?: boolean;
   generatedAt?: string;
   categories?: ServerProviderCategory[];
-  selectedProviderMappings?: Array<{ category?: string; providerKey?: string; secretRef?: string }>;
+  selectedProviderMappings?: Array<{
+    category?: string;
+    providerKey?: string;
+    secretRef?: string;
+  }>;
   whitelist?: ServerWhitelistPolicy;
   secretRefs?: Array<{ ref?: string; providerKey?: string }>;
 }
@@ -116,20 +191,37 @@ export class AdminControlPlaneApi {
   ) {}
 
   async getControlPlane(): Promise<ControlPlaneResponse> {
-    const controlPlane = await this.request<ServerControlPlaneResponse>('/admin/control-plane');
+    const controlPlane = await this.request<ServerControlPlaneResponse>(
+      '/admin/control-plane',
+    );
     const auditEvents = await this.listAuditEvents().catch(() => []);
     return normalizeControlPlane(controlPlane, auditEvents);
   }
 
-  async updateWhitelistPolicy(allowedCapabilities: string[], profileKey = 'workspace-admin'): Promise<WhitelistPolicy> {
-    const response = await this.request<ServerWhitelistPolicy>('/admin/policies/capability-whitelist', {
-      method: 'PATCH',
-      body: JSON.stringify({ profileKey, capabilityKeys: allowedCapabilities, reason: 'Updated through Organization/Admin Console' }),
-    });
+  async updateWhitelistPolicy(
+    allowedCapabilities: string[],
+    profileKey = 'workspace-admin',
+  ): Promise<WhitelistPolicy> {
+    const response = await this.request<ServerWhitelistPolicy>(
+      '/admin/policies/capability-whitelist',
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          profileKey,
+          capabilityKeys: allowedCapabilities,
+          reason: 'Updated through Organization/Admin Console',
+        }),
+      },
+    );
     return normalizeWhitelist(response);
   }
 
-  async selectProvider(category: string, providerKey: string, choiceModel = 'recommended_self_hosted_default', dryRun = false): Promise<void> {
+  async selectProvider(
+    category: string,
+    providerKey: string,
+    choiceModel = 'recommended_self_hosted_default',
+    dryRun = false,
+  ): Promise<void> {
     await this.request('/admin/providers/selections', {
       method: 'POST',
       body: JSON.stringify({
@@ -138,27 +230,72 @@ export class AdminControlPlaneApi {
         choiceModel,
         dryRun,
         secretRef: `secretref://weave/provider/${providerKey}`,
-        reason: dryRun ? 'Dry-run through Organization/Admin Console' : 'Selected through Organization/Admin Console',
+        reason: dryRun
+          ? 'Dry-run through Organization/Admin Console'
+          : 'Selected through Organization/Admin Console',
       }),
     });
   }
 
-  async testProviderReadiness(providerKey: string): Promise<{ providerKey: string; state: CapabilityState; summary: string }> {
-    const response = await this.request<{ providerKey?: string; state?: string; readiness?: string }>('/admin/providers/readiness-tests', {
+  async dryRunProviderReplacement(
+    category: ProviderCategory,
+    targetAdapter: string,
+    choiceModel = 'external_existing_provider',
+  ): Promise<ProviderReplacementDryRunReport> {
+    const response = await this.request<ServerProviderReplacementDryRunReport>(
+      '/admin/providers/replacements/dry-run',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          category: category.key,
+          currentAdapter: category.selectedAdapter,
+          targetAdapter,
+          choiceModel,
+          secretRef: `secretref://weave/provider/${targetAdapter}`,
+          sourceOfTruth:
+            'Admin Console-selected provider category remains Weave source of truth until apply.',
+          lossyMappingNotes: [
+            'Admin Console requested support-safe preflight; backend redaction owns provider diagnostics.',
+          ],
+          reason:
+            'Evaluate provider replacement before activation through Organization/Admin Console',
+        }),
+      },
+    );
+    return normalizeProviderReplacementDryRun(
+      response,
+      category,
+      targetAdapter,
+    );
+  }
+
+  async testProviderReadiness(
+    providerKey: string,
+  ): Promise<{ providerKey: string; state: CapabilityState; summary: string }> {
+    const response = await this.request<{
+      providerKey?: string;
+      state?: string;
+      readiness?: string;
+    }>('/admin/providers/readiness-tests', {
       method: 'POST',
       body: JSON.stringify({ providerKey }),
     });
     return {
       providerKey: response.providerKey ?? providerKey,
       state: normalizeState(response.state ?? response.readiness),
-      summary: response.readiness ?? 'readiness tested through backend control plane',
+      summary:
+        response.readiness ?? 'readiness tested through backend control plane',
     };
   }
 
   async listAuditEvents(): Promise<AuditEvent[]> {
-    const events = await this.request<ServerAuditEvent[]>('/admin/audit/events');
+    const events = await this.request<ServerAuditEvent[]>(
+      '/admin/audit/events',
+    );
     return events.map((event) => ({
-      id: event.idempotencyKey ?? `${event.action ?? 'audit'}-${event.occurredAt ?? 'unknown'}`,
+      id:
+        event.idempotencyKey ??
+        `${event.action ?? 'audit'}-${event.occurredAt ?? 'unknown'}`,
       action: event.action ?? 'unknown',
       actor: event.actorRef ?? 'unknown-actor',
       createdAt: event.occurredAt ?? '',
@@ -173,15 +310,24 @@ export class AdminControlPlaneApi {
     if (init.body) headers.set('Content-Type', 'application/json');
     if (token) headers.set('Authorization', `Bearer ${token}`);
 
-    const response = await this.fetchImpl(`${this.config.apiBaseUrl}${path}`, { ...init, headers });
+    const response = await this.fetchImpl(`${this.config.apiBaseUrl}${path}`, {
+      ...init,
+      headers,
+    });
     if (!response.ok) {
-      throw new AdminApiError(`Admin API request failed with HTTP ${response.status}`, response.status);
+      throw new AdminApiError(
+        `Admin API request failed with HTTP ${response.status}`,
+        response.status,
+      );
     }
     return response.json() as Promise<T>;
   }
 }
 
-function normalizeControlPlane(controlPlane: ServerControlPlaneResponse, auditEvents: AuditEvent[]): ControlPlaneResponse {
+function normalizeControlPlane(
+  controlPlane: ServerControlPlaneResponse,
+  auditEvents: AuditEvent[],
+): ControlPlaneResponse {
   const selections = controlPlane.selectedProviderMappings ?? [];
   const secretRefs = controlPlane.secretRefs ?? [];
   return {
@@ -191,9 +337,19 @@ function normalizeControlPlane(controlPlane: ServerControlPlaneResponse, auditEv
       manifestUrl: '/api/v1/organization/manifest',
       authIssuerUrl: adminConsoleConfig.oidcIssuerUrl,
     },
-    providerConfigSource: controlPlane.providerConfigSource ?? 'admin-control-plane-selected-provider-mappings',
-    bootstrapDefaultsAreSuggestionsOnly: controlPlane.bootstrapDefaultsAreSuggestionsOnly ?? true,
-    providerCategories: (controlPlane.categories ?? []).map((category) => normalizeCategory(category, selections, secretRefs, controlPlane.generatedAt)),
+    providerConfigSource:
+      controlPlane.providerConfigSource ??
+      'admin-control-plane-selected-provider-mappings',
+    bootstrapDefaultsAreSuggestionsOnly:
+      controlPlane.bootstrapDefaultsAreSuggestionsOnly ?? true,
+    providerCategories: (controlPlane.categories ?? []).map((category) =>
+      normalizeCategory(
+        category,
+        selections,
+        secretRefs,
+        controlPlane.generatedAt,
+      ),
+    ),
     whitelistPolicy: normalizeWhitelist(controlPlane.whitelist),
     auditEvents,
   };
@@ -206,31 +362,118 @@ function normalizeCategory(
   generatedAt?: string,
 ): ProviderCategory {
   const key = category.category ?? 'unknown';
-  const selectedAdapter = category.selectedProviderKey ?? selections.find((selection) => selection.category === key)?.providerKey ?? 'awaiting_admin_selection';
+  const selectedAdapter =
+    category.selectedProviderKey ??
+    selections.find((selection) => selection.category === key)?.providerKey ??
+    'awaiting_admin_selection';
   return {
     key,
     label: category.label ?? key,
     selectedAdapter,
     state: normalizeState(category.readiness),
-    summary: category.memberImpact ?? 'Backend control-plane status is support-safe.',
-    supportSafe: category.diagnostics?.secretsReturned === false && category.diagnostics?.rawProviderErrorsReturned === false,
+    summary:
+      category.memberImpact ?? 'Backend control-plane status is support-safe.',
+    supportSafe:
+      category.diagnostics?.secretsReturned === false &&
+      category.diagnostics?.rawProviderErrorsReturned === false,
     selectedByAdmin: category.selectedByAdmin ?? false,
     bootstrapSuggestionOnly: category.bootstrapSuggestionOnly ?? true,
     choiceModel: category.choiceModel ?? 'not_selected',
     providerCandidates: category.providerCandidates ?? [],
     lastCheckedAt: generatedAt,
-    secretRefs: secretRefs.filter((secretRef) => secretRef.providerKey === selectedAdapter).map((secretRef) => secretRef.ref ?? '').filter(Boolean),
+    secretRefs: secretRefs
+      .filter((secretRef) => secretRef.providerKey === selectedAdapter)
+      .map((secretRef) => secretRef.ref ?? '')
+      .filter(Boolean),
   };
 }
 
-function normalizeWhitelist(whitelist?: ServerWhitelistPolicy): WhitelistPolicy {
+function normalizeWhitelist(
+  whitelist?: ServerWhitelistPolicy,
+): WhitelistPolicy {
   const profileCapabilities = whitelist?.profileCapabilities ?? {};
-  const allowedCapabilities = Array.from(new Set([...(whitelist?.effectiveCapabilities ?? []), ...Object.values(profileCapabilities).flat()])).sort();
+  const allowedCapabilities = Array.from(
+    new Set([
+      ...(whitelist?.effectiveCapabilities ?? []),
+      ...Object.values(profileCapabilities).flat(),
+    ]),
+  ).sort();
   return {
     denyByDefault: whitelist?.denyByDefault ?? true,
     allowedCapabilities,
-    blockedCapabilities: ['provider.direct_call', 'provider.secret_export', 'weaver.exec_without_policy'],
+    blockedCapabilities: [
+      'provider.direct_call',
+      'provider.secret_export',
+      'weaver.exec_without_policy',
+    ],
   };
+}
+
+function normalizeProviderReplacementDryRun(
+  response: ServerProviderReplacementDryRunReport,
+  category: ProviderCategory,
+  targetAdapter: string,
+): ProviderReplacementDryRunReport {
+  const lossyMapping = response.lossyMappingReport ?? {};
+  const lifecycle = response.lifecycleExpectations ?? {};
+  return {
+    dryRunId: response.dryRunId ?? `${category.key}-replacement-dry-run`,
+    status: response.status ?? 'dry_run_ready',
+    category: response.category ?? category.key,
+    currentAdapter: response.currentAdapter ?? category.selectedAdapter,
+    targetAdapter: response.targetAdapter ?? targetAdapter,
+    readinessState: normalizeState(response.readinessState),
+    migrationDryRunRequired: response.migrationDryRunRequired ?? true,
+    memberImpactStates: normalizeMemberImpactStates(
+      response.memberImpactStates,
+    ),
+    supportSafe: response.supportSafe ?? true,
+    providerDiagnosticsRedacted: response.providerDiagnosticsRedacted ?? true,
+    cutoverGates: response.cutoverGates ?? [],
+    lossyMappingReport: {
+      canonicalObjects: lossyMapping.canonicalObjects ?? [],
+      contractRisks: lossyMapping.contractRisks ?? [],
+      adminNotes: lossyMapping.adminNotes ?? [],
+      conflicts: lossyMapping.conflicts ?? [],
+      replacementRequirement:
+        lossyMapping.replacementRequirement ??
+        'Backend migration dry-run required before apply.',
+    },
+    lifecycleExpectations: {
+      sourceOfTruthPolicy:
+        lifecycle.sourceOfTruthPolicy ??
+        'Weave remains source of truth for canonical member state.',
+      exportExpectation:
+        lifecycle.exportExpectation ??
+        'Export expectations are evaluated by backend migration contracts.',
+      deleteExpectation:
+        lifecycle.deleteExpectation ??
+        'Delete expectations are evaluated by backend migration contracts.',
+      deprovisionExpectation:
+        lifecycle.deprovisionExpectation ??
+        'Deprovision expectations are evaluated by backend migration contracts.',
+      rollbackSupportBoundary:
+        lifecycle.rollbackSupportBoundary ??
+        'Rollback is bounded by provider export/delete support.',
+    },
+  };
+}
+
+function normalizeMemberImpactStates(
+  values?: string[],
+): Array<'usable' | 'disabled' | 'degraded' | 'policy-blocked'> {
+  const normalized = (values ?? [])
+    .map((value) => (value === 'ready' ? 'usable' : value))
+    .filter(
+      (value): value is 'usable' | 'disabled' | 'degraded' | 'policy-blocked' =>
+        value === 'usable' ||
+        value === 'disabled' ||
+        value === 'degraded' ||
+        value === 'policy-blocked',
+    );
+  return normalized.length > 0
+    ? Array.from(new Set(normalized))
+    : ['usable', 'disabled', 'degraded', 'policy-blocked'];
 }
 
 function normalizeState(value?: string): CapabilityState {
@@ -253,9 +496,12 @@ function normalizeState(value?: string): CapabilityState {
 
 function supportSafeSummary(event: ServerAuditEvent): string {
   const payload = event.payload ?? {};
-  const providerKey = typeof payload.providerKey === 'string' ? payload.providerKey : undefined;
-  const category = typeof payload.category === 'string' ? payload.category : undefined;
-  const target = providerKey ?? category ?? event.sourceRef ?? 'admin control plane';
+  const providerKey =
+    typeof payload.providerKey === 'string' ? payload.providerKey : undefined;
+  const category =
+    typeof payload.category === 'string' ? payload.category : undefined;
+  const target =
+    providerKey ?? category ?? event.sourceRef ?? 'admin control plane';
   return `${event.action ?? 'audit'} for ${target}; payload is redacted and support-safe.`;
 }
 
@@ -274,12 +520,21 @@ export const sampleControlPlane: ControlPlaneResponse = {
       label: 'Identity / IDM',
       selectedAdapter: 'keycloak-realm',
       state: 'ready',
-      summary: 'Central Keycloak realm is the recommended self-hosted identity broker; admin selection is the source of truth.',
+      summary:
+        'Central Keycloak realm is the recommended self-hosted identity broker; admin selection is the source of truth.',
       supportSafe: true,
       selectedByAdmin: true,
       bootstrapSuggestionOnly: false,
       choiceModel: 'recommended_self_hosted_default',
-      providerCandidates: ['keycloak-realm', 'entra-id', 'authentik', 'auth0', 'generic-oidc', 'generic-saml', 'scim-ldap'],
+      providerCandidates: [
+        'keycloak-realm',
+        'entra-id',
+        'authentik',
+        'auth0',
+        'generic-oidc',
+        'generic-saml',
+        'scim-ldap',
+      ],
       lastCheckedAt: '2026-05-24T18:00:00Z',
       secretRefs: ['secretref://weave/provider/keycloak-realm/client-secret'],
     },
@@ -301,12 +556,18 @@ export const sampleControlPlane: ControlPlaneResponse = {
       label: 'Files',
       selectedAdapter: 'nextcloud-files',
       state: 'degraded',
-      summary: 'Files are exposed through Weave canonical file facades; Nextcloud, SharePoint, S3, and SMB adapters remain backend-owned.',
+      summary:
+        'Files are exposed through Weave canonical file facades; Nextcloud, SharePoint, S3, and SMB adapters remain backend-owned.',
       supportSafe: true,
       selectedByAdmin: true,
       bootstrapSuggestionOnly: false,
       choiceModel: 'recommended_self_hosted_default',
-      providerCandidates: ['nextcloud-files', 'sharepoint', 's3-compatible', 'smb'],
+      providerCandidates: [
+        'nextcloud-files',
+        'sharepoint',
+        's3-compatible',
+        'smb',
+      ],
       secretRefs: ['secretref://weave/provider/nextcloud-files'],
     },
     {
@@ -314,12 +575,17 @@ export const sampleControlPlane: ControlPlaneResponse = {
       label: 'Calendar',
       selectedAdapter: 'nextcloud-caldav',
       state: 'degraded',
-      summary: 'Calendar access is normalized through Weave; CalDAV and Microsoft Graph remain adapter choices only.',
+      summary:
+        'Calendar access is normalized through Weave; CalDAV and Microsoft Graph remain adapter choices only.',
       supportSafe: true,
       selectedByAdmin: true,
       bootstrapSuggestionOnly: false,
       choiceModel: 'recommended_self_hosted_default',
-      providerCandidates: ['nextcloud-caldav', 'microsoft-graph-calendar', 'generic-caldav'],
+      providerCandidates: [
+        'nextcloud-caldav',
+        'microsoft-graph-calendar',
+        'generic-caldav',
+      ],
       secretRefs: ['secretref://weave/provider/nextcloud-caldav'],
     },
     {
@@ -327,12 +593,19 @@ export const sampleControlPlane: ControlPlaneResponse = {
       label: 'Boards / tasks',
       selectedAdapter: 'openproject-primary',
       state: 'policy-blocked',
-      summary: 'Boards/tasks stay provider-neutral across OpenProject, Planner, Jira, Vikunja, and Deck adapters.',
+      summary:
+        'Boards/tasks stay provider-neutral across OpenProject, Planner, Jira, Vikunja, and Deck adapters.',
       supportSafe: true,
       selectedByAdmin: true,
       bootstrapSuggestionOnly: false,
       choiceModel: 'recommended_self_hosted_default',
-      providerCandidates: ['openproject-primary', 'microsoft-planner', 'jira', 'vikunja', 'nextcloud-deck'],
+      providerCandidates: [
+        'openproject-primary',
+        'microsoft-planner',
+        'jira',
+        'vikunja',
+        'nextcloud-deck',
+      ],
       secretRefs: ['secretref://weave/provider/openproject-primary'],
     },
     {
@@ -340,12 +613,17 @@ export const sampleControlPlane: ControlPlaneResponse = {
       label: 'Meetings / calls',
       selectedAdapter: 'livekit',
       state: 'misconfigured',
-      summary: 'Meetings are surfaced through Weave calls; LiveKit and external meeting links are backend-selected providers.',
+      summary:
+        'Meetings are surfaced through Weave calls; LiveKit and external meeting links are backend-selected providers.',
       supportSafe: true,
       selectedByAdmin: true,
       bootstrapSuggestionOnly: false,
       choiceModel: 'recommended_self_hosted_default',
-      providerCandidates: ['livekit', 'microsoft-teams-meetings', 'external-meeting-link'],
+      providerCandidates: [
+        'livekit',
+        'microsoft-teams-meetings',
+        'external-meeting-link',
+      ],
       secretRefs: ['secretref://weave/provider/livekit'],
     },
     {
@@ -353,12 +631,18 @@ export const sampleControlPlane: ControlPlaneResponse = {
       label: 'Documents / collaboration',
       selectedAdapter: 'onlyoffice-community',
       state: 'disabled',
-      summary: 'Documents use Weave/WOPI collaboration contracts; Nextcloud/SharePoint/WOPI providers are not member-facing setup.',
+      summary:
+        'Documents use Weave/WOPI collaboration contracts; Nextcloud/SharePoint/WOPI providers are not member-facing setup.',
       supportSafe: true,
       selectedByAdmin: true,
       bootstrapSuggestionOnly: false,
       choiceModel: 'recommended_self_hosted_default',
-      providerCandidates: ['onlyoffice-community', 'collabora-code', 'wopi-host', 'microsoft-365-office-graph'],
+      providerCandidates: [
+        'onlyoffice-community',
+        'collabora-code',
+        'wopi-host',
+        'microsoft-365-office-graph',
+      ],
       secretRefs: ['secretref://weave/provider/onlyoffice-community'],
     },
     {
@@ -366,7 +650,8 @@ export const sampleControlPlane: ControlPlaneResponse = {
       label: 'Weaver runtime',
       selectedAdapter: 'awaiting_admin_selection',
       state: 'policy-blocked',
-      summary: 'Governed per-user PA runtime remains disabled by default and Weave-owned decisions stay backend-policy controlled.',
+      summary:
+        'Governed per-user PA runtime remains disabled by default and Weave-owned decisions stay backend-policy controlled.',
       supportSafe: true,
       selectedByAdmin: false,
       bootstrapSuggestionOnly: true,
@@ -386,7 +671,8 @@ export const sampleControlPlane: ControlPlaneResponse = {
       action: 'provider.readiness.tested',
       actor: 'operator@weave.local',
       createdAt: '2026-05-24T18:00:00Z',
-      summary: 'Readiness tested for keycloak-realm; result redacted and support-safe.',
+      summary:
+        'Readiness tested for keycloak-realm; result redacted and support-safe.',
     },
   ],
 };

--- a/admin-console/src/copy.ts
+++ b/admin-console/src/copy.ts
@@ -1,0 +1,36 @@
+export const adminConsoleMessages = {
+  en: {
+    effectivePolicyHeading: 'Effective policy explanation',
+    effectivePolicySummary:
+      'Owner/admin choices define provider mappings and whitelist policy. Operators can inspect support-safe readiness. Members receive only stable capability states.',
+    roleVisibilityHeading: 'Role visibility boundaries',
+    ownerAdminRole: 'Owner/Admin',
+    ownerAdminDescription:
+      'Configure provider categories, replacement dry-runs, whitelist policy, and apply changes through backend admin APIs.',
+    operatorRole: 'Operator',
+    operatorDescription:
+      'Inspect readiness, audit evidence, and support-safe diagnostics without seeing raw provider secrets or downstream bodies.',
+    memberRole: 'Member',
+    memberDescription:
+      'Use Weave product capabilities with only usable, disabled, degraded, or policy-blocked states.',
+    memberPreviewHeading: 'Member capability preview',
+    memberPreviewDescription:
+      'This preview intentionally hides provider adapters, SecretRefs, tenant URLs, raw diagnostics, and admin-only controls.',
+    memberStateLabel: 'Member state',
+    memberStateDescription:
+      'Members see only the stable capability state for this product area.',
+    replacementHeading: 'Provider replacement dry-run results',
+    replacementSummary:
+      'Dry-run replacement checks validate adapter swaps before apply. Results show lossy mapping, cutover gates, lifecycle expectations, and member impact only after backend redaction.',
+    replacementButton: 'Dry-run replacement contract',
+    replacementEmpty:
+      'Run a replacement dry-run to review support-safe evidence before applying provider changes.',
+    replacementStatusSuccess: 'Replacement dry-run completed',
+  },
+} as const;
+
+export type AdminConsoleLocale = keyof typeof adminConsoleMessages;
+
+export function adminCopy(locale: AdminConsoleLocale = 'en') {
+  return adminConsoleMessages[locale];
+}

--- a/client/test/architecture/member_client_provider_boundary_contract_test.dart
+++ b/client/test/architecture/member_client_provider_boundary_contract_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// V01_ADMIN_CONSOLE_MVP / issue #350: normal members consume Weave product state only.
+void main() {
+  test(
+    'member client does not call admin/provider control-plane APIs directly',
+    () {
+      final libFiles = Directory('lib')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.dart'));
+
+      final forbiddenFragments = <String>[
+        '/admin/control-plane',
+        '/admin/providers',
+        '/admin/policies',
+        '/admin/audit',
+        'secretref://',
+        'SecretRef inventory',
+        'provider replacement dry-run',
+      ];
+
+      for (final file in libFiles) {
+        final source = file.readAsStringSync();
+        for (final fragment in forbiddenFragments) {
+          expect(
+            source,
+            isNot(contains(fragment)),
+            reason:
+                '${file.path} must not expose admin/provider control-plane fragment `$fragment` to normal members.',
+          );
+        }
+      }
+    },
+  );
+
+  test(
+    'member client does not add optional provider SDK imports outside approved legacy Matrix seam',
+    () {
+      final libFiles = Directory('lib')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.dart'));
+
+      final forbiddenImportFragments = <String>[
+        'package:slack_',
+        'package:microsoft_graph',
+        'package:msgraph',
+        'package:nextcloud',
+        'package:livekit',
+        'package:caldav',
+      ];
+
+      for (final file in libFiles) {
+        final source = file.readAsStringSync();
+        for (final fragment in forbiddenImportFragments) {
+          expect(
+            source,
+            isNot(contains(fragment)),
+            reason:
+                '${file.path} must use Weave backend facades instead of optional provider SDK imports.',
+          );
+        }
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Adds Admin Console role boundaries and effective-policy explanation for owner/admin, operator, and member views.
- Wires provider replacement dry-run results into the Admin Console through backend admin APIs only, with support-safe redaction and member-impact states.
- Adds client/admin architecture tests so normal member paths stay provider-neutral and provider/admin setup does not leak into the Flutter member client.

## Tests
- `cd admin-console && npm run ci`
- `cd client && flutter test test/architecture/member_client_provider_boundary_contract_test.dart`
- `./gradlew clientCi adminCi acceptanceContract`

Closes #350
