### PR TITLE
feat: start Sprint 6 identity provider ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Use this page for release-affecting changes that have merged but are not include
 - MkDocs documentation site foundation with handbook navigation, diagrams, GitFlow/PR workflow, and release notes process.
 - Root Gradle wrapper and orchestration tasks for delegated server, client, admin, infra, docs, acceptance, CI, and release-notes checks.
 - Local release notes generator for merged PR metadata grouped by release-notes labels.
+- Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
 
 ## Changed
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Start with:
 2. Root README — public product entry point and architecture-at-a-glance.
 3. [Product acceptance flows](product-acceptance-flows.md) — product-language acceptance paths.
 4. [Sprint 5 closure report](sprint-5-closure-report.md) — project-readiness evidence and release-candidate gaps.
+5. [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md) — active RC/provider-ops entry slice.
 
 ### Member / user
 
@@ -83,6 +84,7 @@ Release and evidence docs:
 - [Build evidence delivery system](build-evidence-delivery-system.md)
 - [Manuals and release notes integration](manuals-and-release-notes-integration.md)
 - [Sprint 5 closure report](sprint-5-closure-report.md)
+- [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md)
 
 Historical/context docs:
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -7,6 +7,7 @@ Use this page for release-affecting changes that have merged but are not include
 - MkDocs documentation site foundation with handbook navigation, diagrams, GitFlow/PR workflow, and release notes process.
 - Root Gradle wrapper and orchestration tasks for delegated server, client, admin, infra, docs, acceptance, CI, and release-notes checks.
 - Local release notes generator for merged PR metadata grouped by release-notes labels.
+- Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
 
 ## Changed
 

--- a/docs/sprint-6-kickoff-plan.md
+++ b/docs/sprint-6-kickoff-plan.md
@@ -1,0 +1,34 @@
+# Sprint 6 kickoff: release candidate and provider operations
+
+Status: active kickoff plan, 2026-05-27.
+
+Sprint 6 starts from `main` at `e5aa689` after PR #359 merged the enterprise README readiness work for #354. The milestone is **Sprint 6 — Release Candidate & Provider Operations**.
+
+## Entry truth
+
+- Sprint 5 project-readiness foundation is closed; Sprint 6 owns release-candidate evidence and the first provider-operations slice.
+- #354 is closed in the Sprint 6 milestone as readiness/kickoff documentation, not Sprint 5 scope.
+- Current `main` checks for `e5aa689`: Gradle CI green; release-notes label check skipped on `main` as expected.
+- Live Stack E2E is a release-candidate gate. A current-head manual run was dispatched: [run 26498446059](https://github.com/masssi164/weave/actions/runs/26498446059), tracked by #360.
+
+## First execution slice
+
+Sprint 6 starts with the narrow provider/ops path:
+
+1. **RC gate:** #360 — credentialed Live Stack E2E on the release-candidate head. A green sanitized artifact or explicit release-owner waiver is required before any RC promotion/tag.
+2. **Admin-owned identity setup:** #212 — keep OIDC/realm setup in owner/admin workflows and keep normal member onboarding to sign-in only.
+3. **Keycloak realm provider dry-run:** #233 — introduce a backend/provisioner contract for desired realm state, dry-run/diff/readiness, and later gated apply.
+
+Why this slice: it advances release-candidate readiness and the admin/provider boundary already proven in Sprint 5. It is narrow, fail-closed, and evidence-preserving. It does not broaden member UX, does not claim generic provider marketplace support, and does not make Weaver active by default.
+
+## Explicitly not first slice
+
+- #283 stays blocked until identity/provider dry-run evidence is ready; do not mix boards/OpenProject vertical mapping into the kickoff slice.
+- #218 and #216 remain valid product work, but workflow/meeting expansion must not dilute the RC gate or identity/provider-ops scaffold.
+
+## Guardrails
+
+- Do not tag or promote a v0.1 release candidate without #360 green evidence or an explicit waiver.
+- Provider credentials, tenant URLs, raw downstream bodies, SecretRefs, and private live logs stay out of member UX, docs examples, PR bodies, and support artifacts.
+- Destructive provider apply remains unavailable by default until audit, rollback/restore, last-admin guard, and support-safe evidence are proven.
+- Weaver remains opt-in, governed, audited, capability-whitelisted, and disabled by default.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Sprint 4 plan: sprint-4-plan.md
       - Sprint 4 closure report: sprint-4-closure-report.md
       - Sprint 5 closure report: sprint-5-closure-report.md
+      - Sprint 6 kickoff plan: sprint-6-kickoff-plan.md
       - Accessibility release gate: accessibility-release-gate.md
       - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md
   - Product and Release Scope:

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDesiredState.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDesiredState.java
@@ -1,0 +1,50 @@
+package com.massimotter.weave.backend.identity.realm;
+
+import java.util.List;
+
+/**
+ * Product-level identity realm intent owned by the Weave admin control plane.
+ *
+ * <p>This is deliberately provider-shaped enough for Keycloak/OIDC realm planning,
+ * but it is not Terraform state and it must not contain raw secrets.</p>
+ */
+public record IdentityRealmDesiredState(
+        String realmId,
+        List<RealmClient> clients,
+        List<String> roles,
+        List<String> scopes,
+        List<ClaimMapper> claimMappers,
+        List<String> redirectOrigins,
+        List<String> providerWarnings,
+        List<String> blockers) {
+
+    public IdentityRealmDesiredState {
+        clients = clients == null ? List.of() : List.copyOf(clients);
+        roles = roles == null ? List.of() : List.copyOf(roles);
+        scopes = scopes == null ? List.of() : List.copyOf(scopes);
+        claimMappers = claimMappers == null ? List.of() : List.copyOf(claimMappers);
+        redirectOrigins = redirectOrigins == null ? List.of() : List.copyOf(redirectOrigins);
+        providerWarnings = providerWarnings == null ? List.of() : List.copyOf(providerWarnings);
+        blockers = blockers == null ? List.of() : List.copyOf(blockers);
+    }
+
+    public record RealmClient(
+            String clientId,
+            boolean publicClient,
+            List<String> redirectOrigins,
+            List<String> roles,
+            List<String> scopes) {
+        public RealmClient {
+            redirectOrigins = redirectOrigins == null ? List.of() : List.copyOf(redirectOrigins);
+            roles = roles == null ? List.of() : List.copyOf(roles);
+            scopes = scopes == null ? List.of() : List.copyOf(scopes);
+        }
+    }
+
+    public record ClaimMapper(
+            String name,
+            String sourceClaim,
+            String targetClaim,
+            boolean required) {
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDryRunReport.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDryRunReport.java
@@ -1,0 +1,24 @@
+package com.massimotter.weave.backend.identity.realm;
+
+import java.util.List;
+
+public record IdentityRealmDryRunReport(
+        String providerKey,
+        String realmId,
+        String operation,
+        String readiness,
+        boolean destructiveApplyAvailable,
+        boolean supportSafe,
+        boolean rawSecretExposed,
+        List<String> diff,
+        List<String> warnings,
+        List<String> blockers,
+        List<String> nextActions) {
+
+    public IdentityRealmDryRunReport {
+        diff = diff == null ? List.of() : List.copyOf(diff);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        blockers = blockers == null ? List.of() : List.copyOf(blockers);
+        nextActions = nextActions == null ? List.of() : List.copyOf(nextActions);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmProvider.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmProvider.java
@@ -1,0 +1,12 @@
+package com.massimotter.weave.backend.identity.realm;
+
+public interface IdentityRealmProvider {
+
+    String providerKey();
+
+    IdentityRealmDryRunReport dryRun(IdentityRealmDesiredState desiredState);
+
+    default boolean destructiveApplyAvailable() {
+        return false;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/KeycloakRealmDryRunProvider.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/KeycloakRealmDryRunProvider.java
@@ -1,0 +1,83 @@
+package com.massimotter.weave.backend.identity.realm;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+public class KeycloakRealmDryRunProvider implements IdentityRealmProvider {
+
+    private static final String PROVIDER_KEY = "keycloak-realm";
+    private static final Pattern SECRET_LIKE = Pattern.compile(
+            "(?i)(password|passwd|secret|token|bearer|api[_-]?key|x-access-token|client_secret)");
+
+    @Override
+    public String providerKey() {
+        return PROVIDER_KEY;
+    }
+
+    @Override
+    public IdentityRealmDryRunReport dryRun(IdentityRealmDesiredState desiredState) {
+        IdentityRealmDesiredState desired = desiredState == null
+                ? new IdentityRealmDesiredState(null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of("realm desired state is required"))
+                : desiredState;
+        List<String> blockers = new ArrayList<>(safeList(desired.blockers()));
+        if (blank(desired.realmId())) {
+            blockers.add("realm id is required before import planning");
+        }
+        if (desired.clients().isEmpty()) {
+            blockers.add("at least one OIDC client must be declared");
+        }
+        List<String> warnings = new ArrayList<>(safeList(desired.providerWarnings()));
+        if (desired.roles().stream().noneMatch(role -> "owner".equals(role) || "admin".equals(role))) {
+            warnings.add("owner/admin role baseline is not present in desired realm state");
+        }
+        List<String> diff = new ArrayList<>();
+        diff.add("plan realm " + safe(desired.realmId()));
+        diff.add("plan clients=" + desired.clients().size());
+        diff.add("plan roles=" + desired.roles().size());
+        diff.add("plan scopes=" + desired.scopes().size());
+        diff.add("plan claimMappers=" + desired.claimMappers().size());
+        desired.clients().stream()
+                .map(client -> "client " + safe(client.clientId()) + " redirects=" + safeList(client.redirectOrigins()))
+                .forEach(diff::add);
+        return new IdentityRealmDryRunReport(
+                providerKey(),
+                safe(desired.realmId()),
+                "dry-run",
+                blockers.isEmpty() ? "ready-for-admin-review" : "blocked-until-realm-contract-is-complete",
+                destructiveApplyAvailable(),
+                true,
+                false,
+                diff,
+                warnings,
+                blockers,
+                List.of(
+                        "Review desired realm diff in the Admin Console boundary.",
+                        "Store provider credentials only as SecretRef values before any future gated apply.",
+                        "Keep destructive realm apply disabled until audit, rollback, and last-admin guards are proven."));
+    }
+
+    private boolean blank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private List<String> safeList(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream().map(this::safe).toList();
+    }
+
+    private String safe(String value) {
+        if (value == null || value.isBlank()) {
+            return "missing";
+        }
+        String trimmed = value.trim();
+        String lowered = trimmed.toLowerCase(Locale.ROOT);
+        if (SECRET_LIKE.matcher(lowered).find() || lowered.contains("@github.com/") || lowered.contains("x-access-token:")) {
+            return "redacted-secret-like-value";
+        }
+        return trimmed;
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/identity/realm/KeycloakRealmDryRunProviderTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/identity/realm/KeycloakRealmDryRunProviderTest.java
@@ -1,0 +1,84 @@
+package com.massimotter.weave.backend.identity.realm;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeycloakRealmDryRunProviderTest {
+
+    private final KeycloakRealmDryRunProvider provider = new KeycloakRealmDryRunProvider();
+
+    @Test
+    void plansRealmImportWithoutEnablingDestructiveApply() {
+        IdentityRealmDesiredState desiredState = new IdentityRealmDesiredState(
+                "weave-dogfood",
+                List.of(new IdentityRealmDesiredState.RealmClient(
+                        "weave-app",
+                        true,
+                        List.of("https://weave.local/*"),
+                        List.of("owner", "admin", "member", "guest"),
+                        List.of("openid", "profile", "email"))),
+                List.of("owner", "admin", "member", "guest"),
+                List.of("openid", "profile", "email", "weave:workspace"),
+                List.of(new IdentityRealmDesiredState.ClaimMapper("tenant", "weave_tenant", "organizationId", true)),
+                List.of("https://weave.local/*"),
+                List.of(),
+                List.of());
+
+        IdentityRealmDryRunReport report = provider.dryRun(desiredState);
+
+        assertThat(report.providerKey()).isEqualTo("keycloak-realm");
+        assertThat(report.operation()).isEqualTo("dry-run");
+        assertThat(report.readiness()).isEqualTo("ready-for-admin-review");
+        assertThat(report.destructiveApplyAvailable()).isFalse();
+        assertThat(report.supportSafe()).isTrue();
+        assertThat(report.rawSecretExposed()).isFalse();
+        assertThat(report.diff()).contains("plan realm weave-dogfood", "plan clients=1", "plan roles=4");
+        assertThat(report.blockers()).isEmpty();
+    }
+
+    @Test
+    void redactsSecretLikeValuesFromDryRunEvidence() {
+        IdentityRealmDesiredState desiredState = new IdentityRealmDesiredState(
+                "client_secret=please-do-not-print",
+                List.of(new IdentityRealmDesiredState.RealmClient(
+                        "weave-app",
+                        true,
+                        List.of("https://x-access-token:abc123@github.com/masssi164/weave.git"),
+                        List.of("member"),
+                        List.of("openid"))),
+                List.of("member"),
+                List.of("openid"),
+                List.of(),
+                List.of(),
+                List.of("token leaked by downstream provider"),
+                List.of());
+
+        IdentityRealmDryRunReport report = provider.dryRun(desiredState);
+
+        assertThat(report.rawSecretExposed()).isFalse();
+        assertThat(String.join("\n", report.diff())).doesNotContain("please-do-not-print", "abc123", "x-access-token");
+        assertThat(report.realmId()).isEqualTo("redacted-secret-like-value");
+        assertThat(report.warnings()).contains("redacted-secret-like-value");
+        assertThat(report.destructiveApplyAvailable()).isFalse();
+    }
+
+    @Test
+    void blocksIncompleteRealmPlans() {
+        IdentityRealmDryRunReport report = provider.dryRun(new IdentityRealmDesiredState(
+                "",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of()));
+
+        assertThat(report.readiness()).isEqualTo("blocked-until-realm-contract-is-complete");
+        assertThat(report.blockers())
+                .contains("realm id is required before import planning", "at least one OIDC client must be declared");
+        assertThat(report.destructiveApplyAvailable()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- add the Sprint 6 kickoff plan for the RC/provider-ops first slice
- create the RC Live Stack E2E evidence gate issue and link the current-head run
- add the first backend Keycloak realm dry-run provider contract scaffold: desired realm state, dry-run report, fail-closed provider interface, and secret-redaction tests

## Linked issues
- Starts #233
- Supports #212
- Tracks RC gate in #360

## Evidence
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew doctor -q`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew docsCheck releaseEvidenceCheck acceptanceContract`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew serverCi`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew test --tests 'com.massimotter.weave.backend.identity.realm.KeycloakRealmDryRunProviderTest'` from `server/`

## Live Stack / RC gate
- Current-head Live Stack E2E was dispatched separately: https://github.com/masssi164/weave/actions/runs/26498446059
- This PR does not declare RC promotion. #360 remains required before tagging/promoting a release candidate unless a release owner records an explicit waiver.

## Risks
- No destructive realm apply is introduced; the provider contract reports destructive apply unavailable by default.
- Provider secrets and credential-bearing URLs are redacted from dry-run evidence.
- Weaver remains disabled by default and out of this slice.

Copilot review requested if available; do not block Sprint 6 kickoff on Copilot availability.