### PR TITLE
fix: grant live E2E boards capability

### DIFF
--- a/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/main.tf
+++ b/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/main.tf
@@ -48,6 +48,19 @@ locals {
     guest    = "workspace-guests"
   }
 
+  weave_capability_groups = {
+    board_editors    = "weave-board-editors"
+    calendar_editors = "weave-calendar-editors"
+    document_editors = "weave-document-editors"
+    meeting_hosts    = "weave-meeting-hosts"
+    decision_records = "weave-decision-recorders"
+    weaver_pilot     = "weave-weaver-pilot"
+  }
+
+  live_e2e_test_user_capability_groups = [
+    "board_editors",
+  ]
+
   client_defaults = {
     enabled                             = true
     standard_flow_enabled               = false
@@ -171,6 +184,13 @@ resource "keycloak_group" "weave_product_role" {
   name     = each.value
 }
 
+resource "keycloak_group" "weave_capability" {
+  for_each = local.weave_capability_groups
+
+  realm_id = keycloak_realm.tenant.id
+  name     = each.value
+}
+
 resource "keycloak_group_roles" "weave_product_role" {
   for_each = local.weave_product_role_groups
 
@@ -192,9 +212,10 @@ resource "keycloak_user_groups" "test_member" {
 
   realm_id = keycloak_realm.tenant.id
   user_id  = keycloak_user.test[0].id
-  group_ids = [
-    keycloak_group.weave_product_role["member"].id,
-  ]
+  group_ids = concat(
+    [keycloak_group.weave_product_role["member"].id],
+    [for group_key in local.live_e2e_test_user_capability_groups : keycloak_group.weave_capability[group_key].id],
+  )
 }
 
 resource "keycloak_openid_client" "client" {
@@ -298,6 +319,28 @@ resource "keycloak_openid_client_default_scopes" "weave_admin_console" {
   depends_on = [
     keycloak_openid_client_scope.weave_workspace,
   ]
+}
+
+resource "keycloak_openid_group_membership_protocol_mapper" "weave_app_groups" {
+  realm_id            = keycloak_realm.tenant.id
+  client_id           = keycloak_openid_client.client["weave_app"].id
+  name                = "groups"
+  claim_name          = "groups"
+  full_path           = false
+  add_to_id_token     = true
+  add_to_access_token = true
+  add_to_userinfo     = true
+}
+
+resource "keycloak_openid_group_membership_protocol_mapper" "weave_admin_console_groups" {
+  realm_id            = keycloak_realm.tenant.id
+  client_id           = keycloak_openid_client.client["weave_admin_console"].id
+  name                = "groups"
+  claim_name          = "groups"
+  full_path           = false
+  add_to_id_token     = true
+  add_to_access_token = true
+  add_to_userinfo     = true
 }
 
 resource "keycloak_openid_group_membership_protocol_mapper" "nextcloud_groups" {

--- a/infra/weave-workspace/tests/infra-product-contract-test.sh
+++ b/infra/weave-workspace/tests/infra-product-contract-test.sh
@@ -110,8 +110,11 @@ for role in owner admin member guest; do
   grep -Eq "^[[:space:]]+${role}[[:space:]]+=" "${keycloak_main}" || fail "Expected Keycloak product role/group entry for: ${role}"
 done
 assert_file_contains "${keycloak_main}" 'workspace-guests'
+assert_file_contains "${keycloak_main}" 'weave-board-editors'
+assert_file_contains "${keycloak_main}" 'live_e2e_test_user_capability_groups'
 assert_file_contains "${keycloak_main}" 'keycloak_group_roles'
 assert_file_contains "${keycloak_main}" 'keycloak_user_roles'
+assert_file_contains "${keycloak_main}" 'keycloak_openid_group_membership_protocol_mapper" "weave_app_groups"'
 assert_file_contains "${admin_doc}" 'Guests are mapped to `workspace-guests`, not member/admin groups.'
 
 # Connector/interop runtime guardrails must default closed and keep public provider callbacks blocked.


### PR DESCRIPTION
## Summary\n- grant the deterministic live E2E test user the board-editor capability group\n- emit Keycloak group claims for the Weave app/admin console so backend capability policy can see capability groups\n- guard the infra contract so the boards live E2E capability path stays wired\n\n## Evidence\n- terraform -chdir=infra/weave-workspace/02-keycloak-setup init -backend=false -input=false && terraform -chdir=infra/weave-workspace/02-keycloak-setup validate\n- bash infra/weave-workspace/tests/infra-product-contract-test.sh\n- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew releaseEvidenceCheck acceptanceContract\n\nAddresses the current #360 blocker: BOARDS_RESULT missing because /api/boards/.../tasks returned 403 requiredCapability=boards.update_task for the seeded member. #360 should stay open until a credentialed Live Stack E2E run is green or explicitly waived.