### PR TITLE
feat: add enterprise release foundation

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -237,7 +237,13 @@ jobs:
             --mapping e2e/scenario_mappings.json \
             --out "$WEAVE_ACCEPTANCE_EVIDENCE_DIR" \
             --test-log "$WEAVE_ACCEPTANCE_TEST_LOG" \
-            --append-summary "$GITHUB_STEP_SUMMARY"
+            --append-summary "$GITHUB_STEP_SUMMARY" \
+            --source live-stack-e2e \
+            --lane release-candidate-live-evidence \
+            --commit "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       - name: Dump stack logs on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Current maturity is honest and evidence-scoped:
 - [Documentation landing page](docs/index.md) for audience-specific manuals and evidence maps.
 - [Weave product line and Weaver integration plan](docs/product-line-and-weaver-plan.md) for current product ordering.
 - [Sprint 5 closure report](docs/sprint-5-closure-report.md) for project-readiness evidence and release-candidate gaps.
+- [Enterprise release foundation](docs/enterprise-release-foundation.md) for Sprint 6 release lanes, RC evidence, waiver rules, and support-safe artifacts.
 
 ## Product architecture
 
@@ -50,6 +51,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Root Gradle wrapper and orchestration tasks for delegated server, client, admin, infra, docs, acceptance, CI, and release-notes checks.
 - Local release notes generator for merged PR metadata grouped by release-notes labels.
 - Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
+- Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
 
 ## Changed
 
@@ -58,6 +60,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Documentation validation now has a dedicated docs check/build path.
 - PR CI now enforces exactly one release-notes label before review/merge.
 - `make release-notes-check` now verifies release-notes label edge cases and generator fixture output.
+- Live Stack acceptance artifacts now include `release-evidence-manifest.json` with commit/run metadata, artifact list, support-safe exclusions, and the RC promotion rule.
 
 ## Fixed
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ registerRootCommandTask('acceptanceContract', ['bash', '-lc', 'cd client && dart
 registerCommandTask('clientCi', file('client'), ['bash', '-lc', 'flutter gen-l10n && dart run build_runner build --delete-conflicting-outputs && dart format --output=none --set-exit-if-changed . && flutter analyze --fatal-infos && flutter test && make marketing-screenshots && git -C .. diff --exit-code -- client/lib client/test docs/assets/marketing docs/assets/roadmap && make offline-contract-test'], 'Run Flutter generated-code, format, analysis, tests, screenshots, and offline contract checks.')
 registerCommandTask('serverCi', file('server'), ['./gradlew', 'test'], 'Run server checks through the existing server Gradle build.')
 registerCommandTask('adminCi', file('admin-console'), ['npm', 'run', 'ci'], 'Run admin console npm CI checks.')
-registerRootCommandTask('infraStatic', ['bash', '-lc', "cd infra/weave-workspace/01-infrastructure && tofu fmt -check -recursive && tofu init -backend=false && tofu validate && cd ../02-keycloak-setup && tofu fmt -check -recursive && tofu init -backend=false && tofu validate && cd ../../.. && find infra/weave-workspace/tests -maxdepth 1 -type f -name '*-test.sh' -print0 | sort -z | xargs -0 -n1 bash"], 'Run OpenTofu format/validate and static infrastructure script checks.')
+registerRootCommandTask('infraStatic', ['bash', '-lc', "cd infra/weave-workspace/01-infrastructure && tofu fmt -check -recursive && tofu init -backend=false -lockfile=readonly && tofu validate && cd ../02-keycloak-setup && tofu fmt -check -recursive && tofu init -backend=false -lockfile=readonly && tofu validate && cd ../../.. && find infra/weave-workspace/tests -maxdepth 1 -type f -name '*-test.sh' -print0 | sort -z | xargs -0 -n1 bash"], 'Run OpenTofu format/validate and static infrastructure script checks without mutating provider lock files.')
 registerRootCommandTask('docsBuild', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; rm -rf build/docs/user build/docs/admin; "$PYTHON" -m mkdocs build --strict --site-dir build/docs/user; "$PYTHON" -m mkdocs build --strict --site-dir build/docs/admin'], 'Build deterministic user and admin MkDocs outputs with strict validation.')
 registerRootCommandTask('docsStructureCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py'], 'Run lightweight documentation structure checks.')
 registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs serve'], 'Serve the MkDocs site locally.')
@@ -35,7 +35,8 @@ registerRootCommandTask('releaseNotesLabelCheck', ['bash', '-lc', 'if [ -n "${PR
 registerRootCommandTask('generateReleaseNotes', ['python3', 'tools/release_notes_generate.py', '--input', 'tools/fixtures/release_notes_prs.json'], 'Generate reviewable release notes under build/release-notes by default.')
 registerRootCommandTask('updateReadmeReleaseNotes', ['python3', 'tools/readme_release_notes.py', '--update'], 'Explicitly update the managed README release-notes evidence block.')
 registerRootCommandTask('projectReadinessEvidenceCheck', ['python3', 'tools/project_readiness_evidence_check.py'], 'Validate Sprint 5 project-readiness evidence remains mapped and support-safe.')
-registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py'], 'Validate release notes structure, README markers, labels, generator fixture evidence, and Sprint 5 project-readiness closure evidence.')
+registerRootCommandTask('enterpriseReleaseGateCheck', ['python3', 'tools/release_gate_check.py'], 'Validate the Sprint 6 enterprise release lane/gate contract and support-safe evidence requirements.')
+registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py'], 'Validate release notes structure, README markers, labels, generator fixture evidence, Sprint 5 project-readiness closure evidence, and Sprint 6 enterprise release gates.')
 
 tasks.register('docsCheck') {
     group = 'verification'
@@ -68,7 +69,8 @@ ext.ciEvidenceGates = [
     'docsCheck',
     'releaseNotesLabelCheck',
     'releaseEvidenceCheck',
-    'projectReadinessEvidenceCheck'
+    'projectReadinessEvidenceCheck',
+    'enterpriseReleaseGateCheck'
 ]
 
 ext.safeCommandOutput = { List<String> args ->
@@ -160,6 +162,8 @@ List<String> artifactPathsForGate(String gateName) {
             return ['README.md', 'tools/fixtures/release_notes_unreleased.expected.md']
         case 'projectReadinessEvidenceCheck':
             return ['docs/sprint-5-closure-report.md', 'e2e/scenario_mappings.json']
+        case 'enterpriseReleaseGateCheck':
+            return ['release/enterprise-release-gates.json', 'docs/enterprise-release-foundation.md']
         default:
             return []
     }
@@ -233,7 +237,7 @@ tasks.register('ci') {
     dependsOn 'doctor', 'acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
 }
 
-['acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'].each { taskName ->
+['acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck'].each { taskName ->
     tasks.named(taskName) {
         mustRunAfter tasks.named('doctor')
     }

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -202,6 +203,76 @@ ACCESSIBILITY_RESULT accessible=true accessibility=ok accessToken=redacted acces
     expect(sanitized, isNot(contains('token')));
     expect(sanitized, isNot(contains('id')));
     expect(sanitized, isNot(contains('displayName')));
+  });
+
+  test('release evidence manifest is support-safe and traceable', () {
+    const mapping = acceptance.ScenarioMapping(
+      tag: '@weave-live-auth-shell',
+      scenario: 'Sign-in restores the Weave workspace and profile',
+      featurePath: 'e2e/features/live_stack_app.feature',
+      executableTest: 'integration_test/live_stack_e2e_test.dart',
+      evidenceMarkers: <String>['AUTH_RESULT'],
+      additionalEvidence: <acceptance.AdditionalEvidenceMapping>[],
+    );
+    final result = acceptance.validateAcceptanceContract(
+      root: Directory.current.parent,
+      scenarios: const <acceptance.FeatureScenario>[
+        acceptance.FeatureScenario(
+          featurePath: 'e2e/features/live_stack_app.feature',
+          line: 1,
+          name: 'Sign-in restores the Weave workspace and profile',
+          tags: <String>['@weave-live-auth-shell'],
+        ),
+      ],
+      mappings: const <acceptance.ScenarioMapping>[mapping],
+      runtimeEvidence: const acceptance.RuntimeEvidence(
+        wasCollected: true,
+        markers: <String, acceptance.SanitizedEvidenceMarker>{
+          'AUTH_RESULT': acceptance.SanitizedEvidenceMarker(
+            marker: 'AUTH_RESULT',
+            count: 1,
+            sanitizedFields: <String, String>{'status': 'ok'},
+          ),
+        },
+      ),
+    );
+
+    final manifest = acceptance.renderReleaseEvidenceManifest(
+      result,
+      const acceptance.RuntimeEvidence(
+        wasCollected: true,
+        markers: <String, acceptance.SanitizedEvidenceMarker>{
+          'AUTH_RESULT': acceptance.SanitizedEvidenceMarker(
+            marker: 'AUTH_RESULT',
+            count: 1,
+            sanitizedFields: <String, String>{'status': 'ok'},
+          ),
+        },
+      ),
+      const acceptance.ReleaseEvidenceMetadata(
+        source: 'live-stack-e2e',
+        lane: 'release-candidate-live-evidence',
+        commit: 'abc123',
+        runId: '26503862442',
+        runAttempt: '1',
+        runUrl: 'https://github.com/masssi164/weave/actions/runs/26503862442',
+      ),
+    );
+    final encoded = jsonEncode(manifest).toLowerCase();
+
+    expect(manifest['schemaVersion'], 1);
+    expect(manifest['source'], 'live-stack-e2e');
+    expect(manifest['commit'], 'abc123');
+    expect(manifest['lane'], 'release-candidate-live-evidence');
+    expect(
+      manifest['rcPromotionRule'],
+      contains('green-credentialed-live-stack-e2e'),
+    );
+    expect(manifest['artifacts'], contains('release-evidence-manifest.json'));
+    expect(encoded, isNot(contains('authorization')));
+    expect(encoded, isNot(contains('bearer ')));
+    expect(encoded, isNot(contains('access_token')));
+    expect(encoded, isNot(contains('client_secret')));
   });
 
   test(

--- a/client/tool/acceptance_contract.dart
+++ b/client/tool/acceptance_contract.dart
@@ -70,6 +70,12 @@ void main(List<String> args) {
   final outputDir = options['out'];
   final testLogPath = options['test-log'];
   final appendSummaryPath = options['append-summary'];
+  final evidenceSource = options['source'] ?? 'acceptance-contract';
+  final evidenceLane = options['lane'];
+  final evidenceCommit = options['commit'];
+  final evidenceRunId = options['run-id'];
+  final evidenceRunAttempt = options['run-attempt'];
+  final evidenceRunUrl = options['run-url'];
 
   final scenarios = parseFeatureDirectory(root, featuresDir);
   final mappings = loadScenarioMappings(root, mappingPath);
@@ -88,6 +94,14 @@ void main(List<String> args) {
       Directory(_join(root.path, outputDir)),
       result,
       runtimeEvidence,
+      metadata: ReleaseEvidenceMetadata(
+        source: evidenceSource,
+        lane: evidenceLane,
+        commit: evidenceCommit,
+        runId: evidenceRunId,
+        runAttempt: evidenceRunAttempt,
+        runUrl: evidenceRunUrl,
+      ),
     );
   }
 
@@ -420,8 +434,9 @@ RuntimeEvidence extractRuntimeEvidence(
 void writeAcceptanceArtifacts(
   Directory outputDir,
   AcceptanceContractResult result,
-  RuntimeEvidence runtimeEvidence,
-) {
+  RuntimeEvidence runtimeEvidence, {
+  required ReleaseEvidenceMetadata metadata,
+}) {
   outputDir.createSync(recursive: true);
   File(_join(outputDir.path, 'gherkin-scenarios.json')).writeAsStringSync(
     const JsonEncoder.withIndent(
@@ -439,7 +454,60 @@ void writeAcceptanceArtifacts(
   File(
     _join(outputDir.path, 'acceptance-summary.md'),
   ).writeAsStringSync(renderMarkdownSummary(result, runtimeEvidence));
+  File(
+    _join(outputDir.path, 'release-evidence-manifest.json'),
+  ).writeAsStringSync(
+    const JsonEncoder.withIndent(
+      '  ',
+    ).convert(renderReleaseEvidenceManifest(result, runtimeEvidence, metadata)),
+  );
 }
+
+Map<String, Object?> renderReleaseEvidenceManifest(
+  AcceptanceContractResult result,
+  RuntimeEvidence runtimeEvidence,
+  ReleaseEvidenceMetadata metadata,
+) => <String, Object?>{
+  'schemaVersion': 1,
+  'generatedAtUtc': DateTime.now().toUtc().toIso8601String(),
+  'source': metadata.source,
+  if (metadata.commit != null) 'commit': metadata.commit,
+  if (metadata.runId != null) 'runId': metadata.runId,
+  if (metadata.runAttempt != null) 'runAttempt': metadata.runAttempt,
+  if (metadata.runUrl != null) 'runUrl': metadata.runUrl,
+  'lane':
+      metadata.lane ??
+      (runtimeEvidence.wasCollected
+          ? 'release-candidate-live-evidence'
+          : 'pr-safe-ci'),
+  'rcPromotionRule':
+      'no-v0.1-rc-promotion-without-green-credentialed-live-stack-e2e-or-explicit-release-owner-waiver',
+  'acceptanceContract': <String, Object?>{
+    'valid': result.isValid,
+    'scenarioCount': result.scenarios.length,
+    'mappingCount': result.mappings.length,
+    'runtimeEvidenceCollected': runtimeEvidence.wasCollected,
+    'observedMarkers': runtimeEvidence.observedMarkers.toList()..sort(),
+    'findings': result.findings
+        .map((finding) => finding.message)
+        .toList(growable: false),
+  },
+  'artifacts': <String>[
+    'acceptance-summary.md',
+    'gherkin-scenarios.json',
+    'scenario-mapping-results.json',
+    'evidence-markers.json',
+    'release-evidence-manifest.json',
+  ],
+  'supportSafe': true,
+  'supportSafeExclusions': <String>[
+    'raw credentials',
+    'credential-bearing URLs',
+    'provider internals',
+    'downstream provider error bodies',
+    'private live logs',
+  ],
+};
 
 String renderMarkdownSummary(
   AcceptanceContractResult result,
@@ -546,6 +614,12 @@ Options:
   --out <dir>             Optional artifact output directory
   --test-log <file>       Optional live E2E log to extract sanitized evidence markers
   --append-summary <file> Optional markdown file to append the acceptance summary to
+  --source <name>         Evidence source name for release-evidence-manifest.json
+  --lane <name>           Evidence lane for release-evidence-manifest.json
+  --commit <sha>          Commit under test for release-evidence-manifest.json
+  --run-id <id>           Workflow/run id for release-evidence-manifest.json
+  --run-attempt <number>  Workflow/run attempt for release-evidence-manifest.json
+  --run-url <url>         Workflow/run URL for release-evidence-manifest.json
 ''');
 }
 
@@ -792,4 +866,22 @@ class AcceptanceFinding {
   final String message;
 
   Map<String, Object?> toJson() => <String, Object?>{'message': message};
+}
+
+class ReleaseEvidenceMetadata {
+  const ReleaseEvidenceMetadata({
+    required this.source,
+    this.lane,
+    this.commit,
+    this.runId,
+    this.runAttempt,
+    this.runUrl,
+  });
+
+  final String source;
+  final String? lane;
+  final String? commit;
+  final String? runId;
+  final String? runAttempt;
+  final String? runUrl;
 }

--- a/docs/acceptance-contracts.md
+++ b/docs/acceptance-contracts.md
@@ -15,9 +15,13 @@ machine-readable mapping to executable evidence.
   - `gherkin-scenarios.json`
   - `scenario-mapping-results.json`
   - `evidence-markers.json`
+  - `release-evidence-manifest.json`
 
-The artifact includes sanitized marker summaries only. It must not include raw
-secrets, tokens, cookies, private keys, or full live E2E logs.
+The artifact includes sanitized marker summaries and a release-evidence manifest
+that names the source lane, commit, workflow run metadata, required artifact
+files, and RC promotion rule. It must not include raw secrets, tokens, cookies,
+private keys, credential-bearing URLs, provider internals, downstream provider
+bodies, or full live E2E logs.
 
 ## ATDD/TDD rule
 
@@ -29,8 +33,10 @@ For new product behavior:
    evidence exists.
 3. Drive the implementation with focused unit, provider, widget, integration, or
    backend tests. Do not push implementation details into the feature file.
-4. Keep live-stack E2E sparse. It proves critical end-to-end contracts only;
-   lower-level tests carry the detailed technical coverage.
+4. Keep live-stack E2E sparse. It proves critical end-to-end product contracts
+   only; lower-level tests carry the detailed technical coverage. Admin/provider
+   setup and policy checks belong in backend/admin/control-plane CI unless the
+   member/operator product journey explicitly consumes the stable facade state.
 5. Run `make offline-contract-test` before review. Use `make integration-test`
    only on the dedicated live-stack runner or another explicitly prepared local
    stack, keeping generated evidence sanitized.

--- a/docs/build-evidence-delivery-system.md
+++ b/docs/build-evidence-delivery-system.md
@@ -26,7 +26,8 @@ Root Gradle is the build and delivery source of truth. `./gradlew ci` is the can
 | `adminCi` | Run admin console checks. |
 | `infraStatic` | Run static infrastructure checks. |
 | `docsBuild` | Build user/admin manuals deterministically. |
-| `releaseEvidenceCheck` | Validate release labels, README release markers, and generated-release evidence behavior. |
+| `enterpriseReleaseGateCheck` | Validate `release/enterprise-release-gates.json`, the enterprise release foundation doc, required lanes/gates, support-safe Live Stack artifacts, and runtime marker requirements. |
+| `releaseEvidenceCheck` | Validate release labels, README release markers, generated-release evidence behavior, Sprint closure evidence, and enterprise release gates. |
 | `ci` | Canonical aggregate for default PR-safe checks. |
 
 ## Branch map for small PRs
@@ -38,6 +39,7 @@ Use short-lived branches from `origin/main`:
 - `build/evidence-artifacts` — sanitized `build/evidence/ci-summary.json` and PR checklist integration.
 - `docs/mkdocs-help-foundation` — pinned MkDocs user/admin manual build outputs.
 - `release/evidence-automation` — release evidence checks, generated release-note artifacts, explicit README update task.
+- `release/enterprise-foundation` — release lanes, RC promotion contract, support-safe manifest, and live-evidence artifact contract.
 - `build/ci-gradle-migration` — GitHub Actions migration to `./gradlew ci` and least permissions.
 - `build/make-transition-reduction` — remove or reduce Make after Gradle parity is proven.
 

--- a/docs/enterprise-release-foundation.md
+++ b/docs/enterprise-release-foundation.md
@@ -1,0 +1,114 @@
+# Enterprise release foundation
+
+Status: Sprint 6 enterprise foundation, source-backed release engineering contract.
+
+This page defines the professional release spine for Weave. It deliberately separates product validation from admin/control-plane work: **Live Stack E2E is evidence**, not an Admin Portal feature. Admin/operator surfaces own setup, policy, readiness, and support-safe remediation; member journeys stay provider-neutral and are proved through the acceptance contract.
+
+The machine-readable contract lives at `release/enterprise-release-gates.json` and is checked by `tools/release_gate_check.py` through `./gradlew releaseEvidenceCheck`.
+
+## Operating principles
+
+- `main` is protected and release-candidate source of truth; use short-lived PR branches only.
+- No v0.1 release-candidate promotion without green credentialed Live Stack E2E on the release-candidate head, or an explicit release-owner waiver.
+- A waiver is not a green build. It must name the exact blocker, commit, owner, expiry/next action, and compensating evidence.
+- Provider-specific IDs, raw endpoints, SecretRefs, credential-bearing URLs, downstream bodies, and private live logs stay out of public/support artifacts.
+- Weaver remains governed, opt-in, capability-whitelisted, audited, and default-disabled; it must not be used to bypass release evidence.
+- The `weave-co-leader` orchestrates cross-domain delivery; specialist agents implement scoped slices, while release evidence remains deterministic and human-reviewable.
+
+## Enterprise lanes
+
+### `pr-safe-ci`
+
+Purpose: fast deterministic confidence before merge.
+
+Required gates:
+
+- `gradle-ci` runs `./gradlew ci` and uploads sanitized `build/evidence/ci-summary.json` plus docs artifacts.
+- `release-notes-label-check` enforces exactly one release-notes label for PRs.
+
+This lane must stay PR-safe: no real provider credentials, no destructive live runner reset, no public release promotion, and no claim that runtime evidence was collected.
+
+### `release-candidate-live-evidence`
+
+Purpose: prove the candidate on the dedicated self-hosted live runner with credentials and a real local stack.
+
+Required gate:
+
+- `credentialed-live-stack-e2e` via `.github/workflows/live-stack-e2e.yml`.
+
+Required artifacts:
+
+- `weave-live-stack-acceptance-evidence/acceptance-summary.md`
+- `weave-live-stack-acceptance-evidence/scenario-mapping-results.json`
+- `weave-live-stack-acceptance-evidence/evidence-markers.json`
+- `weave-live-stack-acceptance-evidence/release-evidence-manifest.json`
+
+Required runtime markers for the v0.1 dogfood candidate:
+
+- `AUTH_RESULT`
+- `PROFILE_RESULT`
+- `CHAT_RESULT`
+- `MATRIX_RESULT`
+- `E2EE_RESULT`
+- `FILES_RESULT`
+- `PROVIDER_STACK_RESULT`
+- `CALENDAR_RESULT`
+- `BOARDS_RESULT`
+
+The live lane validates product flows. It must not become a junk drawer for admin/control-plane assertions. Admin/provider readiness can be part of the product evidence only when it is consumed through stable backend-owned facades and support-safe member/operator states.
+
+### `release-promotion`
+
+Purpose: turn evidence into a reviewable release candidate decision.
+
+Required gates:
+
+- `release-draft-review` creates a draft release from generated release notes and review artifacts.
+- `release-owner-signoff` records the release owner decision with commit, artifact links, blocker/waiver if any, rollback note, and owner.
+
+Promotion must cite the live evidence run or the explicit waiver. A successful PR-safe CI run alone is not enough.
+
+## Evidence artifact contract
+
+Every Live Stack E2E artifact directory must include a support-safe manifest:
+
+- schema version and generation time;
+- source lane and workflow identity;
+- commit under test;
+- run id, run attempt, and run URL when available;
+- acceptance artifact file list;
+- support-safe exclusions;
+- RC rule reminder.
+
+This makes evidence portable: a release owner can inspect one artifact directory and know what commit, run, lane, and contract it represents without reading private runner logs.
+
+## Product/context alignment
+
+Sprint 6 changes must keep these layers coherent:
+
+- Gherkin scenario first in `e2e/features`.
+- Mapping in `e2e/scenario_mappings.json` with stable evidence markers.
+- Executable proof in the smallest appropriate lane:
+  - PR-safe unit/contract/static checks for deterministic boundaries;
+  - admin/control-plane CI for setup, policy, and readiness APIs;
+  - Live Stack E2E only for credentialed product journeys.
+- Documentation in `docs/product-acceptance-flows.md`, `docs/acceptance-contracts.md`, and this enterprise release page.
+- Release evidence checks in `./gradlew releaseEvidenceCheck` so docs and machine-readable gates drift together.
+
+## Sprint 6 implementation priority
+
+1. Keep #360 honest: merge the current capability fix only with green PR checks, rerun Live Stack E2E on `main`, and update #360 with sanitized artifacts or exact blocker.
+2. Land the enterprise release contract: lanes, gates, manifest, support-safe checks, and docs wired into `releaseEvidenceCheck`.
+3. Split future work by evidence lane instead of feature excitement:
+   - identity/provider dry-run ops in admin/control-plane CI;
+   - context/member flows in acceptance mappings and client/server tests;
+   - credentialed product journeys in Live Stack E2E.
+4. Add provider-ops depth only after the release spine can prove or block a candidate without ambiguity.
+
+## What this foundation prevents
+
+- Calling an RC green because offline tests passed while credentialed E2E failed.
+- Treating Admin Portal work as the cause or solution for every E2E failure.
+- Uploading raw live logs as “evidence”.
+- Expanding the milestone with unrelated UX/provider work before the release gate is reliable.
+- Losing traceability between feature scenarios, runtime markers, release notes, and promotion decisions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,8 @@ Start with:
 2. Root README — public product entry point and architecture-at-a-glance.
 3. [Product acceptance flows](product-acceptance-flows.md) — product-language acceptance paths.
 4. [Sprint 5 closure report](sprint-5-closure-report.md) — project-readiness evidence and release-candidate gaps.
-5. [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md) — active RC/provider-ops entry slice.
+5. [Enterprise release foundation](enterprise-release-foundation.md) — release lanes, RC gate, waiver semantics, and support-safe artifacts.
+6. [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md) — active RC/provider-ops entry slice.
 
 ### Member / user
 
@@ -39,6 +40,7 @@ Start with:
 2. [Control-plane infra bootstrap](control-plane-infra-bootstrap.md) — infra/control-plane foundation.
 3. [Provider replacement and anti-silo contract](provider-replacement-and-anti-silo-contract.md) — dry-run, migration, export/delete, rollback, and evidence requirements.
 4. [Quality and acceptance evidence](quality-and-evidence.md) — evidence handling and sanitized artifacts.
+5. [Enterprise release foundation](enterprise-release-foundation.md) — release-candidate promotion, live evidence, and waiver contract.
 
 ### Developer / contributor
 
@@ -82,6 +84,7 @@ Release and evidence docs:
 - [Release notes](release-notes/index.md)
 - [Quality and acceptance evidence](quality-and-evidence.md)
 - [Build evidence delivery system](build-evidence-delivery-system.md)
+- [Enterprise release foundation](enterprise-release-foundation.md)
 - [Manuals and release notes integration](manuals-and-release-notes-integration.md)
 - [Sprint 5 closure report](sprint-5-closure-report.md)
 - [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md)

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -14,6 +14,7 @@ Weave uses layered evidence so contributors can move quickly while release claim
 | Admin-provisioned first-use guard | Normal members stay out of OIDC/provider/infra setup and Workspace Health remains the admin/operator control plane. | [Admin-provisioned first use boundary](admin-provisioned-first-use.md), `client/test/architecture/admin_provisioned_first_use_contract_test.dart`, `client/test/features/settings/settings_screen_test.dart`, `client/test/features/onboarding/first_run_screen_test.dart`. |
 | Docs build | User/admin handbook content builds without broken links, secret-pattern docs drift, or image-only instructions. | `build/docs/user` and `build/docs/admin` from `./gradlew docsBuild`. |
 | CI summary artifact | The root Gradle task graph emitted a sanitized summary of commit, branch, tool versions, gate outcomes, artifact paths, and live-E2E skip reason. | `build/evidence/ci-summary.json` from `./gradlew ci` or `./gradlew ciSummary`. |
+| Enterprise release gate contract | Release lanes, required gates, Live Stack artifact names, marker requirements, and waiver rules stay machine-checkable. | [Enterprise release foundation](enterprise-release-foundation.md), `release/enterprise-release-gates.json`, `./gradlew enterpriseReleaseGateCheck`. |
 | Live Stack E2E | A prepared self-hosted stack can boot the app-level journey and upload acceptance evidence artifacts. | `.github/workflows/live-stack-e2e.yml` workflow runs and their uploaded artifacts. |
 
 ## Default PR validation
@@ -51,14 +52,14 @@ These checks are intentionally cheap enough for normal pull requests and do not 
 
 The live-stack path is expensive and runs on a dedicated self-hosted macOS ARM64 runner. Use it when a change affects sign-in, backend facade contracts, Matrix/files/calendar live behavior, acceptance scenarios, or integration boundaries.
 
-The workflow prepares an acceptance evidence directory, runs the app-level live-stack E2E, and uploads artifacts such as logs and acceptance evidence from the run. Do not cite a single workflow run ID as a permanent product claim; link to the workflow, the relevant docs, and the PR evidence instead.
+The workflow prepares an acceptance evidence directory, runs the app-level live-stack E2E, and uploads support-safe acceptance evidence from the run. The artifact set includes `release-evidence-manifest.json`, which names the source lane, commit, workflow run metadata, artifact list, and RC promotion rule. Do not cite a single workflow run ID as a permanent product claim; link to the workflow, the relevant docs, the manifest, and the PR evidence instead.
 
 ## Interpreting pass/fail states
 
 - **Offline Flutter failure**: inspect the failing command first. Re-run locally after regenerating l10n/build output.
 - **Screenshot drift**: run `make marketing-screenshots`, review the SVG diff as product copy, and commit the regenerated assets if intentional.
 - **Acceptance mapping failure**: update the scenario-to-test mapping or remove stale scenario claims. Do not leave product acceptance text unmapped.
-- **Live-stack contract failure**: confirm the stack bootstrapped correctly, then inspect backend/API, auth, and app logs. Treat credential or runner-budget problems as infrastructure blockers, not product proof.
+- **Live-stack contract failure**: confirm the stack bootstrapped correctly, then inspect backend/API, auth, and app logs. Treat credential, runner, or environment problems as named infrastructure blockers, not product proof. Missing required markers such as `BOARDS_RESULT` block RC promotion until a green rerun or explicit release-owner waiver exists.
 - **Accessibility evidence gap**: do not promote the flow as release-ready until the automated and manual evidence in the accessibility gate is complete.
 - **Admin-provisioned first-use failure**: inspect member-visible first-use, settings, and navigation copy first. Normal members must not see provider setup diagnostics, OIDC/provider/infra setup fields, preview/scaffold/coming-soon release-scope language, or raw provider errors; move setup/readiness detail to Workspace Health for admins/operators.
 
@@ -79,3 +80,4 @@ The workflow prepares an acceptance evidence directory, runs the app-level live-
 - [Accessibility Release Gate](accessibility-release-gate.md)
 - [ISO 9241-110 Dogfood UX Gate](iso-9241-110-dogfood-ux-gate.md)
 - [Roadmap and guarded surfaces](roadmap-and-guarded-surfaces.md)
+- [Enterprise release foundation](enterprise-release-foundation.md)

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -8,6 +8,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Root Gradle wrapper and orchestration tasks for delegated server, client, admin, infra, docs, acceptance, CI, and release-notes checks.
 - Local release notes generator for merged PR metadata grouped by release-notes labels.
 - Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
+- Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
 
 ## Changed
 
@@ -16,6 +17,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Documentation validation now has a dedicated docs check/build path.
 - PR CI now enforces exactly one release-notes label before review/merge.
 - `make release-notes-check` now verifies release-notes label edge cases and generator fixture output.
+- Live Stack acceptance artifacts now include `release-evidence-manifest.json` with commit/run metadata, artifact list, support-safe exclusions, and the RC promotion rule.
 
 ## Fixed
 

--- a/docs/sprint-6-kickoff-plan.md
+++ b/docs/sprint-6-kickoff-plan.md
@@ -11,13 +11,20 @@ Sprint 6 starts from `main` at `e5aa689` after PR #359 merged the enterprise REA
 - Current `main` checks for `e5aa689`: Gradle CI green; release-notes label check skipped on `main` as expected.
 - Live Stack E2E is a release-candidate gate. A current-head manual run was dispatched: [run 26498446059](https://github.com/masssi164/weave/actions/runs/26498446059), tracked by #360.
 
+## Enterprise foundation update
+
+After #360 exposed that an offline-green stack can still fail credentialed product evidence, Sprint 6 now starts with an explicit enterprise release foundation before broadening provider scope. The release lane contract is [Enterprise release foundation](enterprise-release-foundation.md) and the checked contract is `release/enterprise-release-gates.json`.
+
+This update does not turn E2E into an Admin Portal feature. E2E remains validation/evidence; Admin/operator work remains setup, policy, readiness, and support-safe remediation.
+
 ## First execution slice
 
 Sprint 6 starts with the narrow provider/ops path:
 
-1. **RC gate:** #360 — credentialed Live Stack E2E on the release-candidate head. A green sanitized artifact or explicit release-owner waiver is required before any RC promotion/tag.
-2. **Admin-owned identity setup:** #212 — keep OIDC/realm setup in owner/admin workflows and keep normal member onboarding to sign-in only.
-3. **Keycloak realm provider dry-run:** #233 — introduce a backend/provisioner contract for desired realm state, dry-run/diff/readiness, and later gated apply.
+1. **Enterprise release foundation:** release lanes, machine-checked gate contract, Live Stack manifest, support-safe artifact contract, and waiver semantics wired into `releaseEvidenceCheck`.
+2. **RC gate:** #360 — credentialed Live Stack E2E on the release-candidate head. A green sanitized artifact or explicit release-owner waiver is required before any RC promotion/tag.
+3. **Admin-owned identity setup:** #212 — keep OIDC/realm setup in owner/admin workflows and keep normal member onboarding to sign-in only.
+4. **Keycloak realm provider dry-run:** #233 — introduce a backend/provisioner contract for desired realm state, dry-run/diff/readiness, and later gated apply.
 
 Why this slice: it advances release-candidate readiness and the admin/provider boundary already proven in Sprint 5. It is narrow, fail-closed, and evidence-preserving. It does not broaden member UX, does not claim generic provider marketplace support, and does not make Weaver active by default.
 

--- a/infra/weave-workspace/01-infrastructure/.terraform.lock.hcl
+++ b/infra/weave-workspace/01-infrastructure/.terraform.lock.hcl
@@ -1,30 +1,59 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/local" {
+provider "registry.opentofu.org/hashicorp/local" {
   version     = "2.8.0"
   constraints = "~> 2.5"
   hashes = [
-    "h1:3jWHVwO5QUIS9V1NsK10ZzdpkK2ABuB4G+UIWrVeGp4=",
-    "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
-    "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
-    "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",
-    "zh:6cbedc09b67a5cdb9501ff1b18a315fa46a38e0530424cab1c7f4b3acc75f489",
-    "zh:71b3bd50f89fb385a42a436ba2ce2b8e00f9de53535ce956deff1477b0b117dc",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9d45ac0a00b85cabdd398b859349d17f124c598b6e6bf272f1bb01321ce708a8",
-    "zh:a453efe8641a8f31fe806b597bf2b34d7b78b971a8e3919061ea89d61fda7b8d",
-    "zh:ac692bacb8c3dca8b5b37e5383168aca1f87d3cd7b40615efd300defb76494f5",
-    "zh:bda9e90c8547d90c9c573206985c5675cc1406047605af037a5069942c3c5966",
-    "zh:c30a1967de040d00f5038086dd53cdbfb78cc05d1dbc75037410f011bf2a20d8",
-    "zh:c80bbd1c3f56b3c836d80cf93ac0e8809305c2642f0c98b54bf5d05d3b12718c",
+    "h1:+aI41fUmWwO+PfOoRW+vFQCSJzm6kmHHxfQbqMjUPQ8=",
+    "h1:1xJna0B1GsBtxy9stlpmlIm0JKQFUUUH+ILo2mqYOAY=",
+    "h1:3c528BCbO8BFB7199qOBFpJ20Xoals6eSDcLX/GRzxA=",
+    "h1:8cQrJKaypDzLLmtBZQwMyobVJIFW3fLnHbFpB3M67+A=",
+    "h1:9cAw42HUn9iMcrteWwD8L09JuOy2J20ykmEeP1tmGSA=",
+    "h1:EoVu7zNegPTuOEloKTX7Ss966M7IVj8XhqAGW0cZGC0=",
+    "h1:GNGbDmFt0lhM5IyATKYHCzCBQK6Kka6hsPDiXcLyV5w=",
+    "h1:GfH8H391WOg00jkUg3+pt1zj76mSj8R8BMyFKVnLudg=",
+    "h1:RynjUS+wJtuEt5tLQOSqgupTFqLWfMkH+3hTHK7TYp4=",
+    "h1:X/bA7cd5DhdNmHOS9JvhIUGJ8wv3lHxQ5RIXubyDKNc=",
+    "h1:XybiBEkq4bcztcMIb1YZJo33oFgx40i63lhPG0TmiRU=",
+    "h1:h73rGR7XRK7ZR3qUB8dZH++D9yEUH3Zo2p1csYXyrJY=",
+    "h1:hMQtGKCeFN5SHSshwNZC1JW/Xdl5BgJLc1qOIyXZEG0=",
+    "h1:jXWz06IG4F2wETtwBbB9n9HgRqJ5gdgK9B+XsnhtiUI=",
+    "h1:yHA8Q4tOqP3Klf0/7kdq31/D3P65UIcXJyxAybrackM=",
+    "zh:0aaa04a29638eb2f84145aeec030ed4b469980c51f60f7f72ddbd705e0c9ceea",
+    "zh:1d2f29cdfdc607f6b6b641e8bc7b00c73ac29f572ae8aa9b18fd068c107a7315",
+    "zh:3cba45610ee2abbbe73694f5604d6628b036cee35d5e77f2353043088e950ff2",
+    "zh:435fca586d45fcf200974d90962fa4cffaf761bad4c774bd34d1b92463a9887f",
+    "zh:662748c6ad1e3d64500b70d3e2ccd5d2b04471dfd687c524f15bf3dbe68954a2",
+    "zh:68f3a6dd1a6ddb7f4935ce894861740dd39f2202c5ba4aebc217c742e426a80c",
+    "zh:75267c8b3d693125e7c6814058fef6189e0dae6c44c47cd63109d919b35e665e",
+    "zh:88a1e4c13876774fae1ae20129a328cb6031e3aca00435bc7899e4038c2f43f7",
+    "zh:8b8bffe1adeedf13a5c4af7b208b47ca5d4cac09ff51028962a3465e26830fef",
+    "zh:b99ddf3c8fb730e4a9e4ded4c5706bcca3b7b8d2f2ea458f01a4dda26c78fdd3",
+    "zh:d08174d23b2fe4a53b7f81f32ff0089e6ca76162a9de3c411deff7eb45d3d677",
+    "zh:d220cd9f2ea3426ab5e2c528700c15d8fbcd4254496a84945b38885c6e4b18d3",
+    "zh:de1e7f2ec372aaf717a26017e25f24bc22cbfc0e1691711484df26d828c6f8a0",
+    "zh:e1b7c0ccaea53904b999a0d3993e86b97766eaa3698040c0bbe14b453cefd91a",
+    "zh:e7eacd0e7a223fee0ac1fee5f032199219fde3cf0db43ad9d31b75a122f440ae",
   ]
 }
 
-provider "registry.terraform.io/kreuzwerker/docker" {
+provider "registry.opentofu.org/kreuzwerker/docker" {
   version     = "3.9.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:EAdNh5KgGPJT5jm848MRIfNfHUVJeTBdKKcFLax5g38=",
+    "h1:Eglp2bA01CEx8KV/K9CMZ1deQaWKW5HVhE2n+2jIp20=",
+    "h1:G/077y/oYgghD2b+X1RLgfcvPhy2SKmbKuLs9DNNCtc=",
+    "h1:MmhVJBgNpE2Fbksv/XObZJncwm4th4mFE7Ai+6LiIy4=",
+    "h1:Q0p3icHxAgpepYKx8gmg8pkfhgbNEeTeesjAqCrd8co=",
+    "h1:R6PZNIJ3wO5UEOA1YNntoYA9ZQWi3CuX1hADvxTMOdM=",
+    "h1:SKvPUrYkuuFYI9+nuvwkQhTStU67njNrNYUcfTvFnq8=",
+    "h1:VSqlOY7A//UzK89fphsLnCXtlAVE58Qg9kb0A3zTA8Y=",
+    "h1:bk/xY7+9c6rnsdp3zXIZaY8b9E3FNQUtJcCCsdkgEec=",
+    "h1:h/BTzZtag+INPIDWKR+ZMA4K+MFLjJDbkKNc4vIknn0=",
+    "h1:kOwGKqVcyI5i0ewb4hIxWbuGw9jS8CTj/dMLfCwMyJ8=",
+    "h1:o/2lXPHpHZr4fuVmCgcJu8Dk3/bnL6qp8fr0JM36bBM=",
     "h1:p65AjYSOmmHPjKkIYlEnxSMyrprTHKf1qBzKhCnCtG8=",
     "zh:0ead8281830e9b9496651282235d9a139ba1b1b6ff79e395eb8c78658dc446b9",
     "zh:0f17d37d8d3872df3fb75c68b5272e0c981343f53b506a9675b4405191edd3ef",

--- a/infra/weave-workspace/02-keycloak-setup/.terraform.lock.hcl
+++ b/infra/weave-workspace/02-keycloak-setup/.terraform.lock.hcl
@@ -1,11 +1,27 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/mrparkers/keycloak" {
+provider "registry.opentofu.org/mrparkers/keycloak" {
   version     = "4.4.0"
-  constraints = ">= 4.0.0"
+  constraints = "4.4.0"
   hashes = [
+    "h1:0Tbm1qYAbn+7EnlKeT8M0OQzYIeueaTuMPQyCXR2aGA=",
+    "h1:5i8KGldxrlinglSLhnig7hTeZ9Oymac53YmwERBA6Lo=",
+    "h1:6Y5ViyEP5yVF9lp7heZwi88RFHPfX+Zj1WCtNQKxu3Y=",
+    "h1:EfI15pfQIaL5pQCJKriBVUQjDVkfEwcALxzFbrWn/nE=",
+    "h1:FH9j76zRv05qxk7I/w0mycmBEuew/+XP+Qx+Ptz/onw=",
+    "h1:NA2iexfalzIj0P3QIf9VUgJa5vOCCDe0iDMamUt1y6I=",
+    "h1:Nfy6wuk7dmerNebfSiwHC9v5bnrHOQWiDuuDvJQyUcI=",
+    "h1:VEifrgoPzdXJfnhrZix+tdYG1Ql16xlPDy2SX1lc3sY=",
+    "h1:VZkxgjWkEwwt5MqEfEKe8PykGa+JlJ1cQVWs/Sl6Is0=",
+    "h1:XyJbmbKwEmHXPhQXnO8ia0bc5l//rHMbALcfyzDtteE=",
+    "h1:ZpOkiEWHitdNErJ+0NbAuP+gwatmXdfASEANKvLo95A=",
+    "h1:ea32VJf5Tr/1MGjtXC/CdBoL13oN3EKNCT8sXQV6BFc=",
     "h1:kQM1QZ3JEe7uhWABjke536lyLE54hDWUJyqpz6vbGjo=",
+    "h1:nbNJyL1DVGKVsNdr9Yxg5VU/KG9a+c8BMWnKJv58Qm4=",
+    "h1:uRDnZq2i5jOFcG6W3lq0Pbmm5WdmDhc6daBZrvaYAsQ=",
+    "h1:vGDIJkwRa6NQPK7rLYu9XLSL1TEGcwgVaH/urThkp3E=",
+    "h1:zaW8CldBkfYlZTOcRItD9HN5hOsLyNyacwquE/XUJh4=",
     "zh:0116d63fb4a4436d67cc793038899e0de23c3a5c78f5bf3cf76ee006ad886979",
     "zh:0fa399fcdeef21dd914ff7413b8489e47900cbe7bc65b50eeb0d75b71a2b561d",
     "zh:30371fee6d0ae438908b1bf03278f6d0a0cb2992a97814028676a05a55d92f19",

--- a/infra/weave-workspace/02-keycloak-setup/main.tf
+++ b/infra/weave-workspace/02-keycloak-setup/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     keycloak = {
       source  = "mrparkers/keycloak"
-      version = ">= 4.0.0"
+      version = "4.4.0"
     }
   }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Acceptance contracts: acceptance-contracts.md
       - Quality and evidence: quality-and-evidence.md
       - Build, evidence, and delivery system: build-evidence-delivery-system.md
+      - Enterprise release foundation: enterprise-release-foundation.md
       - Sprint 1 completion report: sprint-1-completion-report.md
       - Sprint 3 closure report: sprint-3-closure-report.md
       - Sprint 4 plan: sprint-4-plan.md

--- a/release/enterprise-release-gates.json
+++ b/release/enterprise-release-gates.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": 1,
+  "status": "sprint-6-enterprise-foundation",
+  "promotionModel": {
+    "branching": "protected-main-with-short-lived-pr-branches",
+    "releaseCandidateSource": "main",
+    "promotionRule": "no-v0.1-rc-promotion-without-green-credentialed-live-stack-e2e-or-explicit-release-owner-waiver",
+    "waiverOwner": "release-owner",
+    "waiverEvidence": "checked-in or issue-linked support-safe rationale with exact blocker, compensating evidence, commit, expiry, and owner"
+  },
+  "lanes": [
+    {
+      "id": "pr-safe-ci",
+      "purpose": "fast deterministic monorepo confidence before merge",
+      "trigger": "pull_request and push",
+      "requiredFor": ["merge-readiness"],
+      "gates": [
+        {
+          "id": "gradle-ci",
+          "command": "./gradlew ci",
+          "required": true,
+          "evidence": ["build/evidence/ci-summary.json", "build/docs"]
+        },
+        {
+          "id": "release-notes-label-check",
+          "command": "./gradlew releaseNotesLabelCheck",
+          "required": true,
+          "evidence": ["exactly-one-release-notes-label"]
+        }
+      ]
+    },
+    {
+      "id": "release-candidate-live-evidence",
+      "purpose": "credentialed product-flow proof on the dedicated self-hosted live runner",
+      "trigger": "manual workflow_dispatch, nightly schedule, or approved workflow_call",
+      "requiredFor": ["v0.1-rc-promotion", "dogfood-production-tag"],
+      "gates": [
+        {
+          "id": "credentialed-live-stack-e2e",
+          "workflow": ".github/workflows/live-stack-e2e.yml",
+          "required": true,
+          "evidence": [
+            "weave-live-stack-acceptance-evidence/acceptance-summary.md",
+            "weave-live-stack-acceptance-evidence/scenario-mapping-results.json",
+            "weave-live-stack-acceptance-evidence/evidence-markers.json",
+            "weave-live-stack-acceptance-evidence/release-evidence-manifest.json"
+          ],
+          "mustObserveMarkers": ["AUTH_RESULT", "PROFILE_RESULT", "CHAT_RESULT", "MATRIX_RESULT", "E2EE_RESULT", "FILES_RESULT", "PROVIDER_STACK_RESULT", "CALENDAR_RESULT", "BOARDS_RESULT"],
+          "supportSafeExclusions": ["raw credentials", "credential-bearing URLs", "provider internals", "downstream provider error bodies", "private live logs"]
+        }
+      ]
+    },
+    {
+      "id": "release-promotion",
+      "purpose": "reviewable release candidate decision and draft publication",
+      "trigger": "release owner decision after evidence review",
+      "requiredFor": ["release-draft", "tagging"],
+      "gates": [
+        {
+          "id": "release-draft-review",
+          "workflow": ".github/workflows/release-draft.yml",
+          "required": true,
+          "evidence": ["release-draft-review-<tag>", "docs/release-notes/v0.1.md"]
+        },
+        {
+          "id": "release-owner-signoff",
+          "required": true,
+          "evidence": ["GitHub issue or release checklist naming commit, artifacts, blocker/waiver if any, rollback note, owner"]
+        }
+      ]
+    }
+  ],
+  "ownership": {
+    "releaseOwner": "human release owner",
+    "orchestration": "weave-co-leader coordinates specialist agents; main session verifies gates and reports",
+    "secrets": "GitHub environment/repository secrets and SecretRef-style runtime configuration only",
+    "logs": "support-safe summaries by default; raw provider logs stay private runner/operator diagnostics"
+  }
+}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILDPLATFORM
 ARG TARGETPLATFORM
 
-FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy AS build
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy AS build
 WORKDIR /workspace
 
 COPY gradlew gradlew.bat build.gradle settings.gradle ./
@@ -11,7 +11,7 @@ RUN chmod +x ./gradlew
 COPY src ./src
 RUN ./gradlew --no-daemon bootJar
 
-FROM --platform=$TARGETPLATFORM eclipse-temurin:17-jre-jammy
+FROM --platform=$TARGETPLATFORM eclipse-temurin:21-jre-jammy
 WORKDIR /app
 
 COPY --from=build /workspace/build/libs/*.jar /app/app.jar

--- a/server/README.md
+++ b/server/README.md
@@ -75,7 +75,7 @@ Historical issue drafts live under `docs/issues/`; do not treat them as current 
 
 ## Local development
 
-Run tests with Java 17:
+Run tests with Java 21+:
 
 ```bash
 ./gradlew test
@@ -90,7 +90,7 @@ docker run --rm \
   -e GRADLE_USER_HOME=/tmp/.gradle \
   -v "$PWD:/workspace" \
   -w /workspace \
-  eclipse-temurin:17-jdk \
+  eclipse-temurin:21-jdk \
   ./gradlew test
 ```
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -9,7 +9,7 @@ version = '0.1.0'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/tools/docs_check.py
+++ b/tools/docs_check.py
@@ -27,6 +27,7 @@ REQUIRED_DOCS = [
     "admin-operator-handbook.md",
     "developer-handbook.md",
     "gitflow-pr-workflow.md",
+    "enterprise-release-foundation.md",
     "diagrams/index.md",
     "release-notes/index.md",
     "release-notes/unreleased.md",

--- a/tools/release_gate_check.py
+++ b/tools/release_gate_check.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Validate Weave's enterprise release gate contract stays explicit and support-safe."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "release" / "enterprise-release-gates.json"
+DOC = ROOT / "docs" / "enterprise-release-foundation.md"
+FORBIDDEN_FRAGMENTS = (
+    "authorization:",
+    "bearer ",
+    "access_token",
+    "refresh_token",
+    "client_secret=",
+    "password=",
+    "BEGIN PRIVATE KEY",
+)
+REQUIRED_LANES = {
+    "pr-safe-ci",
+    "release-candidate-live-evidence",
+    "release-promotion",
+}
+REQUIRED_GATES = {
+    "gradle-ci",
+    "release-notes-label-check",
+    "credentialed-live-stack-e2e",
+    "release-draft-review",
+    "release-owner-signoff",
+}
+REQUIRED_LIVE_ARTIFACTS = {
+    "weave-live-stack-acceptance-evidence/acceptance-summary.md",
+    "weave-live-stack-acceptance-evidence/scenario-mapping-results.json",
+    "weave-live-stack-acceptance-evidence/evidence-markers.json",
+    "weave-live-stack-acceptance-evidence/release-evidence-manifest.json",
+}
+REQUIRED_MARKERS = {
+    "AUTH_RESULT",
+    "PROFILE_RESULT",
+    "CHAT_RESULT",
+    "MATRIX_RESULT",
+    "E2EE_RESULT",
+    "FILES_RESULT",
+    "PROVIDER_STACK_RESULT",
+    "CALENDAR_RESULT",
+    "BOARDS_RESULT",
+}
+
+
+def fail(message: str) -> None:
+    print(f"release-gate-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing contract: {path.relative_to(ROOT)}")
+    except json.JSONDecodeError as error:
+        fail(f"invalid JSON in {path.relative_to(ROOT)}: {error}")
+    if not isinstance(data, dict):
+        fail("release gate contract root must be an object")
+    return data
+
+
+def all_gates(contract: dict[str, Any]) -> list[dict[str, Any]]:
+    lanes = contract.get("lanes")
+    if not isinstance(lanes, list):
+        fail("contract must contain a lanes list")
+    gates: list[dict[str, Any]] = []
+    for lane in lanes:
+        if not isinstance(lane, dict):
+            fail("each lane must be an object")
+        lane_gates = lane.get("gates")
+        if not isinstance(lane_gates, list) or not lane_gates:
+            fail(f"lane {lane.get('id', '<missing>')} must contain gates")
+        for gate in lane_gates:
+            if not isinstance(gate, dict):
+                fail(f"lane {lane.get('id', '<missing>')} contains a non-object gate")
+            gates.append(gate)
+    return gates
+
+
+def check_contract(contract: dict[str, Any]) -> None:
+    if contract.get("schemaVersion") != 1:
+        fail("schemaVersion must be 1")
+    promotion = contract.get("promotionModel")
+    if not isinstance(promotion, dict):
+        fail("promotionModel must be present")
+    rule = str(promotion.get("promotionRule", ""))
+    if "green-credentialed-live-stack-e2e" not in rule or "waiver" not in rule:
+        fail("promotion rule must require green credentialed Live Stack E2E or waiver")
+
+    lanes = contract["lanes"]
+    lane_ids = {lane.get("id") for lane in lanes if isinstance(lane, dict)}
+    missing_lanes = REQUIRED_LANES - lane_ids
+    if missing_lanes:
+        fail(f"missing release lanes: {', '.join(sorted(missing_lanes))}")
+
+    gates = all_gates(contract)
+    gate_ids = {gate.get("id") for gate in gates}
+    missing_gates = REQUIRED_GATES - gate_ids
+    if missing_gates:
+        fail(f"missing release gates: {', '.join(sorted(missing_gates))}")
+
+    for gate in gates:
+        if not gate.get("required", False):
+            fail(f"gate {gate.get('id', '<missing>')} must declare required=true")
+        evidence = gate.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            fail(f"gate {gate.get('id', '<missing>')} must name evidence artifacts")
+
+    live_gate = next(gate for gate in gates if gate.get("id") == "credentialed-live-stack-e2e")
+    live_artifacts = set(live_gate.get("evidence", []))
+    if REQUIRED_LIVE_ARTIFACTS - live_artifacts:
+        fail("credentialed-live-stack-e2e is missing required support-safe artifacts")
+    live_markers = set(live_gate.get("mustObserveMarkers", []))
+    if REQUIRED_MARKERS - live_markers:
+        fail("credentialed-live-stack-e2e is missing required runtime markers")
+
+
+def check_support_safe_text() -> None:
+    for path in (CONTRACT, DOC):
+        text = path.read_text(encoding="utf-8")
+        lowered = text.lower()
+        for fragment in FORBIDDEN_FRAGMENTS:
+            if fragment.lower() in lowered:
+                fail(f"support-safety forbidden fragment in {path.relative_to(ROOT)}: {fragment}")
+
+
+def check_docs(contract: dict[str, Any]) -> None:
+    try:
+        doc = DOC.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        fail(f"missing doc: {DOC.relative_to(ROOT)}")
+    for lane in REQUIRED_LANES:
+        if lane not in doc:
+            fail(f"enterprise release foundation doc does not mention lane {lane}")
+    for gate in REQUIRED_GATES:
+        if gate not in doc:
+            fail(f"enterprise release foundation doc does not mention gate {gate}")
+    for marker in REQUIRED_MARKERS:
+        if marker not in doc:
+            fail(f"enterprise release foundation doc does not mention marker {marker}")
+    contract_rel = str(CONTRACT.relative_to(ROOT))
+    if contract_rel not in doc:
+        fail(f"enterprise release foundation doc must link {contract_rel}")
+
+
+def main() -> None:
+    contract = read_json(CONTRACT)
+    check_contract(contract)
+    check_docs(contract)
+    check_support_safe_text()
+    print("release-gate-check: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the Sprint 6 enterprise release foundation before further RC promotion work:

- machine-readable release lane/gate contract in `release/enterprise-release-gates.json`
- checked `enterpriseReleaseGateCheck` / `releaseEvidenceCheck` guard for support-safe RC evidence
- Live Stack acceptance `release-evidence-manifest.json` with source/lane/commit/run metadata and support-safe exclusions
- docs/MkDocs/README updates for enterprise release lanes, waiver semantics, and E2E-as-evidence boundary
- Java 21 alignment for the server build/runtime image and Keycloak provider pin used by infra validation

## Strategy / boundaries

- Live Stack E2E remains a release evidence gate, not an Admin Portal feature.
- No v0.1 RC promotion without green credentialed Live Stack E2E or explicit release-owner waiver.
- Support artifacts must not contain secrets, credential-bearing URLs, provider internals, raw downstream bodies, or private live logs.
- This PR does **not** dispatch #360; #360 should be rerun only after this foundation lands on `main`.

## Evidence

Local, with `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home`:

- `./gradlew ci --console=plain` ✅
- `flutter test test/live_stack_feature_mapping_test.dart` ✅
- `./gradlew serverCi infraStatic docsBuild releaseEvidenceCheck --console=plain` ✅
- Co-Leader review: approved; no content-level architecture must-fix.

## Follow-up

After merge:

- rerun Live Stack E2E for #360 on updated `main`
- update #360 with sanitized evidence manifest/artifacts or exact blocker
- future hardening: redact/downgrade raw failure container log dumps in `.github/workflows/live-stack-e2e.yml`
