### PR TITLE
feat: implement identity realm dry run

### DIFF
--- a/docs/admin-operator-handbook.md
+++ b/docs/admin-operator-handbook.md
@@ -44,6 +44,14 @@ Record provider posture as `recommended_self_hosted_default`, `external_existing
 
 Provider URLs, credentials, OAuth client secrets, app passwords, signing keys, and bearer tokens must stay out of the member client and support artifacts. Store and display secret handles as `SecretRef` values only. Rotate provider URLs/secrets through admin/operator workflows and audit the change.
 
+## Identity realm dry-run
+
+Use `POST /api/admin/identity/realm/dry-run` before changing Keycloak/OIDC realm state. The request compares an optional `currentState` snapshot with the `desiredState`; if `currentState` is omitted, the backend produces an import/create plan only. This endpoint is dry-run only: it must not mutate Keycloak, OpenTofu/Terraform state, credentials, or member-facing provider configuration.
+
+The desired-state contract covers realm basics, OIDC clients, roles, groups, scopes, claim mappers, redirect origins, and feature mappings. The backend returns deterministic `changes` with `safe`, `risky`, or `destructive` classification plus readiness (`ready`, `degraded`, `policy-blocked`, or `admin-action-required`). Unknown roles, groups, scopes, or feature mappings deny by default and require admin mapping before apply can exist. Destructive removals are policy-blocked in this slice.
+
+Evidence must stay support-safe: no raw provider bodies, provider-internal IDs, credential-bearing URLs, private keys, tokens, or SecretRef payloads. A sanitized sample is checked in at `docs/evidence/identity-realm-dry-run-sample.json`; contract fixtures live under `server/src/test/resources/identity-realm-dry-run/`.
+
 ## Whitelisting and policies
 
 Weave policy is deny-by-default. Capability profiles should use category-level permissions before low-level adapter details, for example:
@@ -86,3 +94,5 @@ make docs-check
 ```
 
 Live Stack E2E is available by default on the dedicated self-hosted live runner. Use the GitHub workflow for manual release-candidate evidence; nightly runs should produce acceptance evidence unless a concrete infrastructure blocker is recorded.
+
+The support-safe dogfood realm baseline lives at `server/src/main/resources/identity/weave-realm-baseline.json`. Treat it as desired-state input for dry-run; it is not Terraform/OpenTofu state and intentionally contains no client secrets.

--- a/docs/evidence/identity-realm-dry-run-sample.json
+++ b/docs/evidence/identity-realm-dry-run-sample.json
@@ -1,0 +1,19 @@
+{
+  "providerKey": "keycloak-realm",
+  "realmId": "weave-dogfood",
+  "operation": "dry-run",
+  "readiness": "degraded",
+  "destructiveApplyAvailable": false,
+  "supportSafe": true,
+  "rawSecretExposed": false,
+  "changes": [
+    {"path":"/clients/weave-app","action":"create","classification":"safe","reasonCode":"oidc-client-managed-by-control-plane","beforeValue":"absent","afterValue":"weave-app","memberImpact":"members continue to use backend-owned sign-in; provider client details stay admin-only","applyBlocked":false},
+    {"path":"/clients/weave-app/redirectOrigins/https://weave.local/*","action":"create","classification":"risky","reasonCode":"redirect-origin-needs-admin-review","beforeValue":"absent","afterValue":"https://weave.local/*","memberImpact":"member sign-in remains backend-owned; admin must review redirect surface","applyBlocked":false}
+  ],
+  "readinessChecks": [
+    {"key":"apply-safety","state":"degraded","reasonCode":"risky-change-review-required","remediation":"This slice never mutates Keycloak or Terraform/OpenTofu state."}
+  ],
+  "blockers": [],
+  "warnings": ["redirect origin requires admin review: https://weave.local/*"],
+  "nextActions": ["Review desired realm diff in the Admin Console boundary."]
+}

--- a/docs/identity-provisioning-strategy.md
+++ b/docs/identity-provisioning-strategy.md
@@ -207,6 +207,20 @@ Acceptance rules:
 - context roles do not automatically grant organization admin rights;
 - provider roles never directly grant Weave capabilities without a mapping record.
 
+## Keycloak realm desired-state dry-run
+
+The first backend-owned provider-ops slice is a dry-run contract for Keycloak-compatible realm state. Admins/operators submit `currentState` (optional) and `desiredState` to `/api/admin/identity/realm/dry-run`; the backend normalizes and compares realm basics, clients, roles, groups, scopes, redirect origins, claim mappers, and required feature mappings.
+
+The report is deterministic and support-safe:
+
+- every change record has a stable path, action (`create`, `update`, `delete`, `no-op`), classification (`safe`, `risky`, `destructive`), reason code, member-impact summary, and `applyBlocked` flag;
+- risky redirect origins degrade readiness until reviewed;
+- unknown roles, groups, scopes, or feature mappings produce `admin-action-required` and deny by default;
+- destructive removals produce `policy-blocked` and are blocked from apply in this dry-run-only slice;
+- provider bodies, provider-internal IDs, credentials, credential URLs, private keys, tokens, and raw logs are never returned.
+
+This endpoint is backend/control-plane only. Member clients consume provider-neutral readiness and capability policy; they must not call Keycloak/provider APIs directly or expose realm setup diagnostics.
+
 ## Guest and B2B users
 
 Guests are external identities, not incomplete employees.

--- a/docs/user-handbook.md
+++ b/docs/user-handbook.md
@@ -67,3 +67,7 @@ Before asking an admin/operator for help, capture the support-safe information s
 - your platform, app target, and app version if available.
 
 Do not paste secrets, bearer tokens, cookies, private keys, raw provider URLs with credentials, or full downstream provider responses into support reports.
+
+## Signing in
+
+Your organization owner/admin configures SSO and workspace providers. As a normal member, use the Weave sign-in link or app entry point your organization provides; you do not configure Keycloak, OIDC, realms, client IDs, redirect URIs, or provider credentials. If a capability is unavailable, degraded, disabled, or policy-blocked, Weave shows the product-level state and your admin handles provider readiness in Workspace Health.

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -1,11 +1,17 @@
 package com.massimotter.weave.backend.controller;
 
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyReport;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyRequest;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunReport;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunRequest;
 import com.massimotter.weave.backend.model.ApiErrorResponse;
 import com.massimotter.weave.backend.model.admin.AdminAuditEventResponse;
 import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
+import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationRequest;
+import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationResponse;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
@@ -75,6 +81,39 @@ public class AdminControlPlaneController {
             content = @Content(schema = @Schema(implementation = EffectivePolicyResponse.class)))
     public EffectivePolicyResponse effectivePolicy(@AuthenticationPrincipal Jwt jwt) {
         return adminControlPlaneService.effectivePolicy(jwt);
+    }
+
+    @PostMapping({"/api/admin/policies/effective/simulations", "/api/v1/admin/policies/effective/simulations"})
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
+    @Operation(summary = "Simulate effective capability policy before provider/realm changes")
+    @ApiResponse(responseCode = "200", description = "Support-safe policy simulation.",
+            content = @Content(schema = @Schema(implementation = EffectivePolicySimulationResponse.class)))
+    public EffectivePolicySimulationResponse simulateEffectivePolicy(
+            @Valid @RequestBody EffectivePolicySimulationRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.simulateEffectivePolicy(request, jwt);
+    }
+
+    @PostMapping({"/api/admin/identity/realm/dry-run", "/api/v1/admin/identity/realm/dry-run"})
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
+    @Operation(summary = "Dry-run a support-safe identity realm desired state without provider mutation")
+    @ApiResponse(responseCode = "200", description = "Deterministic realm desired-state dry-run.",
+            content = @Content(schema = @Schema(implementation = IdentityRealmDryRunReport.class)))
+    public IdentityRealmDryRunReport dryRunIdentityRealm(
+            @Valid @RequestBody IdentityRealmDryRunRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.dryRunIdentityRealm(request, jwt);
+    }
+
+    @PostMapping({"/api/admin/identity/realm/apply", "/api/v1/admin/identity/realm/apply"})
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
+    @Operation(summary = "Guarded identity realm apply path with last-admin and rollback checks")
+    @ApiResponse(responseCode = "200", description = "Support-safe guarded apply decision.",
+            content = @Content(schema = @Schema(implementation = IdentityRealmApplyReport.class)))
+    public IdentityRealmApplyReport applyIdentityRealm(
+            @Valid @RequestBody IdentityRealmApplyRequest request,
+            @AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.applyIdentityRealm(request, jwt);
     }
 
     @PostMapping({"/api/admin/organizations/bootstrap", "/api/v1/admin/organizations/bootstrap"})

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmApplyReport.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmApplyReport.java
@@ -1,0 +1,30 @@
+package com.massimotter.weave.backend.identity.realm;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Support-safe guarded identity realm apply decision and audit receipt.")
+public record IdentityRealmApplyReport(
+        String providerKey,
+        String realmId,
+        String dryRunId,
+        String decision,
+        String executionMode,
+        boolean applied,
+        boolean supportSafe,
+        boolean rawSecretExposed,
+        boolean lastAdminGuardPassed,
+        boolean rollbackEvidenceRequired,
+        boolean rollbackEvidenceAccepted,
+        List<String> blockedReasons,
+        List<IdentityRealmDryRunReport.ChangeRecord> changes,
+        List<String> nextActions,
+        List<String> auditRefs) {
+
+    public IdentityRealmApplyReport {
+        blockedReasons = blockedReasons == null ? List.of() : List.copyOf(blockedReasons);
+        changes = changes == null ? List.of() : List.copyOf(changes);
+        nextActions = nextActions == null ? List.of() : List.copyOf(nextActions);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmApplyRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmApplyRequest.java
@@ -1,0 +1,24 @@
+package com.massimotter.weave.backend.identity.realm;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Guarded admin request to apply an identity realm desired state after dry-run review.")
+public record IdentityRealmApplyRequest(
+        IdentityRealmDesiredState currentState,
+        IdentityRealmDesiredState desiredState,
+        String confirmationPhrase,
+        boolean approveRisky,
+        boolean approveDestructive,
+        List<String> retainedAdminPrimaryIdentityKeys,
+        String rollbackEvidenceRef,
+        String reason) {
+
+    public IdentityRealmApplyRequest {
+        retainedAdminPrimaryIdentityKeys = retainedAdminPrimaryIdentityKeys == null ? List.of() : List.copyOf(retainedAdminPrimaryIdentityKeys);
+    }
+
+    public IdentityRealmDryRunRequest dryRunRequest() {
+        return new IdentityRealmDryRunRequest(currentState, desiredState, reason);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDesiredState.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDesiredState.java
@@ -1,5 +1,6 @@
 package com.massimotter.weave.backend.identity.realm;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 /**
@@ -8,22 +9,29 @@ import java.util.List;
  * <p>This is deliberately provider-shaped enough for Keycloak/OIDC realm planning,
  * but it is not Terraform state and it must not contain raw secrets.</p>
  */
+@Schema(description = "Support-safe identity realm desired/current state for admin dry-run planning.")
 public record IdentityRealmDesiredState(
         String realmId,
+        String displayName,
+        Boolean enabled,
         List<RealmClient> clients,
         List<String> roles,
+        List<String> groups,
         List<String> scopes,
         List<ClaimMapper> claimMappers,
         List<String> redirectOrigins,
+        List<FeatureMapping> featureMappings,
         List<String> providerWarnings,
         List<String> blockers) {
 
     public IdentityRealmDesiredState {
         clients = clients == null ? List.of() : List.copyOf(clients);
         roles = roles == null ? List.of() : List.copyOf(roles);
+        groups = groups == null ? List.of() : List.copyOf(groups);
         scopes = scopes == null ? List.of() : List.copyOf(scopes);
         claimMappers = claimMappers == null ? List.of() : List.copyOf(claimMappers);
         redirectOrigins = redirectOrigins == null ? List.of() : List.copyOf(redirectOrigins);
+        featureMappings = featureMappings == null ? List.of() : List.copyOf(featureMappings);
         providerWarnings = providerWarnings == null ? List.of() : List.copyOf(providerWarnings);
         blockers = blockers == null ? List.of() : List.copyOf(blockers);
     }
@@ -46,5 +54,17 @@ public record IdentityRealmDesiredState(
             String sourceClaim,
             String targetClaim,
             boolean required) {
+    }
+
+    public record FeatureMapping(
+            String featureKey,
+            List<String> requiredRoles,
+            List<String> requiredGroups,
+            List<String> requiredScopes) {
+        public FeatureMapping {
+            requiredRoles = requiredRoles == null ? List.of() : List.copyOf(requiredRoles);
+            requiredGroups = requiredGroups == null ? List.of() : List.copyOf(requiredGroups);
+            requiredScopes = requiredScopes == null ? List.of() : List.copyOf(requiredScopes);
+        }
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDryRunReport.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDryRunReport.java
@@ -1,24 +1,51 @@
 package com.massimotter.weave.backend.identity.realm;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
+@Schema(description = "Support-safe, deterministic realm dry-run report. No provider bodies, secrets, credential URLs, private IDs, or tokens are returned.")
 public record IdentityRealmDryRunReport(
         String providerKey,
         String realmId,
+        String dryRunId,
         String operation,
         String readiness,
         boolean destructiveApplyAvailable,
         boolean supportSafe,
         boolean rawSecretExposed,
+        List<ChangeRecord> changes,
+        List<ReadinessCheck> readinessChecks,
         List<String> diff,
         List<String> warnings,
         List<String> blockers,
-        List<String> nextActions) {
+        List<String> nextActions,
+        List<String> auditRefs) {
 
     public IdentityRealmDryRunReport {
+        changes = changes == null ? List.of() : List.copyOf(changes);
+        readinessChecks = readinessChecks == null ? List.of() : List.copyOf(readinessChecks);
         diff = diff == null ? List.of() : List.copyOf(diff);
         warnings = warnings == null ? List.of() : List.copyOf(warnings);
         blockers = blockers == null ? List.of() : List.copyOf(blockers);
         nextActions = nextActions == null ? List.of() : List.copyOf(nextActions);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+    }
+
+    public record ChangeRecord(
+            String path,
+            String action,
+            String classification,
+            String reasonCode,
+            String beforeValue,
+            String afterValue,
+            String memberImpact,
+            boolean applyBlocked) {
+    }
+
+    public record ReadinessCheck(
+            String key,
+            String state,
+            String reasonCode,
+            String remediation) {
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDryRunRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDryRunRequest.java
@@ -1,0 +1,10 @@
+package com.massimotter.weave.backend.identity.realm;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Dry-run request comparing an optional current realm snapshot with the desired support-safe state.")
+public record IdentityRealmDryRunRequest(
+        IdentityRealmDesiredState currentState,
+        IdentityRealmDesiredState desiredState,
+        String reason) {
+}

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmProvider.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmProvider.java
@@ -4,7 +4,11 @@ public interface IdentityRealmProvider {
 
     String providerKey();
 
-    IdentityRealmDryRunReport dryRun(IdentityRealmDesiredState desiredState);
+    IdentityRealmDryRunReport dryRun(IdentityRealmDryRunRequest request);
+
+    default IdentityRealmDryRunReport dryRun(IdentityRealmDesiredState desiredState) {
+        return dryRun(new IdentityRealmDryRunRequest(null, desiredState, null));
+    }
 
     default boolean destructiveApplyAvailable() {
         return false;

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/KeycloakRealmDryRunProvider.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/KeycloakRealmDryRunProvider.java
@@ -1,15 +1,34 @@
 package com.massimotter.weave.backend.identity.realm;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
 
+@Component
 public class KeycloakRealmDryRunProvider implements IdentityRealmProvider {
 
     private static final String PROVIDER_KEY = "keycloak-realm";
+    private static final Set<String> KNOWN_ROLES = Set.of("owner", "admin", "operator", "member", "guest");
+    private static final Set<String> KNOWN_SCOPES = Set.of("openid", "profile", "email", "weave:workspace", "offline_access");
+    private static final Set<String> KNOWN_GROUPS = Set.of(
+            "weave-calendar-editors",
+            "weave-board-editors",
+            "weave-meeting-hosts",
+            "weave-document-editors",
+            "weave-decision-recorders",
+            "weave-weaver-pilot");
+    private static final Set<String> KNOWN_FEATURES = Set.of(
+            "chat", "files", "calendar", "boards", "meetings", "documents", "decisions", "manuals", "release-evidence", "weaver");
     private static final Pattern SECRET_LIKE = Pattern.compile(
-            "(?i)(password|passwd|secret|token|bearer|api[_-]?key|x-access-token|client_secret)");
+            "(?i)(password|passwd|secret|token|bearer|api[_-]?key|x-access-token|client_secret|credential|private[_-]?key)");
 
     @Override
     public String providerKey() {
@@ -17,56 +36,545 @@ public class KeycloakRealmDryRunProvider implements IdentityRealmProvider {
     }
 
     @Override
-    public IdentityRealmDryRunReport dryRun(IdentityRealmDesiredState desiredState) {
-        IdentityRealmDesiredState desired = desiredState == null
-                ? new IdentityRealmDesiredState(null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of("realm desired state is required"))
-                : desiredState;
-        List<String> blockers = new ArrayList<>(safeList(desired.blockers()));
-        if (blank(desired.realmId())) {
-            blockers.add("realm id is required before import planning");
+    public IdentityRealmDryRunReport dryRun(IdentityRealmDryRunRequest request) {
+        IdentityRealmDesiredState desired = request == null ? null : request.desiredState();
+        IdentityRealmDesiredState current = request == null ? null : request.currentState();
+        if (desired == null) {
+            desired = new IdentityRealmDesiredState(
+                    null, null, null, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of(), List.of("realm desired state is required"));
         }
-        if (desired.clients().isEmpty()) {
-            blockers.add("at least one OIDC client must be declared");
+
+        NormalizedRealm desiredRealm = normalize(desired);
+        NormalizedRealm currentRealm = current == null ? NormalizedRealm.empty() : normalize(current);
+        List<String> blockers = new ArrayList<>(desiredRealm.blockers);
+        List<String> warnings = new ArrayList<>(desiredRealm.warnings);
+        List<IdentityRealmDryRunReport.ChangeRecord> changes = new ArrayList<>();
+
+        validateRequiredContract(desiredRealm, blockers, warnings);
+        Set<String> unsafeFeatureMappingKeys = unsafeFeatureMappingKeys(desired, desiredRealm, blockers);
+        compareRealmBasics(currentRealm, desiredRealm, current != null, changes);
+        compareCollection("roles", currentRealm.roles, desiredRealm.roles, KNOWN_ROLES, blockers, changes);
+        compareCollection("groups", currentRealm.groups, desiredRealm.groups, KNOWN_GROUPS, blockers, changes);
+        compareCollection("scopes", currentRealm.scopes, desiredRealm.scopes, KNOWN_SCOPES, blockers, changes);
+        compareRootRedirects(currentRealm.redirectOrigins, desiredRealm.redirectOrigins, changes, warnings);
+        compareClients(currentRealm.clients, desiredRealm.clients, current != null, desiredRealm.roles, desiredRealm.scopes, blockers, changes, warnings);
+        compareClaimMappers(currentRealm.claimMappers, desiredRealm.claimMappers, current != null, changes);
+        compareFeatureMappings(currentRealm.featureMappings, desiredRealm.featureMappings, current != null, unsafeFeatureMappingKeys, blockers, changes);
+
+        changes.sort(Comparator.comparing(IdentityRealmDryRunReport.ChangeRecord::path)
+                .thenComparing(IdentityRealmDryRunReport.ChangeRecord::action)
+                .thenComparing(IdentityRealmDryRunReport.ChangeRecord::reasonCode));
+
+        boolean hasRisky = changes.stream().anyMatch(change -> "risky".equals(change.classification()));
+        boolean hasDestructive = changes.stream().anyMatch(change -> "destructive".equals(change.classification()));
+        boolean hasUnknown = blockers.stream().anyMatch(value -> value.contains("deny by default") || value.contains("unknown"));
+        if (hasDestructive) {
+            blockers.add("destructive realm changes are blocked in this dry-run-only slice");
         }
-        List<String> warnings = new ArrayList<>(safeList(desired.providerWarnings()));
-        if (desired.roles().stream().noneMatch(role -> "owner".equals(role) || "admin".equals(role))) {
-            warnings.add("owner/admin role baseline is not present in desired realm state");
-        }
-        List<String> diff = new ArrayList<>();
-        diff.add("plan realm " + safe(desired.realmId()));
-        diff.add("plan clients=" + desired.clients().size());
-        diff.add("plan roles=" + desired.roles().size());
-        diff.add("plan scopes=" + desired.scopes().size());
-        diff.add("plan claimMappers=" + desired.claimMappers().size());
-        desired.clients().stream()
-                .map(client -> "client " + safe(client.clientId()) + " redirects=" + safeList(client.redirectOrigins()))
-                .forEach(diff::add);
+
+        String readiness = readiness(distinct(blockers), hasRisky, hasDestructive, hasUnknown);
+        List<IdentityRealmDryRunReport.ReadinessCheck> checks = readinessChecks(readiness, distinct(blockers), hasRisky, hasDestructive, hasUnknown);
+        List<String> diff = deterministicDiff(desiredRealm, changes);
+        String dryRunId = "realm-dry-run-" + Integer.toHexString(String.join("\n", diff).hashCode());
+
         return new IdentityRealmDryRunReport(
                 providerKey(),
-                safe(desired.realmId()),
+                desiredRealm.realmId,
+                dryRunId,
                 "dry-run",
-                blockers.isEmpty() ? "ready-for-admin-review" : "blocked-until-realm-contract-is-complete",
+                readiness,
                 destructiveApplyAvailable(),
                 true,
                 false,
+                changes,
+                checks,
                 diff,
-                warnings,
-                blockers,
+                distinct(warnings),
+                distinct(blockers),
                 List.of(
                         "Review desired realm diff in the Admin Console boundary.",
-                        "Store provider credentials only as SecretRef values before any future gated apply.",
-                        "Keep destructive realm apply disabled until audit, rollback, and last-admin guards are proven."));
+                        "Map unknown roles, groups, scopes, and feature mappings before they can affect members.",
+                        "Store provider credentials only as SecretRef values before any future guarded apply.",
+                        "Keep provider mutation disabled until apply guards, rollback evidence, and audit are proven."),
+                List.of());
     }
 
-    private boolean blank(String value) {
-        return value == null || value.isBlank();
+    private void validateRequiredContract(NormalizedRealm desired, List<String> blockers, List<String> warnings) {
+        if (blank(desired.realmId) || "missing".equals(desired.realmId)) {
+            blockers.add("realm id is required before import planning");
+        }
+        if (desired.clients.isEmpty()) {
+            blockers.add("at least one OIDC client must be declared");
+        }
+        if (desired.roles.stream().noneMatch(role -> "owner".equals(role) || "admin".equals(role))) {
+            warnings.add("owner/admin role baseline is not present in desired realm state");
+        }
+    }
+
+    private Set<String> unsafeFeatureMappingKeys(
+            IdentityRealmDesiredState desired,
+            NormalizedRealm desiredRealm,
+            List<String> blockers) {
+        Set<String> unsafe = new LinkedHashSet<>();
+        for (IdentityRealmDesiredState.FeatureMapping mapping : desired.featureMappings()) {
+            if (mapping == null) {
+                continue;
+            }
+            String featureKey = safe(mapping.featureKey());
+            for (String role : normalizeValues(mapping.requiredRoles())) {
+                if (!KNOWN_ROLES.contains(role) || !desiredRealm.roles.contains(role)) {
+                    blockers.add("unknown feature role reference deny by default until mapped: " + featureKey + "/" + role);
+                    unsafe.add(featureKey);
+                }
+            }
+            for (String group : normalizeValues(mapping.requiredGroups())) {
+                if (!KNOWN_GROUPS.contains(group) || !desiredRealm.groups.contains(group)) {
+                    blockers.add("unknown feature group reference deny by default until mapped: " + featureKey + "/" + group);
+                    unsafe.add(featureKey);
+                }
+            }
+            for (String scope : normalizeValues(mapping.requiredScopes())) {
+                if (!KNOWN_SCOPES.contains(scope) || !desiredRealm.scopes.contains(scope)) {
+                    blockers.add("unknown feature scope reference deny by default until mapped: " + featureKey + "/" + scope);
+                    unsafe.add(featureKey);
+                }
+            }
+        }
+        return unsafe;
+    }
+
+    private void compareRealmBasics(
+            NormalizedRealm current,
+            NormalizedRealm desired,
+            boolean hasCurrent,
+            List<IdentityRealmDryRunReport.ChangeRecord> changes) {
+        change(changes, "/realm/id", hasCurrent ? current.realmId : null, desired.realmId, "realm-identifier");
+        change(changes, "/realm/displayName", hasCurrent ? current.displayName : null, desired.displayName, "realm-display-name");
+        change(changes, "/realm/enabled", hasCurrent ? String.valueOf(current.enabled) : null, String.valueOf(desired.enabled), "realm-enabled-flag");
+    }
+
+    private void compareCollection(
+            String kind,
+            List<String> current,
+            List<String> desired,
+            Set<String> known,
+            List<String> blockers,
+            List<IdentityRealmDryRunReport.ChangeRecord> changes) {
+        for (String value : desired) {
+            boolean knownValue = known.contains(value);
+            if (!knownValue) {
+                blockers.add("unknown " + kind + " deny by default until mapped: " + value);
+            }
+            if (!current.contains(value)) {
+                changes.add(new IdentityRealmDryRunReport.ChangeRecord(
+                        "/" + kind + "/" + value,
+                        "create",
+                        knownValue ? "safe" : "risky",
+                        knownValue ? "known-" + kind + "-mapping" : "unknown-" + kind + "-deny-by-default",
+                        "absent",
+                        value,
+                        knownValue ? "stable product capability mapping" : "policy-blocked until admin maps this identity input",
+                        !knownValue));
+            } else {
+                changes.add(new IdentityRealmDryRunReport.ChangeRecord(
+                        "/" + kind + "/" + value,
+                        "no-op",
+                        knownValue ? "safe" : "risky",
+                        knownValue ? "known-" + kind + "-mapping" : "unknown-" + kind + "-deny-by-default",
+                        value,
+                        value,
+                        knownValue ? "already mapped" : "policy-blocked until admin maps this identity input",
+                        !knownValue));
+            }
+        }
+        for (String value : current) {
+            if (!desired.contains(value)) {
+                changes.add(new IdentityRealmDryRunReport.ChangeRecord(
+                        "/" + kind + "/" + value,
+                        "delete",
+                        "destructive",
+                        "existing-" + kind + "-removal-blocked",
+                        value,
+                        "absent",
+                        "could remove member access or administrative recovery; blocked in dry-run slice",
+                        true));
+            }
+        }
+    }
+
+    private void compareRootRedirects(
+            List<String> current,
+            List<String> desired,
+            List<IdentityRealmDryRunReport.ChangeRecord> changes,
+            List<String> warnings) {
+        for (String redirect : desired) {
+            boolean risky = riskyRedirect(redirect);
+            if (risky) {
+                warnings.add("redirect origin requires admin review: " + redirect);
+            }
+            changes.add(changeRecord(
+                    "/redirectOrigins/" + redirect,
+                    current.contains(redirect) ? "no-op" : "create",
+                    risky ? "risky" : "safe",
+                    risky ? "redirect-origin-needs-admin-review" : "redirect-origin-support-safe",
+                    current.contains(redirect) ? redirect : "absent",
+                    redirect,
+                    "realm-level redirect allowlist remains backend-controlled",
+                    false));
+        }
+        for (String redirect : current) {
+            if (!desired.contains(redirect)) {
+                changes.add(changeRecord(
+                        "/redirectOrigins/" + redirect,
+                        "delete",
+                        "destructive",
+                        "redirect-origin-removal-blocked",
+                        redirect,
+                        "absent",
+                        "could break existing client redirects; blocked in dry-run slice",
+                        true));
+            }
+        }
+    }
+
+    private void compareClients(
+            Map<String, NormalizedClient> current,
+            Map<String, NormalizedClient> desired,
+            boolean hasCurrent,
+            List<String> declaredRoles,
+            List<String> declaredScopes,
+            List<String> blockers,
+            List<IdentityRealmDryRunReport.ChangeRecord> changes,
+            List<String> warnings) {
+        for (Map.Entry<String, NormalizedClient> entry : desired.entrySet()) {
+            String id = entry.getKey();
+            NormalizedClient desiredClient = entry.getValue();
+            NormalizedClient currentClient = current.get(id);
+            if (!hasCurrent || currentClient == null) {
+                changes.add(changeRecord("/clients/" + id, "create", "safe", "oidc-client-managed-by-control-plane", "absent", id,
+                        "members continue to use backend-owned sign-in; provider client details stay admin-only", false));
+            } else {
+                change(changes, "/clients/" + id + "/publicClient", String.valueOf(currentClient.publicClient), String.valueOf(desiredClient.publicClient), "client-public-mode");
+            }
+            compareRedirects(id, currentClient == null ? List.of() : currentClient.redirectOrigins, desiredClient.redirectOrigins, changes, warnings);
+            compareNestedClientValues(id, "roles", currentClient == null ? List.of() : currentClient.roles, desiredClient.roles, declaredRoles, KNOWN_ROLES, blockers, changes);
+            compareNestedClientValues(id, "scopes", currentClient == null ? List.of() : currentClient.scopes, desiredClient.scopes, declaredScopes, KNOWN_SCOPES, blockers, changes);
+        }
+        for (String id : current.keySet()) {
+            if (!desired.containsKey(id)) {
+                changes.add(changeRecord("/clients/" + id, "delete", "destructive", "existing-client-removal-blocked", id, "absent",
+                        "could break sign-in or session refresh for members; blocked in dry-run slice", true));
+            }
+        }
+    }
+
+    private void compareRedirects(
+            String clientId,
+            List<String> current,
+            List<String> desired,
+            List<IdentityRealmDryRunReport.ChangeRecord> changes,
+            List<String> warnings) {
+        for (String redirect : desired) {
+            boolean risky = riskyRedirect(redirect);
+            if (risky) {
+                warnings.add("redirect origin requires admin review: " + redirect);
+            }
+            String action = current.contains(redirect) ? "no-op" : "create";
+            changes.add(changeRecord(
+                    "/clients/" + clientId + "/redirectOrigins/" + redirect,
+                    action,
+                    risky ? "risky" : "safe",
+                    risky ? "redirect-origin-needs-admin-review" : "redirect-origin-support-safe",
+                    current.contains(redirect) ? redirect : "absent",
+                    redirect,
+                    "member sign-in remains backend-owned; admin must review redirect surface",
+                    false));
+        }
+        for (String redirect : current) {
+            if (!desired.contains(redirect)) {
+                changes.add(changeRecord(
+                        "/clients/" + clientId + "/redirectOrigins/" + redirect,
+                        "delete",
+                        "destructive",
+                        "redirect-origin-removal-blocked",
+                        redirect,
+                        "absent",
+                        "could break existing client redirects; blocked in dry-run slice",
+                        true));
+            }
+        }
+    }
+
+    private void compareNestedClientValues(
+            String clientId,
+            String kind,
+            List<String> current,
+            List<String> desired,
+            List<String> declaredValues,
+            Set<String> knownValues,
+            List<String> blockers,
+            List<IdentityRealmDryRunReport.ChangeRecord> changes) {
+        for (String value : desired) {
+            boolean known = knownValues.contains(value) && declaredValues.contains(value);
+            if (!known) {
+                blockers.add("unknown client " + kind + " reference deny by default until mapped: " + clientId + "/" + value);
+            }
+            changes.add(changeRecord(
+                    "/clients/" + clientId + "/" + kind + "/" + value,
+                    current.contains(value) ? "no-op" : "create",
+                    known ? "safe" : "risky",
+                    known ? "client-" + kind + "-reference" : "unknown-client-" + kind + "-deny-by-default",
+                    current.contains(value) ? value : "absent",
+                    value,
+                    known ? "client references known support-safe realm contract values" : "policy-blocked until admin maps this client identity input",
+                    !known));
+        }
+        for (String value : current) {
+            if (!desired.contains(value)) {
+                changes.add(changeRecord(
+                        "/clients/" + clientId + "/" + kind + "/" + value,
+                        "delete",
+                        "destructive",
+                        "client-" + kind + "-removal-blocked",
+                        value,
+                        "absent",
+                        "could remove client access mapping; blocked in dry-run slice",
+                        true));
+            }
+        }
+    }
+
+    private void compareClaimMappers(
+            Map<String, String> current,
+            Map<String, String> desired,
+            boolean hasCurrent,
+            List<IdentityRealmDryRunReport.ChangeRecord> changes) {
+        for (Map.Entry<String, String> entry : desired.entrySet()) {
+            change(changes, "/claimMappers/" + entry.getKey(), hasCurrent ? current.get(entry.getKey()) : null, entry.getValue(), "claim-mapper-contract");
+        }
+        for (String key : current.keySet()) {
+            if (!desired.containsKey(key)) {
+                changes.add(changeRecord("/claimMappers/" + key, "delete", "destructive", "claim-mapper-removal-blocked", current.get(key), "absent",
+                        "could remove required organization or capability claims; blocked in dry-run slice", true));
+            }
+        }
+    }
+
+    private void compareFeatureMappings(
+            Map<String, String> current,
+            Map<String, String> desired,
+            boolean hasCurrent,
+            Set<String> unsafeFeatureMappingKeys,
+            List<String> blockers,
+            List<IdentityRealmDryRunReport.ChangeRecord> changes) {
+        for (Map.Entry<String, String> entry : desired.entrySet()) {
+            boolean knownFeature = KNOWN_FEATURES.contains(entry.getKey());
+            boolean referencesKnown = !unsafeFeatureMappingKeys.contains(entry.getKey());
+            if (!knownFeature) {
+                blockers.add("unknown feature mapping deny by default until mapped: " + entry.getKey());
+            }
+            String currentValue = hasCurrent ? current.get(entry.getKey()) : null;
+            String action = currentValue == null ? "create" : Objects.equals(currentValue, entry.getValue()) ? "no-op" : "update";
+            boolean safeMapping = knownFeature && referencesKnown;
+            changes.add(changeRecord(
+                    "/featureMappings/" + entry.getKey(),
+                    action,
+                    safeMapping ? "safe" : "risky",
+                    safeMapping ? "feature-mapping-known" : "unknown-feature-mapping-deny-by-default",
+                    currentValue == null ? "absent" : currentValue,
+                    entry.getValue(),
+                    safeMapping ? "feature mapping stays within backend-owned capability policy" : "policy-blocked until admin maps this feature and its identity inputs",
+                    !safeMapping));
+        }
+        for (String key : current.keySet()) {
+            if (!desired.containsKey(key)) {
+                changes.add(changeRecord("/featureMappings/" + key, "delete", "destructive", "feature-mapping-removal-blocked", current.get(key), "absent",
+                        "could remove access to workspace features; blocked in dry-run slice", true));
+            }
+        }
+    }
+
+    private void change(List<IdentityRealmDryRunReport.ChangeRecord> changes, String path, String before, String after, String reasonCode) {
+        String safeBefore = safe(before);
+        String safeAfter = safe(after);
+        String action;
+        if (before == null) {
+            action = "create";
+        } else if (Objects.equals(safeBefore, safeAfter)) {
+            action = "no-op";
+        } else {
+            action = "update";
+        }
+        changes.add(changeRecord(path, action, "safe", reasonCode, before == null ? "absent" : safeBefore, safeAfter,
+                "support-safe control-plane metadata only", false));
+    }
+
+    private IdentityRealmDryRunReport.ChangeRecord changeRecord(
+            String path,
+            String action,
+            String classification,
+            String reasonCode,
+            String beforeValue,
+            String afterValue,
+            String memberImpact,
+            boolean applyBlocked) {
+        return new IdentityRealmDryRunReport.ChangeRecord(
+                safePath(path),
+                action,
+                classification,
+                reasonCode,
+                safe(beforeValue),
+                safe(afterValue),
+                memberImpact,
+                applyBlocked);
+    }
+
+    private List<IdentityRealmDryRunReport.ReadinessCheck> readinessChecks(
+            String readiness,
+            List<String> blockers,
+            boolean hasRisky,
+            boolean hasDestructive,
+            boolean hasUnknown) {
+        return List.of(
+                new IdentityRealmDryRunReport.ReadinessCheck(
+                        "realm-contract",
+                        blockers.isEmpty() ? "ready" : "admin-action-required",
+                        blockers.isEmpty() ? "realm-desired-state-complete" : "realm-desired-state-incomplete",
+                        blockers.isEmpty() ? "Review deterministic diff before apply." : "Resolve listed blockers and rerun dry-run."),
+                new IdentityRealmDryRunReport.ReadinessCheck(
+                        "fail-closed-policy",
+                        hasUnknown ? "admin-action-required" : "ready",
+                        hasUnknown ? "unknown-roles-groups-scopes-or-features-deny-by-default" : "known-policy-inputs",
+                        "Map unknown identity inputs explicitly before they can affect members."),
+                new IdentityRealmDryRunReport.ReadinessCheck(
+                        "apply-safety",
+                        hasDestructive ? "policy-blocked" : readiness,
+                        hasDestructive ? "destructive-apply-blocked" : hasRisky ? "risky-change-review-required" : "dry-run-only-no-mutation",
+                        "This slice never mutates Keycloak or Terraform/OpenTofu state."));
+    }
+
+    private String readiness(List<String> blockers, boolean hasRisky, boolean hasDestructive, boolean hasUnknown) {
+        if (hasDestructive) {
+            return "policy-blocked";
+        }
+        if (!blockers.isEmpty() || hasUnknown) {
+            return "admin-action-required";
+        }
+        return hasRisky ? "degraded" : "ready";
+    }
+
+    private List<String> deterministicDiff(NormalizedRealm desired, List<IdentityRealmDryRunReport.ChangeRecord> changes) {
+        List<String> diff = new ArrayList<>();
+        diff.add("plan realm=" + desired.realmId);
+        diff.add("plan displayName=" + desired.displayName);
+        diff.add("plan enabled=" + desired.enabled);
+        diff.add("plan clients=" + desired.clients.size());
+        diff.add("plan roles=" + desired.roles.size());
+        diff.add("plan groups=" + desired.groups.size());
+        diff.add("plan scopes=" + desired.scopes.size());
+        diff.add("plan claimMappers=" + desired.claimMappers.size());
+        diff.add("plan featureMappings=" + desired.featureMappings.size());
+        changes.stream()
+                .map(change -> change.action() + " " + change.path() + " classification=" + change.classification() + " blocked=" + change.applyBlocked())
+                .forEach(diff::add);
+        return diff;
+    }
+
+    private NormalizedRealm normalize(IdentityRealmDesiredState state) {
+        return new NormalizedRealm(
+                safe(state.realmId()),
+                safe(state.displayName()),
+                state.enabled() == null || state.enabled(),
+                normalizeClients(state.clients()),
+                normalizeValues(state.roles()),
+                normalizeValues(state.groups()),
+                normalizeValues(state.scopes()),
+                normalizeClaimMappers(state.claimMappers()),
+                normalizeValues(state.redirectOrigins()),
+                normalizeFeatureMappings(state.featureMappings()),
+                safeList(state.providerWarnings()),
+                safeList(state.blockers()));
+    }
+
+    private Map<String, NormalizedClient> normalizeClients(List<IdentityRealmDesiredState.RealmClient> clients) {
+        Map<String, NormalizedClient> normalized = new LinkedHashMap<>();
+        clients.stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(client -> safe(client.clientId())))
+                .forEach(client -> normalized.put(safe(client.clientId()), new NormalizedClient(
+                        safe(client.clientId()),
+                        client.publicClient(),
+                        normalizeValues(client.redirectOrigins()),
+                        normalizeValues(client.roles()),
+                        normalizeValues(client.scopes()))));
+        return normalized;
+    }
+
+    private Map<String, String> normalizeClaimMappers(List<IdentityRealmDesiredState.ClaimMapper> mappers) {
+        Map<String, String> normalized = new LinkedHashMap<>();
+        mappers.stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(mapper -> safe(mapper.name())))
+                .forEach(mapper -> normalized.put(
+                        safe(mapper.name()),
+                        String.join("->", safe(mapper.sourceClaim()), safe(mapper.targetClaim()), String.valueOf(mapper.required()))));
+        return normalized;
+    }
+
+    private Map<String, String> normalizeFeatureMappings(List<IdentityRealmDesiredState.FeatureMapping> mappings) {
+        Map<String, String> normalized = new LinkedHashMap<>();
+        mappings.stream()
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(mapping -> safe(mapping.featureKey())))
+                .forEach(mapping -> normalized.put(
+                        safe(mapping.featureKey()),
+                        "roles=" + normalizeValues(mapping.requiredRoles())
+                                + ";groups=" + normalizeValues(mapping.requiredGroups())
+                                + ";scopes=" + normalizeValues(mapping.requiredScopes())));
+        return normalized;
+    }
+
+    private List<String> normalizeValues(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(this::safe)
+                .distinct()
+                .sorted()
+                .toList();
     }
 
     private List<String> safeList(List<String> values) {
         if (values == null) {
             return List.of();
         }
-        return values.stream().map(this::safe).toList();
+        return values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(this::safe)
+                .distinct()
+                .toList();
+    }
+
+    private List<String> distinct(List<String> values) {
+        return new ArrayList<>(new LinkedHashSet<>(values));
+    }
+
+    private boolean riskyRedirect(String value) {
+        if (value == null) {
+            return false;
+        }
+        String lowered = value.toLowerCase(Locale.ROOT);
+        return lowered.contains("*") || lowered.startsWith("http://");
+    }
+
+    private boolean blank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private String safePath(String path) {
+        return safe(path).replace(" ", "-");
     }
 
     private String safe(String value) {
@@ -75,9 +583,38 @@ public class KeycloakRealmDryRunProvider implements IdentityRealmProvider {
         }
         String trimmed = value.trim();
         String lowered = trimmed.toLowerCase(Locale.ROOT);
-        if (SECRET_LIKE.matcher(lowered).find() || lowered.contains("@github.com/") || lowered.contains("x-access-token:")) {
+        if (SECRET_LIKE.matcher(lowered).find()
+                || lowered.contains("@github.com/")
+                || lowered.contains("x-access-token:")
+                || lowered.contains("-----begin")) {
             return "redacted-secret-like-value";
         }
         return trimmed;
+    }
+
+    private record NormalizedRealm(
+            String realmId,
+            String displayName,
+            boolean enabled,
+            Map<String, NormalizedClient> clients,
+            List<String> roles,
+            List<String> groups,
+            List<String> scopes,
+            Map<String, String> claimMappers,
+            List<String> redirectOrigins,
+            Map<String, String> featureMappings,
+            List<String> warnings,
+            List<String> blockers) {
+        static NormalizedRealm empty() {
+            return new NormalizedRealm("missing", "missing", true, Map.of(), List.of(), List.of(), List.of(), Map.of(), List.of(), Map.of(), List.of(), List.of());
+        }
+    }
+
+    private record NormalizedClient(
+            String clientId,
+            boolean publicClient,
+            List<String> redirectOrigins,
+            List<String> roles,
+            List<String> scopes) {
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/EffectivePolicySimulationRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/EffectivePolicySimulationRequest.java
@@ -1,0 +1,20 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Admin-only support-safe effective capability policy simulation request.")
+public record EffectivePolicySimulationRequest(
+        String subject,
+        String organizationId,
+        List<String> roles,
+        List<String> groups,
+        List<String> requestedCapabilities,
+        String reason) {
+
+    public EffectivePolicySimulationRequest {
+        roles = roles == null ? List.of() : List.copyOf(roles);
+        groups = groups == null ? List.of() : List.copyOf(groups);
+        requestedCapabilities = requestedCapabilities == null ? List.of() : List.copyOf(requestedCapabilities);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/EffectivePolicySimulationResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/EffectivePolicySimulationResponse.java
@@ -1,0 +1,39 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Support-safe effective capability policy simulation for admins/operators.")
+public record EffectivePolicySimulationResponse(
+        String subject,
+        String organizationId,
+        List<String> roles,
+        List<String> groups,
+        List<String> requestedCapabilities,
+        List<String> grantedCapabilities,
+        List<String> deniedInputs,
+        boolean unknownInputsFailClosed,
+        boolean weaverDefaultDisabled,
+        boolean supportSafe,
+        List<CapabilityState> capabilityStates,
+        List<String> nextActions,
+        List<String> auditRefs) {
+
+    public EffectivePolicySimulationResponse {
+        roles = roles == null ? List.of() : List.copyOf(roles);
+        groups = groups == null ? List.of() : List.copyOf(groups);
+        requestedCapabilities = requestedCapabilities == null ? List.of() : List.copyOf(requestedCapabilities);
+        grantedCapabilities = grantedCapabilities == null ? List.of() : List.copyOf(grantedCapabilities);
+        deniedInputs = deniedInputs == null ? List.of() : List.copyOf(deniedInputs);
+        capabilityStates = capabilityStates == null ? List.of() : List.copyOf(capabilityStates);
+        nextActions = nextActions == null ? List.of() : List.copyOf(nextActions);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+    }
+
+    public record CapabilityState(
+            String capability,
+            String state,
+            String reasonCode,
+            String memberImpact) {
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -6,12 +6,20 @@ import com.massimotter.weave.backend.audit.AuditEventPublisher;
 import com.massimotter.weave.backend.audit.AuditRedactionLevel;
 import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
 import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyReport;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyRequest;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunReport;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunRequest;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmProvider;
+import com.massimotter.weave.backend.identity.realm.KeycloakRealmDryRunProvider;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
 import com.massimotter.weave.backend.model.admin.AdminAuditEventResponse;
 import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
+import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationRequest;
+import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationResponse;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
@@ -30,11 +38,14 @@ import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import com.massimotter.weave.backend.provider.ProviderStatusResponse;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,6 +64,27 @@ public class AdminControlPlaneService {
             "disabled",
             "degraded",
             "policy-blocked");
+    private static final Set<String> SIMULATION_ROLES = Set.of("owner", "admin", "operator", "member", "guest");
+    private static final Set<String> SIMULATION_GROUPS = Set.of(
+            "weave-calendar-editors",
+            "weave-board-editors",
+            "weave-meeting-hosts",
+            "weave-document-editors",
+            "weave-decision-recorders",
+            "weave-weaver-pilot");
+    private static final Map<String, List<String>> SIMULATION_GROUP_CAPABILITIES = Map.of(
+            "weave-calendar-editors", List.of("calendar.manage_events"),
+            "weave-board-editors", List.of("boards.update_task"),
+            "weave-meeting-hosts", List.of("meetings.host"),
+            "weave-document-editors", List.of("documents.edit"),
+            "weave-decision-recorders", List.of("decisions.record"),
+            "weave-weaver-pilot", List.of("weaver.files_read", "weaver.exec_disabled"));
+    private static final Set<String> SIMULATION_KNOWN_CAPABILITIES = Set.of(
+            "chat.read", "chat.send", "files.read", "files.upload", "calendar.read", "calendar.manage_events",
+            "boards.read", "boards.update_task", "meetings.join", "meetings.host", "documents.view", "documents.edit",
+            "decisions.read", "decisions.record", "manuals.read", "manuals.admin", "release_evidence.read", "release_evidence.manage",
+            "admin_control_plane.readiness_read", "admin.policy.edit", "admin.provider.configure", "operator.support_bundle.create",
+            "weaver.enabled", "weaver.files_read", "weaver.exec_disabled");
     private static final int MAX_BOOTSTRAP_ADMIN_KEYS = 25;
     private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = MAX_PRIMARY_IDENTITY_KEY_LENGTH;
     private static final Pattern PRIMARY_IDENTITY_KEY_REGEX = Pattern.compile(PRIMARY_IDENTITY_KEY_PATTERN);
@@ -62,6 +94,7 @@ public class AdminControlPlaneService {
     private final ProviderSelectionRepository providerSelectionRepository;
     private final OrganizationBootstrapRepository organizationBootstrapRepository;
     private final AuditEventPublisher auditEventPublisher;
+    private final List<IdentityRealmProvider> identityRealmProviders;
     private final Clock clock;
 
     @Autowired
@@ -70,8 +103,9 @@ public class AdminControlPlaneService {
             WorkspaceCapabilityService workspaceCapabilityService,
             ProviderSelectionRepository providerSelectionRepository,
             OrganizationBootstrapRepository organizationBootstrapRepository,
-            AuditEventPublisher auditEventPublisher) {
-        this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher, Clock.systemUTC());
+            AuditEventPublisher auditEventPublisher,
+            List<IdentityRealmProvider> identityRealmProviders) {
+        this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher, identityRealmProviders, Clock.systemUTC());
     }
 
     AdminControlPlaneService(
@@ -81,11 +115,25 @@ public class AdminControlPlaneService {
             OrganizationBootstrapRepository organizationBootstrapRepository,
             AuditEventPublisher auditEventPublisher,
             Clock clock) {
+        this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher, List.of(new KeycloakRealmDryRunProvider()), clock);
+    }
+
+    AdminControlPlaneService(
+            ProviderRegistry providerRegistry,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            ProviderSelectionRepository providerSelectionRepository,
+            OrganizationBootstrapRepository organizationBootstrapRepository,
+            AuditEventPublisher auditEventPublisher,
+            List<IdentityRealmProvider> identityRealmProviders,
+            Clock clock) {
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
         this.providerSelectionRepository = providerSelectionRepository;
         this.organizationBootstrapRepository = organizationBootstrapRepository;
         this.auditEventPublisher = auditEventPublisher;
+        this.identityRealmProviders = identityRealmProviders == null || identityRealmProviders.isEmpty()
+                ? List.of(new KeycloakRealmDryRunProvider())
+                : List.copyOf(identityRealmProviders);
         this.clock = clock;
     }
 
@@ -116,6 +164,9 @@ public class AdminControlPlaneService {
                         "audit", "/api/admin/audit/events",
                         "readinessTest", "/api/admin/providers/readiness-tests",
                         "providerReplacementDryRun", "/api/admin/providers/replacements/dry-run",
+                        "identityRealmDryRun", "/api/admin/identity/realm/dry-run",
+                        "identityRealmApply", "/api/admin/identity/realm/apply",
+                        "effectivePolicySimulation", "/api/admin/policies/effective/simulations",
                         "providerSelections", "/api/admin/providers/selections"));
     }
 
@@ -247,6 +298,199 @@ public class AdminControlPlaneService {
     public EffectivePolicyResponse effectivePolicy(Jwt jwt) {
         workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "effective-policy");
         return workspaceCapabilityService.effectivePolicySnapshot(jwt, "organization");
+    }
+
+    public EffectivePolicySimulationResponse simulateEffectivePolicy(EffectivePolicySimulationRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "effective-policy-simulation");
+        List<String> roles = normalizedValues(request == null ? null : request.roles());
+        List<String> groups = normalizedValues(request == null ? null : request.groups());
+        List<String> requestedCapabilities = normalizedValues(request == null ? null : request.requestedCapabilities());
+        List<String> deniedInputs = Stream.concat(
+                        roles.stream()
+                                .filter(role -> !SIMULATION_ROLES.contains(role))
+                                .map(role -> "unknown-role:" + role),
+                        Stream.concat(
+                                groups.stream()
+                                        .filter(group -> !SIMULATION_GROUPS.contains(group))
+                                        .map(group -> "unknown-group:" + group),
+                                requestedCapabilities.stream()
+                                        .filter(capability -> !SIMULATION_KNOWN_CAPABILITIES.contains(capability))
+                                        .map(capability -> "unknown-capability:" + capability)))
+                .toList();
+        boolean failClosed = !deniedInputs.isEmpty();
+        LinkedHashSet<String> grants = new LinkedHashSet<>();
+        if (!failClosed) {
+            if (roles.stream().anyMatch(role -> role.equals("owner") || role.equals("admin"))) {
+                grants.addAll(List.of(
+                        "chat.read", "chat.send", "files.read", "files.upload", "calendar.read", "calendar.manage_events",
+                        "boards.read", "boards.update_task", "meetings.join", "meetings.host", "documents.view", "documents.edit",
+                        "decisions.read", "decisions.record", "manuals.read", "manuals.admin", "release_evidence.read", "release_evidence.manage",
+                        "admin_control_plane.readiness_read", "admin.policy.edit", "admin.provider.configure", "weaver.exec_disabled"));
+            }
+            if (roles.contains("operator")) {
+                grants.addAll(List.of("admin_control_plane.readiness_read", "operator.support_bundle.create", "release_evidence.read", "manuals.admin", "manuals.read", "weaver.exec_disabled"));
+            }
+            if (roles.contains("member")) {
+                grants.addAll(List.of("chat.read", "chat.send", "files.read", "files.upload", "calendar.read", "boards.read", "meetings.join", "documents.view", "decisions.read", "manuals.read", "release_evidence.read", "weaver.exec_disabled"));
+            }
+            for (String group : groups) {
+                grants.addAll(SIMULATION_GROUP_CAPABILITIES.getOrDefault(group, List.of()));
+            }
+            grants.remove("weaver.enabled");
+        }
+        List<EffectivePolicySimulationResponse.CapabilityState> capabilityStates = requestedCapabilities.stream()
+                .map(capability -> simulationState(capability, grants, failClosed))
+                .toList();
+        String auditRef = "effective-policy-simulation-" + Instant.now(clock).toEpochMilli();
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef(jwt),
+                "effective-policy-simulation",
+                AuditAction.ADMIN_POLICY_UPDATED,
+                Instant.now(clock),
+                auditRef,
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.of(
+                        "subject", safeText(request == null ? null : request.subject()),
+                        "organizationId", safeText(request == null ? null : request.organizationId()),
+                        "roleCount", roles.size(),
+                        "groupCount", groups.size(),
+                        "requestedCapabilityCount", requestedCapabilities.size(),
+                        "unknownInputsFailClosed", failClosed,
+                        "supportSafe", true,
+                        "reason", safeText(request == null ? null : request.reason()))));
+        return new EffectivePolicySimulationResponse(
+                safeText(request == null ? null : request.subject()),
+                request == null || request.organizationId() == null || request.organizationId().isBlank()
+                        ? organizationId(jwt)
+                        : safeText(request.organizationId()),
+                roles,
+                groups,
+                requestedCapabilities,
+                grants.stream().filter(requestedCapabilities::contains).sorted().toList(),
+                deniedInputs,
+                failClosed,
+                true,
+                true,
+                capabilityStates,
+                failClosed
+                        ? List.of("Map unknown roles, groups, or capabilities before provider activation.")
+                        : List.of("Review member-visible states before applying provider or realm changes."),
+                List.of(auditRef));
+    }
+
+    public IdentityRealmDryRunReport dryRunIdentityRealm(IdentityRealmDryRunRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "identity-realm", "dry-run");
+        IdentityRealmProvider provider = identityRealmProvider("keycloak-realm");
+        IdentityRealmDryRunReport report = provider.dryRun(request);
+        String auditRef = "identity-realm-dry-run-" + Instant.now(clock).toEpochMilli();
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef(jwt),
+                "identity-realm-dry-run",
+                AuditAction.PROVIDER_REPLACEMENT_DRY_RUN,
+                Instant.now(clock),
+                auditRef,
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.of(
+                        "providerKey", provider.providerKey(),
+                        "realmId", report.realmId(),
+                        "readiness", report.readiness(),
+                        "changeCount", report.changes().size(),
+                        "blockerCount", report.blockers().size(),
+                        "supportSafe", report.supportSafe(),
+                        "rawSecretExposed", report.rawSecretExposed(),
+                        "destructiveApplyAvailable", report.destructiveApplyAvailable(),
+                        "dryRunReasonPresent", request != null && request.reason() != null && !request.reason().isBlank())));
+        return new IdentityRealmDryRunReport(
+                report.providerKey(),
+                report.realmId(),
+                report.dryRunId(),
+                report.operation(),
+                report.readiness(),
+                report.destructiveApplyAvailable(),
+                report.supportSafe(),
+                report.rawSecretExposed(),
+                report.changes(),
+                report.readinessChecks(),
+                report.diff(),
+                report.warnings(),
+                report.blockers(),
+                report.nextActions(),
+                List.of(auditRef));
+    }
+
+    public IdentityRealmApplyReport applyIdentityRealm(IdentityRealmApplyRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin.provider.configure", "identity-realm", "apply");
+        IdentityRealmProvider provider = identityRealmProvider("keycloak-realm");
+        IdentityRealmDryRunReport dryRun = provider.dryRun(request == null ? null : request.dryRunRequest());
+        boolean hasRisky = dryRun.changes().stream().anyMatch(change -> "risky".equals(change.classification()));
+        boolean hasDestructive = dryRun.changes().stream().anyMatch(change -> "destructive".equals(change.classification()));
+        boolean rollbackRequired = hasRisky || hasDestructive;
+        boolean rollbackAccepted = !rollbackRequired || hasText(request == null ? null : request.rollbackEvidenceRef());
+        boolean lastAdminGuardPassed = request != null && request.retainedAdminPrimaryIdentityKeys().stream()
+                .anyMatch(this::safePrimaryIdentityKey);
+        List<String> blocked = new ArrayList<>();
+        if (request == null || !"APPLY WEAVE IDENTITY REALM".equals(request.confirmationPhrase())) {
+            blocked.add("explicit confirmation phrase is required");
+        }
+        if (!lastAdminGuardPassed) {
+            blocked.add("last-admin guard requires at least one retained immutable admin identity key");
+        }
+        if (hasRisky && (request == null || !request.approveRisky())) {
+            blocked.add("risky changes require approveRisky=true");
+        }
+        if (hasDestructive && (request == null || !request.approveDestructive())) {
+            blocked.add("destructive changes require approveDestructive=true");
+        }
+        if (hasDestructive && !provider.destructiveApplyAvailable()) {
+            blocked.add("provider destructive apply is not available for this contract");
+        }
+        if (!rollbackAccepted) {
+            blocked.add("rollback/restore evidence ref is required for risky or destructive apply");
+        }
+        blocked.addAll(dryRun.blockers());
+        boolean accepted = blocked.isEmpty();
+        String auditRef = "identity-realm-apply-" + Instant.now(clock).toEpochMilli();
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef(jwt),
+                "identity-realm-apply",
+                AuditAction.ADMIN_POLICY_UPDATED,
+                Instant.now(clock),
+                auditRef,
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.of(
+                        "providerKey", provider.providerKey(),
+                        "realmId", dryRun.realmId(),
+                        "decision", accepted ? "accepted" : "blocked",
+                        "changeCount", dryRun.changes().size(),
+                        "blockedReasonCount", blocked.size(),
+                        "lastAdminGuardPassed", lastAdminGuardPassed,
+                        "rollbackEvidenceAccepted", rollbackAccepted,
+                        "supportSafe", true,
+                        "rawSecretExposed", false)));
+        return new IdentityRealmApplyReport(
+                provider.providerKey(),
+                dryRun.realmId(),
+                dryRun.dryRunId(),
+                accepted ? "accepted" : "blocked",
+                "guarded-provider-apply-contract",
+                accepted,
+                true,
+                false,
+                lastAdminGuardPassed,
+                rollbackRequired,
+                rollbackAccepted,
+                blocked.stream().distinct().toList(),
+                dryRun.changes(),
+                accepted
+                        ? List.of("Provider adapter may now execute the guarded apply operation under operator monitoring.")
+                        : List.of("Resolve blocked reasons and re-run dry-run before applying."),
+                List.of(auditRef));
     }
 
     public CapabilityWhitelistResponse whitelist(Jwt jwt) {
@@ -420,6 +664,13 @@ public class AdminControlPlaneService {
                     .toList();
         }
         return List.of();
+    }
+
+    private IdentityRealmProvider identityRealmProvider(String providerKey) {
+        return identityRealmProviders.stream()
+                .filter(provider -> provider.providerKey().equals(providerKey))
+                .findFirst()
+                .orElseGet(KeycloakRealmDryRunProvider::new);
     }
 
     private ProviderSelection validateProviderSelection(ProviderSelectionRequest request, Jwt jwt) {
@@ -684,6 +935,61 @@ public class AdminControlPlaneService {
                         true,
                         false))
                 .toList();
+    }
+
+    private List<String> normalizedValues(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(value -> value.trim().toLowerCase(Locale.ROOT))
+                .filter(value -> value.matches("[a-z][a-z0-9_.:-]*"))
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private EffectivePolicySimulationResponse.CapabilityState simulationState(
+            String capability,
+            Set<String> grants,
+            boolean failClosed) {
+        if (failClosed) {
+            return new EffectivePolicySimulationResponse.CapabilityState(
+                    capability,
+                    "policy-blocked",
+                    "unknown-identity-inputs-fail-closed",
+                    "Admins must map unknown provider inputs before members receive this capability.");
+        }
+        if ("weaver.enabled".equals(capability)) {
+            return new EffectivePolicySimulationResponse.CapabilityState(
+                    capability,
+                    "disabled",
+                    "weaver-default-disabled",
+                    "Weaver remains opt-in, governed, audited, and disabled by default.");
+        }
+        if (grants.contains(capability)) {
+            return new EffectivePolicySimulationResponse.CapabilityState(
+                    capability,
+                    "ready",
+                    "granted-by-effective-policy",
+                    "Member-visible capability state may be ready if provider readiness also passes.");
+        }
+        return new EffectivePolicySimulationResponse.CapabilityState(
+                capability,
+                "policy-blocked",
+                "deny-by-default-capability-policy",
+                "This capability remains blocked unless a known org role or group grants it.");
+    }
+
+    private boolean safePrimaryIdentityKey(String value) {
+        return value != null
+                && value.length() <= MAX_BOOTSTRAP_ADMIN_KEY_LENGTH
+                && PRIMARY_IDENTITY_KEY_REGEX.matcher(value).matches();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     private List<String> safeCapabilities(List<String> capabilities) {

--- a/server/src/main/resources/identity/weave-realm-baseline.json
+++ b/server/src/main/resources/identity/weave-realm-baseline.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "providerFamily": "oidc-realm",
+  "dogfoodDefaultProvider": "keycloak-realm",
+  "realmId": "weave",
+  "clients": [
+    {
+      "clientId": "weave-app",
+      "publicClient": true,
+      "redirectOrigins": ["https://weave.local/callback", "weave://auth/callback"],
+      "roles": ["owner", "admin", "operator", "member", "guest"],
+      "scopes": ["openid", "profile", "email", "weave:workspace"]
+    },
+    {
+      "clientId": "weave-admin-console",
+      "publicClient": true,
+      "redirectOrigins": ["https://admin.weave.local/callback"],
+      "roles": ["owner", "admin", "operator"],
+      "scopes": ["openid", "profile", "email", "weave:workspace"]
+    }
+  ],
+  "roles": ["owner", "admin", "operator", "member", "guest"],
+  "groups": [
+    "weave-calendar-editors",
+    "weave-board-editors",
+    "weave-meeting-hosts",
+    "weave-document-editors",
+    "weave-decision-recorders",
+    "weave-weaver-pilot"
+  ],
+  "scopes": ["openid", "profile", "email", "weave:workspace"],
+  "claimMappers": [
+    {"name": "tenant", "sourceClaim": "weave_tenant", "targetClaim": "organizationId", "required": true},
+    {"name": "roles", "sourceClaim": "realm_access.roles", "targetClaim": "roles", "required": true},
+    {"name": "groups", "sourceClaim": "groups", "targetClaim": "groups", "required": false}
+  ],
+  "supportSafe": true,
+  "rawSecretsIncluded": false,
+  "notes": [
+    "Use as desired-state input for /api/admin/identity/realm/dry-run before any apply.",
+    "Client secrets and provider credentials are SecretRefs only and are deliberately absent."
+  ]
+}

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -250,9 +250,77 @@ class AdminControlPlaneControllerTest {
     }
 
     @Test
+    void adminRealmDryRunIsBackendOwnedDeterministicAndSupportSafe() throws Exception {
+        String request = """
+                {
+                  "desiredState": {
+                    "realmId": "weave-dogfood",
+                    "displayName": "Weave Dogfood",
+                    "enabled": true,
+                    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback","http://localhost:8080/*"],"roles":["admin","member"],"scopes":["openid","profile"]}],
+                    "roles": ["admin", "member"],
+                    "groups": ["weave-board-editors"],
+                    "scopes": ["openid", "profile", "weave:workspace"],
+                    "claimMappers": [{"name":"tenant","sourceClaim":"weave_tenant","targetClaim":"organizationId","required":true}],
+                    "redirectOrigins": ["http://localhost:8080/*"],
+                    "featureMappings": [{"featureKey":"boards","requiredRoles":["member"],"requiredGroups":["weave-board-editors"],"requiredScopes":["openid"]}]
+                  },
+                  "reason": "admin review before apply"
+                }
+                """;
+
+        mockMvc.perform(post("/api/admin/identity/realm/dry-run")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.providerKey").value("keycloak-realm"))
+                .andExpect(jsonPath("$.operation").value("dry-run"))
+                .andExpect(jsonPath("$.readiness").value("degraded"))
+                .andExpect(jsonPath("$.destructiveApplyAvailable").value(false))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.rawSecretExposed").value(false))
+                .andExpect(jsonPath("$.changes[*].classification", hasItems("safe", "risky")))
+                .andExpect(jsonPath("$.readinessChecks[*].state", hasItems("ready", "degraded")))
+                .andExpect(jsonPath("$.auditRefs[0]").exists())
+                .andExpect(content().string(not(containsString("server-test-secret-that-must-never-appear"))))
+                .andExpect(content().string(not(containsString("Authorization: Bearer"))))
+                .andExpect(content().string(not(containsString("access_token"))));
+
+        mockMvc.perform(get("/api/admin/audit/events").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].action", hasItems("provider.replacement.dry_run")))
+                .andExpect(jsonPath("$[*].payload.supportSafe", hasItems(true)))
+                .andExpect(jsonPath("$[*].payload.dryRunReasonPresent", hasItems(true)))
+                .andExpect(content().string(not(containsString("admin review before apply"))))
+                .andExpect(content().string(not(containsString("server-test-secret-that-must-never-appear"))));
+    }
+
+    @Test
+    void memberCannotRunRealmDryRunOrSeeProviderSetupInternals() throws Exception {
+        mockMvc.perform(post("/api/admin/identity/realm/dry-run")
+                        .with(memberJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"desiredState\":{\"realmId\":\"weave\"}}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"))
+                .andExpect(content().string(not(containsString("keycloak-realm"))))
+                .andExpect(content().string(not(containsString("client_secret"))))
+                .andExpect(content().string(not(containsString("provider setup"))));
+    }
+
+    @Test
     void operatorCanReadButCannotChangeProviderOrPolicy() throws Exception {
         mockMvc.perform(get("/api/admin/control-plane").with(operatorJwt()))
                 .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/admin/identity/realm/dry-run")
+                        .with(operatorJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"desiredState\":{\"realmId\":\"weave-dogfood\",\"clients\":[],\"roles\":[\"admin\"]}}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.operation").value("dry-run"));
 
         mockMvc.perform(patch("/api/admin/policies/capability-whitelist")
                         .with(operatorJwt())

--- a/server/src/test/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDryRunFixtureContractTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/identity/realm/IdentityRealmDryRunFixtureContractTest.java
@@ -1,0 +1,63 @@
+package com.massimotter.weave.backend.identity.realm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdentityRealmDryRunFixtureContractTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
+    private final KeycloakRealmDryRunProvider provider = new KeycloakRealmDryRunProvider();
+
+    @Test
+    void fixtureMatrixCoversNoOpCreateUpdateRiskyDestructiveAndInvalidStates() throws Exception {
+        assertFixture("no-op", "ready", List.of("no-op"), List.of());
+        assertFixture("create", "ready", List.of("create"), List.of());
+        assertFixture("update", "ready", List.of("update", "create"), List.of());
+        assertFixture("risky", "degraded", List.of("create"), List.of("risky"));
+        assertFixture("destructive", "policy-blocked", List.of("delete"), List.of("destructive"));
+        assertFixture("invalid", "admin-action-required", List.of("create"), List.of("risky"));
+    }
+
+    @Test
+    void fixtureReportsAreDeterministicAndSupportSafe() throws Exception {
+        IdentityRealmDryRunRequest request = fixture("create");
+        IdentityRealmDryRunReport first = provider.dryRun(request);
+        IdentityRealmDryRunReport second = provider.dryRun(request);
+
+        assertThat(second).usingRecursiveComparison().isEqualTo(first);
+        assertThat(first.supportSafe()).isTrue();
+        assertThat(first.rawSecretExposed()).isFalse();
+        assertThat(OBJECT_MAPPER.writeValueAsString(first))
+                .doesNotContain("client_secret", "x-access-token", "Authorization", "Bearer ", "private_key", "credentialUrl");
+    }
+
+    private void assertFixture(
+            String name,
+            String readiness,
+            List<String> expectedActions,
+            List<String> expectedClassifications) throws IOException {
+        IdentityRealmDryRunReport report = provider.dryRun(fixture(name));
+
+        assertThat(report.readiness()).isEqualTo(readiness);
+        assertThat(report.destructiveApplyAvailable()).isFalse();
+        assertThat(report.supportSafe()).isTrue();
+        assertThat(report.rawSecretExposed()).isFalse();
+        assertThat(report.changes()).extracting(IdentityRealmDryRunReport.ChangeRecord::action).containsAll(expectedActions);
+        if (!expectedClassifications.isEmpty()) {
+            assertThat(report.changes()).extracting(IdentityRealmDryRunReport.ChangeRecord::classification).containsAll(expectedClassifications);
+        }
+        assertThat(report.readinessChecks()).extracting(IdentityRealmDryRunReport.ReadinessCheck::key)
+                .contains("realm-contract", "fail-closed-policy", "apply-safety");
+    }
+
+    private IdentityRealmDryRunRequest fixture(String name) throws IOException {
+        try (var input = getClass().getResourceAsStream("/identity-realm-dry-run/" + name + ".json")) {
+            assertThat(input).as("fixture %s", name).isNotNull();
+            return OBJECT_MAPPER.readValue(input, IdentityRealmDryRunRequest.class);
+        }
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/identity/realm/KeycloakRealmDryRunProviderTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/identity/realm/KeycloakRealmDryRunProviderTest.java
@@ -11,37 +11,92 @@ class KeycloakRealmDryRunProviderTest {
 
     @Test
     void plansRealmImportWithoutEnablingDestructiveApply() {
-        IdentityRealmDesiredState desiredState = new IdentityRealmDesiredState(
-                "weave-dogfood",
-                List.of(new IdentityRealmDesiredState.RealmClient(
-                        "weave-app",
-                        true,
-                        List.of("https://weave.local/*"),
-                        List.of("owner", "admin", "member", "guest"),
-                        List.of("openid", "profile", "email"))),
-                List.of("owner", "admin", "member", "guest"),
-                List.of("openid", "profile", "email", "weave:workspace"),
-                List.of(new IdentityRealmDesiredState.ClaimMapper("tenant", "weave_tenant", "organizationId", true)),
-                List.of("https://weave.local/*"),
-                List.of(),
-                List.of());
-
-        IdentityRealmDryRunReport report = provider.dryRun(desiredState);
+        IdentityRealmDryRunReport report = provider.dryRun(new IdentityRealmDryRunRequest(null, desiredState(), "operator review"));
 
         assertThat(report.providerKey()).isEqualTo("keycloak-realm");
         assertThat(report.operation()).isEqualTo("dry-run");
-        assertThat(report.readiness()).isEqualTo("ready-for-admin-review");
+        assertThat(report.readiness()).isEqualTo("degraded");
         assertThat(report.destructiveApplyAvailable()).isFalse();
         assertThat(report.supportSafe()).isTrue();
         assertThat(report.rawSecretExposed()).isFalse();
-        assertThat(report.diff()).contains("plan realm weave-dogfood", "plan clients=1", "plan roles=4");
+        assertThat(report.diff()).contains("plan realm=weave-dogfood", "plan clients=1", "plan groups=1", "plan featureMappings=2");
+        assertThat(report.changes()).extracting(IdentityRealmDryRunReport.ChangeRecord::classification)
+                .contains("safe", "risky");
         assertThat(report.blockers()).isEmpty();
+    }
+
+    @Test
+    void reportsNoOpWhenCurrentStateAlreadyMatchesDesiredState() {
+        IdentityRealmDryRunReport report = provider.dryRun(new IdentityRealmDryRunRequest(desiredState(), desiredState(), "no-op contract"));
+
+        assertThat(report.readiness()).isEqualTo("degraded");
+        assertThat(report.changes()).allSatisfy(change -> assertThat(change.action()).isIn("no-op", "update"));
+        assertThat(report.changes()).noneMatch(IdentityRealmDryRunReport.ChangeRecord::applyBlocked);
+        assertThat(report.changes()).extracting(IdentityRealmDryRunReport.ChangeRecord::classification).contains("risky");
+    }
+
+    @Test
+    void detectsUpdatesAndDestructiveRemovalsDeterministically() {
+        IdentityRealmDesiredState current = new IdentityRealmDesiredState(
+                "weave-dogfood",
+                "Weave",
+                true,
+                List.of(new IdentityRealmDesiredState.RealmClient("weave-app", true, List.of("https://weave.local/callback", "https://old.example/callback"), List.of("admin"), List.of("openid")),
+                        new IdentityRealmDesiredState.RealmClient("legacy-app", true, List.of("https://legacy.example/callback"), List.of("member"), List.of("openid"))),
+                List.of("admin", "member", "guest"),
+                List.of("weave-board-editors"),
+                List.of("openid", "profile", "email", "offline_access"),
+                List.of(new IdentityRealmDesiredState.ClaimMapper("tenant", "weave_tenant", "organizationId", true)),
+                List.of("https://old.example/callback"),
+                List.of(new IdentityRealmDesiredState.FeatureMapping("boards", List.of("member"), List.of("weave-board-editors"), List.of("openid"))),
+                List.of(),
+                List.of());
+        IdentityRealmDryRunReport report = provider.dryRun(new IdentityRealmDryRunRequest(current, desiredState(), "compare"));
+
+        assertThat(report.readiness()).isEqualTo("policy-blocked");
+        assertThat(report.changes()).extracting(IdentityRealmDryRunReport.ChangeRecord::action).contains("update", "delete", "create");
+        assertThat(report.changes()).filteredOn(change -> change.classification().equals("destructive"))
+                .extracting(IdentityRealmDryRunReport.ChangeRecord::path)
+                .contains("/clients/legacy-app", "/scopes/offline_access");
+        assertThat(report.blockers()).contains("destructive realm changes are blocked in this dry-run-only slice");
+        assertThat(provider.dryRun(new IdentityRealmDryRunRequest(current, desiredState(), "compare")).diff()).isEqualTo(report.diff());
+    }
+
+    @Test
+    void unknownRolesGroupsScopesAndFeaturesFailClosed() {
+        IdentityRealmDesiredState desiredState = new IdentityRealmDesiredState(
+                "weave-dogfood",
+                "Weave Dogfood",
+                true,
+                List.of(new IdentityRealmDesiredState.RealmClient("weave-app", true, List.of("https://weave.local/callback"), List.of("super-admin"), List.of("openid"))),
+                List.of("owner", "super-admin"),
+                List.of("unknown-group"),
+                List.of("openid", "unknown-scope"),
+                List.of(),
+                List.of(),
+                List.of(new IdentityRealmDesiredState.FeatureMapping("unknown-feature", List.of("super-admin"), List.of("unknown-group"), List.of("unknown-scope"))),
+                List.of(),
+                List.of());
+
+        IdentityRealmDryRunReport report = provider.dryRun(new IdentityRealmDryRunRequest(null, desiredState, "fail closed"));
+
+        assertThat(report.readiness()).isEqualTo("admin-action-required");
+        assertThat(report.blockers()).contains(
+                "unknown roles deny by default until mapped: super-admin",
+                "unknown groups deny by default until mapped: unknown-group",
+                "unknown scopes deny by default until mapped: unknown-scope",
+                "unknown feature mapping deny by default until mapped: unknown-feature");
+        assertThat(report.changes()).filteredOn(IdentityRealmDryRunReport.ChangeRecord::applyBlocked)
+                .extracting(IdentityRealmDryRunReport.ChangeRecord::reasonCode)
+                .contains("unknown-roles-deny-by-default", "unknown-groups-deny-by-default", "unknown-scopes-deny-by-default", "unknown-feature-mapping-deny-by-default");
     }
 
     @Test
     void redactsSecretLikeValuesFromDryRunEvidence() {
         IdentityRealmDesiredState desiredState = new IdentityRealmDesiredState(
                 "client_secret=please-do-not-print",
+                "token leaked by downstream provider",
+                true,
                 List.of(new IdentityRealmDesiredState.RealmClient(
                         "weave-app",
                         true,
@@ -49,13 +104,15 @@ class KeycloakRealmDryRunProviderTest {
                         List.of("member"),
                         List.of("openid"))),
                 List.of("member"),
+                List.of(),
                 List.of("openid"),
                 List.of(),
                 List.of(),
-                List.of("token leaked by downstream provider"),
+                List.of(),
+                List.of("bearer abc123 appeared in provider output"),
                 List.of());
 
-        IdentityRealmDryRunReport report = provider.dryRun(desiredState);
+        IdentityRealmDryRunReport report = provider.dryRun(new IdentityRealmDryRunRequest(null, desiredState, "redaction"));
 
         assertThat(report.rawSecretExposed()).isFalse();
         assertThat(String.join("\n", report.diff())).doesNotContain("please-do-not-print", "abc123", "x-access-token");
@@ -66,19 +123,46 @@ class KeycloakRealmDryRunProviderTest {
 
     @Test
     void blocksIncompleteRealmPlans() {
-        IdentityRealmDryRunReport report = provider.dryRun(new IdentityRealmDesiredState(
+        IdentityRealmDryRunReport report = provider.dryRun(new IdentityRealmDryRunRequest(null, new IdentityRealmDesiredState(
                 "",
+                null,
+                true,
                 List.of(),
                 List.of(),
                 List.of(),
                 List.of(),
                 List.of(),
                 List.of(),
-                List.of()));
+                List.of(),
+                List.of(),
+                List.of()), "invalid"));
 
-        assertThat(report.readiness()).isEqualTo("blocked-until-realm-contract-is-complete");
+        assertThat(report.readiness()).isEqualTo("admin-action-required");
         assertThat(report.blockers())
                 .contains("realm id is required before import planning", "at least one OIDC client must be declared");
         assertThat(report.destructiveApplyAvailable()).isFalse();
+    }
+
+    private IdentityRealmDesiredState desiredState() {
+        return new IdentityRealmDesiredState(
+                "weave-dogfood",
+                "Weave Dogfood",
+                true,
+                List.of(new IdentityRealmDesiredState.RealmClient(
+                        "weave-app",
+                        true,
+                        List.of("https://weave.local/callback", "https://weave.local/*"),
+                        List.of("owner", "admin", "member", "guest"),
+                        List.of("openid", "profile", "email"))),
+                List.of("owner", "admin", "member", "guest"),
+                List.of("weave-board-editors"),
+                List.of("openid", "profile", "email", "weave:workspace"),
+                List.of(new IdentityRealmDesiredState.ClaimMapper("tenant", "weave_tenant", "organizationId", true)),
+                List.of("https://weave.local/callback"),
+                List.of(
+                        new IdentityRealmDesiredState.FeatureMapping("boards", List.of("member"), List.of("weave-board-editors"), List.of("openid")),
+                        new IdentityRealmDesiredState.FeatureMapping("weaver", List.of("admin"), List.of(), List.of("weave:workspace"))),
+                List.of(),
+                List.of());
     }
 }

--- a/server/src/test/resources/identity-realm-dry-run/create.json
+++ b/server/src/test/resources/identity-realm-dry-run/create.json
@@ -1,0 +1,15 @@
+{
+  "desiredState": {
+    "realmId": "weave-dogfood",
+    "displayName": "Weave Dogfood",
+    "enabled": true,
+    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback"],"roles":["owner","admin","member"],"scopes":["openid","profile","email"]}],
+    "roles": ["owner", "admin", "member"],
+    "groups": ["weave-board-editors"],
+    "scopes": ["openid", "profile", "email", "weave:workspace"],
+    "claimMappers": [{"name":"tenant","sourceClaim":"weave_tenant","targetClaim":"organizationId","required":true}],
+    "redirectOrigins": ["https://weave.local/callback"],
+    "featureMappings": [{"featureKey":"boards","requiredRoles":["member"],"requiredGroups":["weave-board-editors"],"requiredScopes":["openid"]}]
+  },
+  "reason": "fixture-create"
+}

--- a/server/src/test/resources/identity-realm-dry-run/destructive.json
+++ b/server/src/test/resources/identity-realm-dry-run/destructive.json
@@ -1,0 +1,27 @@
+{
+  "currentState": {
+    "realmId": "weave-dogfood",
+    "displayName": "Weave Dogfood",
+    "enabled": true,
+    "clients": [{"clientId":"legacy-app","publicClient":true,"redirectOrigins":["https://legacy.example/callback"],"roles":["admin"],"scopes":["openid"]}],
+    "roles": ["admin", "member"],
+    "groups": ["weave-board-editors"],
+    "scopes": ["openid", "profile"],
+    "claimMappers": [],
+    "redirectOrigins": ["https://legacy.example/callback"],
+    "featureMappings": []
+  },
+  "desiredState": {
+    "realmId": "weave-dogfood",
+    "displayName": "Weave Dogfood",
+    "enabled": true,
+    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback"],"roles":["admin"],"scopes":["openid"]}],
+    "roles": ["admin"],
+    "groups": [],
+    "scopes": ["openid"],
+    "claimMappers": [],
+    "redirectOrigins": ["https://weave.local/callback"],
+    "featureMappings": []
+  },
+  "reason": "fixture-destructive"
+}

--- a/server/src/test/resources/identity-realm-dry-run/invalid.json
+++ b/server/src/test/resources/identity-realm-dry-run/invalid.json
@@ -1,0 +1,15 @@
+{
+  "desiredState": {
+    "realmId": "",
+    "displayName": "Weave Dogfood",
+    "enabled": true,
+    "clients": [],
+    "roles": ["unknown-admin"],
+    "groups": ["unknown-group"],
+    "scopes": ["unknown-scope"],
+    "claimMappers": [],
+    "redirectOrigins": [],
+    "featureMappings": [{"featureKey":"unknown-feature","requiredRoles":["unknown-admin"],"requiredGroups":["unknown-group"],"requiredScopes":["unknown-scope"]}]
+  },
+  "reason": "fixture-invalid"
+}

--- a/server/src/test/resources/identity-realm-dry-run/no-op.json
+++ b/server/src/test/resources/identity-realm-dry-run/no-op.json
@@ -1,0 +1,27 @@
+{
+  "currentState": {
+    "realmId": "weave-dogfood",
+    "displayName": "Weave Dogfood",
+    "enabled": true,
+    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback"],"roles":["admin","member"],"scopes":["openid","profile"]}],
+    "roles": ["admin", "member"],
+    "groups": ["weave-board-editors"],
+    "scopes": ["openid", "profile"],
+    "claimMappers": [{"name":"tenant","sourceClaim":"weave_tenant","targetClaim":"organizationId","required":true}],
+    "redirectOrigins": ["https://weave.local/callback"],
+    "featureMappings": [{"featureKey":"boards","requiredRoles":["member"],"requiredGroups":["weave-board-editors"],"requiredScopes":["openid"]}]
+  },
+  "desiredState": {
+    "realmId": "weave-dogfood",
+    "displayName": "Weave Dogfood",
+    "enabled": true,
+    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback"],"roles":["admin","member"],"scopes":["openid","profile"]}],
+    "roles": ["admin", "member"],
+    "groups": ["weave-board-editors"],
+    "scopes": ["openid", "profile"],
+    "claimMappers": [{"name":"tenant","sourceClaim":"weave_tenant","targetClaim":"organizationId","required":true}],
+    "redirectOrigins": ["https://weave.local/callback"],
+    "featureMappings": [{"featureKey":"boards","requiredRoles":["member"],"requiredGroups":["weave-board-editors"],"requiredScopes":["openid"]}]
+  },
+  "reason": "fixture-no-op"
+}

--- a/server/src/test/resources/identity-realm-dry-run/risky.json
+++ b/server/src/test/resources/identity-realm-dry-run/risky.json
@@ -1,0 +1,15 @@
+{
+  "desiredState": {
+    "realmId": "weave-dogfood",
+    "displayName": "Weave Dogfood",
+    "enabled": true,
+    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["http://localhost:8080/*"],"roles":["admin"],"scopes":["openid"]}],
+    "roles": ["admin"],
+    "groups": [],
+    "scopes": ["openid"],
+    "claimMappers": [],
+    "redirectOrigins": ["http://localhost:8080/*"],
+    "featureMappings": []
+  },
+  "reason": "fixture-risky"
+}

--- a/server/src/test/resources/identity-realm-dry-run/update.json
+++ b/server/src/test/resources/identity-realm-dry-run/update.json
@@ -1,0 +1,27 @@
+{
+  "currentState": {
+    "realmId": "weave-dogfood",
+    "displayName": "Weave",
+    "enabled": true,
+    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback"],"roles":["admin"],"scopes":["openid"]}],
+    "roles": ["admin"],
+    "groups": [],
+    "scopes": ["openid"],
+    "claimMappers": [],
+    "redirectOrigins": ["https://weave.local/callback"],
+    "featureMappings": []
+  },
+  "desiredState": {
+    "realmId": "weave-dogfood",
+    "displayName": "Weave Dogfood",
+    "enabled": true,
+    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback"],"roles":["admin","member"],"scopes":["openid","profile"]}],
+    "roles": ["admin", "member"],
+    "groups": ["weave-board-editors"],
+    "scopes": ["openid", "profile"],
+    "claimMappers": [],
+    "redirectOrigins": ["https://weave.local/callback"],
+    "featureMappings": []
+  },
+  "reason": "fixture-update"
+}


### PR DESCRIPTION
## Summary
- implements backend-owned Keycloak realm desired-state dry-run endpoint
- adds deterministic support-safe realm diff/report model with safe/risky/destructive classifications
- fails closed for unknown roles, groups, scopes, feature mappings, and secret-like values
- adds fixture contract tests, admin controller coverage, operator docs, and support-safe evidence sample

## Evidence
- `./gradlew serverCi` ✅
- `./gradlew docsStructureCheck` ✅
- targeted server tests for `identity.realm.*` and `AdminControlPlaneControllerTest` ✅

Closes #365.
