### PR TITLE
admin: expose identity provider readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Local release notes generator for merged PR metadata grouped by release-notes labels.
 - Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
 - Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
+- Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
 
 ## Changed
 
@@ -62,6 +63,7 @@ Use this page for release-affecting changes that have merged but are not include
 - PR CI now enforces exactly one release-notes label before review/merge.
 - `make release-notes-check` now verifies release-notes label edge cases and generator fixture output.
 - Live Stack acceptance artifacts now include `release-evidence-manifest.json` with commit/run metadata, artifact list, support-safe exclusions, and the RC promotion rule.
+- Admin Console treats missing identity readiness contracts as `admin-action-required` and keeps member flows provider-neutral/fail-closed during version skew.
 
 ## Fixed
 

--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -76,6 +76,9 @@ describe('Admin Console MVP', () => {
       screen.getByRole('heading', { name: /provider categories/i }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { name: /identity provider readiness/i }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('heading', {
         name: /provider selection and readiness/i,
       }),
@@ -104,9 +107,40 @@ describe('Admin Console MVP', () => {
       screen.getByLabelText(/identity \/ idm status is ready/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/provider source of truth/i)).toBeInTheDocument();
+    expect(screen.getByText(/backend-owned facade/i)).toBeInTheDocument();
+    expect(screen.getByText(/Stable states:/i)).toHaveTextContent(
+      /admin action required/i,
+    );
     expect(
       screen.getAllByText(/policy is deny-by-default/i).length,
     ).toBeGreaterThan(0);
+  });
+
+  it('renders identity readiness as backend-owned support-safe Workspace Health cards', async () => {
+    render(<App api={mockApi()} />);
+
+    expect(
+      await screen.findByRole('heading', { name: /identity provider readiness/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/realm import readiness state is ready/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/oidc client readiness state is ready/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/roles and groups mapping state is ready/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/login readiness state is ready/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/policy readiness state is ready/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/member provider setup:/i),
+    ).toHaveTextContent(/blocked/i);
+    expect(document.body).not.toHaveTextContent(/client_secret|access_token/i);
   });
 
   it('keeps admin/provider setup separate from the member client and direct providers', async () => {
@@ -256,6 +290,11 @@ describe('Admin Console MVP', () => {
     expect(document.body).not.toHaveTextContent(
       /keycloak|nextcloud|matrix|microsoft graph|slack|teams|livekit/i,
     );
+    expect(
+      screen.queryByRole('heading', {
+        name: /identity provider readiness/i,
+      }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('heading', {
         name: /provider selection and readiness/i,

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -46,6 +46,7 @@ const stateColor: Record<
   disabled: 'default',
   degraded: 'warning',
   'policy-blocked': 'info',
+  'admin-action-required': 'warning',
   misconfigured: 'error',
   unsupported: 'error',
   not_configured: 'default',
@@ -63,6 +64,8 @@ function memberStableState(state: CapabilityState): MemberStableState {
       return 'usable';
     case 'policy-blocked':
       return 'policy-blocked';
+    case 'admin-action-required':
+      return 'degraded';
     case 'disabled':
     case 'unsupported':
     case 'not_configured':
@@ -444,6 +447,93 @@ export default function App({
                   </Stack>
                 </CardContent>
               </Card>
+
+              {canInspectReadiness ? (
+                <Card component="section" aria-labelledby="identity-readiness-heading">
+                  <CardContent>
+                    <Typography
+                      id="identity-readiness-heading"
+                      variant="h2"
+                      sx={{ fontSize: '1.35rem', mb: 2 }}
+                    >
+                      Identity provider readiness
+                    </Typography>
+                    <Alert severity="info" sx={{ mb: 2 }}>
+                      Workspace Health reads identity readiness only from the
+                      Weave backend facade. Member clients do not receive OIDC
+                      URLs, client ids, realm internals, raw provider errors, or
+                      credentials.
+                    </Alert>
+                    <Stack spacing={1}>
+                      <Typography>
+                        Contract:{' '}
+                        <code>
+                          {controlPlane.identityProviderReadiness.contractVersion}
+                        </code>
+                        ; overall state:{' '}
+                        <strong>
+                          {readableState(
+                            controlPlane.identityProviderReadiness.overallState,
+                          )}
+                        </strong>
+                        ; backend-owned facade:{' '}
+                        <strong>
+                          {controlPlane.identityProviderReadiness.backendOwnedFacade
+                            ? 'yes'
+                            : 'no'}
+                        </strong>
+                        ; member provider setup:{' '}
+                        <strong>
+                          {controlPlane.identityProviderReadiness
+                            .memberClientMayConfigureIdentityProvider
+                            ? 'allowed'
+                            : 'blocked'}
+                        </strong>
+                        .
+                      </Typography>
+                      <Typography>
+                        Stable states:{' '}
+                        {controlPlane.identityProviderReadiness.stableStates
+                          .map(readableState)
+                          .join(', ')}
+                      </Typography>
+                    </Stack>
+                    <Stack spacing={2} sx={{ mt: 2 }}>
+                      {controlPlane.identityProviderReadiness.cards.map((card) => (
+                        <Card key={card.key} variant="outlined">
+                          <CardContent>
+                            <Stack spacing={1}>
+                              <Typography variant="h3" sx={{ fontSize: '1.05rem' }}>
+                                {card.label}
+                              </Typography>
+                              <Chip
+                                color={stateColor[card.state]}
+                                label={`State: ${readableState(card.state)}`}
+                                aria-label={`${card.label} state is ${readableState(card.state)}`}
+                              />
+                              <Typography>{card.summary}</Typography>
+                              <Typography>
+                                Member impact: {card.memberImpact}.
+                              </Typography>
+                              <Typography>Remediation: {card.remediation}</Typography>
+                              <Typography>
+                                Next actions:{' '}
+                                {card.nextActions.join('; ') ||
+                                  'No action reported by backend.'}
+                              </Typography>
+                              <Typography>
+                                Evidence refs:{' '}
+                                {card.evidenceRefs.join(', ') ||
+                                  'support-safe backend evidence'}
+                              </Typography>
+                            </Stack>
+                          </CardContent>
+                        </Card>
+                      ))}
+                    </Stack>
+                  </CardContent>
+                </Card>
+              ) : null}
 
               <Card
                 component="section"

--- a/admin-console/src/api.test.ts
+++ b/admin-console/src/api.test.ts
@@ -8,8 +8,40 @@ describe('AdminControlPlaneApi provider boundary', () => {
     const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
       calls.push(String(input));
       const path = String(input);
-      const body = path.includes('/replacements/dry-run')
+      const body = path.includes('/identity/readiness')
         ? {
+            contractVersion: 'identity-provider-readiness-v1',
+            category: 'identity-idm',
+            providerKey: 'keycloak-realm',
+            overallState: 'admin-action-required',
+            supportSafe: true,
+            providerDiagnosticsRedacted: true,
+            backendOwnedFacade: true,
+            memberClientMayConfigureIdentityProvider: false,
+            optionalForMemberFlows: true,
+            stableStates: [
+              'ready',
+              'degraded',
+              'policy-blocked',
+              'admin-action-required',
+              'disabled',
+            ],
+            cards: [
+              {
+                key: 'realm-import',
+                label: 'Realm import readiness',
+                state: 'admin-action-required',
+                summary: 'Select an identity provider mapping.',
+                memberImpact: 'degraded',
+                remediation: 'Run backend realm dry-run.',
+                nextActions: ['Run dry-run'],
+                evidenceRefs: ['identity-realm-dry-run'],
+              },
+            ],
+            nextActions: ['Resolve admin-action-required cards'],
+          }
+        : path.includes('/replacements/dry-run')
+          ? {
             status: 'dry_run_ready',
             category: 'chat',
             currentAdapter: 'synapse-homeserver',
@@ -56,9 +88,13 @@ describe('AdminControlPlaneApi provider boundary', () => {
     };
 
     await api.selectProvider('chat', 'slack');
+    const identityReadiness = await api.getIdentityProviderReadiness();
     await api.testProviderReadiness('slack');
     const report = await api.dryRunProviderReplacement(category, 'slack');
 
+    expect(identityReadiness.overallState).toBe('admin-action-required');
+    expect(identityReadiness.memberClientMayConfigureIdentityProvider).toBe(false);
+    expect(identityReadiness.cards[0]?.memberImpact).toBe('degraded');
     expect(report.supportSafe).toBe(true);
     expect(report.memberImpactStates).toEqual([
       'usable',
@@ -68,6 +104,7 @@ describe('AdminControlPlaneApi provider boundary', () => {
     ]);
     expect(calls).toEqual([
       'https://api.example.invalid/api/admin/providers/selections',
+      'https://api.example.invalid/api/admin/identity/readiness',
       'https://api.example.invalid/api/admin/providers/readiness-tests',
       'https://api.example.invalid/api/admin/providers/replacements/dry-run',
     ]);

--- a/admin-console/src/api.test.ts
+++ b/admin-console/src/api.test.ts
@@ -112,4 +112,45 @@ describe('AdminControlPlaneApi provider boundary', () => {
       /slack\.com|graph\.microsoft\.com|nextcloud|matrix|livekit/i,
     );
   });
+
+  it('fails closed when older backends omit the optional identity readiness contract', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      const body = path.includes('/audit/events')
+        ? []
+        : {
+            organizationId: 'weave-dogfood',
+            categories: [],
+            whitelist: { denyByDefault: true },
+          };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const api = new AdminControlPlaneApi(
+      {
+        apiBaseUrl: 'https://api.example.invalid/api',
+        oidcIssuerUrl: 'https://auth.example.invalid',
+        oidcClientId: 'weave-admin-console',
+      },
+      fetchImpl as typeof fetch,
+    );
+
+    const controlPlane = await api.getControlPlane();
+
+    expect(controlPlane.identityProviderReadiness.overallState).toBe(
+      'admin-action-required',
+    );
+    expect(controlPlane.identityProviderReadiness.cards[0]).toEqual(
+      expect.objectContaining({
+        key: 'identity-readiness-contract-missing',
+        state: 'admin-action-required',
+        memberImpact: 'degraded',
+      }),
+    );
+    expect(controlPlane.identityProviderReadiness.nextActions).toContain(
+      'Treat missing identity readiness as admin-action-required and fail closed.',
+    );
+  });
 });

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -3,6 +3,7 @@ export type CapabilityState =
   | 'disabled'
   | 'degraded'
   | 'policy-blocked'
+  | 'admin-action-required'
   | 'misconfigured'
   | 'unsupported'
   | 'not_configured'
@@ -21,6 +22,32 @@ export interface ProviderCategory {
   providerCandidates: string[];
   lastCheckedAt?: string;
   secretRefs: string[];
+}
+
+export interface IdentityProviderReadinessCard {
+  key: string;
+  label: string;
+  state: CapabilityState;
+  summary: string;
+  memberImpact: 'ready' | 'disabled' | 'degraded' | 'policy-blocked';
+  remediation: string;
+  nextActions: string[];
+  evidenceRefs: string[];
+}
+
+export interface IdentityProviderReadiness {
+  contractVersion: string;
+  category: string;
+  providerKey: string;
+  overallState: CapabilityState;
+  supportSafe: boolean;
+  providerDiagnosticsRedacted: boolean;
+  backendOwnedFacade: boolean;
+  memberClientMayConfigureIdentityProvider: boolean;
+  optionalForMemberFlows: boolean;
+  stableStates: CapabilityState[];
+  cards: IdentityProviderReadinessCard[];
+  nextActions: string[];
 }
 
 export interface WhitelistPolicy {
@@ -97,6 +124,7 @@ export interface ControlPlaneResponse {
   providerConfigSource: string;
   bootstrapDefaultsAreSuggestionsOnly: boolean;
   providerCategories: ProviderCategory[];
+  identityProviderReadiness: IdentityProviderReadiness;
   whitelistPolicy: WhitelistPolicy;
   auditEvents: AuditEvent[];
 }
@@ -152,7 +180,32 @@ interface ServerControlPlaneResponse {
     secretRef?: string;
   }>;
   whitelist?: ServerWhitelistPolicy;
+  identityProviderReadiness?: ServerIdentityProviderReadiness;
   secretRefs?: Array<{ ref?: string; providerKey?: string }>;
+}
+
+interface ServerIdentityProviderReadiness {
+  contractVersion?: string;
+  category?: string;
+  providerKey?: string;
+  overallState?: string;
+  supportSafe?: boolean;
+  providerDiagnosticsRedacted?: boolean;
+  backendOwnedFacade?: boolean;
+  memberClientMayConfigureIdentityProvider?: boolean;
+  optionalForMemberFlows?: boolean;
+  stableStates?: string[];
+  cards?: Array<{
+    key?: string;
+    label?: string;
+    state?: string;
+    summary?: string;
+    memberImpact?: string;
+    remediation?: string;
+    nextActions?: string[];
+    evidenceRefs?: string[];
+  }>;
+  nextActions?: string[];
 }
 
 interface ServerProviderCategory {
@@ -269,6 +322,13 @@ export class AdminControlPlaneApi {
     );
   }
 
+  async getIdentityProviderReadiness(): Promise<IdentityProviderReadiness> {
+    const response = await this.request<ServerIdentityProviderReadiness>(
+      '/admin/identity/readiness',
+    );
+    return normalizeIdentityProviderReadiness(response);
+  }
+
   async testProviderReadiness(
     providerKey: string,
   ): Promise<{ providerKey: string; state: CapabilityState; summary: string }> {
@@ -350,8 +410,74 @@ function normalizeControlPlane(
         controlPlane.generatedAt,
       ),
     ),
+    identityProviderReadiness: normalizeIdentityProviderReadiness(
+      controlPlane.identityProviderReadiness,
+    ),
     whitelistPolicy: normalizeWhitelist(controlPlane.whitelist),
     auditEvents,
+  };
+}
+
+function normalizeIdentityProviderReadiness(
+  readiness?: ServerIdentityProviderReadiness,
+): IdentityProviderReadiness {
+  const cards = (readiness?.cards ?? []).map((card) => ({
+    key: card.key ?? 'identity-readiness-card',
+    label: card.label ?? 'Identity provider readiness',
+    state: normalizeState(card.state),
+    summary:
+      card.summary ??
+      'Identity readiness is provided by the backend control-plane facade.',
+    memberImpact: normalizeIdentityMemberImpact(card.memberImpact),
+    remediation:
+      card.remediation ??
+      'Run the backend readiness contract and resolve admin-action-required items.',
+    nextActions: card.nextActions ?? [],
+    evidenceRefs: card.evidenceRefs ?? [],
+  }));
+  const versionSkewCards = [
+    {
+      key: 'identity-readiness-contract-missing',
+      label: 'Identity readiness contract missing',
+      state: 'admin-action-required' as CapabilityState,
+      summary:
+        'The backend did not return identity readiness details; Admin Console fails closed during version skew.',
+      memberImpact: 'degraded' as const,
+      remediation:
+        'Upgrade or restart the backend control-plane facade, then run the identity readiness check again.',
+      nextActions: [
+        'Verify GET /api/admin/identity/readiness on the backend',
+        'Keep member provider setup blocked until readiness evidence exists',
+      ],
+      evidenceRefs: ['version-skew-fail-closed'],
+    },
+  ];
+  return {
+    contractVersion:
+      readiness?.contractVersion ?? 'identity-provider-readiness-v1',
+    category: readiness?.category ?? 'identity-idm',
+    providerKey: readiness?.providerKey ?? 'awaiting_admin_selection',
+    overallState: normalizeState(
+      readiness?.overallState ?? 'admin-action-required',
+    ),
+    supportSafe: readiness?.supportSafe ?? true,
+    providerDiagnosticsRedacted:
+      readiness?.providerDiagnosticsRedacted ?? true,
+    backendOwnedFacade: readiness?.backendOwnedFacade ?? true,
+    memberClientMayConfigureIdentityProvider:
+      readiness?.memberClientMayConfigureIdentityProvider ?? false,
+    optionalForMemberFlows: readiness?.optionalForMemberFlows ?? true,
+    stableStates: (readiness?.stableStates ?? [
+      'ready',
+      'degraded',
+      'policy-blocked',
+      'admin-action-required',
+      'disabled',
+    ]).map(normalizeState),
+    cards: cards.length > 0 ? cards : versionSkewCards,
+    nextActions: readiness?.nextActions ?? [
+      'Treat missing identity readiness as admin-action-required and fail closed.',
+    ],
   };
 }
 
@@ -459,6 +585,24 @@ function normalizeProviderReplacementDryRun(
   };
 }
 
+function normalizeIdentityMemberImpact(
+  value?: string,
+): 'ready' | 'disabled' | 'degraded' | 'policy-blocked' {
+  switch (value) {
+    case 'ready':
+    case 'disabled':
+    case 'degraded':
+    case 'policy-blocked':
+      return value;
+    case 'policy_blocked':
+      return 'policy-blocked';
+    case 'usable':
+      return 'ready';
+    default:
+      return 'degraded';
+  }
+}
+
 function normalizeMemberImpactStates(
   values?: string[],
 ): Array<'usable' | 'disabled' | 'degraded' | 'policy-blocked'> {
@@ -489,6 +633,9 @@ function normalizeState(value?: string): CapabilityState {
     case 'policy_blocked':
     case 'policy-blocked':
       return 'policy-blocked';
+    case 'admin_action_required':
+    case 'admin-action-required':
+      return 'admin-action-required';
     default:
       return 'degraded';
   }
@@ -660,6 +807,82 @@ export const sampleControlPlane: ControlPlaneResponse = {
       secretRefs: [],
     },
   ],
+  identityProviderReadiness: {
+    contractVersion: 'identity-provider-readiness-v1',
+    category: 'identity-idm',
+    providerKey: 'keycloak-realm',
+    overallState: 'ready',
+    supportSafe: true,
+    providerDiagnosticsRedacted: true,
+    backendOwnedFacade: true,
+    memberClientMayConfigureIdentityProvider: false,
+    optionalForMemberFlows: true,
+    stableStates: [
+      'ready',
+      'degraded',
+      'policy-blocked',
+      'admin-action-required',
+      'disabled',
+    ],
+    cards: [
+      {
+        key: 'realm-import',
+        label: 'Realm import readiness',
+        state: 'ready',
+        summary:
+          'Backend dry-run evidence confirms realm desired-state readiness without exposing realm internals.',
+        memberImpact: 'ready',
+        remediation: 'Run the realm dry-run again before apply if drift is suspected.',
+        nextActions: ['Run /api/admin/identity/realm/dry-run before apply'],
+        evidenceRefs: ['identity-realm-dry-run'],
+      },
+      {
+        key: 'oidc-client-readiness',
+        label: 'OIDC client readiness',
+        state: 'ready',
+        summary:
+          'OIDC client readiness is summarized by backend contracts; client identifiers are redacted from support views.',
+        memberImpact: 'ready',
+        remediation: 'Keep client secrets as SecretRef handles only.',
+        nextActions: ['Validate client scopes through backend dry-run output'],
+        evidenceRefs: ['identity-client-contract'],
+      },
+      {
+        key: 'roles-groups-mapping',
+        label: 'Roles and groups mapping',
+        state: 'ready',
+        summary:
+          'Roles and groups map into canonical Weave capability profiles with deny-by-default fallback.',
+        memberImpact: 'ready',
+        remediation: 'Map unknown roles/groups before activation.',
+        nextActions: ['Review effective policy simulation'],
+        evidenceRefs: ['effective-policy-simulation'],
+      },
+      {
+        key: 'login-readiness',
+        label: 'Login readiness',
+        state: 'ready',
+        summary:
+          'Member login is exposed only as product-level availability; provider endpoints stay backend-owned.',
+        memberImpact: 'ready',
+        remediation: 'Keep member sign-in fail-closed until readiness evidence exists.',
+        nextActions: ['Verify member clients expose only stable capability states'],
+        evidenceRefs: ['member-boundary'],
+      },
+      {
+        key: 'policy-readiness',
+        label: 'Policy readiness',
+        state: 'ready',
+        summary:
+          'Capability policy gates identity claims before product access.',
+        memberImpact: 'ready',
+        remediation: 'Retain deny-by-default and last-admin recovery capabilities.',
+        nextActions: ['Review policy simulation before realm apply'],
+        evidenceRefs: ['capability-whitelist'],
+      },
+    ],
+    nextActions: ['Monitor audit/readiness transitions and keep support bundles redacted.'],
+  },
   whitelistPolicy: {
     denyByDefault: true,
     allowedCapabilities: ['chat.read', 'files.read'],

--- a/client/test/architecture/member_client_provider_boundary_contract_test.dart
+++ b/client/test/architecture/member_client_provider_boundary_contract_test.dart
@@ -14,6 +14,8 @@ void main() {
 
       final forbiddenFragments = <String>[
         '/admin/control-plane',
+        '/admin/identity/readiness',
+        '/identity/readiness',
         '/admin/providers',
         '/admin/policies',
         '/admin/audit',

--- a/docs/admin-operator-handbook.md
+++ b/docs/admin-operator-handbook.md
@@ -52,6 +52,20 @@ The desired-state contract covers realm basics, OIDC clients, roles, groups, sco
 
 Evidence must stay support-safe: no raw provider bodies, provider-internal IDs, credential-bearing URLs, private keys, tokens, or SecretRef payloads. A sanitized sample is checked in at `docs/evidence/identity-realm-dry-run-sample.json`; contract fixtures live under `server/src/test/resources/identity-realm-dry-run/`.
 
+## Identity provider readiness in Workspace Health
+
+Workspace Health reads identity/provider readiness from backend-owned facades only. Use `GET /api/admin/identity/readiness` or the embedded `identityProviderReadiness` block on `GET /api/admin/control-plane`; normal members must not call these admin endpoints.
+
+The identity readiness contract is optional/version-skew safe: if an older backend omits it, Admin Console treats identity readiness as `admin-action-required` and fails closed rather than enabling member provider setup. Stable admin states are:
+
+- `ready`;
+- `degraded`;
+- `policy-blocked`;
+- `admin-action-required`;
+- `disabled`.
+
+Workspace Health currently renders five operator cards: realm import, OIDC client readiness, roles/groups mapping, login readiness, and policy readiness. Each card must include support-safe remediation and next actions. Do not include OIDC issuer URLs, client IDs, redirect URIs, realm internals, raw provider errors, credentials, tokens, or service endpoints in these cards. Member clients only see product-level capability states (`ready`, `disabled`, `degraded`, or `policy-blocked`) and never provider setup controls.
+
 ## Whitelisting and policies
 
 Weave policy is deny-by-default. Capability profiles should use category-level permissions before low-level adapter details, for example:
@@ -66,7 +80,7 @@ Whitelists restrict which providers, adapters, tools, and later Weaver capabilit
 
 ## Readiness and audit
 
-Readiness states must be support-safe and action-oriented. Member contracts encode `ready`, `disabled`, `degraded`, or `policy-blocked`; admin/operator views may additionally show `admin-setup-required`, `misconfigured`, `sync-pending`, `conflict-quarantined`, `migration-dry-run-required`, or `unsupported`. They must not expose raw downstream bodies, provider-internal IDs, credential-bearing URLs, tokens, cookies, or private keys.
+Readiness states must be support-safe and action-oriented. Member contracts encode `ready`, `disabled`, `degraded`, or `policy-blocked`; admin/operator identity readiness uses `ready`, `degraded`, `policy-blocked`, `admin-action-required`, or `disabled`. Other admin/operator provider views may additionally show `misconfigured`, `sync-pending`, `conflict-quarantined`, `migration-dry-run-required`, or `unsupported`. They must not expose raw downstream bodies, provider-internal IDs, credential-bearing URLs, tokens, cookies, or private keys.
 
 Workspace/Admin Health is the operator control plane for this posture. The client readiness cockpit summarizes overall posture, category health, support-safe evidence, member/admin boundaries, and the next operator action from backend-owned readiness snapshots. Category rows should state member impact and policy state without leaking provider internals; provider adapter evidence remains admin-only.
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -10,6 +10,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Local release notes generator for merged PR metadata grouped by release-notes labels.
 - Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
 - Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
+- Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
 
 ## Changed
 
@@ -19,6 +20,7 @@ Use this page for release-affecting changes that have merged but are not include
 - PR CI now enforces exactly one release-notes label before review/merge.
 - `make release-notes-check` now verifies release-notes label edge cases and generator fixture output.
 - Live Stack acceptance artifacts now include `release-evidence-manifest.json` with commit/run metadata, artifact list, support-safe exclusions, and the RC promotion rule.
+- Admin Console treats missing identity readiness contracts as `admin-action-required` and keeps member flows provider-neutral/fail-closed during version skew.
 
 ## Fixed
 

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -12,6 +12,7 @@ import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateReques
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
 import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationResponse;
+import com.massimotter.weave.backend.model.admin.IdentityProviderReadinessResponse;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
@@ -92,6 +93,15 @@ public class AdminControlPlaneController {
             @Valid @RequestBody EffectivePolicySimulationRequest request,
             @AuthenticationPrincipal Jwt jwt) {
         return adminControlPlaneService.simulateEffectivePolicy(request, jwt);
+    }
+
+    @GetMapping({"/api/admin/identity/readiness", "/api/v1/admin/identity/readiness"})
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
+    @Operation(summary = "Read support-safe identity provider readiness for Workspace Health")
+    @ApiResponse(responseCode = "200", description = "Backend-owned identity provider readiness facade.",
+            content = @Content(schema = @Schema(implementation = IdentityProviderReadinessResponse.class)))
+    public IdentityProviderReadinessResponse identityProviderReadiness(@AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.identityProviderReadiness(jwt);
     }
 
     @PostMapping({"/api/admin/identity/realm/dry-run", "/api/v1/admin/identity/realm/dry-run"})

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
@@ -22,6 +22,7 @@ public record AdminControlPlaneResponse(
         List<ProviderCategoryStatusResponse> categories,
         List<ProviderSelectionResponse> selectedProviderMappings,
         CapabilityWhitelistResponse whitelist,
+        IdentityProviderReadinessResponse identityProviderReadiness,
         List<SecretRefResponse> secretRefs,
         Map<String, String> adminApiRoutes) {
     public AdminControlPlaneResponse {

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/IdentityProviderReadinessCardResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/IdentityProviderReadinessCardResponse.java
@@ -1,0 +1,48 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "One support-safe identity provider readiness card for Workspace Health/Admin Console.")
+public record IdentityProviderReadinessCardResponse(
+        @Schema(description = "Stable card key owned by the backend readiness facade.") String key,
+        @Schema(description = "Accessibility-friendly card label.") String label,
+        @Schema(description = "Stable support-safe state: ready, degraded, policy-blocked, admin-action-required, or disabled.") String state,
+        @Schema(description = "Support-safe operator summary with no provider internals or raw downstream payloads.") String summary,
+        @Schema(description = "Member impact expressed as product-level state only.") String memberImpact,
+        @Schema(description = "Immediate operator remediation copy.") String remediation,
+        @Schema(description = "Concrete next operator/admin actions.") List<String> nextActions,
+        @Schema(description = "Support-safe evidence refs/codes only; no URLs, client ids, realm internals, secrets, or raw provider errors.") List<String> evidenceRefs,
+        @Schema(description = "Support-safe diagnostics booleans/counts/contract keys only.") Map<String, Object> diagnostics) {
+    public IdentityProviderReadinessCardResponse {
+        key = requireText(key, "key");
+        label = requireText(label, "label");
+        state = normalizeState(state);
+        summary = requireText(summary, "summary");
+        memberImpact = requireText(memberImpact, "memberImpact");
+        remediation = requireText(remediation, "remediation");
+        nextActions = nextActions == null ? List.of() : List.copyOf(nextActions);
+        evidenceRefs = evidenceRefs == null ? List.of() : List.copyOf(evidenceRefs);
+        diagnostics = diagnostics == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(diagnostics));
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    private static String normalizeState(String value) {
+        if (value == null || value.isBlank()) {
+            return "admin-action-required";
+        }
+        String normalized = value.trim().replace('_', '-');
+        return switch (normalized) {
+            case "ready", "degraded", "policy-blocked", "admin-action-required", "disabled" -> normalized;
+            default -> "admin-action-required";
+        };
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/IdentityProviderReadinessResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/IdentityProviderReadinessResponse.java
@@ -1,0 +1,54 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Backend-owned, support-safe identity provider readiness facade for Workspace Health/Admin Console.")
+public record IdentityProviderReadinessResponse(
+        String contractVersion,
+        String category,
+        String providerKey,
+        String overallState,
+        boolean supportSafe,
+        boolean providerDiagnosticsRedacted,
+        boolean backendOwnedFacade,
+        boolean memberClientMayConfigureIdentityProvider,
+        boolean optionalForMemberFlows,
+        Instant generatedAt,
+        List<String> stableStates,
+        List<IdentityProviderReadinessCardResponse> cards,
+        List<String> nextActions,
+        Map<String, String> adminApiRoutes,
+        Map<String, Object> diagnostics) {
+    public IdentityProviderReadinessResponse {
+        contractVersion = contractVersion == null || contractVersion.isBlank()
+                ? "identity-provider-readiness-v1"
+                : contractVersion.trim();
+        category = category == null || category.isBlank() ? "identity-idm" : category.trim();
+        providerKey = providerKey == null || providerKey.isBlank() ? "awaiting_admin_selection" : providerKey.trim();
+        overallState = normalizeState(overallState);
+        supportSafe = supportSafe && providerDiagnosticsRedacted && backendOwnedFacade && !memberClientMayConfigureIdentityProvider;
+        generatedAt = generatedAt == null ? Instant.EPOCH : generatedAt;
+        stableStates = stableStates == null || stableStates.isEmpty()
+                ? List.of("ready", "degraded", "policy-blocked", "admin-action-required", "disabled")
+                : List.copyOf(stableStates.stream().map(IdentityProviderReadinessResponse::normalizeState).distinct().toList());
+        cards = cards == null ? List.of() : List.copyOf(cards);
+        nextActions = nextActions == null ? List.of() : List.copyOf(nextActions);
+        adminApiRoutes = adminApiRoutes == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(adminApiRoutes));
+        diagnostics = diagnostics == null ? Map.of() : Map.copyOf(new LinkedHashMap<>(diagnostics));
+    }
+
+    private static String normalizeState(String value) {
+        if (value == null || value.isBlank()) {
+            return "admin-action-required";
+        }
+        String normalized = value.trim().replace('_', '-');
+        return switch (normalized) {
+            case "ready", "degraded", "policy-blocked", "admin-action-required", "disabled" -> normalized;
+            default -> "admin-action-required";
+        };
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -20,6 +20,8 @@ import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateReques
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
 import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationResponse;
+import com.massimotter.weave.backend.model.admin.IdentityProviderReadinessCardResponse;
+import com.massimotter.weave.backend.model.admin.IdentityProviderReadinessResponse;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
@@ -32,9 +34,11 @@ import com.massimotter.weave.backend.model.admin.SecretRefResponse;
 import com.massimotter.weave.backend.provider.ProviderCapabilityContracts;
 import com.massimotter.weave.backend.provider.ProviderCategoryCatalog;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderModule;
 import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
 import com.massimotter.weave.backend.provider.ProviderSelection;
 import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.provider.ProviderState;
 import com.massimotter.weave.backend.provider.ProviderStatusResponse;
 import java.time.Clock;
 import java.time.Instant;
@@ -157,6 +161,7 @@ public class AdminControlPlaneService {
                         .map(selection -> toSelectionResponse(selection, false, readinessFor(selection.category(), registry)))
                         .toList(),
                 whitelist(jwt),
+                identityProviderReadiness(registry, jwt),
                 secretRefs(registry),
                 Map.of(
                         "providers", "/api/providers/status",
@@ -164,10 +169,16 @@ public class AdminControlPlaneService {
                         "audit", "/api/admin/audit/events",
                         "readinessTest", "/api/admin/providers/readiness-tests",
                         "providerReplacementDryRun", "/api/admin/providers/replacements/dry-run",
+                        "identityReadiness", "/api/admin/identity/readiness",
                         "identityRealmDryRun", "/api/admin/identity/realm/dry-run",
                         "identityRealmApply", "/api/admin/identity/realm/apply",
                         "effectivePolicySimulation", "/api/admin/policies/effective/simulations",
                         "providerSelections", "/api/admin/providers/selections"));
+    }
+
+    public IdentityProviderReadinessResponse identityProviderReadiness(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "identity-provider", "readiness");
+        return identityProviderReadiness(providerRegistry.status(), jwt);
     }
 
     public ProviderSelectionResponse selectProvider(ProviderSelectionRequest request, Jwt jwt) {
@@ -664,6 +675,192 @@ public class AdminControlPlaneService {
                     .toList();
         }
         return List.of();
+    }
+
+    private IdentityProviderReadinessResponse identityProviderReadiness(ProviderRegistryResponse registry, Jwt jwt) {
+        var identityCategory = registry.categories().stream()
+                .filter(category -> "identity-idm".equals(category.category()))
+                .findFirst();
+        ProviderStatusResponse identityProvider = registry.providers().stream()
+                .filter(provider -> provider.module() == ProviderModule.IDENTITY_REALM)
+                .findFirst()
+                .orElse(null);
+        boolean selectedByAdmin = identityCategory.map(category -> category.selectedByAdmin()).orElse(false);
+        boolean configured = identityProvider != null && identityProvider.configured();
+        boolean enabled = identityProvider != null && identityProvider.enabled();
+        boolean failClosed = identityProvider == null || identityProvider.failClosed();
+        boolean supportSafe = identityProvider == null || identityProvider.supportSafe();
+        String providerKey = identityCategory.map(category -> category.selectedProviderKey())
+                .filter(value -> value != null && !value.isBlank())
+                .orElse(identityProvider == null ? "awaiting_admin_selection" : identityProvider.providerKey());
+        CapabilityWhitelistResponse whitelist = whitelist(jwt);
+
+        List<IdentityProviderReadinessCardResponse> cards = List.of(
+                readinessCard(
+                        "realm-import",
+                        "Realm import readiness",
+                        !selectedByAdmin ? "admin-action-required" : configured ? "ready" : "admin-action-required",
+                        selectedByAdmin
+                                ? "Identity realm is selected in the backend control plane; import/apply evidence is evaluated by backend dry-run contracts."
+                                : "Identity realm provider mapping has not been selected by an admin.",
+                        selectedByAdmin && configured ? "ready" : "degraded",
+                        selectedByAdmin
+                                ? "Run the realm desired-state dry-run and attach support-safe evidence before apply."
+                                : "Select an identity provider mapping in Admin Console before exposing sign-in readiness.",
+                        List.of("Run /api/admin/identity/realm/dry-run", "Review blockers and audit refs before apply"),
+                        List.of("identity-realm-dry-run", "admin-control-plane-selection"),
+                        Map.of(
+                                "selectedByAdmin", selectedByAdmin,
+                                "configured", configured,
+                                "enabled", enabled,
+                                "secretsReturned", false,
+                                "rawProviderErrorsReturned", false)),
+                readinessCard(
+                        "oidc-client-readiness",
+                        "OIDC client readiness",
+                        selectedByAdmin && configured ? "ready" : "admin-action-required",
+                        "OIDC client posture is summarized by the backend; client identifiers, redirect details, and secrets are not exposed to members.",
+                        selectedByAdmin && configured ? "ready" : "degraded",
+                        "Confirm client scopes and redirect allowlists through backend dry-run output, not frontend provider APIs.",
+                        List.of("Validate client scope mappings", "Keep client secrets as SecretRef handles only"),
+                        List.of("identity-client-contract", "secretref-boundary"),
+                        Map.of(
+                                "clientDetailsRedacted", true,
+                                "clientSecretsReturned", false,
+                                "selectedByAdmin", selectedByAdmin,
+                                "configured", configured)),
+                readinessCard(
+                        "roles-groups-mapping",
+                        "Roles and groups mapping",
+                        whitelist.denyByDefault() ? "ready" : "policy-blocked",
+                        "Known roles and groups map into canonical Weave capability profiles; unknown inputs deny by default.",
+                        whitelist.denyByDefault() ? "ready" : "policy-blocked",
+                        "Map unknown roles/groups before activation and keep email out of primary identity keys.",
+                        List.of("Review effective policy simulation", "Map unknown identity inputs before they affect members"),
+                        List.of("effective-policy-simulation", "deny-by-default-policy"),
+                        Map.of(
+                                "denyByDefault", whitelist.denyByDefault(),
+                                "profileCount", whitelist.profileCapabilities().size(),
+                                "stableMemberImpactStateCount", whitelist.stableMemberImpactStates().size(),
+                                "emailPrimaryKeyAllowed", false)),
+                readinessCard(
+                        "login-readiness",
+                        "Login readiness",
+                        loginReadinessState(selectedByAdmin, configured, enabled, failClosed),
+                        "Member login is exposed only as product-level availability; provider endpoints and raw auth errors stay out of member flows.",
+                        selectedByAdmin && configured && enabled ? "ready" : "degraded",
+                        "Keep member sign-in fail-closed until selected provider configuration and backend readiness evidence are present.",
+                        List.of("Verify backend auth facade readiness", "Confirm member client shows only stable capability states"),
+                        List.of("member-boundary", "backend-auth-facade"),
+                        Map.of(
+                                "memberClientMayConfigureProvider", false,
+                                "providerEndpointsReturned", false,
+                                "rawAuthErrorsReturned", false,
+                                "failClosed", failClosed)),
+                readinessCard(
+                        "policy-readiness",
+                        "Policy readiness",
+                        whitelist.denyByDefault() && failClosed ? "ready" : "policy-blocked",
+                        "Capability policy is the gate between provider claims and Weave product access.",
+                        whitelist.denyByDefault() && failClosed ? "ready" : "policy-blocked",
+                        "Retain deny-by-default policy and last-admin recovery capabilities before provider apply.",
+                        List.of("Retain admin.policy.edit for workspace-admin", "Review policy simulation before realm apply"),
+                        List.of("capability-whitelist", "last-admin-guard"),
+                        Map.of(
+                                "denyByDefault", whitelist.denyByDefault(),
+                                "failClosed", failClosed,
+                                "normalMembersMayAuthorPolicy", whitelist.normalMembersMayAuthorPolicy())));
+        String overallState = aggregateIdentityReadiness(cards);
+        return new IdentityProviderReadinessResponse(
+                "identity-provider-readiness-v1",
+                "identity-idm",
+                providerKey,
+                overallState,
+                supportSafe,
+                true,
+                true,
+                false,
+                true,
+                registry.generatedAt(),
+                List.of("ready", "degraded", "policy-blocked", "admin-action-required", "disabled"),
+                cards,
+                identityNextActions(overallState),
+                Map.of(
+                        "overview", "/api/admin/control-plane",
+                        "readiness", "/api/admin/identity/readiness",
+                        "realmDryRun", "/api/admin/identity/realm/dry-run",
+                        "effectivePolicySimulation", "/api/admin/policies/effective/simulations"),
+                Map.of(
+                        "contractOptional", true,
+                        "versionSkewSafe", true,
+                        "memberClientMayConfigureIdentityProvider", false,
+                        "providerDiagnosticsRedacted", true,
+                        "selectedByAdmin", selectedByAdmin,
+                        "configured", configured,
+                        "enabled", enabled,
+                        "secretsReturned", false,
+                        "rawProviderErrorsReturned", false));
+    }
+
+    private IdentityProviderReadinessCardResponse readinessCard(
+            String key,
+            String label,
+            String state,
+            String summary,
+            String memberImpact,
+            String remediation,
+            List<String> nextActions,
+            List<String> evidenceRefs,
+            Map<String, Object> diagnostics) {
+        return new IdentityProviderReadinessCardResponse(
+                key,
+                label,
+                state,
+                summary,
+                memberImpact,
+                remediation,
+                nextActions,
+                evidenceRefs,
+                diagnostics);
+    }
+
+    private String loginReadinessState(boolean selectedByAdmin, boolean configured, boolean enabled, boolean failClosed) {
+        if (!enabled) {
+            return selectedByAdmin ? "admin-action-required" : "disabled";
+        }
+        if (!selectedByAdmin || !configured) {
+            return "admin-action-required";
+        }
+        return failClosed ? "ready" : "policy-blocked";
+    }
+
+    private List<String> identityNextActions(String overallState) {
+        return switch (overallState) {
+            case "ready" -> List.of("Monitor audit/readiness transitions and keep support bundles redacted.");
+            case "policy-blocked" -> List.of("Resolve policy blockers, unknown mappings, or last-admin guard failures before provider apply.");
+            case "disabled" -> List.of("Select an identity provider mapping or keep member flows disabled by policy.");
+            default -> List.of(
+                    "Run the backend identity realm dry-run.",
+                    "Resolve admin-action-required cards before treating sign-in as ready.",
+                    "Verify member clients expose only product-level states.");
+        };
+    }
+
+    private String aggregateIdentityReadiness(List<IdentityProviderReadinessCardResponse> cards) {
+        List<String> states = cards.stream().map(IdentityProviderReadinessCardResponse::state).toList();
+        if (states.contains("policy-blocked")) {
+            return "policy-blocked";
+        }
+        if (states.contains("admin-action-required")) {
+            return "admin-action-required";
+        }
+        if (states.contains("degraded")) {
+            return "degraded";
+        }
+        if (states.stream().allMatch("disabled"::equals)) {
+            return "disabled";
+        }
+        return "ready";
     }
 
     private IdentityRealmProvider identityRealmProvider(String providerKey) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -225,12 +225,51 @@ class AdminControlPlaneControllerTest {
                 .andExpect(jsonPath("$.whitelist.normalMembersMayAuthorPolicy").value(false))
                 .andExpect(jsonPath("$.whitelist.stableMemberImpactStates[*]", hasItems("ready", "disabled", "degraded", "policy-blocked")))
                 .andExpect(jsonPath("$.whitelist.profileCapabilities['guest-deny-default']").isArray())
+                .andExpect(jsonPath("$.identityProviderReadiness.contractVersion").value("identity-provider-readiness-v1"))
+                .andExpect(jsonPath("$.identityProviderReadiness.backendOwnedFacade").value(true))
+                .andExpect(jsonPath("$.identityProviderReadiness.memberClientMayConfigureIdentityProvider").value(false))
+                .andExpect(jsonPath("$.identityProviderReadiness.stableStates[*]", hasItems("ready", "degraded", "policy-blocked", "admin-action-required", "disabled")))
+                .andExpect(jsonPath("$.identityProviderReadiness.cards[*].key", hasItems("realm-import", "oidc-client-readiness", "roles-groups-mapping", "login-readiness", "policy-readiness")))
+                .andExpect(jsonPath("$.identityProviderReadiness.cards[*].diagnostics.secretsReturned", hasItems(false)))
+                .andExpect(jsonPath("$.identityProviderReadiness.cards[*].diagnostics.rawProviderErrorsReturned", hasItems(false)))
+                .andExpect(jsonPath("$.adminApiRoutes.identityReadiness").value("/api/admin/identity/readiness"))
                 .andExpect(jsonPath("$.secretRefs[*].supportSafe", hasItems(true)))
                 .andExpect(jsonPath("$.secretRefs[*].rawSecretExposed", hasItems(false)))
                 .andExpect(jsonPath("$.adminApiRoutes.policy").value("/api/admin/policies/capability-whitelist"))
                 .andExpect(content().string(not(containsString("server-test-secret-that-must-never-appear"))))
+                .andExpect(content().string(not(containsString("weave-app"))))
+                .andExpect(content().string(not(containsString("client_secret"))))
                 .andExpect(content().string(not(containsString("Authorization: Bearer"))))
                 .andExpect(content().string(not(containsString("access_token"))));
+    }
+
+    @Test
+    void identityProviderReadinessIsBackendOwnedAndMembersCannotReadIt() throws Exception {
+        mockMvc.perform(get("/api/admin/identity/readiness").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.contractVersion").value("identity-provider-readiness-v1"))
+                .andExpect(jsonPath("$.category").value("identity-idm"))
+                .andExpect(jsonPath("$.overallState").value("admin-action-required"))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.providerDiagnosticsRedacted").value(true))
+                .andExpect(jsonPath("$.backendOwnedFacade").value(true))
+                .andExpect(jsonPath("$.memberClientMayConfigureIdentityProvider").value(false))
+                .andExpect(jsonPath("$.optionalForMemberFlows").value(true))
+                .andExpect(jsonPath("$.cards[*].key", hasItems("realm-import", "oidc-client-readiness", "roles-groups-mapping", "login-readiness", "policy-readiness")))
+                .andExpect(jsonPath("$.cards[*].state", hasItems("ready", "admin-action-required")))
+                .andExpect(jsonPath("$.cards[*].remediation").isArray())
+                .andExpect(content().string(not(containsString("server-test-secret-that-must-never-appear"))))
+                .andExpect(content().string(not(containsString("weave-app"))))
+                .andExpect(content().string(not(containsString("client_secret"))))
+                .andExpect(content().string(not(containsString("Authorization: Bearer"))));
+
+        mockMvc.perform(get("/api/admin/identity/readiness").with(memberJwt()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"))
+                .andExpect(jsonPath("$.details.diagnosticsRedacted").value(true))
+                .andExpect(content().string(not(containsString("keycloak-realm"))))
+                .andExpect(content().string(not(containsString("weave-app"))));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add backend-owned `identityProviderReadiness` contract and `/api/admin/identity/readiness` facade for Workspace Health/Admin Console
- render support-safe readiness cards for realm import, OIDC client readiness, roles/groups mapping, login readiness, and policy readiness
- keep normal member flows fail-closed/provider-neutral, including version-skew fallback when older backends omit readiness
- update operator docs, release notes, README release notes block, and member boundary tests

Closes #366.

## Evidence
- `./gradlew ci` ✅
- `npm run ci` in `admin-console/` ✅
- `./gradlew test --tests 'com.massimotter.weave.backend.controller.AdminControlPlaneControllerTest'` ✅
- `./gradlew releaseNotesCheck docsCheck` ✅
- `git diff --check` ✅

## Notes
- Admin Console reads identity/provider readiness only from Weave backend admin APIs.
- Readiness output stays support-safe: no provider raw bodies, secrets, credential URLs, private keys, or provider-internal IDs.
