### PR TITLE
ci: harden Live Stack E2E failure diagnostics

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -245,15 +245,14 @@ jobs:
             --run-attempt "$GITHUB_RUN_ATTEMPT" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
-      - name: Dump stack logs on failure
+      - name: Generate support-safe failure diagnostics
         if: failure()
+        env:
+          WEAVE_LIVE_STACK_FAILURE_DIAGNOSTICS_DIR: ${{ env.WEAVE_ACCEPTANCE_EVIDENCE_DIR }}/failure-diagnostics
+          WEAVE_LIVE_STACK_SUPPORT_BUNDLE_LOG_LINES: '80'
         run: |
-          bash weave/infra/weave-workspace/operator-check.sh || true
-          docker ps -a
-          for container in weave-proxy weave-keycloak weave-backend weave-mas weave-synapse weave-nextcloud weave-db; do
-            echo "--- ${container}"
-            docker logs "${container}" || true
-          done
+          set -euo pipefail
+          bash weave/infra/weave-workspace/live-stack-failure-diagnostics.sh "$WEAVE_LIVE_STACK_FAILURE_DIAGNOSTICS_DIR"
 
       - name: Destroy stack and scrub stale resources
         if: always()

--- a/docs/enterprise-release-foundation.md
+++ b/docs/enterprise-release-foundation.md
@@ -43,6 +43,15 @@ Required artifacts:
 - `weave-live-stack-acceptance-evidence/evidence-markers.json`
 - `weave-live-stack-acceptance-evidence/release-evidence-manifest.json`
 
+Failure-only support-safe diagnostics:
+
+- `weave-live-stack-acceptance-evidence/failure-diagnostics/failure-summary.md`
+- `weave-live-stack-acceptance-evidence/failure-diagnostics/failure-summary.json`
+- `weave-live-stack-acceptance-evidence/failure-diagnostics/container-status.tsv`
+- `weave-live-stack-acceptance-evidence/failure-diagnostics/failed-markers.json`
+- `weave-live-stack-acceptance-evidence/failure-diagnostics/health-checks/operator-check.txt`
+- `weave-live-stack-acceptance-evidence/failure-diagnostics/support-bundle/weave-support-*.tar.gz`
+
 Required runtime markers for the v0.1 dogfood candidate:
 
 - `AUTH_RESULT`
@@ -79,6 +88,8 @@ Every Live Stack E2E artifact directory must include a support-safe manifest:
 - acceptance artifact file list;
 - support-safe exclusions;
 - RC rule reminder.
+
+On failure, diagnostics are additive and support-safe: container state, health/readiness output after redaction, failed or missing runtime markers, and a redacted support bundle reference. The workflow must not print or upload raw container logs as default evidence. If an operator deliberately enables private raw-log capture for deeper debugging, the destination must stay outside the uploaded evidence directory and remain a private runner/operator artifact.
 
 This makes evidence portable: a release owner can inspect one artifact directory and know what commit, run, lane, and contract it represents without reading private runner logs.
 

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -52,20 +52,21 @@ These checks are intentionally cheap enough for normal pull requests and do not 
 
 The live-stack path is expensive and runs on a dedicated self-hosted macOS ARM64 runner. Use it when a change affects sign-in, backend facade contracts, Matrix/files/calendar live behavior, acceptance scenarios, or integration boundaries.
 
-The workflow prepares an acceptance evidence directory, runs the app-level live-stack E2E, and uploads support-safe acceptance evidence from the run. The artifact set includes `release-evidence-manifest.json`, which names the source lane, commit, workflow run metadata, artifact list, and RC promotion rule. Do not cite a single workflow run ID as a permanent product claim; link to the workflow, the relevant docs, the manifest, and the PR evidence instead.
+The workflow prepares an acceptance evidence directory, runs the app-level live-stack E2E, and uploads support-safe acceptance evidence from the run. The artifact set includes `release-evidence-manifest.json`, which names the source lane, commit, workflow run metadata, artifact list, and RC promotion rule. On failure, the same uploaded artifact may include `failure-diagnostics/` with `failure-summary.md`, `failure-summary.json`, `container-status.tsv`, `failed-markers.json`, redacted readiness output, and a redacted support-bundle reference. It must not include blindly dumped raw container logs. Do not cite a single workflow run ID as a permanent product claim; link to the workflow, the relevant docs, the manifest, and the PR evidence instead.
 
 ## Interpreting pass/fail states
 
 - **Offline Flutter failure**: inspect the failing command first. Re-run locally after regenerating l10n/build output.
 - **Screenshot drift**: run `make marketing-screenshots`, review the SVG diff as product copy, and commit the regenerated assets if intentional.
 - **Acceptance mapping failure**: update the scenario-to-test mapping or remove stale scenario claims. Do not leave product acceptance text unmapped.
-- **Live-stack contract failure**: confirm the stack bootstrapped correctly, then inspect backend/API, auth, and app logs. Treat credential, runner, or environment problems as named infrastructure blockers, not product proof. Missing required markers such as `BOARDS_RESULT` block RC promotion until a green rerun or explicit release-owner waiver exists.
+- **Live-stack contract failure**: start with `failure-diagnostics/failure-summary.md`, `container-status.tsv`, `health-checks/operator-check.txt`, and `failed-markers.json` in the uploaded evidence artifact. Treat credential, runner, or environment problems as named infrastructure blockers, not product proof. Missing required markers such as `BOARDS_RESULT` block RC promotion until a green rerun or explicit release-owner waiver exists. Operators who need deeper private debugging may rerun diagnostics on the self-hosted runner with private raw-log collection enabled, but those files stay outside uploaded/support evidence.
 - **Accessibility evidence gap**: do not promote the flow as release-ready until the automated and manual evidence in the accessibility gate is complete.
 - **Admin-provisioned first-use failure**: inspect member-visible first-use, settings, and navigation copy first. Normal members must not see provider setup diagnostics, OIDC/provider/infra setup fields, preview/scaffold/coming-soon release-scope language, or raw provider errors; move setup/readiness detail to Workspace Health for admins/operators.
 
 ## Artifact hygiene
 
 - Never commit live credentials, generated secret files, or raw logs that contain tokens/passwords.
+- Live Stack failure artifacts must use support-safe diagnostics by default: status, readiness, failed markers, and redacted support bundles instead of raw provider/container logs.
 - Prefer redacted summaries in docs and PR bodies.
 - Use `build/evidence/ci-summary.json` for task outcomes; it must not include secrets, tokens, credential URLs, raw provider payloads, or raw provider errors.
 - Keep evidence explanations screen-reader friendly; do not make images or badge colors the only source of truth.

--- a/infra/weave-workspace/live-stack-failure-diagnostics.sh
+++ b/infra/weave-workspace/live-stack-failure-diagnostics.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+# shellcheck source=infra/weave-workspace/support-bundle.sh
+source "${SCRIPT_DIR}/support-bundle.sh"
+
+OUTPUT_DIR="${1:-${WEAVE_LIVE_STACK_FAILURE_DIAGNOSTICS_DIR:-${ROOT_DIR}/.generated/live-stack-failure-diagnostics}}"
+CREATED_AT_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+PRIVATE_RAW_LOGS_ENABLED="${WEAVE_LIVE_STACK_PRIVATE_RAW_LOGS:-false}"
+PRIVATE_RAW_LOGS_DIR="${WEAVE_PRIVATE_RAW_LOGS_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/weave-private-raw-live-logs}"
+
+log() {
+  printf '%s\n' "$*"
+}
+
+json_escape() {
+  jq -Rs .
+}
+
+relative_or_absolute() {
+  local path="$1"
+  case "${path}" in
+    "${ROOT_DIR}"/*) printf '%s' "${path#"${ROOT_DIR}/"}" ;;
+    *) printf '%s' "${path}" ;;
+  esac
+}
+
+is_path_under() {
+  local child="$1"
+  local parent="$2"
+  local child_real parent_real
+  child_real="$(mkdir -p "${child}" && cd "${child}" && pwd -P)"
+  parent_real="$(mkdir -p "${parent}" && cd "${parent}" && pwd -P)"
+  [[ "${child_real}" == "${parent_real}" || "${child_real}" == "${parent_real}"/* ]]
+}
+
+write_container_status() {
+  local target="$1"
+  mkdir -p "$(dirname -- "${target}")"
+  {
+    printf 'container\tstate\thealth\texitCode\n'
+    if ! command -v docker >/dev/null 2>&1; then
+      printf 'docker\tunavailable\tn/a\tn/a\n'
+      return
+    fi
+    local container line
+    for container in "${DEFAULT_CONTAINERS[@]}"; do
+      line="$(docker inspect --format '{{.Name}}\t{{.State.Status}}\t{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}\t{{.State.ExitCode}}' "${container}" 2>/dev/null || true)"
+      if [[ -z "${line}" ]]; then
+        printf '%s\tnot-found\tn/a\tn/a\n' "${container}"
+      else
+        printf '%s\n' "${line#/}" | redact_stream
+      fi
+    done
+  } >"${target}"
+}
+
+write_operator_check() {
+  local target="$1"
+  local status_target="$2"
+  mkdir -p "$(dirname -- "${target}")"
+  set +e
+  bash "${ROOT_DIR}/operator-check.sh" 2>&1 | redact_stream >"${target}"
+  local status=${PIPESTATUS[0]}
+  set -e
+  printf '%s\n' "${status}" >"${status_target}"
+}
+
+write_failed_markers() {
+  local target="$1"
+  local evidence_markers="${WEAVE_LIVE_STACK_EVIDENCE_MARKERS:-${WEAVE_ACCEPTANCE_EVIDENCE_DIR:-}/evidence-markers.json}"
+  local scenario_results="${WEAVE_LIVE_STACK_SCENARIO_RESULTS:-${WEAVE_ACCEPTANCE_EVIDENCE_DIR:-}/scenario-mapping-results.json}"
+  mkdir -p "$(dirname -- "${target}")"
+
+  if [[ -s "${scenario_results}" ]]; then
+    jq '{schema:"weave-live-stack-failed-markers-v1", failedOrIncompleteScenarios: [.scenarioResults[]? | select(.runtimeStatus == "failedOrIncomplete") | {scenario: .scenario.name, markers: [.markers[]?.marker]}]}' "${scenario_results}" >"${target}" 2>/dev/null || printf '{"schema":"weave-live-stack-failed-markers-v1","error":"scenario-results-unreadable"}\n' >"${target}"
+    return
+  fi
+
+  if [[ -s "${evidence_markers}" ]]; then
+    jq '{schema:"weave-live-stack-failed-markers-v1", observedMarkers: (.observedMarkers // []), markerCount: ((.observedMarkers // []) | length)}' "${evidence_markers}" >"${target}" 2>/dev/null || printf '{"schema":"weave-live-stack-failed-markers-v1","error":"evidence-markers-unreadable"}\n' >"${target}"
+    return
+  fi
+
+  printf '{"schema":"weave-live-stack-failed-markers-v1","status":"acceptance-evidence-not-generated"}\n' >"${target}"
+}
+
+write_support_bundle() {
+  local target_dir="$1"
+  mkdir -p "${target_dir}"
+  set +e
+  WEAVE_SUPPORT_BUNDLE_RUN_CHECKS=true \
+    WEAVE_SUPPORT_BUNDLE_LOG_LINES="${WEAVE_LIVE_STACK_SUPPORT_BUNDLE_LOG_LINES:-80}" \
+    bash "${ROOT_DIR}/support-bundle.sh" "${target_dir}" >"${target_dir}/support-bundle-command.txt" 2>&1
+  local status=$?
+  set -e
+  redact_stream <"${target_dir}/support-bundle-command.txt" >"${target_dir}/support-bundle-command.redacted.txt"
+  mv "${target_dir}/support-bundle-command.redacted.txt" "${target_dir}/support-bundle-command.txt"
+  printf '%s\n' "${status}" >"${target_dir}/support-bundle-exit-status.txt"
+  find "${target_dir}" -maxdepth 1 -name 'weave-support-*.tar.gz' -print -quit
+}
+
+write_private_raw_logs_if_requested() {
+  local output_dir="$1"
+  local target="$2"
+  if [[ "${PRIVATE_RAW_LOGS_ENABLED}" != "true" ]]; then
+    printf 'disabled\n' >"${target}"
+    return
+  fi
+
+  if is_path_under "${PRIVATE_RAW_LOGS_DIR}" "${output_dir}"; then
+    printf 'refused: private raw log directory must not be inside uploaded evidence output\n' >"${target}"
+    return
+  fi
+
+  mkdir -p "${PRIVATE_RAW_LOGS_DIR}"
+  chmod 700 "${PRIVATE_RAW_LOGS_DIR}" || true
+  if ! command -v docker >/dev/null 2>&1; then
+    printf 'skipped: docker unavailable\n' >"${target}"
+    return
+  fi
+
+  local container
+  for container in "${DEFAULT_CONTAINERS[@]}"; do
+    docker logs "${container}" >"${PRIVATE_RAW_LOGS_DIR}/${container}.log" 2>&1 || true
+  done
+  chmod -R go-rwx "${PRIVATE_RAW_LOGS_DIR}" || true
+  printf 'written outside uploaded evidence: %s\n' "${PRIVATE_RAW_LOGS_DIR}" >"${target}"
+}
+
+main() {
+  mkdir -p "${OUTPUT_DIR}/health-checks" "${OUTPUT_DIR}/support-bundle"
+
+  local container_status="${OUTPUT_DIR}/container-status.tsv"
+  local operator_check="${OUTPUT_DIR}/health-checks/operator-check.txt"
+  local operator_status="${OUTPUT_DIR}/health-checks/operator-check-exit-status.txt"
+  local failed_markers="${OUTPUT_DIR}/failed-markers.json"
+  local private_status="${OUTPUT_DIR}/private-raw-logs-status.txt"
+
+  write_container_status "${container_status}"
+  write_operator_check "${operator_check}" "${operator_status}"
+  write_failed_markers "${failed_markers}"
+  local support_bundle=""
+  support_bundle="$(write_support_bundle "${OUTPUT_DIR}/support-bundle" || true)"
+  write_private_raw_logs_if_requested "${OUTPUT_DIR}" "${private_status}"
+
+  local operator_exit support_exit private_status_text bundle_reference
+  operator_exit="$(cat "${operator_status}")"
+  support_exit="$(cat "${OUTPUT_DIR}/support-bundle/support-bundle-exit-status.txt")"
+  private_status_text="$(cat "${private_status}" | redact_stream)"
+  if [[ -n "${support_bundle}" ]]; then
+    bundle_reference="$(relative_or_absolute "${support_bundle}")"
+  else
+    bundle_reference="support bundle not written; see support-bundle/support-bundle-command.txt"
+  fi
+
+  cat >"${OUTPUT_DIR}/failure-summary.md" <<MD
+## Live Stack failure diagnostics
+
+Generated UTC: ${CREATED_AT_ISO}
+
+This directory is support-safe by default. It intentionally does not dump raw container logs.
+
+- Container status: \`container-status.tsv\`
+- Readiness check output: \`health-checks/operator-check.txt\` (exit ${operator_exit})
+- Failed or missing acceptance markers: \`failed-markers.json\`
+- Redacted support bundle: \`${bundle_reference}\` (exit ${support_exit})
+- Private raw logs: ${private_status_text}
+
+Raw container logs are operator-private diagnostics only. Enable them deliberately with
+\`WEAVE_LIVE_STACK_PRIVATE_RAW_LOGS=true\` and keep \`WEAVE_PRIVATE_RAW_LOGS_DIR\` outside the uploaded evidence directory.
+MD
+
+  {
+    printf '{\n'
+    printf '  "schema": "weave-live-stack-failure-diagnostics-v1",\n'
+    printf '  "generatedAtUtc": %s,\n' "$(printf '%s' "${CREATED_AT_ISO}" | json_escape)"
+    printf '  "supportSafe": true,\n'
+    printf '  "rawContainerLogsIncluded": false,\n'
+    printf '  "containerStatus": "container-status.tsv",\n'
+    printf '  "operatorCheck": {"path": "health-checks/operator-check.txt", "exitStatus": %s},\n' "${operator_exit}"
+    printf '  "failedMarkers": "failed-markers.json",\n'
+    printf '  "supportBundleReference": %s,\n' "$(printf '%s' "${bundle_reference}" | json_escape)"
+    printf '  "privateRawLogs": %s\n' "$(printf '%s' "${private_status_text}" | json_escape)"
+    printf '}\n'
+  } >"${OUTPUT_DIR}/failure-summary.json"
+
+  scan_for_unredacted_secrets "${OUTPUT_DIR}"
+  log "Support-safe live stack failure diagnostics written to ${OUTPUT_DIR}"
+}
+
+main "$@"

--- a/infra/weave-workspace/support-bundle.sh
+++ b/infra/weave-workspace/support-bundle.sh
@@ -115,14 +115,17 @@ cleanup() {
     rm -rf "${WORK_DIR}"
   fi
 }
-trap cleanup EXIT
-
 redact_stream() {
   perl -0pe '
     s/-----BEGIN [^-]*PRIVATE KEY-----.*?-----END [^-]*PRIVATE KEY-----/<redacted-private-key>/gs;
+    s#([a-z][a-z0-9+.-]*://)([^\s/@:]+):([^\s/@]+)@#${1}<redacted>@#gi;
     s/(Authorization:\s*)(Bearer|Basic)\s+[^\r\n]+/${1}<redacted>/gi;
     s/((?:Set-)?Cookie:\s*)[^\r\n]+/${1}<redacted>/gi;
-    s/((?:password|passwd|token|secret|private[_-]?key|signing[_-]?key|credential|authorization|cookie)\s*[=:]\s*)([^\s\r\n"'"'"']+)/${1}<redacted>/gi;
+    s/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/<redacted-email>/gi;
+    s/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/<redacted-cloud-token>/g;
+    s/\b(?:ghp|gho|ghu|ghs|ghr|github_pat|glpat|xox[baprs])-[-_A-Za-z0-9]{20,}\b/<redacted-cloud-token>/g;
+    s/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/<redacted-jwt>/g;
+    s/(([A-Za-z0-9_]*(?:password|passwd|token|secret|private[_-]?key|signing[_-]?key|credential|authorization|cookie)[A-Za-z0-9_]*\s*[=:]\s*)([^\s\r\n"'"'"']+))/${2}<redacted>/gi;
     s/("(?:password|passwd|token|secret|privateKey|signingKey|credential|authorization|cookie)"\s*:\s*")[^"]+/${1}<redacted>/gi;
   '
 }
@@ -131,12 +134,12 @@ scan_for_unredacted_secrets() {
   local path="$1"
   local findings=""
 
-  findings="$(grep -RInE \
-    'BEGIN (RSA |EC |OPENSSH |)?PRIVATE KEY|Authorization:[[:space:]]+(Bearer|Basic)[[:space:]]+[^<[:space:]]|Cookie:[[:space:]]+[^<[:space:]]|Set-Cookie:[[:space:]]+[^<[:space:]]|([A-Za-z0-9_]*(PASSWORD|TOKEN|SECRET|PRIVATE_KEY|SIGNING_KEY|CREDENTIAL)[A-Za-z0-9_]*[=:][[:space:]]*[^<[:space:]]+)' \
+  findings="$(grep -RIliE \
+    'BEGIN ((RSA|EC|OPENSSH) )?PRIVATE KEY|[a-z][a-z0-9+.-]*://[^[:space:]/@:]+:[^[:space:]/@]+@|Authorization:[[:space:]]+(Bearer|Basic)[[:space:]]+[^<[:space:]]|Cookie:[[:space:]]+[^<[:space:]]|Set-Cookie:[[:space:]]+[^<[:space:]]|([A-Za-z0-9_]*(PASSWORD|TOKEN|SECRET|PRIVATE_KEY|SIGNING_KEY|CREDENTIAL)[A-Za-z0-9_]*[=:][[:space:]]*[^<[:space:]]+)|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|(AKIA|ASIA)[A-Z0-9]{16}|(ghp|gho|ghu|ghs|ghr|github_pat|glpat|xox[baprs])-[-_A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}' \
     "${path}" 2>/dev/null || true)"
 
   if [[ -n "${findings}" ]]; then
-    printf 'Support bundle redaction check failed. Possible secret material remains:\n%s\n' "${findings}" >&2
+    printf 'Support bundle redaction check failed. Possible secret material remains in these files only; values are intentionally not printed:\n%s\n' "${findings}" >&2
     return 1
   fi
 }
@@ -444,8 +447,11 @@ main() {
     fail "WEAVE_SUPPORT_BUNDLE_LOG_LINES must be numeric"
   fi
 
+  trap cleanup EXIT
   local output_dir="${1:-${SUPPORT_BUNDLE_OUTPUT_DIR}}"
   create_bundle "${output_dir}"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/infra/weave-workspace/tests/live-stack-failure-diagnostics-test.sh
+++ b/infra/weave-workspace/tests/live-stack-failure-diagnostics-test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly ROOT_DIR
+readonly SCRIPT="${ROOT_DIR}/live-stack-failure-diagnostics.sh"
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf -- "${work_dir}"' EXIT
+
+stub_bin="${work_dir}/bin"
+mkdir -p "${stub_bin}"
+cat >"${stub_bin}/docker" <<'DOCKER'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  inspect)
+    name="${@: -1}"
+    printf '/%s\trunning\tnone\t0\n' "${name}"
+    ;;
+  logs)
+    cat <<'LOGS'
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payloadpayload.signature123
+callback=https://runner:secret-password@provider.internal.example/path
+operator=person@example.com
+LOGS
+    ;;
+  ps)
+    printf 'weave-backend\trunning\n'
+    ;;
+  volume)
+    printf 'local weave-data\n'
+    ;;
+  system)
+    printf 'TYPE TOTAL ACTIVE SIZE RECLAIMABLE\n'
+    ;;
+  exec)
+    printf 'stubbed-docker-exec\n'
+    ;;
+  *)
+    printf 'stubbed docker %s\n' "$*"
+    ;;
+esac
+DOCKER
+chmod +x "${stub_bin}/docker"
+cat >"${stub_bin}/curl" <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+if printf '%s\n' "$@" | grep -qx -- '-w'; then
+  printf '503'
+else
+  printf '{"status":"down"}'
+fi
+CURL
+chmod +x "${stub_bin}/curl"
+
+acceptance_dir="${work_dir}/acceptance"
+output_dir="${acceptance_dir}/failure-diagnostics"
+mkdir -p "${acceptance_dir}"
+cat >"${acceptance_dir}/scenario-mapping-results.json" <<'JSON'
+{
+  "scenarioResults": [
+    {
+      "runtimeStatus": "failedOrIncomplete",
+      "scenario": {"name": "Matrix chat sends and reads a workspace message"},
+      "markers": [{"marker": "CHAT_RESULT"}]
+    }
+  ]
+}
+JSON
+
+PATH="${stub_bin}:${PATH}" \
+  WEAVE_ACCEPTANCE_EVIDENCE_DIR="${acceptance_dir}" \
+  WEAVE_LIVE_STACK_PRIVATE_RAW_LOGS=false \
+  bash "${SCRIPT}" "${output_dir}"
+
+[[ -s "${output_dir}/failure-summary.md" ]] || { echo "missing failure summary markdown" >&2; exit 1; }
+[[ -s "${output_dir}/failure-summary.json" ]] || { echo "missing failure summary json" >&2; exit 1; }
+[[ -s "${output_dir}/container-status.tsv" ]] || { echo "missing container status" >&2; exit 1; }
+grep -Fq 'intentionally does not dump raw container logs' "${output_dir}/failure-summary.md"
+grep -Fq 'rawContainerLogsIncluded": false' "${output_dir}/failure-summary.json"
+grep -Fq 'CHAT_RESULT' "${output_dir}/failed-markers.json"
+
+if grep -R -Fq 'secret-password' "${output_dir}" || grep -R -Fq 'person@example.com' "${output_dir}" || grep -R -Fq 'eyJhbGci' "${output_dir}"; then
+  echo "failure diagnostics leaked raw private log content" >&2
+  grep -R -n -E 'secret-password|person@example\.com|eyJhbGci' "${output_dir}" >&2 || true
+  exit 1
+fi
+
+printf '%s\n' 'Live Stack failure diagnostics fixture test passed'

--- a/infra/weave-workspace/tests/support-bundle-redaction-test.sh
+++ b/infra/weave-workspace/tests/support-bundle-redaction-test.sh
@@ -4,13 +4,13 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
-readonly ROOT_DIR
 readonly SCRIPT="${ROOT_DIR}/support-bundle.sh"
 
 output_dir="$(mktemp -d)"
 work_home="$(mktemp -d)"
 bootstrap_env="${ROOT_DIR}/.generated/bootstrap.env"
 app_config_env="${ROOT_DIR}/.generated/app-config.env"
+operator_leak_fixture="${ROOT_DIR}/.generated/operator-leak-fixture.log"
 bootstrap_backup=""
 app_config_backup=""
 
@@ -42,11 +42,21 @@ restore_file() {
 cleanup() {
   restore_file "${bootstrap_backup}" "${bootstrap_env}"
   restore_file "${app_config_backup}" "${app_config_env}"
+  rm -f "${operator_leak_fixture}"
   rm -rf "${output_dir}" "${work_home}"
 }
 trap cleanup EXIT
 
 mkdir -p "${ROOT_DIR}/.generated"
+cat >"${operator_leak_fixture}" <<'LOG'
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payloadpayload.signature123
+cloud_access_key=AKIAABCDEFGHIJKLMNOP
+callback=https://weave-admin:super-secret-password@provider.internal.example/path
+-----BEGIN PRIVATE KEY-----
+raw-private-key-material
+-----END PRIVATE KEY-----
+operator=person@example.com
+LOG
 cat >"${bootstrap_env}" <<'ENV'
 TF_VAR_tenant_domain=weave.local
 TF_VAR_public_scheme=https
@@ -97,11 +107,27 @@ grep -Fq '"domain": "boards-tasks"' "${extracted}/checks/adapter-readiness-summa
 grep -Fq '"adapterKey": "openproject-primary"' "${extracted}/checks/adapter-readiness-summary.json"
 grep -Fq '"configured": true' "${extracted}/checks/adapter-readiness-summary.json"
 
-if grep -R -Fq 'super-secret' "${extracted}" || grep -R -Fq 'calendar-token' "${extracted}" || grep -R -Fq 'slack-signing-secret' "${extracted}" || grep -R -Fq 'slack-client-secret-ref' "${extracted}" || grep -R -Fq 'openproject-super-secret' "${extracted}" || grep -R -Fq 'openproject-secret-key-base' "${extracted}" || grep -R -Fq 'openproject-app-token' "${extracted}" || grep -R -Fq 'boards-provider-secret' "${extracted}" || grep -R -Fq 'boards-runtime-token' "${extracted}" || grep -R -Fq 'openproject.example' "${extracted}" || grep -R -Fq 'files.weave.local' "${extracted}"; then
+if grep -R -Fq 'super-secret' "${extracted}" || grep -R -Fq 'calendar-token' "${extracted}" || grep -R -Fq 'slack-signing-secret' "${extracted}" || grep -R -Fq 'slack-client-secret-ref' "${extracted}" || grep -R -Fq 'openproject-super-secret' "${extracted}" || grep -R -Fq 'openproject-secret-key-base' "${extracted}" || grep -R -Fq 'openproject-app-token' "${extracted}" || grep -R -Fq 'boards-provider-secret' "${extracted}" || grep -R -Fq 'boards-runtime-token' "${extracted}" || grep -R -Fq 'openproject.example' "${extracted}" || grep -R -Fq 'files.weave.local' "${extracted}" || grep -R -Fq 'AKIAABCDEFGHIJKLMNOP' "${extracted}" || grep -R -Fq 'person@example.com' "${extracted}" || grep -R -Fq 'raw-private-key-material' "${extracted}"; then
   echo "support bundle leaked a test secret" >&2
-  grep -R -n -E 'super-secret|calendar-token|slack-signing-secret|slack-client-secret-ref|openproject-super-secret|openproject-secret-key-base|openproject-app-token|boards-provider-secret|boards-runtime-token|openproject\.example|files\.weave\.local' "${extracted}" >&2 || true
+  grep -R -n -E 'super-secret|calendar-token|slack-signing-secret|slack-client-secret-ref|openproject-super-secret|openproject-secret-key-base|openproject-app-token|boards-provider-secret|boards-runtime-token|openproject\.example|files\.weave\.local|AKIAABCDEFGHIJKLMNOP|person@example\.com|raw-private-key-material' "${extracted}" >&2 || true
   exit 1
 fi
+
+# Scanner failures must be actionable without echoing the secret value back into CI logs.
+# shellcheck source=infra/weave-workspace/support-bundle.sh
+source "${SCRIPT}"
+leaky_dir="$(mktemp -d)"
+printf 'api_password=hunter2\n' >"${leaky_dir}/leak.txt"
+if scan_for_unredacted_secrets "${leaky_dir}" 2>"${leaky_dir}/scan.err"; then
+  echo "support bundle scanner accepted a known leak fixture" >&2
+  exit 1
+fi
+if grep -Fq 'hunter2' "${leaky_dir}/scan.err"; then
+  echo "support bundle scanner printed a raw secret value" >&2
+  cat "${leaky_dir}/scan.err" >&2
+  exit 1
+fi
+rm -rf "${leaky_dir}"
 
 if grep -R -Eq 'PASSWORD=|TOKEN=|SECRET=' "${extracted}/config/public-env-summary.env"; then
   echo "support bundle public env summary included secret keys" >&2

--- a/release/enterprise-release-gates.json
+++ b/release/enterprise-release-gates.json
@@ -43,7 +43,13 @@
             "weave-live-stack-acceptance-evidence/acceptance-summary.md",
             "weave-live-stack-acceptance-evidence/scenario-mapping-results.json",
             "weave-live-stack-acceptance-evidence/evidence-markers.json",
-            "weave-live-stack-acceptance-evidence/release-evidence-manifest.json"
+            "weave-live-stack-acceptance-evidence/release-evidence-manifest.json",
+            "weave-live-stack-acceptance-evidence/failure-diagnostics/failure-summary.md",
+            "weave-live-stack-acceptance-evidence/failure-diagnostics/failure-summary.json",
+            "weave-live-stack-acceptance-evidence/failure-diagnostics/container-status.tsv",
+            "weave-live-stack-acceptance-evidence/failure-diagnostics/failed-markers.json",
+            "weave-live-stack-acceptance-evidence/failure-diagnostics/health-checks/operator-check.txt",
+            "weave-live-stack-acceptance-evidence/failure-diagnostics/support-bundle/weave-support-*.tar.gz"
           ],
           "mustObserveMarkers": ["AUTH_RESULT", "PROFILE_RESULT", "CHAT_RESULT", "MATRIX_RESULT", "E2EE_RESULT", "FILES_RESULT", "PROVIDER_STACK_RESULT", "CALENDAR_RESULT", "BOARDS_RESULT"],
           "supportSafeExclusions": ["raw credentials", "credential-bearing URLs", "provider internals", "downstream provider error bodies", "private live logs"]


### PR DESCRIPTION
## Summary

Hardened Live Stack E2E failure diagnostics so failed runs upload support-safe summaries instead of dumping raw container logs into workflow output or support evidence.

## Changes

- Replace the failure-time raw `docker logs` workflow step with a support-safe failure diagnostics generator.
- Add `live-stack-failure-diagnostics.sh` to collect container status, redacted readiness output, failed markers, and a redacted support-bundle reference.
- Strengthen support-bundle redaction/scanning for private keys, auth headers, credential URLs, JWT-like values, cloud-style tokens, and email addresses without printing raw findings.
- Document failure artifact shape and the private operator-only raw-log path.

## Evidence / Testing

- `bash -n infra/weave-workspace/live-stack-failure-diagnostics.sh infra/weave-workspace/tests/live-stack-failure-diagnostics-test.sh infra/weave-workspace/tests/support-bundle-redaction-test.sh infra/weave-workspace/support-bundle.sh`
- `find infra/weave-workspace/tests -maxdepth 1 -type f -name '*-test.sh' -print0 | sort -z | xargs -0 -n1 bash`
- `./gradlew enterpriseReleaseGateCheck releaseReadinessFixtureTest`
- `./gradlew acceptanceContract`
- `./gradlew infraStatic`

Fixes masssi164/weave#368