### PR TITLE
identity: simulate effective provider capability policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
 - Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
 - Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
+- Admin/operator effective policy simulation endpoint with support-safe capability impact output, fail-closed unknown identity inputs, Weaver disabled-by-default evidence, and audited counts before provider or realm changes apply.
 
 ## Changed
 

--- a/docs/admin-operator-handbook.md
+++ b/docs/admin-operator-handbook.md
@@ -78,6 +78,14 @@ Weave policy is deny-by-default. Capability profiles should use category-level p
 
 Whitelists restrict which providers, adapters, tools, and later Weaver capabilities are visible to an organization or role. A missing whitelist entry does not grant access.
 
+## Effective policy simulation
+
+Use `POST /api/admin/policies/effective/simulations` before applying identity, realm, or provider policy changes. The endpoint is admin/operator only and simulates the member-visible impact of selected roles, groups, and requested capabilities without mutating provider configuration, realm state, whitelists, or member accounts.
+
+The simulation complements Workspace Health/admin readiness work (#212): readiness explains whether backend-owned provider setup is ready or degraded, while effective policy simulation explains whether known identity inputs would grant, disable, degrade, or policy-block product capabilities for members. It also fits before the identity realm dry-run/apply path (#233): run the realm dry-run to inspect desired realm changes, then run effective policy simulation to preview capability impact before any guarded apply.
+
+Unknown roles, groups, or capabilities fail closed and produce `policy-blocked` member states. The response uses only stable member state labels (`ready`, `disabled`, `degraded`, `policy-blocked`) and admin reason codes; it must not expose email as a primary identity key, raw provider IDs, endpoint URLs, tokens, credentials, SecretRef payloads, or provider internals. Weaver remains disabled by default in this slice; `weaver.enabled` reports `disabled` unless later governed policy work explicitly enables a runtime. A support-safe fixture is checked in at `server/src/test/resources/effective-policy-simulation/admin-operator-preview.json`.
+
 ## Readiness and audit
 
 Readiness states must be support-safe and action-oriented. Member contracts encode `ready`, `disabled`, `degraded`, or `policy-blocked`; admin/operator identity readiness uses `ready`, `degraded`, `policy-blocked`, `admin-action-required`, or `disabled`. Other admin/operator provider views may additionally show `misconfigured`, `sync-pending`, `conflict-quarantined`, `migration-dry-run-required`, or `unsupported`. They must not expose raw downstream bodies, provider-internal IDs, credential-bearing URLs, tokens, cookies, or private keys.

--- a/docs/identity-provisioning-strategy.md
+++ b/docs/identity-provisioning-strategy.md
@@ -221,6 +221,12 @@ The report is deterministic and support-safe:
 
 This endpoint is backend/control-plane only. Member clients consume provider-neutral readiness and capability policy; they must not call Keycloak/provider APIs directly or expose realm setup diagnostics.
 
+## Effective policy simulation before apply
+
+`POST /api/admin/policies/effective/simulations` is the backend/admin companion to the #233 realm dry-run/apply flow and the #212 admin readiness surface. Realm dry-run compares desired provider state; readiness reports support-safe setup posture; effective policy simulation previews how selected known roles, groups, and capabilities would appear to members before provider changes are applied.
+
+The simulation is read-only and deterministic enough for support fixtures: unknown roles, groups, or capabilities fail closed; member states stay within `ready`, `disabled`, `degraded`, and `policy-blocked`; audit payloads record counts/support-safe booleans instead of free-text reasons; and emails, raw provider identifiers, tokens, SecretRefs, and provider internals stay out of the contract.
+
 ## Guest and B2B users
 
 Guests are external identities, not incomplete employees.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -11,6 +11,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
 - Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
 - Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
+- Admin/operator effective policy simulation endpoint with support-safe capability impact output, fail-closed unknown identity inputs, Weaver disabled-by-default evidence, and audited counts before provider or realm changes apply.
 
 ## Changed
 

--- a/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
+++ b/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
@@ -13,6 +13,7 @@ public enum AuditAction {
     BOARD_TASK_COMPLETED("board.task.completed"),
     CONSENT_GRANTED("consent.granted"),
     CONSENT_REVOKED("consent.revoked"),
+    EFFECTIVE_POLICY_SIMULATED("effective_policy.simulated"),
     ADMIN_POLICY_UPDATED("admin.policy.updated"),
     PROVIDER_READINESS_TESTED("provider.readiness.tested"),
     PROVIDER_REPLACEMENT_DRY_RUN("provider.replacement.dry_run"),

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -313,21 +313,17 @@ public class AdminControlPlaneService {
 
     public EffectivePolicySimulationResponse simulateEffectivePolicy(EffectivePolicySimulationRequest request, Jwt jwt) {
         workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "effective-policy-simulation");
-        List<String> roles = normalizedValues(request == null ? null : request.roles());
-        List<String> groups = normalizedValues(request == null ? null : request.groups());
-        List<String> requestedCapabilities = normalizedValues(request == null ? null : request.requestedCapabilities());
-        List<String> deniedInputs = Stream.concat(
-                        roles.stream()
-                                .filter(role -> !SIMULATION_ROLES.contains(role))
-                                .map(role -> "unknown-role:" + role),
-                        Stream.concat(
-                                groups.stream()
-                                        .filter(group -> !SIMULATION_GROUPS.contains(group))
-                                        .map(group -> "unknown-group:" + group),
-                                requestedCapabilities.stream()
-                                        .filter(capability -> !SIMULATION_KNOWN_CAPABILITIES.contains(capability))
-                                        .map(capability -> "unknown-capability:" + capability)))
+        List<String> deniedInputs = Stream.of(
+                        deniedInputCodes(request == null ? null : request.roles(), "role", SIMULATION_ROLES),
+                        deniedInputCodes(request == null ? null : request.groups(), "group", SIMULATION_GROUPS),
+                        deniedInputCodes(request == null ? null : request.requestedCapabilities(), "capability", SIMULATION_KNOWN_CAPABILITIES))
+                .flatMap(List::stream)
+                .distinct()
+                .sorted()
                 .toList();
+        List<String> roles = normalizedKnownValues(request == null ? null : request.roles(), SIMULATION_ROLES);
+        List<String> groups = normalizedKnownValues(request == null ? null : request.groups(), SIMULATION_GROUPS);
+        List<String> requestedCapabilities = normalizedKnownValues(request == null ? null : request.requestedCapabilities(), SIMULATION_KNOWN_CAPABILITIES);
         boolean failClosed = !deniedInputs.isEmpty();
         LinkedHashSet<String> grants = new LinkedHashSet<>();
         if (!failClosed) {
@@ -358,21 +354,22 @@ public class AdminControlPlaneService {
                 "admin-control-plane",
                 actorRef(jwt),
                 "effective-policy-simulation",
-                AuditAction.ADMIN_POLICY_UPDATED,
+                AuditAction.EFFECTIVE_POLICY_SIMULATED,
                 Instant.now(clock),
                 auditRef,
                 AuditRedactionLevel.SECRET_REDACTED,
                 Map.of(
-                        "subject", safeText(request == null ? null : request.subject()),
-                        "organizationId", safeText(request == null ? null : request.organizationId()),
+                        "subjectProvided", request != null && request.subject() != null && !request.subject().isBlank(),
+                        "organizationProvided", request != null && request.organizationId() != null && !request.organizationId().isBlank(),
                         "roleCount", roles.size(),
                         "groupCount", groups.size(),
                         "requestedCapabilityCount", requestedCapabilities.size(),
+                        "unknownInputCount", deniedInputs.size(),
                         "unknownInputsFailClosed", failClosed,
                         "supportSafe", true,
-                        "reason", safeText(request == null ? null : request.reason()))));
+                        "reasonProvided", request != null && request.reason() != null && !request.reason().isBlank())));
         return new EffectivePolicySimulationResponse(
-                safeText(request == null ? null : request.subject()),
+                safeSimulationIdentityRef(request == null ? null : request.subject()),
                 request == null || request.organizationId() == null || request.organizationId().isBlank()
                         ? organizationId(jwt)
                         : safeText(request.organizationId()),
@@ -1134,17 +1131,46 @@ public class AdminControlPlaneService {
                 .toList();
     }
 
-    private List<String> normalizedValues(List<String> values) {
+    private List<String> normalizedKnownValues(List<String> values, Set<String> knownValues) {
         if (values == null) {
             return List.of();
         }
         return values.stream()
                 .filter(value -> value != null && !value.isBlank())
                 .map(value -> value.trim().toLowerCase(Locale.ROOT))
-                .filter(value -> value.matches("[a-z][a-z0-9_.:-]*"))
+                .filter(this::safeSimulationInputToken)
+                .filter(knownValues::contains)
                 .distinct()
                 .sorted()
                 .toList();
+    }
+
+    private List<String> deniedInputCodes(List<String> values, String kind, Set<String> knownValues) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .map(value -> {
+                    if (value == null || value.isBlank()) {
+                        return "invalid-" + kind;
+                    }
+                    String normalized = value.trim().toLowerCase(Locale.ROOT);
+                    if (!safeSimulationInputToken(normalized)) {
+                        return "invalid-" + kind;
+                    }
+                    if (!knownValues.contains(normalized)) {
+                        return "unknown-" + kind;
+                    }
+                    return null;
+                })
+                .filter(value -> value != null)
+                .distinct()
+                .sorted()
+                .toList();
+    }
+
+    private boolean safeSimulationInputToken(String value) {
+        return value != null && value.matches("[a-z][a-z0-9_.:-]*");
     }
 
     private EffectivePolicySimulationResponse.CapabilityState simulationState(
@@ -1177,6 +1203,17 @@ public class AdminControlPlaneService {
                 "policy-blocked",
                 "deny-by-default-capability-policy",
                 "This capability remains blocked unless a known org role or group grants it.");
+    }
+
+    private String safeSimulationIdentityRef(String value) {
+        if (value == null || value.isBlank()) {
+            return "not-provided";
+        }
+        String trimmed = value.trim();
+        if (trimmed.contains("@") || trimmed.matches("(?i).*(bearer\\s+|xox[baprs]-|secret(ref)?://|https?://|token|secret).*")) {
+            return "identity-ref-redacted";
+        }
+        return safeText(trimmed);
     }
 
     private boolean safePrimaryIdentityKey(String value) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -288,6 +288,75 @@ class AdminControlPlaneControllerTest {
                 .andExpect(content().string(not(containsString("alice@example.com"))));
     }
 
+
+    @Test
+    void effectivePolicySimulationIsAdminOperatorOnlySupportSafeAndAudited() throws Exception {
+        String request = """
+                {
+                  "subject": "alice@example.com",
+                  "organizationId": "weave-dogfood",
+                  "roles": ["member"],
+                  "groups": ["weave-board-editors"],
+                  "requestedCapabilities": ["chat.send", "boards.update_task", "admin.provider.configure", "weaver.enabled"],
+                  "reason": "preview before provider change with Bearer secret-token and client_secret"
+                }
+                """;
+
+        mockMvc.perform(post("/api/admin/policies/effective/simulations")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.subject").value("identity-ref-redacted"))
+                .andExpect(jsonPath("$.organizationId").value("weave-dogfood"))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.unknownInputsFailClosed").value(false))
+                .andExpect(jsonPath("$.weaverDefaultDisabled").value(true))
+                .andExpect(jsonPath("$.grantedCapabilities[*]", hasItems("chat.send", "boards.update_task")))
+                .andExpect(jsonPath("$.deniedInputs").isEmpty())
+                .andExpect(jsonPath("$.capabilityStates[*].state", hasItems("ready", "disabled", "policy-blocked")))
+                .andExpect(jsonPath("$.capabilityStates[?(@.capability == 'weaver.enabled')].reasonCode", hasItems("weaver-default-disabled")))
+                .andExpect(jsonPath("$.capabilityStates[?(@.capability == 'admin.provider.configure')].state", hasItems("policy-blocked")))
+                .andExpect(content().string(not(containsString("alice@example.com"))))
+                .andExpect(content().string(not(containsString("secret-token"))))
+                .andExpect(content().string(not(containsString("client_secret"))))
+                .andExpect(content().string(not(containsString("keycloak-realm"))));
+
+        mockMvc.perform(post("/api/admin/policies/effective/simulations")
+                        .with(operatorJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"roles\":[\"member\"],\"requestedCapabilities\":[\"chat.read\"]}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.grantedCapabilities[*]", hasItems("chat.read")));
+
+        mockMvc.perform(get("/api/admin/audit/events").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].action", hasItems("effective_policy.simulated")))
+                .andExpect(jsonPath("$[*].payload.roleCount", hasItems(1)))
+                .andExpect(jsonPath("$[*].payload.groupCount", hasItems(1)))
+                .andExpect(jsonPath("$[*].payload.requestedCapabilityCount", hasItems(4)))
+                .andExpect(jsonPath("$[*].payload.supportSafe", hasItems(true)))
+                .andExpect(jsonPath("$[*].payload.reasonProvided", hasItems(true)))
+                .andExpect(content().string(not(containsString("preview before provider change"))))
+                .andExpect(content().string(not(containsString("secret-token"))))
+                .andExpect(content().string(not(containsString("alice@example.com"))));
+    }
+
+    @Test
+    void memberCannotRunEffectivePolicySimulationOrSeePolicyInternals() throws Exception {
+        mockMvc.perform(post("/api/admin/policies/effective/simulations")
+                        .with(memberJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"roles\":[\"admin\"],\"groups\":[\"weave-board-editors\"],\"requestedCapabilities\":[\"admin.provider.configure\"]}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"))
+                .andExpect(jsonPath("$.details.diagnosticsRedacted").value(true))
+                .andExpect(content().string(not(containsString("admin.provider.configure"))))
+                .andExpect(content().string(not(containsString("weave-board-editors"))))
+                .andExpect(content().string(not(containsString("keycloak-realm"))));
+    }
+
     @Test
     void adminRealmDryRunIsBackendOwnedDeterministicAndSupportSafe() throws Exception {
         String request = """

--- a/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
@@ -1,13 +1,17 @@
 package com.massimotter.weave.backend.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.massimotter.weave.backend.audit.AuditAction;
 import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
+import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationRequest;
 import com.massimotter.weave.backend.provider.InMemoryProviderSelectionRepository;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
+import java.io.InputStream;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -60,6 +64,112 @@ class AdminControlPlaneServiceTest {
         assertThat(auditPublisher.events().get(0).payload())
                 .containsEntry("profileKey", "workspace-admin")
                 .containsEntry("denyByDefault", true);
+    }
+
+
+    @Test
+    void adminAndOperatorCanSimulateEffectiveProviderPolicyBeforeChanges() throws Exception {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        AdminControlPlaneService service = adminControlPlaneService(auditPublisher);
+        EffectivePolicySimulationRequest request = new EffectivePolicySimulationRequest(
+                "issuer+subject:https://auth.example.invalid/realms/weave#member-123",
+                "weave-dogfood",
+                List.of("member"),
+                List.of("weave-board-editors"),
+                List.of("chat.send", "boards.update_task", "admin.provider.configure", "weaver.enabled"),
+                "simulate before #233 dry-run/apply with Bearer operator-token and secretref://weave/provider/keycloak");
+
+        var adminResponse = service.simulateEffectivePolicy(request, jwt("admin"));
+        var operatorResponse = service.simulateEffectivePolicy(request, jwt("operator"));
+
+        assertThat(adminResponse.supportSafe()).isTrue();
+        assertThat(adminResponse.unknownInputsFailClosed()).isFalse();
+        assertThat(adminResponse.weaverDefaultDisabled()).isTrue();
+        assertThat(adminResponse.grantedCapabilities()).containsExactly("boards.update_task", "chat.send");
+        assertThat(adminResponse.capabilityStates()).extracting(state -> state.state())
+                .containsOnly("ready", "disabled", "policy-blocked");
+        assertThat(adminResponse.capabilityStates()).filteredOn(state -> state.capability().equals("weaver.enabled"))
+                .singleElement()
+                .satisfies(state -> {
+                    assertThat(state.state()).isEqualTo("disabled");
+                    assertThat(state.reasonCode()).isEqualTo("weaver-default-disabled");
+                });
+        assertThat(operatorResponse.grantedCapabilities()).containsExactly("boards.update_task", "chat.send");
+
+        assertThat(auditPublisher.events()).hasSize(2);
+        assertThat(auditPublisher.events()).allSatisfy(event -> {
+            assertThat(event.action()).isEqualTo(AuditAction.EFFECTIVE_POLICY_SIMULATED);
+            assertThat(event.payload())
+                    .containsEntry("roleCount", 1)
+                    .containsEntry("groupCount", 1)
+                    .containsEntry("requestedCapabilityCount", 4)
+                    .containsEntry("unknownInputCount", 0)
+                    .containsEntry("supportSafe", true)
+                    .containsEntry("reasonProvided", true);
+            assertThat(event.payload()).doesNotContainKeys("reason", "subject", "organizationId");
+        });
+        assertThat(new ObjectMapper().findAndRegisterModules().writeValueAsString(auditPublisher.events()))
+                .doesNotContain("operator-token", "secretref://", "simulate before #233", "member-123");
+    }
+
+    @Test
+    void unknownSimulationInputsFailClosedForEveryRequestedCapability() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        AdminControlPlaneService service = adminControlPlaneService(auditPublisher);
+        EffectivePolicySimulationRequest request = new EffectivePolicySimulationRequest(
+                "alice@example.com",
+                "weave-dogfood",
+                List.of("super-admin", "not mapped"),
+                List.of("finance-admins"),
+                List.of("chat.read", "provider.internal.token", "Bearer raw-token"),
+                "unknown provider import preview");
+
+        var response = service.simulateEffectivePolicy(request, jwt("admin"));
+
+        assertThat(response.subject()).isEqualTo("identity-ref-redacted");
+        assertThat(response.unknownInputsFailClosed()).isTrue();
+        assertThat(response.grantedCapabilities()).isEmpty();
+        assertThat(response.roles()).isEmpty();
+        assertThat(response.groups()).isEmpty();
+        assertThat(response.requestedCapabilities()).containsExactly("chat.read");
+        assertThat(response.deniedInputs()).containsExactly(
+                "invalid-capability",
+                "invalid-role",
+                "unknown-capability",
+                "unknown-group",
+                "unknown-role");
+        assertThat(response.capabilityStates()).extracting(state -> state.state()).containsOnly("policy-blocked");
+        assertThat(response.capabilityStates()).extracting(state -> state.reasonCode())
+                .containsOnly("unknown-identity-inputs-fail-closed");
+        assertThat(response.toString()).doesNotContain("super-admin", "not mapped", "finance-admins", "provider.internal.token", "raw-token");
+    }
+
+    @Test
+    void checkedInSimulationFixtureIsSupportSafeAndContractShaped() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        try (InputStream input = getClass().getResourceAsStream("/effective-policy-simulation/admin-operator-preview.json")) {
+            assertThat(input).isNotNull();
+            JsonNode fixture = objectMapper.readTree(input);
+
+            assertThat(fixture.path("supportSafe").asBoolean()).isTrue();
+            assertThat(fixture.path("weaverDefaultDisabled").asBoolean()).isTrue();
+            assertThat(fixture.path("unknownInputsFailClosed").asBoolean()).isFalse();
+            assertThat(fixture.path("subject").asText()).startsWith("issuer+subject:");
+            assertThat(fixture.path("capabilityStates")).allSatisfy(state ->
+                    assertThat(state.path("state").asText()).isIn("ready", "disabled", "degraded", "policy-blocked"));
+            assertThat(objectMapper.writeValueAsString(fixture))
+                    .doesNotContain("@", "client_secret", "Authorization", "Bearer ", "access_token", "secretref://", "keycloak-realm");
+        }
+    }
+
+    private AdminControlPlaneService adminControlPlaneService(InMemoryAuditEventPublisher auditPublisher) {
+        return new AdminControlPlaneService(
+                mock(ProviderRegistry.class),
+                workspaceCapabilityService(),
+                new InMemoryProviderSelectionRepository(),
+                new InMemoryOrganizationBootstrapRepository(),
+                auditPublisher,
+                Clock.fixed(Instant.parse("2026-05-27T01:03:39Z"), ZoneOffset.UTC));
     }
 
     private WorkspaceCapabilityService workspaceCapabilityService() {

--- a/server/src/test/resources/effective-policy-simulation/admin-operator-preview.json
+++ b/server/src/test/resources/effective-policy-simulation/admin-operator-preview.json
@@ -1,0 +1,49 @@
+{
+  "subject": "issuer+subject:example-issuer#member-123",
+  "organizationId": "weave-dogfood",
+  "roles": [
+    "member"
+  ],
+  "groups": [
+    "weave-board-editors"
+  ],
+  "requestedCapabilities": [
+    "boards.update_task",
+    "chat.send",
+    "weaver.enabled"
+  ],
+  "grantedCapabilities": [
+    "boards.update_task",
+    "chat.send"
+  ],
+  "deniedInputs": [],
+  "unknownInputsFailClosed": false,
+  "weaverDefaultDisabled": true,
+  "supportSafe": true,
+  "capabilityStates": [
+    {
+      "capability": "boards.update_task",
+      "state": "ready",
+      "reasonCode": "granted-by-effective-policy",
+      "memberImpact": "Member-visible capability state may be ready if provider readiness also passes."
+    },
+    {
+      "capability": "chat.send",
+      "state": "ready",
+      "reasonCode": "granted-by-effective-policy",
+      "memberImpact": "Member-visible capability state may be ready if provider readiness also passes."
+    },
+    {
+      "capability": "weaver.enabled",
+      "state": "disabled",
+      "reasonCode": "weaver-default-disabled",
+      "memberImpact": "Weaver remains opt-in, governed, audited, and disabled by default."
+    }
+  ],
+  "nextActions": [
+    "Review member-visible states before applying provider or realm changes."
+  ],
+  "auditRefs": [
+    "effective-policy-simulation-sample"
+  ]
+}


### PR DESCRIPTION
Closes #369.

## Summary
- hardens the admin/operator effective policy simulation audit path so simulation events use a dedicated support-safe action and count-only payload
- adds backend/controller/service coverage for admin/operator simulation, fail-closed unknown inputs, disabled-by-default Weaver evidence, member denial, and support-safe fixtures
- documents how simulation fits between #212 Workspace Health/admin readiness and #233 realm dry-run/apply

## Evidence
- ./gradlew serverCi
- ./gradlew releaseEvidenceCheck
- ./gradlew ci

## Safety
- no provider mutation or runtime Weaver enablement
- no raw secrets/tokens/provider internals/free-text reasons in responses or audit payloads
