### PR TITLE
identity: add guarded provider apply path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
 - Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
 - Admin/operator effective policy simulation endpoint with support-safe capability impact output, fail-closed unknown identity inputs, Weaver disabled-by-default evidence, and audited counts before provider or realm changes apply.
+- Guarded identity realm apply decision path with explicit confirmation, retained-admin lockout protection, risky/destructive rollback evidence gates, support-safe audit counts, and decision-only provider mutation semantics.
 
 ## Changed
 

--- a/docs/admin-operator-handbook.md
+++ b/docs/admin-operator-handbook.md
@@ -52,6 +52,20 @@ The desired-state contract covers realm basics, OIDC clients, roles, groups, sco
 
 Evidence must stay support-safe: no raw provider bodies, provider-internal IDs, credential-bearing URLs, private keys, tokens, or SecretRef payloads. A sanitized sample is checked in at `docs/evidence/identity-realm-dry-run-sample.json`; contract fixtures live under `server/src/test/resources/identity-realm-dry-run/`.
 
+## Identity realm guarded apply
+
+Use `POST /api/admin/identity/realm/apply` only after the #233 dry-run report and #369 effective policy simulation have both been reviewed. The apply endpoint is a guarded decision scaffold in this sprint: it can accept a support-safe plan, publish audit evidence, and return remediation, but it does not perform live Keycloak, OpenTofu/Terraform, credential, or provider mutation.
+
+Apply is unavailable or blocked when any guard fails:
+
+- missing `confirmationPhrase=APPLY WEAVE IDENTITY REALM`;
+- no retained immutable owner/admin primary identity key such as `issuer+subject`; email addresses are not accepted as recovery keys;
+- risky changes without `approveRisky=true` and a support-safe rollback evidence reference;
+- destructive changes without `approveDestructive=true`, rollback/restore evidence, and provider support for destructive apply; the current Keycloak realm provider reports `destructiveApplyAvailable=false`;
+- dry-run blockers remain, including unknown identity inputs, lockout risk, or destructive removals blocked by the dry-run slice.
+
+The audit trail records only support-safe fields and counts: authenticated actor class, realm candidate, dry-run plan ref, decision/result, change counts, retained-admin count, rollback evidence presence, and mutation-performed=false. It must not include raw reason text, rollback payloads, email primary keys, provider internals, tokens, credentials, SecretRef payloads, or provider response bodies. A support-safe accepted-decision fixture is checked in at `server/src/test/resources/identity-realm-apply/guarded-safe-accepted.json`.
+
 ## Identity provider readiness in Workspace Health
 
 Workspace Health reads identity/provider readiness from backend-owned facades only. Use `GET /api/admin/identity/readiness` or the embedded `identityProviderReadiness` block on `GET /api/admin/control-plane`; normal members must not call these admin endpoints.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -12,6 +12,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
 - Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
 - Admin/operator effective policy simulation endpoint with support-safe capability impact output, fail-closed unknown identity inputs, Weaver disabled-by-default evidence, and audited counts before provider or realm changes apply.
+- Guarded identity realm apply decision path with explicit confirmation, retained-admin lockout protection, risky/destructive rollback evidence gates, support-safe audit counts, and decision-only provider mutation semantics.
 
 ## Changed
 

--- a/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
+++ b/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
@@ -14,6 +14,7 @@ public enum AuditAction {
     CONSENT_GRANTED("consent.granted"),
     CONSENT_REVOKED("consent.revoked"),
     EFFECTIVE_POLICY_SIMULATED("effective_policy.simulated"),
+    IDENTITY_REALM_APPLY_GUARDED("identity.realm.apply.guarded"),
     ADMIN_POLICY_UPDATED("admin.policy.updated"),
     PROVIDER_READINESS_TESTED("provider.readiness.tested"),
     PROVIDER_REPLACEMENT_DRY_RUN("provider.replacement.dry_run"),

--- a/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmApplyReport.java
+++ b/server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmApplyReport.java
@@ -11,6 +11,7 @@ public record IdentityRealmApplyReport(
         String decision,
         String executionMode,
         boolean applied,
+        boolean providerMutationPerformed,
         boolean supportSafe,
         boolean rawSecretExposed,
         boolean lastAdminGuardPassed,

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -434,14 +434,18 @@ public class AdminControlPlaneService {
         workspaceCapabilityService.requireCapability(jwt, "admin.provider.configure", "identity-realm", "apply");
         IdentityRealmProvider provider = identityRealmProvider("keycloak-realm");
         IdentityRealmDryRunReport dryRun = provider.dryRun(request == null ? null : request.dryRunRequest());
-        boolean hasRisky = dryRun.changes().stream().anyMatch(change -> "risky".equals(change.classification()));
-        boolean hasDestructive = dryRun.changes().stream().anyMatch(change -> "destructive".equals(change.classification()));
+        long safeChangeCount = dryRun.changes().stream().filter(change -> "safe".equals(change.classification())).count();
+        long riskyChangeCount = dryRun.changes().stream().filter(change -> "risky".equals(change.classification())).count();
+        long destructiveChangeCount = dryRun.changes().stream().filter(change -> "destructive".equals(change.classification())).count();
+        boolean hasRisky = riskyChangeCount > 0;
+        boolean hasDestructive = destructiveChangeCount > 0;
         boolean rollbackRequired = hasRisky || hasDestructive;
         boolean rollbackAccepted = !rollbackRequired || hasText(request == null ? null : request.rollbackEvidenceRef());
         boolean lastAdminGuardPassed = request != null && request.retainedAdminPrimaryIdentityKeys().stream()
                 .anyMatch(this::safePrimaryIdentityKey);
+        boolean confirmationProvided = request != null && "APPLY WEAVE IDENTITY REALM".equals(request.confirmationPhrase());
         List<String> blocked = new ArrayList<>();
-        if (request == null || !"APPLY WEAVE IDENTITY REALM".equals(request.confirmationPhrase())) {
+        if (!confirmationProvided) {
             blocked.add("explicit confirmation phrase is required");
         }
         if (!lastAdminGuardPassed) {
@@ -461,33 +465,49 @@ public class AdminControlPlaneService {
         }
         blocked.addAll(dryRun.blockers());
         boolean accepted = blocked.isEmpty();
+        boolean providerMutationPerformed = false;
+        String executionMode = "guarded-provider-apply-decision-only";
+        List<String> nextActions = applyNextActions(accepted, blocked, rollbackRequired, hasRisky, hasDestructive);
         String auditRef = "identity-realm-apply-" + Instant.now(clock).toEpochMilli();
+        String actorRef = actorRef(jwt);
         auditEventPublisher.publish(new AuditEvent(
                 organizationId(jwt),
                 "admin-control-plane",
-                actorRef(jwt),
+                actorRef,
                 "identity-realm-apply",
-                AuditAction.ADMIN_POLICY_UPDATED,
+                AuditAction.IDENTITY_REALM_APPLY_GUARDED,
                 Instant.now(clock),
                 auditRef,
-                AuditRedactionLevel.SECRET_REDACTED,
-                Map.of(
-                        "providerKey", provider.providerKey(),
-                        "realmId", dryRun.realmId(),
-                        "decision", accepted ? "accepted" : "blocked",
-                        "changeCount", dryRun.changes().size(),
-                        "blockedReasonCount", blocked.size(),
-                        "lastAdminGuardPassed", lastAdminGuardPassed,
-                        "rollbackEvidenceAccepted", rollbackAccepted,
-                        "supportSafe", true,
-                        "rawSecretExposed", false)));
+                AuditRedactionLevel.SUPPORT_SAFE,
+                Map.ofEntries(
+                        Map.entry("actorRef", actorRef),
+                        Map.entry("candidateRef", "identity-realm:" + dryRun.realmId()),
+                        Map.entry("planRef", dryRun.dryRunId()),
+                        Map.entry("providerKey", provider.providerKey()),
+                        Map.entry("realmId", dryRun.realmId()),
+                        Map.entry("decision", accepted ? "accepted" : "blocked"),
+                        Map.entry("result", accepted ? "accepted-without-provider-mutation" : "blocked-before-provider-mutation"),
+                        Map.entry("executionMode", executionMode),
+                        Map.entry("providerMutationPerformed", providerMutationPerformed),
+                        Map.entry("safeChangeCount", safeChangeCount),
+                        Map.entry("riskyChangeCount", riskyChangeCount),
+                        Map.entry("destructiveChangeCount", destructiveChangeCount),
+                        Map.entry("blockedReasonCount", blocked.size()),
+                        Map.entry("nextActionCount", nextActions.size()),
+                        Map.entry("confirmationProvided", confirmationProvided),
+                        Map.entry("retainedAdminIdentityKeyCount", request == null ? 0 : request.retainedAdminPrimaryIdentityKeys().stream().filter(this::safePrimaryIdentityKey).count()),
+                        Map.entry("rollbackRestoreEvidencePresent", request != null && hasText(request.rollbackEvidenceRef())),
+                        Map.entry("lastAdminGuardPassed", lastAdminGuardPassed),
+                        Map.entry("rollbackEvidenceAccepted", rollbackAccepted),
+                        Map.entry("supportSafe", true))));
         return new IdentityRealmApplyReport(
                 provider.providerKey(),
                 dryRun.realmId(),
                 dryRun.dryRunId(),
                 accepted ? "accepted" : "blocked",
-                "guarded-provider-apply-contract",
-                accepted,
+                executionMode,
+                false,
+                providerMutationPerformed,
                 true,
                 false,
                 lastAdminGuardPassed,
@@ -495,10 +515,39 @@ public class AdminControlPlaneService {
                 rollbackAccepted,
                 blocked.stream().distinct().toList(),
                 dryRun.changes(),
-                accepted
-                        ? List.of("Provider adapter may now execute the guarded apply operation under operator monitoring.")
-                        : List.of("Resolve blocked reasons and re-run dry-run before applying."),
+                nextActions,
                 List.of(auditRef));
+    }
+
+    private List<String> applyNextActions(
+            boolean accepted,
+            List<String> blocked,
+            boolean rollbackRequired,
+            boolean hasRisky,
+            boolean hasDestructive) {
+        if (accepted) {
+            return List.of(
+                    "Guarded apply decision accepted; no live provider mutation was performed in this sprint slice.",
+                    "Archive the dry-run, policy simulation, retained-admin, and rollback evidence with the audit ref before any future provider adapter executor is enabled.");
+        }
+        List<String> nextActions = new ArrayList<>();
+        if (blocked.stream().anyMatch(reason -> reason.contains("confirmation"))) {
+            nextActions.add("Re-submit with confirmationPhrase=APPLY WEAVE IDENTITY REALM after reviewing the dry-run.");
+        }
+        if (blocked.stream().anyMatch(reason -> reason.contains("last-admin"))) {
+            nextActions.add("Retain at least one immutable owner/admin primary identity key such as issuer+subject before retrying.");
+        }
+        if (hasRisky) {
+            nextActions.add("Review risky change classifications, run effective policy simulation, and set approveRisky=true only with operator evidence.");
+        }
+        if (hasDestructive) {
+            nextActions.add("Treat destructive changes as unavailable until provider destructive apply support and restore evidence are explicitly proven.");
+        }
+        if (rollbackRequired && blocked.stream().anyMatch(reason -> reason.contains("rollback/restore evidence"))) {
+            nextActions.add("Attach a support-safe rollback/restore evidence reference before retrying risky or destructive apply.");
+        }
+        nextActions.add("Resolve blockedReasons and re-run /api/admin/identity/realm/dry-run before another apply attempt.");
+        return nextActions.stream().distinct().toList();
     }
 
     public CapabilityWhitelistResponse whitelist(Jwt jwt) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -404,6 +404,93 @@ class AdminControlPlaneControllerTest {
                 .andExpect(content().string(not(containsString("server-test-secret-that-must-never-appear"))));
     }
 
+
+    @Test
+    void adminRealmApplyIsGuardedDecisionOnlySupportSafeAndAudited() throws Exception {
+        String request = """
+                {
+                  "currentState": {
+                    "realmId": "weave-dogfood",
+                    "displayName": "Weave Dogfood",
+                    "enabled": true,
+                    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback"],"roles":["owner","admin","member"],"scopes":["openid","profile","email"]}],
+                    "roles": ["owner", "admin", "member"],
+                    "groups": ["weave-board-editors"],
+                    "scopes": ["openid", "profile", "email", "weave:workspace"],
+                    "claimMappers": [{"name":"tenant","sourceClaim":"weave_tenant","targetClaim":"organizationId","required":true}],
+                    "redirectOrigins": ["https://weave.local/callback"],
+                    "featureMappings": [{"featureKey":"boards","requiredRoles":["member"],"requiredGroups":["weave-board-editors"],"requiredScopes":["openid"]}]
+                  },
+                  "desiredState": {
+                    "realmId": "weave-dogfood",
+                    "displayName": "Weave Dogfood",
+                    "enabled": true,
+                    "clients": [{"clientId":"weave-app","publicClient":true,"redirectOrigins":["https://weave.local/callback"],"roles":["owner","admin","member"],"scopes":["openid","profile","email"]}],
+                    "roles": ["owner", "admin", "member"],
+                    "groups": ["weave-board-editors"],
+                    "scopes": ["openid", "profile", "email", "weave:workspace"],
+                    "claimMappers": [{"name":"tenant","sourceClaim":"weave_tenant","targetClaim":"organizationId","required":true}],
+                    "redirectOrigins": ["https://weave.local/callback"],
+                    "featureMappings": [{"featureKey":"boards","requiredRoles":["member"],"requiredGroups":["weave-board-editors"],"requiredScopes":["openid"]}]
+                  },
+                  "confirmationPhrase": "APPLY WEAVE IDENTITY REALM",
+                  "approveRisky": false,
+                  "approveDestructive": false,
+                  "retainedAdminPrimaryIdentityKeys": ["issuer+subject:https://auth.example.invalid/realms/weave#admin-123"],
+                  "reason": "controller apply with Bearer raw-token and secretref://raw/ref"
+                }
+                """;
+
+        mockMvc.perform(post("/api/admin/identity/realm/apply")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.providerKey").value("keycloak-realm"))
+                .andExpect(jsonPath("$.decision").value("accepted"))
+                .andExpect(jsonPath("$.executionMode").value("guarded-provider-apply-decision-only"))
+                .andExpect(jsonPath("$.applied").value(false))
+                .andExpect(jsonPath("$.providerMutationPerformed").value(false))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.lastAdminGuardPassed").value(true))
+                .andExpect(jsonPath("$.blockedReasons").isEmpty())
+                .andExpect(jsonPath("$.auditRefs[0]").exists())
+                .andExpect(content().string(not(containsString("raw-token"))))
+                .andExpect(content().string(not(containsString("secretref://raw/ref"))));
+
+        mockMvc.perform(get("/api/admin/audit/events").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].action", hasItems("identity.realm.apply.guarded")))
+                .andExpect(jsonPath("$[*].payload.actorRef", hasItems("user:admin-123")))
+                .andExpect(jsonPath("$[*].payload.decision", hasItems("accepted")))
+                .andExpect(jsonPath("$[*].payload.result", hasItems("accepted-without-provider-mutation")))
+                .andExpect(jsonPath("$[*].payload.providerMutationPerformed", hasItems(false)))
+                .andExpect(content().string(not(containsString("raw-token"))))
+                .andExpect(content().string(not(containsString("secretref://raw/ref"))))
+                .andExpect(content().string(not(containsString("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"))));
+    }
+
+    @Test
+    void operatorAndMemberCannotApplyIdentityRealmWhenPolicyForbidsProviderConfiguration() throws Exception {
+        String request = "{\"desiredState\":{\"realmId\":\"weave-dogfood\"},\"confirmationPhrase\":\"APPLY WEAVE IDENTITY REALM\"}";
+
+        mockMvc.perform(post("/api/admin/identity/realm/apply")
+                        .with(operatorJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin.provider.configure"));
+
+        mockMvc.perform(post("/api/admin/identity/realm/apply")
+                        .with(memberJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin.provider.configure"));
+    }
+
     @Test
     void memberCannotRunRealmDryRunOrSeeProviderSetupInternals() throws Exception {
         mockMvc.perform(post("/api/admin/identity/realm/dry-run")

--- a/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
@@ -7,6 +7,8 @@ import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyRequest;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDesiredState;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationRequest;
 import com.massimotter.weave.backend.provider.InMemoryProviderSelectionRepository;
@@ -162,6 +164,175 @@ class AdminControlPlaneServiceTest {
         }
     }
 
+
+    @Test
+    void guardedIdentityRealmApplyAcceptsSafePlanOnlyWithConfirmationAndRetainedAdminKey() throws Exception {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        AdminControlPlaneService service = adminControlPlaneService(auditPublisher);
+        IdentityRealmDesiredState safeState = safeRealmState();
+
+        var missingConfirmation = service.applyIdentityRealm(new IdentityRealmApplyRequest(
+                safeState,
+                safeState,
+                "reviewed only",
+                false,
+                false,
+                List.of("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"),
+                null,
+                "safe apply review"), jwt("admin"));
+
+        assertThat(missingConfirmation.decision()).isEqualTo("blocked");
+        assertThat(missingConfirmation.applied()).isFalse();
+        assertThat(missingConfirmation.providerMutationPerformed()).isFalse();
+        assertThat(missingConfirmation.blockedReasons()).contains("explicit confirmation phrase is required");
+
+        var unsafeAdminKey = service.applyIdentityRealm(new IdentityRealmApplyRequest(
+                safeState,
+                safeState,
+                "APPLY WEAVE IDENTITY REALM",
+                false,
+                false,
+                List.of("alice@example.com"),
+                null,
+                "safe apply review"), jwt("admin"));
+
+        assertThat(unsafeAdminKey.decision()).isEqualTo("blocked");
+        assertThat(unsafeAdminKey.lastAdminGuardPassed()).isFalse();
+        assertThat(unsafeAdminKey.blockedReasons())
+                .contains("last-admin guard requires at least one retained immutable admin identity key");
+
+        var accepted = service.applyIdentityRealm(new IdentityRealmApplyRequest(
+                safeState,
+                safeState,
+                "APPLY WEAVE IDENTITY REALM",
+                false,
+                false,
+                List.of("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"),
+                null,
+                "safe apply review with Bearer token-that-must-not-leak"), jwt("admin"));
+
+        assertThat(accepted.decision()).isEqualTo("accepted");
+        assertThat(accepted.executionMode()).isEqualTo("guarded-provider-apply-decision-only");
+        assertThat(accepted.applied()).isFalse();
+        assertThat(accepted.providerMutationPerformed()).isFalse();
+        assertThat(accepted.lastAdminGuardPassed()).isTrue();
+        assertThat(accepted.rollbackEvidenceRequired()).isFalse();
+        assertThat(accepted.blockedReasons()).isEmpty();
+        assertThat(accepted.changes()).allSatisfy(change -> assertThat(change.classification()).isEqualTo("safe"));
+        assertThat(accepted.nextActions()).anySatisfy(action -> assertThat(action).contains("no live provider mutation"));
+
+        assertThat(auditPublisher.events()).extracting(event -> event.action())
+                .contains(AuditAction.IDENTITY_REALM_APPLY_GUARDED);
+        var auditJson = new ObjectMapper().findAndRegisterModules().writeValueAsString(auditPublisher.events());
+        assertThat(auditJson)
+                .contains("IDENTITY_REALM_APPLY_GUARDED", "user:admin-123", "candidateRef", "planRef", "accepted-without-provider-mutation")
+                .doesNotContain("alice@example.com", "safe apply review", "token-that-must-not-leak", "issuer+subject:https://auth.example.invalid/realms/weave#admin-123");
+    }
+
+    @Test
+    void guardedIdentityRealmApplyBlocksRiskyWithoutApprovalAndRollbackEvidence() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        AdminControlPlaneService service = adminControlPlaneService(auditPublisher);
+        IdentityRealmDesiredState riskyState = riskyRealmState();
+
+        var missingApproval = service.applyIdentityRealm(new IdentityRealmApplyRequest(
+                safeRealmState(),
+                riskyState,
+                "APPLY WEAVE IDENTITY REALM",
+                false,
+                false,
+                List.of("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"),
+                null,
+                "risky apply with secretref://raw/ref"), jwt("admin"));
+
+        assertThat(missingApproval.decision()).isEqualTo("blocked");
+        assertThat(missingApproval.applied()).isFalse();
+        assertThat(missingApproval.providerMutationPerformed()).isFalse();
+        assertThat(missingApproval.rollbackEvidenceRequired()).isTrue();
+        assertThat(missingApproval.blockedReasons()).contains(
+                "risky changes require approveRisky=true",
+                "rollback/restore evidence ref is required for risky or destructive apply");
+        assertThat(missingApproval.nextActions()).anySatisfy(action -> assertThat(action).contains("effective policy simulation"));
+
+        var accepted = service.applyIdentityRealm(new IdentityRealmApplyRequest(
+                safeRealmState(),
+                riskyState,
+                "APPLY WEAVE IDENTITY REALM",
+                true,
+                false,
+                List.of("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"),
+                "rollback-evidence:ticket-370-support-safe",
+                "risky apply with Bearer raw-token"), jwt("admin"));
+
+        assertThat(accepted.decision()).isEqualTo("accepted");
+        assertThat(accepted.applied()).isFalse();
+        assertThat(accepted.providerMutationPerformed()).isFalse();
+        assertThat(accepted.rollbackEvidenceAccepted()).isTrue();
+        assertThat(accepted.changes()).extracting(change -> change.classification()).contains("risky");
+    }
+
+    @Test
+    void guardedIdentityRealmApplyBlocksDestructiveWithoutApprovalsAndWhenProviderUnavailable() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        AdminControlPlaneService service = adminControlPlaneService(auditPublisher);
+        IdentityRealmDesiredState current = riskyRealmState();
+        IdentityRealmDesiredState desired = safeRealmState();
+
+        var missingGuards = service.applyIdentityRealm(new IdentityRealmApplyRequest(
+                current,
+                desired,
+                "APPLY WEAVE IDENTITY REALM",
+                true,
+                false,
+                List.of("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"),
+                null,
+                "destructive review"), jwt("admin"));
+
+        assertThat(missingGuards.decision()).isEqualTo("blocked");
+        assertThat(missingGuards.applied()).isFalse();
+        assertThat(missingGuards.providerMutationPerformed()).isFalse();
+        assertThat(missingGuards.blockedReasons()).contains(
+                "destructive changes require approveDestructive=true",
+                "provider destructive apply is not available for this contract",
+                "rollback/restore evidence ref is required for risky or destructive apply");
+        assertThat(missingGuards.changes()).extracting(change -> change.classification()).contains("destructive");
+        assertThat(missingGuards.nextActions()).anySatisfy(action -> assertThat(action).contains("destructive changes as unavailable"));
+
+        var stillUnavailable = service.applyIdentityRealm(new IdentityRealmApplyRequest(
+                current,
+                desired,
+                "APPLY WEAVE IDENTITY REALM",
+                true,
+                true,
+                List.of("issuer+subject:https://auth.example.invalid/realms/weave#admin-123"),
+                "restore-evidence:backup-370-support-safe",
+                "destructive review"), jwt("admin"));
+
+        assertThat(stillUnavailable.decision()).isEqualTo("blocked");
+        assertThat(stillUnavailable.blockedReasons()).contains("provider destructive apply is not available for this contract");
+        assertThat(stillUnavailable.blockedReasons()).contains("destructive realm changes are blocked in this dry-run-only slice");
+        assertThat(stillUnavailable.applied()).isFalse();
+        assertThat(stillUnavailable.providerMutationPerformed()).isFalse();
+    }
+
+
+    @Test
+    void checkedInApplyFixtureIsSupportSafeDecisionOnlyEvidence() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        try (InputStream input = getClass().getResourceAsStream("/identity-realm-apply/guarded-safe-accepted.json")) {
+            assertThat(input).isNotNull();
+            JsonNode fixture = objectMapper.readTree(input);
+
+            assertThat(fixture.path("supportSafe").asBoolean()).isTrue();
+            assertThat(fixture.path("decision").asText()).isEqualTo("accepted");
+            assertThat(fixture.path("executionMode").asText()).isEqualTo("guarded-provider-apply-decision-only");
+            assertThat(fixture.path("applied").asBoolean()).isFalse();
+            assertThat(fixture.path("providerMutationPerformed").asBoolean()).isFalse();
+            assertThat(objectMapper.writeValueAsString(fixture))
+                    .doesNotContain("@", "client_secret", "Authorization", "Bearer ", "access_token", "secretref://", "rollbackEvidenceRef", "issuer+subject:");
+        }
+    }
+
     private AdminControlPlaneService adminControlPlaneService(InMemoryAuditEventPublisher auditPublisher) {
         return new AdminControlPlaneService(
                 mock(ProviderRegistry.class),
@@ -179,6 +350,49 @@ class AdminControlPlaneServiceTest {
                 properties,
                 new WeaveSecurityProperties("weave-app", "weave-app"),
                 new WorkspaceCapabilityProperties(null, null, null, null, null, null));
+    }
+
+
+    private IdentityRealmDesiredState safeRealmState() {
+        return new IdentityRealmDesiredState(
+                "weave-dogfood",
+                "Weave Dogfood",
+                true,
+                List.of(new IdentityRealmDesiredState.RealmClient(
+                        "weave-app",
+                        true,
+                        List.of("https://weave.local/callback"),
+                        List.of("owner", "admin", "member"),
+                        List.of("openid", "profile", "email"))),
+                List.of("owner", "admin", "member"),
+                List.of("weave-board-editors"),
+                List.of("openid", "profile", "email", "weave:workspace"),
+                List.of(new IdentityRealmDesiredState.ClaimMapper("tenant", "weave_tenant", "organizationId", true)),
+                List.of("https://weave.local/callback"),
+                List.of(new IdentityRealmDesiredState.FeatureMapping("boards", List.of("member"), List.of("weave-board-editors"), List.of("openid"))),
+                List.of(),
+                List.of());
+    }
+
+    private IdentityRealmDesiredState riskyRealmState() {
+        return new IdentityRealmDesiredState(
+                "weave-dogfood",
+                "Weave Dogfood",
+                true,
+                List.of(new IdentityRealmDesiredState.RealmClient(
+                        "weave-app",
+                        true,
+                        List.of("https://weave.local/callback", "http://localhost:8080/*"),
+                        List.of("owner", "admin", "member"),
+                        List.of("openid", "profile", "email"))),
+                List.of("owner", "admin", "member"),
+                List.of("weave-board-editors"),
+                List.of("openid", "profile", "email", "weave:workspace"),
+                List.of(new IdentityRealmDesiredState.ClaimMapper("tenant", "weave_tenant", "organizationId", true)),
+                List.of("https://weave.local/callback", "http://localhost:8080/*"),
+                List.of(new IdentityRealmDesiredState.FeatureMapping("boards", List.of("member"), List.of("weave-board-editors"), List.of("openid"))),
+                List.of(),
+                List.of());
     }
 
     private Jwt jwt(String role) {

--- a/server/src/test/resources/identity-realm-apply/guarded-safe-accepted.json
+++ b/server/src/test/resources/identity-realm-apply/guarded-safe-accepted.json
@@ -1,0 +1,31 @@
+{
+  "providerKey": "keycloak-realm",
+  "realmId": "weave-dogfood",
+  "dryRunId": "realm-dry-run-support-safe-sample",
+  "decision": "accepted",
+  "executionMode": "guarded-provider-apply-decision-only",
+  "applied": false,
+  "providerMutationPerformed": false,
+  "supportSafe": true,
+  "rawSecretExposed": false,
+  "lastAdminGuardPassed": true,
+  "rollbackEvidenceRequired": false,
+  "rollbackEvidenceAccepted": true,
+  "blockedReasons": [],
+  "changes": [
+    {
+      "path": "/clients/weave-app",
+      "action": "no-op",
+      "classification": "safe",
+      "reasonCode": "oidc-client-managed-by-control-plane",
+      "beforeValue": "weave-app",
+      "afterValue": "weave-app",
+      "memberImpact": "members continue to use backend-owned sign-in; provider client details stay admin-only",
+      "applyBlocked": false
+    }
+  ],
+  "nextActions": [
+    "Guarded apply decision accepted; no live provider mutation was performed in this sprint slice."
+  ],
+  "auditRefs": ["identity-realm-apply-support-safe-sample"]
+}


### PR DESCRIPTION
Closes #370.

## Summary
- hardens the identity realm apply endpoint as a guarded decision-only path with explicit confirmation, retained-admin lockout protection, rollback evidence gates, and no live provider mutation
- adds support-safe audit action/payloads that record actor/candidate/plan/decision/result using counts and booleans instead of raw reasons/secrets
- adds backend/controller/service tests plus a support-safe apply fixture
- documents how guarded apply follows realm dry-run and effective policy simulation

## Evidence
- ./gradlew serverCi
- ./gradlew releaseEvidenceCheck
- ./gradlew ci

## Safety
- providerMutationPerformed=false and applied=false for this sprint slice
- risky/destructive paths fail closed without approvals and rollback/restore evidence
- destructive provider apply remains unavailable for the current contract
