### PR TITLE
docs: close Sprint 6 identity epics

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
 - Admin/operator effective policy simulation endpoint with support-safe capability impact output, fail-closed unknown identity inputs, Weaver disabled-by-default evidence, and audited counts before provider or realm changes apply.
 - Guarded identity realm apply decision path with explicit confirmation, retained-admin lockout protection, risky/destructive rollback evidence gates, support-safe audit counts, and decision-only provider mutation semantics.
+- Sprint 6 epic closure map for admin-owned OIDC setup (#212) and Keycloak realm dry-run/apply architecture (#233), linking role/setup contracts, realm baseline fixtures, Workspace Health readiness, policy simulation, and guarded apply evidence.
 
 ## Changed
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Start with:
 4. [Sprint 5 closure report](sprint-5-closure-report.md) — project-readiness evidence and release-candidate gaps.
 5. [Enterprise release foundation](enterprise-release-foundation.md) — release lanes, RC gate, waiver semantics, and support-safe artifacts.
 6. [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md) — active RC/provider-ops entry slice.
+7. [Sprint 6 epic closure report](sprint-6-epic-closure-report.md) — #212/#233 acceptance evidence after the merged identity/admin slices.
 
 ### Member / user
 
@@ -88,6 +89,7 @@ Release and evidence docs:
 - [Manuals and release notes integration](manuals-and-release-notes-integration.md)
 - [Sprint 5 closure report](sprint-5-closure-report.md)
 - [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md)
+- [Sprint 6 epic closure report](sprint-6-epic-closure-report.md)
 
 Historical/context docs:
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -13,6 +13,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
 - Admin/operator effective policy simulation endpoint with support-safe capability impact output, fail-closed unknown identity inputs, Weaver disabled-by-default evidence, and audited counts before provider or realm changes apply.
 - Guarded identity realm apply decision path with explicit confirmation, retained-admin lockout protection, risky/destructive rollback evidence gates, support-safe audit counts, and decision-only provider mutation semantics.
+- Sprint 6 epic closure map for admin-owned OIDC setup (#212) and Keycloak realm dry-run/apply architecture (#233), linking role/setup contracts, realm baseline fixtures, Workspace Health readiness, policy simulation, and guarded apply evidence.
 
 ## Changed
 

--- a/docs/sprint-6-epic-closure-report.md
+++ b/docs/sprint-6-epic-closure-report.md
@@ -1,0 +1,44 @@
+# Sprint 6 epic closure report
+
+Status: closure evidence for issues #212 and #233 after implementation slices #365, #366, #367, #368, #369, and #370.
+
+## Decision
+
+Both Sprint 6 epics still fit the target picture: Weave remains a provider-neutral organization suite where identity/provider setup is owned by the Organization/Admin Console and normal members only sign in to an already-provisioned workspace. The implementation slices materially satisfy the release-aligned acceptance criteria. No new provider executor, broad member UX, or raw Keycloak/Terraform product logic is needed for v0.1 closure.
+
+Future work should treat the live provider mutation executor, richer Admin Console dashboard composition, SCIM/LDAP/Entra adapters, and real rollback orchestration as follow-on issues. They must depend on the contracts below rather than reopening member-side OIDC setup.
+
+## #212 — Admin-owned OIDC setup and realm import
+
+| Acceptance criterion | Closure evidence |
+| --- | --- |
+| Role model is documented: owner, admin, member, guest. | `docs/admin-provisioned-first-use.md` documents `owner`, `admin`, `operator`, `member`, and `guest`; `operator` is deliberately distinct from identity/policy admin. `infra/weave-workspace/activate-user.sh --role owner\|admin\|member\|guest` remains the local activation helper, with the product role contract documented separately. |
+| Admin-owned setup flow is documented separately from user onboarding. | `docs/admin-provisioned-first-use.md` defines the member/admin boundary, while `docs/admin-operator-handbook.md` is the setup/runbook entry point. Normal member onboarding is limited to an invite/deep link or organization auth URL and SSO. |
+| A realm import JSON or generator contract exists for the baseline. | `server/src/main/resources/identity/weave-realm-baseline.json` is the support-safe desired-state input for `/api/admin/identity/realm/dry-run`; `infra/KEYCLOAK_CONTRACT.md` and `infra/weave-workspace/keycloak/weave-dev-realm-contract.json` document the local/dev Keycloak contract. |
+| `owner`/`admin` can be distinguished from `member`/`guest` in backend contracts. | `IdentityRealmDesiredState`, `KeycloakRealmDryRunProvider`, Workspace Health identity readiness, capability simulation, and guarded apply fixtures all model role/group/capability inputs; unknown roles fail closed and admin/provider endpoints require admin control-plane capabilities. |
+| Future admin dashboard work has a clear dependency on this role/setup contract. | Workspace Health/Admin Console must consume `GET /api/admin/identity/readiness`, `GET /api/admin/control-plane`, `/api/admin/identity/realm/dry-run`, `/api/admin/policies/effective/simulations`, and `/api/admin/identity/realm/apply`. It must preserve the role/setup split in `docs/admin-provisioned-first-use.md` and `docs/admin-operator-handbook.md`, showing provider diagnostics only to owner/admin/operator surfaces. |
+| User-facing help says users sign in; it does not ask normal users to configure OIDC. | `docs/admin-provisioned-first-use.md`, `docs/user-handbook.md`, architecture tests, and client setup copy keep OIDC/realm/provider setup out of normal member paths; users sign in through the organization endpoint and consume capability states. |
+
+## #233 — Keycloak realm provider dry-run/apply architecture
+
+| Acceptance criterion | Closure evidence |
+| --- | --- |
+| Inspect current Keycloak Terraform/OpenTofu module. | `infra/KEYCLOAK_CONTRACT.md` and `infra/weave-workspace/02-keycloak-setup` remain the local/dev bootstrap reference; product-level realm state moved into backend desired-state contracts instead of Terraform/OpenTofu as product logic. |
+| Define `IdentityRealmProvider` contract. | `server/src/main/java/com/massimotter/weave/backend/identity/realm/IdentityRealmProvider.java` defines `providerKey`, `dryRun`, and `destructiveApplyAvailable=false` by default. |
+| Model desired realm spec. | `IdentityRealmDesiredState` models realm basics, clients, roles, groups, scopes, claim mappers, redirect origins, feature mappings, provider warnings, and blockers. |
+| Add dry-run/diff/readiness contract. | `KeycloakRealmDryRunProvider` returns deterministic support-safe diffs, readiness checks, warnings/blockers, `destructiveApplyAvailable=false`, and no raw secrets. Contract fixtures cover no-op, create, update, risky, destructive, and invalid states. |
+| Owner/admin-only access boundary. | Admin control-plane endpoints require backend admin/provider capabilities. `docs/admin-operator-handbook.md` states normal members must not call identity readiness or realm endpoints. |
+| Tests prove no secrets leak and destructive apply is unavailable by default. | `IdentityRealmDryRunFixtureContractTest` checks deterministic support-safe output and `destructiveApplyAvailable=false`; `AdminControlPlaneServiceTest` covers guarded apply, retained-admin protection, rollback evidence gates, mutation-performed=false, and redaction of tokens/emails/provider internals. |
+
+## Sprint 6 child-slice evidence
+
+- #365 / PR #371: Keycloak realm desired-state dry-run provider and fixture matrix.
+- #366 / PR #373: identity provider readiness surfaced in Workspace Health/Admin Console contracts.
+- #367 / PR #372: repeatable release-candidate readiness evidence check.
+- #368 / PR #374: Live Stack E2E failure diagnostics and support-safe evidence hardening.
+- #369 / PR #375: effective provider capability policy simulation before apply.
+- #370 / PR #376: guarded identity realm apply decision path without live provider mutation.
+
+## Closure rule
+
+Close #212 and #233 as satisfied by the merged Sprint 6 slices plus this closure map. Do not expand them into a live Keycloak executor or member-facing provider setup. Open new follow-up issues only for release-aligned gaps such as Admin Console dashboard composition, additional IdP adapters, SCIM/LDAP reconciliation, rollback artifact orchestration, or an explicitly reviewed provider mutation executor.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Sprint 4 closure report: sprint-4-closure-report.md
       - Sprint 5 closure report: sprint-5-closure-report.md
       - Sprint 6 kickoff plan: sprint-6-kickoff-plan.md
+      - Sprint 6 epic closure report: sprint-6-epic-closure-report.md
       - Accessibility release gate: accessibility-release-gate.md
       - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md
   - Product and Release Scope:


### PR DESCRIPTION
## Summary

Adds the Sprint 6 epic closure map for the remaining identity/admin epics after the merged implementation slices #365-#370. The report consolidates acceptance evidence for admin-owned OIDC setup (#212) and the Keycloak realm dry-run/apply architecture (#233) without introducing a provider executor or broad UX.

## Changes

- Add `docs/sprint-6-epic-closure-report.md` with acceptance/evidence mapping for #212 and #233.
- Link the closure report from docs index and MkDocs navigation.
- Update unreleased notes and the README managed release-notes block.

## Testing

- `./gradlew releaseEvidenceCheck docsCheck`

Closes #212.
Closes #233.
