### PR TITLE
Add spec-driven agent team framework

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -30,8 +30,19 @@ body:
         - admin/provider readiness
         - manuals/help
         - release/evidence
+        - specs/dev workflow
         - weaver/AI runtime
         - cross-cutting
+    validations:
+      required: true
+  - type: textarea
+    id: spec-link
+    attributes:
+      label: Repo-local spec or acceptance note
+      description: Link `specs/NNNN-slug/spec.md` when available. If not yet available, state whether this should create one or why a lightweight acceptance note is enough.
+      value: |
+        Spec: TBD
+        Spec needed before implementation: yes/no
     validations:
       required: true
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,13 @@
 
 -
 
+## Spec / acceptance link
+
+- Issue:
+- Repo spec or spec note:
+- Acceptance scenario / mapping marker when product behavior changed:
+- Product-core questions intentionally left unresolved: none / listed below
+
 ## Branch, target, and release path
 
 - [ ] Branch started from current `origin/main`
@@ -25,6 +32,7 @@
 
 - [ ] No public API/auth/topology/spec contract change
 - [ ] Contract/spec change documented:
+- [ ] `./gradlew specContract` run for spec/product-contract changes
 
 ## Release notes label
 
@@ -36,11 +44,13 @@ Choose exactly one before review/merge; CI fails otherwise.
 
 ## Review readiness
 
-- [ ] Copilot review requested for this review-ready PR
-- [ ] Copilot findings addressed or fallback review evidence documented
+- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
+- [ ] Copilot findings addressed or fallback human/agent review evidence documented
 
 ## Checks run
 
+- [ ] `./gradlew specContract`
+- [ ] `./gradlew acceptanceContract`
 - [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
 - [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
 - [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   WEAVE_DOCS_VENV: build/docs-venv
@@ -97,5 +98,19 @@ jobs:
           java-version: '21'
       - name: Validate release notes label through Gradle
         env:
-          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        run: ./gradlew releaseNotesLabelCheck
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ACTION: ${{ github.event.action }}
+        run: |
+          labels_json="$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name]')"
+          if [ "$PR_ACTION" = "opened" ] && [ "$labels_json" = "[]" ]; then
+            # `gh pr create --label ...` can emit the opened event before the label
+            # is visible to the workflow. Give GitHub a short propagation window,
+            # then validate the live PR labels instead of the stale event payload.
+            for _ in 1 2 3; do
+              sleep 10
+              labels_json="$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name]')"
+              [ "$labels_json" != "[]" ] && break
+            done
+          fi
+          PR_LABELS_JSON="$labels_json" ./gradlew releaseNotesLabelCheck

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ app.*.map.json
 # Local assistant state
 .openclaw/
 memory/
+!.specify/memory/
+!.specify/memory/constitution.md
 HEARTBEAT.md
 IDENTITY.md
 SOUL.md

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,0 +1,67 @@
+# Weave Specification Constitution
+
+Version: 0.1.0  
+Ratified: 2026-05-28  
+Last amended: 2026-05-28
+
+This constitution governs repo-local specifications under `specs/`, Spec Kit-style templates under `.specify/templates/`, and `weave-co-leader` agent orchestration. It turns Weave planning into versioned, reviewable, executable product contracts.
+
+## Core principles
+
+### I. Repo truth over chat memory
+
+The current source of truth is this monorepo, GitHub issues/PRs, protected-branch status, and sanitized CI/evidence artifacts. Agent memory, old chat, older checkouts, and external notebooks are orientation only. A generated wiki or documentation site may explain specs, but it must not become the canonical source.
+
+### II. Product-core before implementation
+
+Specs must describe Weave product outcomes before implementation tactics. Product vocabulary is category-first and provider-neutral: identity/IDM, chat, files, calendar, boards/tasks, meetings, documents/collaboration, decisions, health, and the optional Weaver runtime. Raw provider setup, secrets, endpoint rotation, support diagnostics, and policy authoring stay admin/operator side.
+
+### III. Acceptance and evidence first
+
+For new product behavior, write or update product-language acceptance before implementation. A reviewable scenario needs a stable mapping to executable evidence in `e2e/scenario_mappings.json` or a named draft/proposed blocker. `./gradlew acceptanceContract` and `./gradlew specContract` are the minimum spec gates.
+
+### IV. Accessibility, supportability, auditability, deployability
+
+These are release blockers, not polish. Specs and plans must call out member/admin/operator impact, screen-reader and non-color-only behavior when relevant, support-safe diagnostics, audit posture, and deployment/release evidence.
+
+### V. Provider-neutral and anti-silo by default
+
+Provider adapters serve Weave-owned domain contracts. Specs must preserve export/delete/provenance/migration/dry-run behavior and must not hardcode one vendor as the product model. Provider names belong in admin readiness and operator evidence, not normal member navigation.
+
+### VI. Weaver is governed and disabled by default
+
+Weaver/OpenClaw-derived PA runtime is optional, later, per-user, isolated, auditable, generated from organization policy, and governed by `user-rights, organization-whitelisted capabilities`. Agentic developer help may be a governed capability, but it must not become the product architecture or a bypass around disabled exec/elevated defaults.
+
+### VII. Small slices, no markdown theater
+
+Full spec workflow is required for product capabilities, architectural migrations, provider/auth/policy/acceptance changes, and release-blocking work. Small bug fixes may use a lightweight issue/spec note, but still need a test/evidence path. Do not create redundant planning documents that reviewers cannot validate.
+
+## Required spec lifecycle
+
+Allowed status values:
+
+- `draft`: incomplete; may contain `[NEEDS CLARIFICATION: ...]` markers.
+- `proposed`: reviewable direction; may still contain explicit open questions.
+- `accepted`: product/technical contract accepted; no clarification markers.
+- `implementing`: active work; no clarification markers.
+- `implemented`: code/evidence merged or ready for merge; no clarification markers.
+- `superseded`: replaced by another spec.
+- `deprecated`: intentionally being phased out.
+- `rejected`: deliberately not pursued.
+
+Every non-draft implementation PR must link issue/spec/evidence and select exactly one release-notes label.
+
+## Agent governance
+
+`weave-co-leader` is an orchestrator, not a mega-coder. It recovers truth from repo/GitHub/CI, selects the smallest next slice, briefs specialists with allowed files and gates, integrates results, and returns evidence. Specialists must return concise evidence, blockers, and diffs/gates — not transcript dumps.
+
+Agent invocation must respect runtime policy:
+
+- Native OpenClaw subagents are used for repo-aware specialists.
+- ACP harnesses are used only when explicitly requested or when a coding harness is the right runtime; use allowed ACP harness IDs and report policy rejections clearly.
+- Do not require Copilot review while premium requests are exhausted; record human/agent fallback review plus green CI instead.
+- Stop before secrets, data loss, live infra mutation, history rewrite, or hidden scope expansion.
+
+## Governance
+
+This constitution supersedes ad-hoc sprint habits for spec-driven work. Amendments require a PR that updates this file, `docs/spec-driven-development.md`, and any affected templates or guards. The guard task is `./gradlew specContract`.

--- a/.specify/templates/weave-agent-briefs.md
+++ b/.specify/templates/weave-agent-briefs.md
@@ -1,0 +1,109 @@
+# Weave agent briefing templates
+
+Use these compact templates for `weave-co-leader` orchestration. Do not paste transcripts. Do not ask specialists to infer product scope from memory.
+
+## Invocation matrix
+
+- Orchestrator: `weave-co-leader` native OpenClaw subagent/session.
+- Repo specialists: native subagents with scoped prompts; logical role may be Product/Spec, Client/A11y, Server/Domain, Admin/Policy, Provider/Infra, QA/Evidence, Docs/Release, Security/Privacy, Integration Review.
+- ACP harnesses: only when explicitly requested or a coding harness is the chosen runtime. Use allowed ACP harness IDs such as `codex`, `claude`, `gemini`, or `opencode`; report policy errors instead of falling back silently. Repo-local example: `weave-agent-team-config.example.json5`.
+- Copilot review: currently fallback-only; do not block PR readiness on Copilot premium review exhaustion.
+- Stop conditions: secrets, live infra mutation, data loss, history rewrite, hidden scope expansion, or unresolved product-core ambiguity.
+
+## Professional optimization loop
+
+Use the smallest pattern that solves the slice:
+
+1. Recover truth from repo/GitHub/CI and identify the contract/spec.
+2. Build a task DAG; parallelize only independent file/contract areas.
+3. Prefer native subagents for repo specialists; use ACP only for explicit harness work.
+4. Verify nested spawning is enabled (`agents.defaults.subagents.maxSpawnDepth >= 2`) before expecting a subagent co-leader to spawn workers.
+5. Give each worker exact inputs, allowed files, required gates, and stop conditions.
+6. Integrate from evidence, not transcript claims.
+7. Run adversarial Integration-Gate review.
+8. If review finds material improvement, create the next scoped brief and repeat.
+9. Stop only when Integration-Gate returns no material optimization opportunity or a product-core clarification blocks safe progress.
+
+Material optimization means a change that improves correctness, traceability, security/privacy, accessibility, supportability, deployability, CI/evidence quality, or reviewability without hidden scope expansion.
+
+## Truth-Recovery
+
+```text
+You are weave-co-leader. Recover current truth from the Weave repo, GitHub issues/PRs, and CI/evidence.
+Do not rely on chat memory except as orientation.
+Return: branch, relevant docs/specs, open PRs/issues, latest CI/evidence, blockers, smallest safe next slice.
+Do not modify files.
+```
+
+## Specialist-Brief
+
+```text
+Role: <Product/Spec | Client/A11y | Server/Domain | Admin/Policy | Provider/Infra | QA/Evidence | Docs/Release | Security/Privacy | Integration Review>
+Goal: <one independently testable outcome>
+Allowed files: <exact paths/globs>
+Inputs: <spec/plan/docs/issues>
+Required gate: <command>
+Stop before: secrets, live infra mutation, data loss, hidden scope expansion, unresolved [NEEDS CLARIFICATION].
+Return only: done/blocked, files changed, evidence command+result, risks, recommended next.
+```
+
+## ACP-Harness-Brief
+
+```text
+Runtime: named ACP profile <weave-codex-acp|weave-claude-acp|weave-gemini-acp|weave-opencode-acp> via OpenClaw sessions_spawn(runtime="acp", agentId="<profile-id>").
+Goal: <one coding-harness-suitable outcome>
+CWD: /Users/flotterotter/code/weave
+Allowed scope: <exact files/globs>; do not touch live infra/secrets/generated artifacts.
+Inputs: <spec/plan/tasks/docs paths>
+Required gate: <command or explain why not runnable>
+Policy: if the operator config intentionally uses direct ACP harness ids, use the configured id such as <codex|claude|gemini|opencode>; otherwise use the named Weave ACP profile. If the id is denied/unavailable, report the policy error. Do not silently switch to native subagent.
+Return only: status, files changed, evidence, risks, follow-up patch suggestion.
+```
+
+## Evidence-Return
+
+```text
+Return concise evidence only:
+- Status: done | blocked | partial
+- Files changed:
+- Gates run:
+- Evidence artifacts:
+- Risks/blockers:
+- Next safe action:
+No transcript recap. No broad architecture essay.
+```
+
+## Integration-Gate
+
+```text
+Inspect the branch/PR against spec and constitution.
+Check: linked issue/spec, release-notes label, acceptance mapping, docs impact, smallest local gate, CI status, review fallback, no unrelated files.
+Evaluate: professionalism, problem-solving strategy, result quality, simplicity, risk posture, and evidence strength.
+Return: merge-ready? yes/no, material optimization opportunities? yes/no, blockers, exact command/evidence, recommended next action.
+```
+
+## Optimization-Review
+
+```text
+Act as adversarial but practical weave-co-leader reviewer.
+Inputs: <diff/spec/tasks/evidence>
+Score 0-3 each: correctness, traceability, spec protection, agent-team usability, ACP/runtime policy clarity, maintainability, evidence quality.
+Find only material improvements; ignore taste-only rewrites.
+Return:
+- Verdict: no-material-optimizations | optimize-before-commit | blocked
+- Scores:
+- Findings, each with path, risk, exact suggested change, required gate
+- If no findings: final evidence needed before commit/PR
+```
+
+## Session-Handoff
+
+```text
+Preserve durable state only:
+- Spec/issue/PR IDs:
+- Decisions made:
+- Evidence/gates:
+- Blockers/open questions:
+- Next safe action:
+Do not include discarded reasoning or logs.
+```

--- a/.specify/templates/weave-agent-team-config.example.json5
+++ b/.specify/templates/weave-agent-team-config.example.json5
@@ -1,0 +1,156 @@
+// Example only. Keep runtime truth in ~/.openclaw/openclaw.json (or managed Gateway config),
+// not in this repository. This file documents the Weave team shape that
+// weave-co-leader should expect when OpenClaw/ACP policy enables it.
+{
+  acp: {
+    enabled: true,
+    dispatch: { enabled: true },
+    backend: "acpx",
+    defaultAgent: "codex",
+    allowedAgents: ["codex", "claude", "gemini", "opencode"],
+    maxConcurrentSessions: 4,
+    stream: {
+      coalesceIdleMs: 300,
+      maxChunkChars: 1200,
+    },
+    runtime: {
+      ttlMinutes: 120,
+    },
+  },
+  agents: {
+    defaults: {
+      subagents: {
+        maxSpawnDepth: 2, // main -> weave-co-leader -> scoped worker
+        maxChildrenPerAgent: 5,
+        maxConcurrent: 8,
+        runTimeoutSeconds: 900,
+      },
+    },
+    list: [
+      {
+        id: "weave-co-leader",
+        name: "Weave co-leader / integrator",
+        workspace: "/Users/flotterotter/code/weave",
+        subagents: {
+          requireAgentId: true,
+          allowAgents: [
+            "weave-product-spec",
+            "weave-client-a11y",
+            "weave-server-domain",
+            "weave-admin-policy",
+            "weave-provider-infra",
+            "weave-qa-evidence",
+            "weave-docs-release",
+            "weave-security-privacy",
+            "weave-integration-reviewer",
+            "weave-codex-acp",
+            "weave-claude-acp",
+            "weave-gemini-acp",
+            "weave-opencode-acp",
+          ],
+        },
+      },
+      {
+        id: "weave-product-spec",
+        name: "Weave product/spec steward",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-client-a11y",
+        name: "Weave client/accessibility specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-server-domain",
+        name: "Weave server/domain specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-admin-policy",
+        name: "Weave admin/policy specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-provider-infra",
+        name: "Weave provider/infra specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-qa-evidence",
+        name: "Weave QA/evidence specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-docs-release",
+        name: "Weave docs/release specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-security-privacy",
+        name: "Weave security/privacy specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-integration-reviewer",
+        name: "Weave integration reviewer",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-codex-acp",
+        name: "Codex ACP harness for explicit coding-harness runs",
+        workspace: "/Users/flotterotter/code/weave",
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "codex",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/Users/flotterotter/code/weave",
+          },
+        },
+      },
+      {
+        id: "weave-claude-acp",
+        name: "Claude ACP harness for explicit Claude Code runs",
+        workspace: "/Users/flotterotter/code/weave",
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "claude",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/Users/flotterotter/code/weave",
+          },
+        },
+      },
+      {
+        id: "weave-gemini-acp",
+        name: "Gemini ACP harness for explicit Gemini runs",
+        workspace: "/Users/flotterotter/code/weave",
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "gemini",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/Users/flotterotter/code/weave",
+          },
+        },
+      },
+      {
+        id: "weave-opencode-acp",
+        name: "OpenCode ACP harness for explicit OpenCode runs",
+        workspace: "/Users/flotterotter/code/weave",
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "opencode",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/Users/flotterotter/code/weave",
+          },
+        },
+      },
+    ],
+  },
+}

--- a/.specify/templates/weave-plan-template.md
+++ b/.specify/templates/weave-plan-template.md
@@ -1,0 +1,73 @@
+# Implementation plan: Replace with title
+
+**Spec**: `specs/0000-slug/spec.md`  
+**Branch**: `type/short-slug`  
+**Date**: YYYY-MM-DD
+
+## Summary
+
+One paragraph: technical approach that satisfies the spec without expanding product scope.
+
+## Constitution check
+
+- Repo truth recovered from `main`, docs, GitHub issue/PR state, and CI evidence: yes/no
+- Product-first/provider-neutral boundary preserved: yes/no
+- Acceptance/evidence path identified before implementation: yes/no
+- Accessibility/supportability/auditability/deployability addressed: yes/no
+- Provider secrets/raw diagnostics remain admin/operator-only: yes/no
+- Weaver/OpenClaw runtime remains governed and disabled-by-default unless explicitly in scope: yes/no
+
+Any `no` requires a blocker or a documented exception before implementation.
+
+## Affected areas
+
+- `client/`:
+- `server/`:
+- `admin-console/`:
+- `infra/`:
+- `e2e/`:
+- `docs/`:
+- `release/`:
+- `tools/`:
+
+## Contracts and tests first
+
+1. Product acceptance/Gherkin:
+2. Mapping/evidence marker:
+3. API/event/schema contracts:
+4. Unit/widget/backend/admin tests:
+5. CI/evidence artifacts:
+
+## Agent work breakdown
+
+Use specialists only when they reduce risk or parallelize independent files. Each brief must include allowed files, stop conditions, and a required gate.
+
+- Product/spec steward:
+- Client/accessibility:
+- Server/domain facade:
+- Admin/policy:
+- Provider/infra:
+- QA/evidence:
+- Docs/release:
+- Security/privacy review:
+
+## Rollout and migration
+
+- Backward compatibility:
+- Data migration:
+- Feature flag/capability gate:
+- Rollback plan:
+- Release evidence:
+
+## Risks and mitigations
+
+- Risk:
+  - Mitigation:
+  - Evidence gate:
+
+## Final gates
+
+- `./gradlew specContract`
+- `./gradlew acceptanceContract`
+- Smallest area gate(s):
+- `./gradlew ci` when cross-stack or release-relevant

--- a/.specify/templates/weave-spec-template.md
+++ b/.specify/templates/weave-spec-template.md
@@ -1,0 +1,87 @@
+---
+id: WEAVE-SPEC-0000
+title: Replace with concise product contract title
+version: 0.1.0
+status: draft
+domain: product-core
+owner: weave-co-leader
+github_issue: null
+supersedes: []
+depends_on: []
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew acceptanceContract
+---
+
+# Feature specification: Replace with title
+
+## Intent
+
+State the product outcome in Weave vocabulary. Describe what changes for members, admins/operators, developers, or release owners. Avoid implementation choices until the plan.
+
+## Product boundaries
+
+### In scope
+
+- ...
+
+### Out of scope
+
+- ...
+
+### Non-negotiable constraints
+
+- Weave remains product-first and provider-neutral.
+- Normal members must not configure raw providers or see provider secrets/diagnostics.
+- Accessibility, supportability, auditability, and deployability are release blockers.
+- Weaver remains disabled by default unless this spec explicitly and safely changes a governed placeholder/runtime contract.
+
+## User/admin/operator stories
+
+### US1 - Title (Priority: P1)
+
+**Actor**: Member | Admin | Operator | Developer | Release owner  
+**Story**: ...  
+**Why now**: ...  
+**Independent test**: ...
+
+**Acceptance scenarios**:
+
+1. Given ..., when ..., then ...
+
+## Functional requirements
+
+- **FR-001**: Weave MUST ...
+- **FR-002**: Weave MUST NOT ...
+
+Use `[NEEDS CLARIFICATION: question]` only while `status` is `draft` or `proposed`. Accepted or implementing specs must resolve every marker.
+
+## Domain model and contracts
+
+- Canonical Weave entities affected:
+- Provider/category contracts affected:
+- API/event contracts affected:
+- Policy/RBAC/capability keys affected:
+- Audit/support evidence affected:
+
+## Acceptance and evidence mapping
+
+- Gherkin feature path(s):
+- `e2e/scenario_mappings.json` marker(s):
+- Unit/widget/backend/admin/contract test path(s):
+- Live Stack E2E required? yes/no + reason:
+- Support-safe evidence artifact(s):
+
+## Release and migration impact
+
+- Member impact:
+- Admin/operator impact:
+- Developer/API impact:
+- Data migration/backfill:
+- Rollback/reversibility:
+- Release-notes label expected: `release-notes-feature` | `release-notes-bugfix` | `release-notes-skip`
+
+## Open questions
+
+- [ ] ...

--- a/.specify/templates/weave-tasks-template.md
+++ b/.specify/templates/weave-tasks-template.md
@@ -1,0 +1,43 @@
+# Tasks: Replace with title
+
+**Spec**: `specs/0000-slug/spec.md`  
+**Plan**: `specs/0000-slug/plan.md`
+
+Task format: `- [ ] T001 [P?] [US?/Area] Description with exact path and gate`
+
+## Phase 0: Truth recovery
+
+- [ ] T001 [Spec] Re-read `AGENTS.md`, `.specify/memory/constitution.md`, the spec, and referenced docs.
+- [ ] T002 [Spec] Verify branch starts from current `origin/main` and no unrelated local changes are present.
+- [ ] T003 [Spec] Verify linked issue/PR status and release-notes label expectations.
+
+## Phase 1: Acceptance and contracts first
+
+- [ ] T010 [Acceptance] Update or create product-language Gherkin under `e2e/features/` when product behavior changes.
+- [ ] T011 [Acceptance] Update `e2e/scenario_mappings.json` with stable marker and executable evidence.
+- [ ] T012 [Contracts] Add or update API/event/provider contract files before implementation.
+- [ ] T013 [Evidence] Run `./gradlew specContract` and `./gradlew acceptanceContract`; expected red/green state documented.
+
+## Phase 2: Implementation slices
+
+Group implementation by independently testable user story. Mark `[P]` only when files do not conflict.
+
+- [ ] T020 [US1] Add failing tests/evidence in exact path.
+- [ ] T021 [US1] Implement smallest code/doc change in exact path.
+- [ ] T022 [US1] Run smallest meaningful gate and record result.
+
+## Phase 3: Cross-cutting quality
+
+- [ ] T030 [A11y] Verify screen-reader/non-color-only behavior where UI changes.
+- [ ] T031 [Support] Verify support-safe diagnostics and no raw provider/secret leakage.
+- [ ] T032 [Audit] Verify audit/policy state where capability or admin actions change.
+- [ ] T033 [Docs] Update product/developer/admin docs and release notes expectations.
+
+## Phase 4: Integration and handoff
+
+- [ ] T040 Run required area gates.
+- [ ] T041 Run `./gradlew ci` for cross-stack/release-relevant changes.
+- [ ] T042 Run Integration-Gate or Optimization-Review; loop on material findings.
+- [ ] T043 Fill PR body with spec ID, acceptance/evidence, risks, and fallback review evidence.
+- [ ] T044 Update spec status/version or document why it remains draft/proposed.
+- [ ] T045 Agent handoff: preserve durable decisions, evidence, blockers, and next safe action only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,13 @@ Weave is one monorepo. `client/`, `server/`, `infra/`, `e2e/`, `docs/`, and `rel
 
 Old `weave-backend` and `weave-infra` checkouts are stale. Ignore them.
 
-Current truth: this repo, README/docs, GitHub issues/PRs, and executable evidence. `~/code/specs` is orientation/cross-session contract context; repo-local docs remain the implementation authority when they are more current.
+Current truth: this repo, README/docs, GitHub issues/PRs, repo-local `specs/`, and executable evidence. `~/code/specs` is orientation/cross-session contract context; repo-local specs/docs remain the implementation authority when they are more current.
 
 Product-line truth: read `docs/product-line-and-weaver-plan.md` before product direction, admin/provider, RBAC/whitelist, or Weaver work. Preserve the order: Weave provider-neutral organization suite first; admin portal/IDM/RBAC/readiness/whitelisting second; Weaver governed per-user PA runtime later. Do not regress to agent-first planning or a fixed Nextcloud/Matrix-only product boundary.
 
 v0.1 is dogfood-production, not preview. No scaffold, roadmap, or coming-soon UX in normal member paths.
 
-Work spec-driven: intent → issue/spec note → acceptance/evidence → implementation → review. Use `docs/weave-operating-model.md` as the delivery/agent orchestration contract.
+Work spec-driven: intent → issue/spec note or repo-local `specs/NNNN-slug/spec.md` → acceptance/evidence → implementation → review. Use `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and `docs/weave-operating-model.md` as the delivery/agent orchestration contract.
 
 Route work:
 - `client/`: Flutter UX, accessibility, l10n.
@@ -21,7 +21,7 @@ Route work:
 
 Default gates: `./gradlew acceptanceContract`, `./gradlew clientCi`, `./gradlew serverCi`, `./gradlew infraStatic`; use `./gradlew ci` for cross-stack changes.
 
-`weave-co-leader` coordinates specialists using five compact templates: Truth-Recovery, Specialist-Brief, Evidence-Return, Integration-Gate, and Session-Handoff. PRs should request `@copilot` review when review-ready.
+`weave-co-leader` coordinates specialists using compact templates: Truth-Recovery, Specialist-Brief, ACP-Harness-Brief, Evidence-Return, Integration-Gate, Optimization-Review, and Session-Handoff. Use `.specify/templates/weave-agent-briefs.md` for role/runtime constraints and `docs/agent-team-orchestration.md` for the professional optimization loop. Copilot review is fallback-only while premium requests are exhausted; do not block PRs on Copilot review during that period.
 
 Stop before secrets, data loss, live infra mutation, history rewrite, or hidden scope expansion.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract docs-build docs-check docs-serve docs-structure-check release-notes-check release-notes-label-check release-evidence-check generate-release-notes update-readme-release-notes live-stack-help doctor
+.PHONY: ci client-ci server-ci infra-static admin-ci acceptance-contract spec-contract spec-contract-test docs-build docs-check docs-serve docs-structure-check release-notes-check release-notes-label-check release-evidence-check generate-release-notes update-readme-release-notes live-stack-help doctor
 
 GRADLE ?= ./gradlew
 
@@ -22,6 +22,12 @@ admin-ci:
 
 acceptance-contract:
 	$(GRADLE) acceptanceContract
+
+spec-contract:
+	$(GRADLE) specContract
+
+spec-contract-test:
+	$(GRADLE) specContractTest
 
 # Install docs tooling with: python3 -m pip install -r docs/requirements.txt
 docs-build:

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ registerRootCommandTask('docsBuild', ['bash', '-lc', 'PYTHON=python3; [ -x build
 registerRootCommandTask('docsStructureCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py'], 'Run lightweight documentation structure checks.')
 registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs serve'], 'Serve the MkDocs site locally.')
 registerRootCommandTask('releaseNotesLabelCheck', ['bash', '-lc', 'if [ -n "${PR_LABELS_JSON:-}" ]; then python3 tools/release_notes_label_check.py; else echo "release-notes-label-check: skipped (PR_LABELS_JSON is not set)"; fi'], 'Validate the current PR release-notes label set from PR_LABELS_JSON when available.')
+registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.py'], 'Validate repo-local Weave specs, lifecycle metadata, and implementation-ready clarification state.')
+registerRootCommandTask('specContractTest', ['python3', 'tools/spec_contract_check_test.py'], 'Run fixture tests for the repo-local Weave spec contract guard.')
 registerRootCommandTask('generateReleaseNotes', ['python3', 'tools/release_notes_generate.py', '--input', 'tools/fixtures/release_notes_prs.json'], 'Generate reviewable release notes under build/release-notes by default.')
 registerRootCommandTask('updateReadmeReleaseNotes', ['python3', 'tools/readme_release_notes.py', '--update'], 'Explicitly update the managed README release-notes evidence block.')
 registerRootCommandTask('projectReadinessEvidenceCheck', ['python3', 'tools/project_readiness_evidence_check.py'], 'Validate Sprint 5 project-readiness evidence remains mapped and support-safe.')
@@ -95,6 +97,8 @@ ext.ciEvidenceGates = [
     'infraStatic',
     'docsCheck',
     'releaseNotesLabelCheck',
+    'specContract',
+    'specContractTest',
     'releaseEvidenceCheck',
     'projectReadinessEvidenceCheck',
     'enterpriseReleaseGateCheck'
@@ -185,6 +189,10 @@ List<String> artifactPathsForGate(String gateName) {
     switch (gateName) {
         case 'docsCheck':
             return ['build/docs/user', 'build/docs/admin']
+        case 'specContract':
+            return ['specs', '.specify/memory/constitution.md', '.specify/templates']
+        case 'specContractTest':
+            return ['tools/spec_contract_check_test.py']
         case 'releaseEvidenceCheck':
             return ['README.md', 'tools/fixtures/release_notes_unreleased.expected.md']
         case 'projectReadinessEvidenceCheck':
@@ -263,10 +271,10 @@ tasks.register('doctor') {
 tasks.register('ci') {
     group = 'verification'
     description = 'Run the canonical monorepo CI orchestration checks.'
-    dependsOn 'doctor', 'acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
+    dependsOn 'doctor', 'acceptanceContract', 'specContract', 'specContractTest', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
 }
 
-['acceptanceContract', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck', 'releaseReadinessFixtureTest', 'releaseReadinessCheck'].each { taskName ->
+['acceptanceContract', 'specContract', 'specContractTest', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck', 'releaseReadinessFixtureTest', 'releaseReadinessCheck'].each { taskName ->
     tasks.named(taskName) {
         mustRunAfter tasks.named('doctor')
     }

--- a/docs/acceptance-contracts.md
+++ b/docs/acceptance-contracts.md
@@ -27,6 +27,7 @@ bodies, or full live E2E logs.
 
 For new product behavior:
 
+0. Create or update the repo-local spec/spec note when the slice changes product contracts, provider boundaries, auth/policy, or release evidence. Keep unresolved product-core questions as `[NEEDS CLARIFICATION: ...]` while the spec is `draft` or `proposed`.
 1. Write or update the product-language Gherkin scenario first.
 2. Add the scenario to `e2e/scenario_mappings.json` with an executable
    test path and evidence marker. The guard should be red until the executable
@@ -37,7 +38,7 @@ For new product behavior:
    only; lower-level tests carry the detailed technical coverage. Admin/provider
    setup and policy checks belong in backend/admin/control-plane CI unless the
    member/operator product journey explicitly consumes the stable facade state.
-5. Run `make offline-contract-test` before review. Use `make integration-test`
+5. Run `./gradlew specContract` when specs or product contracts changed, and run `make offline-contract-test` before review. Use `make integration-test`
    only on the dedicated live-stack runner or another explicitly prepared local
    stack, keeping generated evidence sanitized.
 

--- a/docs/agent-team-orchestration.md
+++ b/docs/agent-team-orchestration.md
@@ -1,0 +1,177 @@
+# Weave agent-team orchestration
+
+Status: active delivery contract, 2026-05-28.
+
+This page defines the professional multi-agent delivery model for Weave. It translates the NotebookLM deep-research result into repo-local, reviewable rules. The research emphasized four recurring practices: keep a lead/orchestrator separate from implementors, use isolated/scoped worker contexts, verify with adversarial reviewers, and make quality gates executable. Relevant source titles include "The Code Agent Orchestra - what makes multi-agent coding work", "Best practices for Claude Code", "Orchestrate teams of Claude Code sessions", "Multi-agent coordination patterns: Five approaches and when to use them", "Agents - OpenCode", "Permissions - OpenCode", and the OpenClaw ACP/subagent docs.
+
+## Operating principle
+
+`weave-co-leader` owns decomposition, integration, and evidence. It does **not** become a mega-coder.
+
+Use this loop until no material optimization remains:
+
+1. Recover truth from this repo, GitHub issues/PRs, and CI/evidence.
+2. Identify the governing issue/spec/acceptance contract.
+3. Build a small task DAG; parallelize only independent file/contract areas.
+4. Spawn a scoped specialist with exact files, inputs, stop conditions, and a required gate.
+5. Integrate only from returned evidence and inspected diffs.
+6. Run an adversarial Integration-Gate review.
+7. Repeat implementation/review for material findings.
+8. Stop only when the reviewer reports no material optimization opportunity or a product-core clarification blocks safe progress.
+
+Material optimization means improved correctness, traceability, security/privacy, accessibility, supportability, deployability, CI/evidence quality, or reviewability without hidden scope expansion.
+
+## Recommended roles
+
+Use native OpenClaw subagents for these repo-aware specialists by default:
+
+- `weave-product-spec`: product-core wording, lifecycle status, frontmatter, non-goals, clarification markers.
+- `weave-client-a11y`: Flutter member/admin UX, accessibility semantics, keyboard/screen-reader behavior, l10n, widget tests.
+- `weave-server-domain`: domain facades, authorization, audit, provider boundaries, backend contract tests.
+- `weave-admin-policy`: Admin Console, workspace health, IDM/RBAC, policy previews, readiness, whitelisting.
+- `weave-provider-infra`: OpenTofu, adapters, runner/environment posture, backup/restore, support bundles.
+- `weave-qa-evidence`: Gherkin, `scenario_mappings.json`, Live Stack evidence, sanitized artifacts.
+- `weave-docs-release`: docs navigation, handbooks, release notes, PR templates, closure reports.
+- `weave-security-privacy`: secrets, raw provider payloads, audit, support-safe diagnostics, external-provider risk.
+- `weave-integration-reviewer`: final diff/spec/PR readiness, evidence strength, scope creep, release-label and CI posture.
+
+Use ACP harnesses only when explicitly requested or intentionally selected for a coding-harness run:
+
+- `codex`: explicit Codex ACP work, especially code-edit loops where ACP behavior is desired.
+- `claude`: explicit Claude Code ACP work.
+- `gemini`: explicit Gemini CLI ACP work or broad alternative review.
+- `opencode`: explicit OpenCode ACP work and OpenCode-style agent-team experiments.
+
+Do not silently fall back across runtimes. If OpenClaw policy denies an ACP agent id, report that policy error and stop.
+
+## OpenClaw configuration shape
+
+The repo does not own live OpenClaw config. The example below documents the expected shape for an operator-managed `~/.openclaw/openclaw.json` or equivalent Gateway config.
+
+Repo-local example: `.specify/templates/weave-agent-team-config.example.json5`.
+
+Important OpenClaw fields used by the example:
+
+- `acp.enabled`, `acp.backend`, `acp.defaultAgent`, `acp.allowedAgents`, `acp.maxConcurrentSessions`, `acp.runtime.ttlMinutes`.
+- `agents.defaults.subagents.maxSpawnDepth = 2` so `main -> weave-co-leader -> scoped worker` is allowed.
+- `agents.defaults.subagents.maxChildrenPerAgent`, `agents.defaults.subagents.maxConcurrent`, and `agents.defaults.subagents.runTimeoutSeconds` to bound fan-out and stuck work.
+- `agents.list[].subagents.requireAgentId` and `agents.list[].subagents.allowAgents` for the `weave-co-leader` native subagent policy.
+- `agents.list[].runtime.type = "acp"` and `agents.list[].runtime.acp.agent/backend/mode/cwd` for named ACP profiles.
+
+Minimal excerpt:
+
+```json5
+{
+  acp: {
+    enabled: true,
+    backend: "acpx",
+    defaultAgent: "codex",
+    allowedAgents: ["codex", "claude", "gemini", "opencode"],
+    maxConcurrentSessions: 4,
+    runtime: { ttlMinutes: 120 },
+  },
+  agents: {
+    defaults: {
+      subagents: {
+        maxSpawnDepth: 2,
+        maxChildrenPerAgent: 5,
+        maxConcurrent: 8,
+        runTimeoutSeconds: 900,
+      },
+    },
+    list: [
+      {
+        id: "weave-co-leader",
+        workspace: "/Users/flotterotter/code/weave",
+        subagents: {
+          requireAgentId: true,
+          allowAgents: [
+            "weave-product-spec",
+            "weave-client-a11y",
+            "weave-server-domain",
+            "weave-admin-policy",
+            "weave-provider-infra",
+            "weave-qa-evidence",
+            "weave-docs-release",
+            "weave-security-privacy",
+            "weave-integration-reviewer",
+            "weave-codex-acp",
+            "weave-claude-acp",
+            "weave-gemini-acp",
+            "weave-opencode-acp",
+          ],
+        },
+      },
+      {
+        id: "weave-codex-acp",
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "codex",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/Users/flotterotter/code/weave",
+          },
+        },
+      },
+    ],
+  },
+}
+```
+
+Without `maxSpawnDepth: 2`, a `weave-co-leader` that was itself spawned as a subagent becomes a leaf and cannot spawn specialists. That is acceptable for simple reviews but not for the team-lead/orchestrator pattern.
+
+The co-leader allowlist must include the named ACP profile ids if it is expected to spawn them with `sessions_spawn(runtime="acp", agentId="weave-codex-acp")` or equivalent. Operators may instead allow direct ACP harness ids such as `codex` or `claude`, but the policy and brief must use the same ids.
+
+Before changing live config, inspect the Gateway schema for the exact path and apply config through Gateway config tools, not manual edits.
+
+## Brief and handoff contracts
+
+Use `.specify/templates/weave-agent-briefs.md` for the stable templates:
+
+- Truth-Recovery
+- Specialist-Brief
+- ACP-Harness-Brief
+- Evidence-Return
+- Integration-Gate
+- Optimization-Review
+- Session-Handoff
+
+A worker prompt must include:
+
+- role and one independently testable goal;
+- exact allowed files or globs;
+- governing spec/plan/tasks/docs paths;
+- required gate or reason the gate cannot run;
+- stop conditions;
+- evidence-only return format.
+
+Do not paste transcripts, broad sprint histories, or hidden product assumptions into workers.
+
+## Professional evaluation rubric
+
+`weave-integration-reviewer` or `weave-co-leader` scores 0-3:
+
+- correctness against spec and acceptance;
+- traceability from issue/spec to evidence;
+- product-core protection and explicit unresolved questions;
+- agent-team usability of briefs/config/docs;
+- ACP/runtime policy clarity;
+- maintainability and simplicity;
+- evidence quality and reproducibility.
+
+A score below 2 in any release-blocking dimension requires another implementation loop or an explicit blocker.
+
+## Guardrails
+
+Stop before:
+
+- secrets or raw provider payload exposure;
+- live infra mutation without approval;
+- data loss or destructive cleanup;
+- history rewrite;
+- hidden scope expansion;
+- accepted/implementing/implemented specs that still contain `[NEEDS CLARIFICATION: ...]`;
+- product-core choices that Massimo/team have not decided.
+
+When blocked by product-core ambiguity, keep the spec `draft` or `proposed`, write the clarification marker, and ask for the one decision needed to proceed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,8 +49,10 @@ Start with:
 
 1. [Developer Handbook](developer-handbook.md) — local prerequisites, Java 21+ requirement, Gradle gates, client/server/admin/infra workflows, and evidence expectations.
 2. [Trunk-based PR and release workflow](gitflow-pr-workflow.md) — branch, review, label, release-note, and merge rules.
-3. [Canonical feature models](canonical-feature-models.md) — provider-neutral domain vocabulary.
-4. [Architecture](architecture.md) and [Diagrams](diagrams/index.md) — facades, data flow, and domain diagrams.
+3. [Spec-driven development for Weave](spec-driven-development.md) — repo-local specs, lifecycle, evidence gates, and agent orchestration.
+4. [Weave agent-team orchestration](agent-team-orchestration.md) — `weave-co-leader`, native subagents, ACP specialists, briefs, and optimization loop.
+5. [Canonical feature models](canonical-feature-models.md) — provider-neutral domain vocabulary.
+5. [Architecture](architecture.md) and [Diagrams](diagrams/index.md) — facades, data flow, and domain diagrams.
 
 ### Security / compliance reviewer
 
@@ -68,6 +70,8 @@ Canonical product docs:
 - Root README
 - [v0.1 Golden Path readiness](v0.1-golden-path.md)
 - [Weave product line and Weaver integration plan](product-line-and-weaver-plan.md)
+- [Spec-driven development for Weave](spec-driven-development.md)
+- [Weave agent-team orchestration](agent-team-orchestration.md)
 - [Canonical feature models](canonical-feature-models.md)
 - [Architecture](architecture.md)
 - [Organization embedding contract](organization-embedding-contract.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ Start with:
 3. [Spec-driven development for Weave](spec-driven-development.md) — repo-local specs, lifecycle, evidence gates, and agent orchestration.
 4. [Weave agent-team orchestration](agent-team-orchestration.md) — `weave-co-leader`, native subagents, ACP specialists, briefs, and optimization loop.
 5. [Canonical feature models](canonical-feature-models.md) — provider-neutral domain vocabulary.
-5. [Architecture](architecture.md) and [Diagrams](diagrams/index.md) — facades, data flow, and domain diagrams.
+6. [Architecture](architecture.md) and [Diagrams](diagrams/index.md) — facades, data flow, and domain diagrams.
 
 ### Security / compliance reviewer
 

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -10,6 +10,7 @@ Weave uses layered evidence so contributors can move quickly while release claim
 | Accessibility gate | Automated checks and the manual assistive-technology evidence required before release sign-off. | [Accessibility Release Gate](accessibility-release-gate.md). |
 | ISO 9241-110 dogfood UX gate | Product dialogue quality, release-scope capability states, banned preview/scaffold wording, and role separation for member vs admin/operator surfaces. | [ISO 9241-110 Dogfood UX Gate](iso-9241-110-dogfood-ux-gate.md), `test/release_1/ux_release_copy_contract_test.dart`. |
 | Deterministic screenshots | README and roadmap SVG assets match the checked-in generator and do not drift silently. | `make marketing-screenshots`, `docs/assets/marketing/`, `docs/assets/roadmap/`, CI screenshot drift step. |
+| Spec contract guard | Repo-local specs keep required metadata, lifecycle status, evidence gates, and implementation-ready clarification discipline. | [Spec-driven development for Weave](spec-driven-development.md), `.specify/memory/constitution.md`, `specs/`, `./gradlew specContract`, `./gradlew specContractTest`. |
 | Acceptance contract guard | Gherkin acceptance scenarios stay mapped to executable frontend/live-stack tests. | [Acceptance contracts](acceptance-contracts.md), [Product acceptance flows](product-acceptance-flows.md), `test/live_stack_feature_mapping_test.dart`. |
 | Admin-provisioned first-use guard | Normal members stay out of OIDC/provider/infra setup and Workspace Health remains the admin/operator control plane. | [Admin-provisioned first use boundary](admin-provisioned-first-use.md), `client/test/architecture/admin_provisioned_first_use_contract_test.dart`, `client/test/features/settings/settings_screen_test.dart`, `client/test/features/onboarding/first_run_screen_test.dart`. |
 | Docs build | User/admin handbook content builds without broken links, secret-pattern docs drift, or image-only instructions. | `build/docs/user` and `build/docs/admin` from `./gradlew docsBuild`. |
@@ -29,6 +30,13 @@ dart format --output=none --set-exit-if-changed .
 flutter analyze --fatal-infos
 flutter test
 make offline-contract-test
+```
+
+For spec or product-contract changes, also run:
+
+```sh
+./gradlew specContract
+./gradlew specContractTest
 ```
 
 For README or screenshot changes, also run:
@@ -58,6 +66,7 @@ The workflow prepares an acceptance evidence directory, runs the app-level live-
 
 - **Offline Flutter failure**: inspect the failing command first. Re-run locally after regenerating l10n/build output.
 - **Screenshot drift**: run `make marketing-screenshots`, review the SVG diff as product copy, and commit the regenerated assets if intentional.
+- **Spec contract failure**: fix missing frontmatter/lifecycle metadata, resolve implementation-ready `[NEEDS CLARIFICATION: ...]` markers, or move the spec back to `draft`/`proposed` until the product-core question is answered.
 - **Acceptance mapping failure**: update the scenario-to-test mapping or remove stale scenario claims. Do not leave product acceptance text unmapped.
 - **Live-stack contract failure**: start with `failure-diagnostics/failure-summary.md`, `container-status.tsv`, `health-checks/operator-check.txt`, and `failed-markers.json` in the uploaded evidence artifact. Treat credential, runner, or environment problems as named infrastructure blockers, not product proof. Missing required markers such as `BOARDS_RESULT` block RC promotion until a green rerun or explicit release-owner waiver exists. Operators who need deeper private debugging may rerun diagnostics on the self-hosted runner with private raw-log collection enabled, but those files stay outside uploaded/support evidence.
 - **Accessibility evidence gap**: do not promote the flow as release-ready until the automated and manual evidence in the accessibility gate is complete.
@@ -76,6 +85,7 @@ The workflow prepares an acceptance evidence directory, runs the app-level live-
 
 - [Developer handbook](developer-handbook.md)
 - [Admin-provisioned first use boundary](admin-provisioned-first-use.md)
+- [Spec-driven development for Weave](spec-driven-development.md)
 - [Acceptance contracts](acceptance-contracts.md)
 - [Product acceptance flows](product-acceptance-flows.md)
 - [Accessibility Release Gate](accessibility-release-gate.md)

--- a/docs/spec-driven-development.md
+++ b/docs/spec-driven-development.md
@@ -1,0 +1,132 @@
+# Spec-driven development for Weave
+
+Status: active delivery framework, 2026-05-28.
+
+Weave uses a lightweight Spec Kit-inspired workflow adapted to the existing monorepo, Gradle gates, Gherkin acceptance contracts, and `weave-co-leader` agent model.
+
+The rule is simple: **Git-versioned specs are truth; generated docs/wiki views are projections.**
+
+## Why not a standalone wiki?
+
+A separate manual wiki would drift from code, CI, and PR evidence. Weave may publish generated documentation from `specs/` and `docs/`, but the canonical source remains:
+
+- `specs/` for versioned product/system contracts;
+- `.specify/memory/constitution.md` for non-negotiable spec rules;
+- `e2e/features/` and `e2e/scenario_mappings.json` for executable acceptance mapping;
+- `build/evidence/` and CI artifacts for proof;
+- GitHub issues/PRs for work tracking.
+
+## Folder model
+
+```text
+.specify/
+├── memory/constitution.md
+└── templates/
+    ├── weave-spec-template.md
+    ├── weave-plan-template.md
+    ├── weave-tasks-template.md
+    ├── weave-agent-briefs.md
+    └── weave-agent-team-config.example.json5
+
+specs/
+├── README.md
+└── 0000-weave-spec-framework/
+    ├── spec.md
+    ├── plan.md
+    ├── tasks.md
+    ├── traceability.yaml
+    ├── contracts/
+    ├── acceptance/
+    └── evidence/
+```
+
+## Lifecycle
+
+- `draft`: safe place for product questions and `[NEEDS CLARIFICATION: ...]` markers.
+- `proposed`: reviewable direction, still allowed to carry explicit unresolved questions.
+- `accepted`: contract approved; no clarification markers.
+- `implementing`: active work; no clarification markers.
+- `implemented`: implemented or merge-ready with evidence; no clarification markers.
+- `superseded`, `deprecated`, `rejected`: historical states.
+
+`./gradlew specContract` enforces required metadata and blocks clarification markers in implementation-ready specs. `./gradlew specContractTest` protects the guard itself with small fixtures.
+
+## When full specs are required
+
+Use full `spec.md` + `plan.md` + `tasks.md` for:
+
+- new product capabilities;
+- provider-neutral domain contracts;
+- auth, IDM, RBAC, policy, whitelisting, or admin readiness;
+- Weaver/OpenClaw runtime integration;
+- Gherkin/acceptance changes;
+- API/event/provider contract changes;
+- release-blocking evidence or architecture migrations.
+
+For tiny bug fixes, a linked issue/spec note plus tests/evidence is enough unless the change touches product contracts.
+
+## Product-core safety rule
+
+Do not let agents invent unresolved product decisions. If the answer changes the product core, keep the spec `draft` or `proposed` and write the uncertainty explicitly.
+
+Product-core questions that require Massimo/team confirmation include:
+
+- first `WEAVE-SPEC-0001` product slice: organization embedding, Chat facade, identity policy, or another foundation;
+- exact minimal domain vocabulary for the first user-visible release;
+- which provider categories must be mandatory vs optional in v0.1/v0.2;
+- when Weaver moves from placeholder category to governed runtime implementation;
+- which agentic developer-assistance capability, if any, is allowed inside Weave policy.
+
+## DevOps traceability
+
+Every implementation PR should connect:
+
+```text
+GitHub issue or spec note
+  -> WEAVE-SPEC-ID and version
+  -> acceptance scenario / mapping marker when product behavior changes
+  -> test/contract/evidence gate
+  -> sanitized CI evidence
+  -> exactly one release-notes label
+```
+
+Minimum review evidence:
+
+- `./gradlew specContract` and `./gradlew specContractTest` for spec/framework changes;
+- `./gradlew acceptanceContract` when product behavior or Gherkin may be affected;
+- the smallest area gate (`clientCi`, `serverCi`, `adminCi`, `infraStatic`, `docsStructureCheck`, etc.);
+- `./gradlew ci` for cross-stack or release-relevant changes.
+
+## Agent team model
+
+`weave-co-leader` coordinates; specialists execute narrow tasks. The detailed runtime/configuration contract is [Weave agent-team orchestration](agent-team-orchestration.md).
+
+Recommended specialist set:
+
+- **Product/spec steward**: product-core wording, lifecycle status, frontmatter, scope boundaries, open questions.
+- **Client/accessibility specialist**: Flutter UX, screen-reader/Braille-friendly behavior, l10n, widget/semantics tests.
+- **Server/domain-facade specialist**: canonical domain models, authorization, audit, provider boundaries, backend contracts.
+- **Admin/policy specialist**: Admin Console, Workspace Health, IDM/RBAC, policy previews, readiness, whitelisting.
+- **Provider/infra specialist**: OpenTofu, adapters, runner/env posture, backup/restore, support bundles.
+- **QA/evidence specialist**: Gherkin, `scenario_mappings.json`, Live Stack evidence, sanitized artifacts.
+- **Docs/release specialist**: docs navigation, handbooks, release notes, PR templates, closure reports.
+- **Security/privacy specialist**: secrets, raw provider payloads, audit, support-safe diagnostics, external-provider risk.
+- **Integration reviewer**: final PR readiness, diff scope, labels, gates, fallback review evidence.
+
+## Agent invocation rules
+
+- Use native OpenClaw subagents for repo-aware specialists and `weave-co-leader` orchestration.
+- Use ACP harnesses only when explicitly requested or when a coding harness is intentionally selected. The harness id must be allowed by OpenClaw ACP policy; report policy errors clearly.
+- Keep named runtime examples in `.specify/templates/weave-agent-team-config.example.json5`; live Gateway config is operator-managed and must be changed through Gateway config tooling.
+- Nested team-lead spawning requires `agents.defaults.subagents.maxSpawnDepth >= 2`; otherwise a spawned `weave-co-leader` is a leaf reviewer, not an orchestrator.
+- Do not use Copilot review as a blocker while premium review requests are exhausted. Record fallback human/agent review plus green CI.
+- Do not paste old transcripts into agents. Give them exact specs/docs, allowed files, required gates, and stop conditions.
+- Run Integration-Gate/Optimization-Review loops until there is no material improvement opportunity or a product-core clarification blocks safe progress.
+- Stop before secrets, live infra mutation, data loss, history rewrite, hidden scope expansion, or unresolved product-core ambiguity.
+
+## First rollout
+
+1. Land the framework and `WEAVE-SPEC-0000`.
+2. Choose `WEAVE-SPEC-0001` only after product-core confirmation.
+3. Run the first real feature through: spec -> plan -> tasks -> acceptance mapping -> implementation -> evidence -> PR.
+4. Generate any wiki/docs view from repo files after the pattern proves useful.

--- a/docs/weave-operating-model.md
+++ b/docs/weave-operating-model.md
@@ -7,7 +7,8 @@ This page is the compact working contract for Weave delivery. It keeps sprint, r
 - Current implementation truth lives in this monorepo, GitHub issues/PRs, protected-branch status, and executable CI/evidence artifacts.
 - Historical chat, agent transcripts, local memories, and old checkouts are orientation only; verify them before acting.
 - Sprint state belongs in GitHub issues, PRs, and closure reports, not in bootstrap prompts.
-- Product and architecture decisions belong in repo docs; PR bodies carry current acceptance/evidence for one slice.
+- Product and architecture decisions belong in repo docs and repo-local `specs/`; PR bodies carry current acceptance/evidence for one slice.
+- `~/code/specs` and external notebooks are orientation only. New durable product/system contracts live under `specs/` and are checked by `./gradlew specContract`.
 
 ## Branch and release model
 
@@ -33,11 +34,11 @@ This page is the compact working contract for Weave delivery. It keeps sprint, r
 
 A PR is review-ready only when it has:
 
-- a linked issue, spec, or acceptance note;
+- a linked issue plus repo-local spec, spec note, or acceptance note;
 - exactly one release-notes label;
 - a filled PR body with scope, user/operator/developer impact, evidence, and risks;
-- the smallest meaningful local gate recorded;
-- Copilot review requested or an explicit fallback noted;
+- the smallest meaningful local gate recorded, including `./gradlew specContract` when specs or product contracts changed;
+- Copilot review requested or an explicit fallback noted; Copilot exhaustion is not a blocker when fallback review evidence and green CI are present;
 - no unrelated local, generated, secret, or assistant workspace files.
 
 A PR is merge-ready only when protected checks are green, required conversations are resolved, Copilot findings or fallback review are addressed, and the branch is mergeable.
@@ -53,16 +54,22 @@ Use this loop:
 3. Spawn scoped specialists only when useful.
 4. Require evidence-only returns.
 5. Run the integration gate before PR handoff or merge.
-6. End with a compact session handoff.
+6. If the gate finds material optimization opportunities, create the next scoped brief and loop.
+7. End only when no material optimization remains or a product-core clarification blocks safe progress.
+8. Preserve a compact session handoff.
 
 Regular specialist scopes:
 
+- Product/spec steward: intent, product-core scope, lifecycle status, non-goals, and clarification markers.
 - Client: Flutter, accessibility, localization, widget/semantics tests.
 - Server: facades, authorization, audit, provider boundaries, backend contracts.
+- Admin/policy: Admin Console, Workspace Health, IDM/RBAC, readiness, whitelisting, and policy previews.
+- Provider/infra: provider adapters, OpenTofu, live-stack runner posture, backup/restore, support bundles.
 - DevOps/release: Gradle, GitHub Actions, branch protection, release labels, environments.
-- QA/evidence: acceptance contracts, Live Stack E2E, dogfood evidence, sanitized artifacts.
+- QA/evidence: acceptance contracts, `scenario_mappings.json`, Live Stack E2E, dogfood evidence, sanitized artifacts.
 - Docs/release: release notes, sprint reports, developer docs, PR templates.
-- Review: architecture risk, scope creep, merge readiness.
+- Security/privacy: secrets, raw provider data, audit, support-safe diagnostics, external-provider risk.
+- Review: architecture risk, scope creep, merge readiness, and material optimization opportunities.
 
 ## Five reusable agent templates
 
@@ -72,6 +79,7 @@ Keep the template names stable and the actual prompt short.
 - Specialist-Brief: assign one scoped task, allowed files, required gate, and stop conditions.
 - Evidence-Return: return done/evidence/verification/blocked/recommended-next without transcript recap.
 - Integration-Gate: inspect PR, checks, reviews, mergeability, blockers, and recommendation.
+- Optimization-Review: score correctness, traceability, spec protection, runtime policy clarity, maintainability, and evidence; return only material findings.
 - Session-Handoff: preserve durable state, references, blockers, next safe action, and discard notes.
 
 Do not paste old transcripts, full sprint histories, broad architecture essays, stale status, or duplicate policy text into agent prompts.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ nav:
   - Developer Handbook:
       - Overview: developer-handbook.md
       - Weave operating model: weave-operating-model.md
+      - Spec-driven development: spec-driven-development.md
+      - Agent-team orchestration: agent-team-orchestration.md
       - Trunk-based PR and release workflow: gitflow-pr-workflow.md
       - Architecture: architecture.md
       - Canonical feature models: canonical-feature-models.md

--- a/specs/0000-weave-spec-framework/evidence/expected-gates.yaml
+++ b/specs/0000-weave-spec-framework/evidence/expected-gates.yaml
@@ -1,0 +1,14 @@
+spec_id: WEAVE-SPEC-0000
+expected_gates:
+  - name: specContract
+    command: ./gradlew specContract
+    required_for: all spec framework changes
+  - name: specContractTest
+    command: ./gradlew specContractTest
+    required_for: guard behavior changes
+  - name: docsStructureCheck
+    command: ./gradlew docsStructureCheck
+    required_for: docs navigation/link changes
+  - name: acceptanceContract
+    command: ./gradlew acceptanceContract
+    required_for: verifies no acceptance regression despite process-only scope

--- a/specs/0000-weave-spec-framework/plan.md
+++ b/specs/0000-weave-spec-framework/plan.md
@@ -1,0 +1,73 @@
+# Implementation plan: Weave spec-driven development framework
+
+**Spec**: `specs/0000-weave-spec-framework/spec.md`  
+**Branch**: local implementation branch or short-lived PR branch  
+**Date**: 2026-05-28
+
+## Summary
+
+Add a lightweight Weave-specific Spec Kit layer without importing a heavy workflow wholesale. The framework stores versioned specs in the repo, validates lifecycle metadata with a local guard, and documents `weave-co-leader` specialist orchestration.
+
+## Constitution check
+
+- Repo truth recovered from `main`, docs, GitHub issue/PR state, and CI evidence: yes
+- Product-first/provider-neutral boundary preserved: yes
+- Acceptance/evidence path identified before implementation: yes
+- Accessibility/supportability/auditability/deployability addressed: yes
+- Provider secrets/raw diagnostics remain admin/operator-only: yes
+- Weaver/OpenClaw runtime remains governed and disabled-by-default unless explicitly in scope: yes
+
+## Affected areas
+
+- `.specify/`: constitution and Weave templates.
+- `specs/`: framework spec and convention README.
+- `docs/`: spec-driven development guide and navigation.
+- `tools/`: deterministic spec contract guard.
+- `build.gradle`/`Makefile`: local gate wiring.
+- `.github/pull_request_template.md`: spec/evidence traceability prompt.
+- `AGENTS.md`: point agents at repo-local specs and fallback review reality.
+
+## Contracts and tests first
+
+1. Product acceptance/Gherkin: not applicable for process-only framework.
+2. Mapping/evidence marker: not applicable.
+3. API/event/schema contracts: not applicable.
+4. Tooling tests: `python3 tools/spec_contract_check.py` and `python3 tools/spec_contract_check_test.py`.
+5. CI/evidence artifacts: Gradle `specContract` and CI summary wiring.
+
+## Agent work breakdown
+
+- Product/spec steward: owns spec lifecycle and frontmatter discipline.
+- Client/accessibility: used when member/admin UI behavior changes.
+- Server/domain facade: used when domain contracts, authz, audit, or provider boundaries change.
+- Admin/policy: used when Admin Console, IDM/RBAC, readiness, whitelisting, or policy changes.
+- Provider/infra: used when adapters, OpenTofu, runner, backup/restore, or live-stack infrastructure changes.
+- QA/evidence: owns Gherkin, mapping, evidence markers, Live Stack evidence, and sanitized artifacts.
+- Docs/release: owns docs nav, handbooks, release notes, closure reports, and PR templates.
+- Security/privacy review: used for secrets, raw provider data, auth, audit, and support-safe diagnostics.
+- Integration review: used before PR handoff/merge readiness.
+
+## Rollout and migration
+
+- Start with framework-only spec `WEAVE-SPEC-0000`.
+- Use the next product-core slice as the first real `WEAVE-SPEC-0001` only after Massimo resolves required product-core questions.
+- Keep generated wiki/docs as projections, not canonical source.
+
+## Risks and mitigations
+
+- Risk: Markdown overload for small bugs.
+  - Mitigation: full workflow only for product/architecture/provider/auth/release-relevant changes; small bugs may use issue/spec notes.
+  - Evidence gate: PR template asks for spec/note and smallest local gate.
+- Risk: Agent hallucination of product core.
+  - Mitigation: clarification markers allowed only in draft/proposed specs; accepted/implementing specs fail guard if markers remain.
+  - Evidence gate: `./gradlew specContract`.
+- Risk: ACP/runtime confusion.
+  - Mitigation: agent brief template documents native vs ACP invocation rules and policy-failure reporting.
+  - Evidence gate: docs review.
+
+## Final gates
+
+- `./gradlew specContract`
+- `./gradlew specContractTest`
+- `./gradlew docsStructureCheck`
+- `./gradlew acceptanceContract`

--- a/specs/0000-weave-spec-framework/spec.md
+++ b/specs/0000-weave-spec-framework/spec.md
@@ -1,0 +1,110 @@
+---
+id: WEAVE-SPEC-0000
+title: Weave spec-driven development framework
+version: 0.1.0
+status: implemented
+domain: delivery
+declared_scope: process-framework
+owner: weave-co-leader
+github_issue: null
+supersedes: []
+depends_on: []
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew specContractTest
+  - ./gradlew docsStructureCheck
+---
+
+# Feature specification: Weave spec-driven development framework
+
+## Intent
+
+Weave needs a repo-local, versioned, evidence-backed specification framework so product-core decisions, implementation plans, acceptance mappings, and agent handoffs stay traceable across humans and AI specialists.
+
+This framework does not define new member-facing product behavior. It defines the governance and tooling that future product-core specs must use.
+
+## Product boundaries
+
+### In scope
+
+- A Weave specification constitution under `.specify/memory/constitution.md`.
+- Weave-specific spec, plan, task, agent briefing, and OpenClaw/ACP team configuration templates.
+- A repo-local `specs/` directory convention.
+- A deterministic `specContract` guard for required metadata and unsafe clarification drift.
+- Documentation that explains how `weave-co-leader` coordinates specialists.
+
+### Out of scope
+
+- Choosing a final Chat/Files/Calendar/Boards product-core slice.
+- Changing runtime behavior for members, admins, providers, or Weaver.
+- Enabling ACP/Copilot/Codex/Gemini runtime configuration.
+- Pushing, releasing, or mutating live infrastructure.
+
+## User/admin/operator stories
+
+### US1 - Developer creates a reviewable spec (Priority: P1)
+
+**Actor**: Developer or agent  
+**Story**: A contributor can create a spec with stable metadata, status, acceptance/evidence expectations, and open product questions without guessing core behavior.  
+**Why now**: Weave is moving from sprint-doc-driven work to product-core spec-driven work.  
+**Independent test**: `./gradlew specContract` validates the framework spec and templates.
+
+**Acceptance scenarios**:
+
+1. Given a repo-local spec, when the guard runs, then required metadata and lifecycle state are validated.
+2. Given an implementation-ready spec, when clarification markers remain, then the guard fails before review.
+
+### US2 - Team lead briefs specialists safely (Priority: P1)
+
+**Actor**: `weave-co-leader`  
+**Story**: The team lead can assign scoped specialist work with allowed files, stop conditions, runtime policy, and required evidence.  
+**Why now**: Weave work should use compact templates and evidence returns instead of transcript dumps.  
+**Independent test**: Agent briefing templates exist and are linked from the docs.
+
+**Acceptance scenarios**:
+
+1. Given a spec plan, when the co-leader needs implementation help, then it can brief only the needed specialist role with exact gates and stop conditions.
+2. Given an ACP harness request, when the runtime policy rejects an agent id, then the co-leader reports the policy error instead of silently switching runtimes.
+
+## Functional requirements
+
+- **FR-001**: The repo MUST contain a Weave specification constitution that preserves product-first, provider-neutral, evidence-first delivery.
+- **FR-002**: The repo MUST contain templates for specs, plans, tasks, and agent briefs.
+- **FR-003**: Specs MUST be versioned in Git under `specs/` and validated by a deterministic local guard.
+- **FR-004**: The guard MUST allow explicit product questions in draft/proposed specs and block them in accepted/implementing/implemented specs.
+- **FR-005**: The framework MUST document which logical specialists `weave-co-leader` can use and the runtime constraints for native subagents vs ACP harnesses.
+- **FR-006**: The framework MUST define an optimization-review loop that repeats implementation/review until no material optimization remains or a product-core clarification blocks safe progress.
+- **FR-007**: The framework MUST include a non-live example of the expected OpenClaw native-subagent and ACP profile configuration shape.
+- **FR-008**: This framework MUST NOT create a parallel wiki as source of truth.
+
+## Domain model and contracts
+
+- **Spec**: Versioned product/system contract with frontmatter, acceptance/evidence links, and lifecycle status.
+- **Plan**: Technical implementation approach constrained by a spec and the constitution.
+- **Task list**: Independently testable slices mapped to stories/areas and gates.
+- **Agent brief**: Scoped work order for a specialist with allowed files, gate, and stop conditions.
+- **Optimization review**: Adversarial but practical review that returns only material improvements against the spec, runtime policy, and evidence.
+- **Evidence gate**: Command or artifact that proves a claim without raw secret/provider leakage.
+
+## Acceptance and evidence mapping
+
+- Gherkin feature path(s): none; process-only framework.
+- `e2e/scenario_mappings.json` marker(s): none; no member-facing product behavior changes.
+- Tooling test path(s): `tools/spec_contract_check.py`, `tools/spec_contract_check_test.py`.
+- Agent team config example: `.specify/templates/weave-agent-team-config.example.json5`.
+- Live Stack E2E required? no; repo-process only.
+- Support-safe evidence artifact(s): `build/evidence/ci-summary.json` when run through `./gradlew ci`.
+
+## Release and migration impact
+
+- Member impact: none.
+- Admin/operator impact: future specs become more traceable.
+- Developer/API impact: new `./gradlew specContract` gate and spec templates.
+- Data migration/backfill: none.
+- Rollback/reversibility: remove the added spec framework files and Gradle/Makefile wiring.
+- Release-notes label expected: `release-notes-skip`.
+
+## Open questions
+
+None for this framework slice. Future product-core specs must keep unresolved product questions in `draft` or `proposed` state until Massimo/team review resolves them.

--- a/specs/0000-weave-spec-framework/tasks.md
+++ b/specs/0000-weave-spec-framework/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: Weave spec-driven development framework
+
+**Spec**: `specs/0000-weave-spec-framework/spec.md`  
+**Plan**: `specs/0000-weave-spec-framework/plan.md`
+
+## Phase 0: Truth recovery
+
+- [x] T001 [Spec] Re-read `AGENTS.md`, `docs/weave-operating-model.md`, `docs/acceptance-contracts.md`, and `docs/quality-and-evidence.md`.
+- [x] T002 [Spec] Check repo branch/status and existing Gradle gates.
+- [x] T003 [Research] Compare Spec Kit template concepts and agent-role templates; adapt, do not blindly import.
+
+## Phase 1: Framework artifacts
+
+- [x] T010 [Spec] Add `.specify/memory/constitution.md`.
+- [x] T011 [Spec] Add Weave spec/plan/task templates.
+- [x] T012 [Agents] Add Weave agent briefing templates with native/ACP runtime rules.
+- [x] T013 [Docs] Add `specs/README.md` and framework spec files.
+- [x] T014 [Research] Run NotebookLM deep research without preselected sources for orchestrator/subagent/ACP team patterns.
+- [x] T015 [Agents] Add `weave-agent-team-config.example.json5` with native subagent and ACP profile shape.
+- [x] T016 [Docs] Add `docs/agent-team-orchestration.md` with roles, loop, rubric, guardrails, and configuration excerpts.
+
+## Phase 2: Guard and wiring
+
+- [x] T020 [Tools] Add `tools/spec_contract_check.py`.
+- [x] T021 [Tools] Add `tools/spec_contract_check_test.py` fixture tests.
+- [x] T022 [Build] Add `specContract` and `specContractTest` Gradle tasks plus CI evidence wiring.
+- [x] T023 [Build] Add `make spec-contract` and `make spec-contract-test` aliases.
+- [x] T024 [Review] Add PR template spec/evidence fields.
+
+## Phase 3: Validation
+
+- [x] T030 [Gate] Run `./gradlew specContract`.
+- [x] T031 [Gate] Run `./gradlew specContractTest`.
+- [x] T032 [Gate] Run `./gradlew docsStructureCheck`.
+- [x] T033 [Gate] Run `./gradlew acceptanceContract`.
+- [x] T034 [Review] Run `weave-co-leader` Optimization-Review and address material findings until none remain.
+- [x] T035 [Gate] Re-run spec/docs gates after optimization loop.

--- a/specs/0000-weave-spec-framework/traceability.yaml
+++ b/specs/0000-weave-spec-framework/traceability.yaml
@@ -1,0 +1,29 @@
+spec_id: WEAVE-SPEC-0000
+version: 0.1.0
+status: implemented
+issue: null
+pull_request: null
+release_notes_label: release-notes-skip
+acceptance:
+  gherkin: []
+  scenario_mapping_markers: []
+evidence:
+  gates:
+    - ./gradlew specContract
+    - ./gradlew specContractTest
+    - ./gradlew docsStructureCheck
+    - ./gradlew acceptanceContract
+  artifacts:
+    - build/evidence/ci-summary.json
+agent_roles:
+  orchestrator: weave-co-leader
+  specialists:
+    - product-spec-steward
+    - client-accessibility
+    - server-domain-facade
+    - admin-policy
+    - provider-infra
+    - qa-evidence
+    - docs-release
+    - security-privacy
+    - integration-review

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,29 @@
+# Weave specs
+
+Repo-local specs are the versioned product/system contracts for Weave. They are the source for implementation, review, evidence, and generated documentation. A wiki or NotebookLM notebook may summarize these files, but must not replace them as truth.
+
+## Workflow
+
+1. Copy `.specify/templates/weave-spec-template.md` into `specs/NNNN-slug/spec.md`.
+2. Keep status `draft` or `proposed` while product-core questions remain.
+3. Add `plan.md`, `tasks.md`, `traceability.yaml`, and contract/evidence folders only when the slice is ready for implementation planning.
+4. Add or update Gherkin and `e2e/scenario_mappings.json` before product implementation.
+5. Run `./gradlew specContract` and `./gradlew acceptanceContract` before review.
+6. Use `weave-co-leader` to brief specialists with small scopes and required gates.
+
+## Status rule
+
+`draft` and `proposed` specs may contain `[NEEDS CLARIFICATION: ...]`. `accepted`, `implementing`, and `implemented` specs may not.
+
+## Directory convention
+
+```text
+specs/0001-short-slug/
+├── spec.md
+├── plan.md
+├── tasks.md
+├── traceability.yaml
+├── contracts/
+├── acceptance/
+└── evidence/
+```

--- a/tools/spec_contract_check.py
+++ b/tools/spec_contract_check.py
@@ -96,13 +96,14 @@ def parse_frontmatter(text: str, path: Path) -> dict[str, Any]:
     for raw_line in match.group(1).splitlines():
         if not raw_line.strip() or raw_line.lstrip().startswith("#"):
             continue
-        if raw_line.startswith("  - "):
+        stripped = raw_line.lstrip()
+        if stripped.startswith("- "):
             if current_key is None:
                 fail(f"{path.relative_to(ROOT)} has list item without key: {raw_line!r}")
             data.setdefault(current_key, [])
             if not isinstance(data[current_key], list):
                 fail(f"{path.relative_to(ROOT)} key {current_key!r} mixes scalar and list values")
-            data[current_key].append(parse_scalar(raw_line[4:]))
+            data[current_key].append(parse_scalar(stripped[2:]))
             continue
         if ":" not in raw_line:
             fail(f"{path.relative_to(ROOT)} unsupported frontmatter line: {raw_line!r}")
@@ -174,7 +175,13 @@ def check_spec_dir(spec_dir: Path) -> None:
 
 
 def check_framework_artifacts(spec_dirs: list[Path]) -> None:
-    has_framework_spec = any((spec_dir / "spec.md").read_text(encoding="utf-8", errors="ignore").find("WEAVE-SPEC-0000") >= 0 for spec_dir in spec_dirs)
+    has_framework_spec = False
+    for spec_dir in spec_dirs:
+        spec_path = spec_dir / "spec.md"
+        meta = parse_frontmatter(spec_path.read_text(encoding="utf-8"), spec_path)
+        if meta.get("id") == "WEAVE-SPEC-0000":
+            has_framework_spec = True
+            break
     if not has_framework_spec:
         return
     for relative, required_markers in FRAMEWORK_REQUIRED_FILES.items():

--- a/tools/spec_contract_check.py
+++ b/tools/spec_contract_check.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Validate Weave repo-local specification contracts."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SPECS_DIR = ROOT / "specs"
+
+REQUIRED_KEYS = {
+    "id",
+    "title",
+    "version",
+    "status",
+    "domain",
+    "owner",
+    "github_issue",
+    "supersedes",
+    "depends_on",
+    "acceptance_features",
+    "evidence_gates",
+}
+
+ALLOWED_STATUSES = {
+    "draft",
+    "proposed",
+    "accepted",
+    "implementing",
+    "implemented",
+    "superseded",
+    "deprecated",
+    "rejected",
+}
+
+CLARIFICATION_ALLOWED = {"draft", "proposed"}
+SPEC_ID_RE = re.compile(r"^WEAVE-SPEC-(\d{4})$")
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+CLARIFICATION_RE = re.compile(r"\[NEEDS CLARIFICATION:[^\]]+\]")
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+FRAMEWORK_REQUIRED_FILES = {
+    ".specify/memory/constitution.md": ["Repo truth over chat memory", "Agent governance"],
+    ".specify/templates/weave-spec-template.md": ["[NEEDS CLARIFICATION:"],
+    ".specify/templates/weave-plan-template.md": ["Constitution check"],
+    ".specify/templates/weave-tasks-template.md": ["Agent handoff"],
+    ".specify/templates/weave-agent-briefs.md": ["Optimization-Review", "ACP-Harness-Brief"],
+    ".specify/templates/weave-agent-team-config.example.json5": [
+        "weave-co-leader",
+        "maxSpawnDepth",
+        "maxChildrenPerAgent",
+        "requireAgentId",
+        "allowAgents",
+        "weave-codex-acp",
+        "weave-claude-acp",
+        "weave-gemini-acp",
+        "weave-opencode-acp",
+        "type: \"acp\"",
+        "allowedAgents",
+    ],
+    "docs/spec-driven-development.md": ["Git-versioned specs are truth", "agent-team-orchestration.md"],
+    "docs/agent-team-orchestration.md": [
+        "Material optimization",
+        "OpenClaw configuration shape",
+        "maxSpawnDepth",
+        "weave-codex-acp",
+    ],
+}
+
+
+def fail(message: str) -> None:
+    print(f"spec-contract-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_scalar(value: str) -> Any:
+    value = value.strip()
+    if value == "null":
+        return None
+    if value == "[]":
+        return []
+    if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+        return value[1:-1]
+    return value
+
+
+def parse_frontmatter(text: str, path: Path) -> dict[str, Any]:
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        fail(f"{path.relative_to(ROOT)} missing YAML frontmatter")
+    data: dict[str, Any] = {}
+    current_key: str | None = None
+    for raw_line in match.group(1).splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        if raw_line.startswith("  - "):
+            if current_key is None:
+                fail(f"{path.relative_to(ROOT)} has list item without key: {raw_line!r}")
+            data.setdefault(current_key, [])
+            if not isinstance(data[current_key], list):
+                fail(f"{path.relative_to(ROOT)} key {current_key!r} mixes scalar and list values")
+            data[current_key].append(parse_scalar(raw_line[4:]))
+            continue
+        if ":" not in raw_line:
+            fail(f"{path.relative_to(ROOT)} unsupported frontmatter line: {raw_line!r}")
+        key, value = raw_line.split(":", 1)
+        key = key.strip()
+        if not key:
+            fail(f"{path.relative_to(ROOT)} has empty frontmatter key")
+        current_key = key
+        value = value.strip()
+        data[key] = [] if value == "" else parse_scalar(value)
+    return data
+
+
+def check_spec_dir(spec_dir: Path) -> None:
+    spec_path = spec_dir / "spec.md"
+    if not spec_path.exists():
+        fail(f"{spec_dir.relative_to(ROOT)} missing spec.md")
+    text = spec_path.read_text(encoding="utf-8")
+    meta = parse_frontmatter(text, spec_path)
+
+    missing = sorted(REQUIRED_KEYS.difference(meta))
+    if missing:
+        fail(f"{spec_path.relative_to(ROOT)} missing required frontmatter keys: {missing}")
+
+    spec_id = str(meta["id"])
+    id_match = SPEC_ID_RE.match(spec_id)
+    if not id_match:
+        fail(f"{spec_path.relative_to(ROOT)} id must match WEAVE-SPEC-NNNN, got {spec_id!r}")
+    if not spec_dir.name.startswith(id_match.group(1) + "-"):
+        fail(f"{spec_dir.relative_to(ROOT)} directory must start with {id_match.group(1)}-")
+
+    status = str(meta["status"])
+    if status not in ALLOWED_STATUSES:
+        fail(f"{spec_path.relative_to(ROOT)} invalid status {status!r}; allowed {sorted(ALLOWED_STATUSES)}")
+
+    version = str(meta["version"])
+    if not VERSION_RE.match(version):
+        fail(f"{spec_path.relative_to(ROOT)} version must be semantic, got {version!r}")
+
+    for key in ["supersedes", "depends_on", "acceptance_features", "evidence_gates"]:
+        if not isinstance(meta[key], list):
+            fail(f"{spec_path.relative_to(ROOT)} {key} must be a YAML list")
+
+    if not meta["evidence_gates"]:
+        fail(f"{spec_path.relative_to(ROOT)} evidence_gates must name at least one gate")
+
+    if status not in CLARIFICATION_ALLOWED:
+        for path in sorted(spec_dir.rglob("*.md")):
+            body = path.read_text(encoding="utf-8")
+            match = CLARIFICATION_RE.search(body)
+            if match:
+                fail(
+                    f"{path.relative_to(ROOT)} status {status!r} cannot contain "
+                    f"clarification marker {match.group(0)!r}"
+                )
+
+    if status in {"accepted", "implementing", "implemented"}:
+        trace = spec_dir / "traceability.yaml"
+        if not trace.exists():
+            fail(f"{spec_dir.relative_to(ROOT)} status {status!r} requires traceability.yaml")
+        trace_text = trace.read_text(encoding="utf-8")
+        if f"spec_id: {spec_id}" not in trace_text:
+            fail(f"{trace.relative_to(ROOT)} must include spec_id: {spec_id}")
+
+    for feature in meta["acceptance_features"]:
+        feature_path = ROOT / str(feature)
+        if not feature_path.exists():
+            fail(f"{spec_path.relative_to(ROOT)} acceptance feature does not exist: {feature}")
+
+
+def check_framework_artifacts(spec_dirs: list[Path]) -> None:
+    has_framework_spec = any((spec_dir / "spec.md").read_text(encoding="utf-8", errors="ignore").find("WEAVE-SPEC-0000") >= 0 for spec_dir in spec_dirs)
+    if not has_framework_spec:
+        return
+    for relative, required_markers in FRAMEWORK_REQUIRED_FILES.items():
+        path = ROOT / relative
+        if not path.exists():
+            fail(f"framework spec requires {relative}")
+        text = path.read_text(encoding="utf-8")
+        for marker in required_markers:
+            if marker not in text:
+                fail(f"{relative} must contain framework marker {marker!r}")
+
+
+def main() -> None:
+    if not SPECS_DIR.exists():
+        fail("missing specs/ directory")
+    spec_dirs = sorted(path for path in SPECS_DIR.iterdir() if path.is_dir() and not path.name.startswith("."))
+    if not spec_dirs:
+        fail("specs/ contains no spec directories")
+    for spec_dir in spec_dirs:
+        check_spec_dir(spec_dir)
+    check_framework_artifacts(spec_dirs)
+    print(f"spec-contract-check: ok ({len(spec_dirs)} spec directory/directories)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/spec_contract_check_test.py
+++ b/tools/spec_contract_check_test.py
@@ -83,6 +83,16 @@ class SpecContractCheckTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.run_main(repo)
 
+    def test_frontmatter_accepts_unindented_list_items(self) -> None:
+        unindented = VALID_SPEC.replace("  - ./gradlew specContract", "- ./gradlew specContract")
+        self.run_main(self.with_repo(unindented))
+
+    def test_framework_reference_does_not_require_framework_artifacts(self) -> None:
+        reference_only = VALID_SPEC.replace(
+            "No unresolved questions.", "This future spec references WEAVE-SPEC-0000 for process context."
+        )
+        self.run_main(self.with_repo(reference_only))
+
     def test_framework_spec_requires_agent_team_artifacts(self) -> None:
         repo = self.with_repo(FRAMEWORK_SPEC, dirname="0000-framework", traceability=FRAMEWORK_TRACEABILITY)
         with self.assertRaises(SystemExit):

--- a/tools/spec_contract_check_test.py
+++ b/tools/spec_contract_check_test.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Fixture tests for spec_contract_check.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import spec_contract_check
+
+
+VALID_SPEC = """---
+id: WEAVE-SPEC-0001
+title: Test spec
+version: 0.1.0
+status: implemented
+domain: delivery
+owner: weave-co-leader
+github_issue: null
+supersedes: []
+depends_on: []
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+---
+
+# Feature specification: Test spec
+
+No unresolved questions.
+"""
+
+TRACEABILITY = """spec_id: WEAVE-SPEC-0001
+version: 0.1.0
+status: implemented
+"""
+
+FRAMEWORK_SPEC = VALID_SPEC.replace("WEAVE-SPEC-0001", "WEAVE-SPEC-0000").replace("0001", "0000")
+FRAMEWORK_TRACEABILITY = TRACEABILITY.replace("WEAVE-SPEC-0001", "WEAVE-SPEC-0000")
+
+
+class SpecContractCheckTest(unittest.TestCase):
+    def with_repo(self, spec_text: str, dirname: str = "0001-test-spec", traceability: str | None = TRACEABILITY) -> Path:
+        tmp = Path(tempfile.mkdtemp(prefix="weave-spec-contract-test-"))
+        spec_dir = tmp / "specs" / dirname
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "spec.md").write_text(spec_text, encoding="utf-8")
+        if traceability is not None:
+            (spec_dir / "traceability.yaml").write_text(traceability, encoding="utf-8")
+        return tmp
+
+    def run_main(self, repo: Path) -> None:
+        with mock.patch.object(spec_contract_check, "ROOT", repo), mock.patch.object(
+            spec_contract_check, "SPECS_DIR", repo / "specs"
+        ):
+            spec_contract_check.main()
+
+    def test_valid_implemented_spec_passes(self) -> None:
+        self.run_main(self.with_repo(VALID_SPEC))
+
+    def test_implemented_spec_with_clarification_fails(self) -> None:
+        repo = self.with_repo(VALID_SPEC.replace("No unresolved questions.", "[NEEDS CLARIFICATION: decide product core]"))
+        with self.assertRaises(SystemExit):
+            self.run_main(repo)
+
+    def test_draft_spec_with_clarification_passes_without_traceability(self) -> None:
+        draft = VALID_SPEC.replace("status: implemented", "status: draft").replace(
+            "No unresolved questions.", "[NEEDS CLARIFICATION: decide product core]"
+        )
+        self.run_main(self.with_repo(draft, traceability=None))
+
+    def test_implemented_spec_with_nested_clarification_fails(self) -> None:
+        repo = self.with_repo(VALID_SPEC)
+        nested = repo / "specs" / "0001-test-spec" / "contracts" / "contract.md"
+        nested.parent.mkdir(parents=True)
+        nested.write_text("[NEEDS CLARIFICATION: hidden product question]\n", encoding="utf-8")
+        with self.assertRaises(SystemExit):
+            self.run_main(repo)
+
+    def test_directory_number_must_match_spec_id(self) -> None:
+        repo = self.with_repo(VALID_SPEC, dirname="0002-wrong")
+        with self.assertRaises(SystemExit):
+            self.run_main(repo)
+
+    def test_framework_spec_requires_agent_team_artifacts(self) -> None:
+        repo = self.with_repo(FRAMEWORK_SPEC, dirname="0000-framework", traceability=FRAMEWORK_TRACEABILITY)
+        with self.assertRaises(SystemExit):
+            self.run_main(repo)
+
+    def test_framework_spec_passes_with_required_agent_team_artifacts(self) -> None:
+        repo = self.with_repo(FRAMEWORK_SPEC, dirname="0000-framework", traceability=FRAMEWORK_TRACEABILITY)
+        files = {
+            ".specify/memory/constitution.md": "Repo truth over chat memory\nAgent governance\n",
+            ".specify/templates/weave-spec-template.md": "[NEEDS CLARIFICATION:\n",
+            ".specify/templates/weave-plan-template.md": "Constitution check\n",
+            ".specify/templates/weave-tasks-template.md": "Agent handoff\n",
+            ".specify/templates/weave-agent-briefs.md": "Optimization-Review\nACP-Harness-Brief\n",
+            ".specify/templates/weave-agent-team-config.example.json5": "weave-co-leader\nmaxSpawnDepth\nmaxChildrenPerAgent\nrequireAgentId\nallowAgents\nweave-codex-acp\nweave-claude-acp\nweave-gemini-acp\nweave-opencode-acp\ntype: \"acp\"\nallowedAgents\n",
+            "docs/spec-driven-development.md": "Git-versioned specs are truth\nagent-team-orchestration.md\n",
+            "docs/agent-team-orchestration.md": "Material optimization\nOpenClaw configuration shape\nmaxSpawnDepth\nweave-codex-acp\n",
+        }
+        for relative, content in files.items():
+            path = repo / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        self.run_main(repo)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add repo-local Weave spec-driven development framework (`.specify/`, `specs/`, `WEAVE-SPEC-0000`).
- Add `weave-co-leader` agent-team orchestration docs, native specialist roles, ACP profile examples, and optimization-review loop.
- Add deterministic `specContract` / `specContractTest` guards, including nested clarification-marker protection for implementation-ready specs.
- Wire spec/evidence expectations into Gradle, Make, docs nav, issue template, and PR template.
- Fix PR release-notes-label CI race by validating live PR labels instead of stale `opened` event payload labels.
- Address Copilot review findings: duplicate docs numbering, framework detection by parsed frontmatter ID, and unindented YAML list support.

## Spec / traceability

- Spec: `specs/0000-weave-spec-framework/spec.md`
- Plan: `specs/0000-weave-spec-framework/plan.md`
- Tasks: `specs/0000-weave-spec-framework/tasks.md`
- Traceability: `specs/0000-weave-spec-framework/traceability.yaml`
- Release-notes label: `release-notes-skip`

## Evidence

Local gates passed:

- `python3 -m py_compile tools/spec_contract_check.py tools/spec_contract_check_test.py`
- `python3 tools/spec_contract_check_test.py`
- `./gradlew specContract specContractTest docsStructureCheck acceptanceContract`
- `./gradlew docsBuild`
- `PR_LABELS_JSON='["release-notes-skip"]' ./gradlew releaseNotesLabelCheck`
- `git diff --check`

Review evidence:

- `weave-co-leader` Optimization-Review found and fixed two material issues:
  - ACP profile allowlist mismatch.
  - nested `[NEEDS CLARIFICATION: ...]` guard gap.
- Final `weave-co-leader` Optimization-Review: `no-material-optimizations`, material finding count `0`.
- `@copilot` review requested and all three review threads addressed/resolved.

## Risk / rollback

- Process/framework/CI-only; no member/admin runtime behavior change claimed.
- No live infra mutation, secrets, provider payloads, or release action.
- Rollback: revert this PR and remove Gradle/Make/doc/template/workflow wiring.

## Review notes

- Product-core decisions for `WEAVE-SPEC-0001` remain intentionally unresolved and must be confirmed separately.
