### PR TITLE
Define WEAVE-SPEC-0001 admin provider neutrality

### DIFF
--- a/.specify/templates/weave-agent-briefs.md
+++ b/.specify/templates/weave-agent-briefs.md
@@ -96,6 +96,52 @@ Return:
 - If no findings: final evidence needed before commit/PR
 ```
 
+## Sprint-Planning
+
+```text
+You are weave-co-leader. Plan a real Weave sprint from the governing spec.
+Inputs: <spec.md/plan.md/tasks.md/docs/issues>.
+Do first: recover truth from main, specs, GitHub issues/PRs, CI/evidence.
+Output: sprint goal, issue DAG, PR train order, specialist roles, required gates, merge authorization status, product-core blockers.
+If issues are missing and GitHub access is available, create/update them with dependency notes and parallel/sequential labels.
+Do not implement yet.
+```
+
+## Issue-DAG
+
+```text
+Create or update GitHub issues for the sprint.
+Each issue must include: spec id, user/admin/operator value, allowed scope, dependencies, acceptance/gate, release-notes expectation, and whether it is parallel or sequential.
+Do not create vague umbrella tasks unless they link concrete implementation/review issues.
+Return: issue numbers, dependency order, blockers.
+```
+
+## PR-Train
+
+```text
+For the next unblocked issue in the DAG, cut/update a short-lived branch from current main, implement the smallest reviewable slice, open a PR, set exactly one release-notes label, and run the required local gate.
+After CI and Integration-Gate pass, merge only if the sprint brief authorizes autonomous merge; otherwise report merge-ready with the one missing decision.
+After merge, fetch/fast-forward main before continuing dependent PRs.
+Return: issue, branch, PR, gates, CI, merge status, next unblocked issue.
+```
+
+## Sprint-Closure
+
+```text
+Close the sprint only after all planned issues/PRs are merged or an explicit blocker is recorded.
+Report exactly:
+- Verdict
+- Governing spec(s)
+- Issue DAG with final state
+- Merged PRs in order
+- Gates and CI evidence
+- Release notes / RC impact
+- Product decisions made or still blocked
+- Docs/spec updates
+- Next safe action
+A green unmerged PR is not a completed sprint.
+```
+
 ## Session-Handoff
 
 ```text

--- a/.specify/templates/weave-agent-team-config.example.json5
+++ b/.specify/templates/weave-agent-team-config.example.json5
@@ -31,17 +31,24 @@
         id: "weave-co-leader",
         name: "Weave co-leader / integrator",
         workspace: "/Users/flotterotter/code/weave",
+        systemPromptOverride: "You are weave-co-leader for the Weave monorepo. A sprint means spec -> issue DAG -> ordered PR train -> merges -> closure report; never treat one green PR as a completed sprint. Recover truth from repo/GitHub/CI first. Create/update issues when missing. Spawn scoped specialists from the allowlist for narrow slices. Enforce exactly one release-notes label per PR, green gates/CI, Integration-Gate review, and merge in dependency order when authorized. Keep durable state in specs/issues/PRs/reports, not chat transcripts. Stop for product-core ambiguity, live-infra/destructive actions, secrets, or missing merge authorization.",
         subagents: {
           requireAgentId: true,
           allowAgents: [
             "weave-product-spec",
+            "weave-architecture-contract",
+            "weave-client-ui",
             "weave-client-a11y",
+            "weave-admin-console",
             "weave-server-domain",
-            "weave-admin-policy",
+            "weave-server-auth-audit",
+            "weave-provider-adapters",
             "weave-provider-infra",
+            "weave-e2e-acceptance",
             "weave-qa-evidence",
             "weave-docs-release",
             "weave-security-privacy",
+            "weave-devex-ci",
             "weave-integration-reviewer",
             "weave-codex-acp",
             "weave-claude-acp",
@@ -56,8 +63,23 @@
         workspace: "/Users/flotterotter/code/weave",
       },
       {
+        id: "weave-architecture-contract",
+        name: "Weave architecture/contract specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-client-ui",
+        name: "Weave client/UI specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
         id: "weave-client-a11y",
         name: "Weave client/accessibility specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-admin-console",
+        name: "Weave admin console/policy specialist",
         workspace: "/Users/flotterotter/code/weave",
       },
       {
@@ -66,13 +88,23 @@
         workspace: "/Users/flotterotter/code/weave",
       },
       {
-        id: "weave-admin-policy",
-        name: "Weave admin/policy specialist",
+        id: "weave-server-auth-audit",
+        name: "Weave server auth/audit specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-provider-adapters",
+        name: "Weave provider adapter specialist",
         workspace: "/Users/flotterotter/code/weave",
       },
       {
         id: "weave-provider-infra",
         name: "Weave provider/infra specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-e2e-acceptance",
+        name: "Weave E2E/acceptance specialist",
         workspace: "/Users/flotterotter/code/weave",
       },
       {
@@ -88,6 +120,11 @@
       {
         id: "weave-security-privacy",
         name: "Weave security/privacy specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-devex-ci",
+        name: "Weave DevEx/CI specialist",
         workspace: "/Users/flotterotter/code/weave",
       },
       {

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -171,6 +171,34 @@ Scenario: Tagged over several lines
     ]);
   });
 
+  test('feature parser treats scenario outlines as acceptance scenarios', () {
+    final directory = Directory.systemTemp.createTempSync(
+      'weave_feature_outline_',
+    );
+    addTearDown(() => directory.deleteSync(recursive: true));
+    final featureFile =
+        File('${directory.path}${Platform.pathSeparator}outline.feature')
+          ..writeAsStringSync('''
+Feature: Outlined evidence
+
+@weave-live-outline
+Scenario Outline: Capability state is support-safe
+  Given a <state> capability
+  Then the member sees support-safe copy
+
+Examples:
+  | state          |
+  | ready          |
+  | policy-blocked |
+''');
+
+    final scenarios = acceptance.parseFeatureFile(directory, featureFile);
+
+    expect(scenarios, hasLength(1));
+    expect(scenarios.single.name, 'Capability state is support-safe');
+    expect(scenarios.single.tags, <String>['@weave-live-outline']);
+  });
+
   test('runtime evidence sanitizer keeps accessibility fields', () {
     final directory = Directory.systemTemp.createTempSync('weave_evidence_');
     addTearDown(() => directory.deleteSync(recursive: true));

--- a/client/tool/acceptance_contract.dart
+++ b/client/tool/acceptance_contract.dart
@@ -154,8 +154,9 @@ List<FeatureScenario> parseFeatureFile(Directory root, File file) {
       );
       continue;
     }
-    if (line.startsWith('Scenario: ')) {
-      final scenarioName = line.substring('Scenario: '.length).trim();
+    final scenarioPrefix = _scenarioKeywordPrefix(line);
+    if (scenarioPrefix != null) {
+      final scenarioName = line.substring(scenarioPrefix.length).trim();
       scenarios.add(
         FeatureScenario(
           featurePath: relativePath,
@@ -641,6 +642,20 @@ String _relativePath(String rootPath, String path) {
       ? path.substring(normalizedRoot.length)
       : path;
   return relativePath.replaceAll(Platform.pathSeparator, '/');
+}
+
+String? _scenarioKeywordPrefix(String line) {
+  const scenarioKeywords = <String>[
+    'Scenario: ',
+    'Scenario Outline: ',
+    'Scenario Template: ',
+  ];
+  for (final keyword in scenarioKeywords) {
+    if (line.startsWith(keyword)) {
+      return keyword;
+    }
+  }
+  return null;
 }
 
 String _escapeMarkdown(String value) => value.replaceAll('|', r'\|');

--- a/docs/agent-team-orchestration.md
+++ b/docs/agent-team-orchestration.md
@@ -6,33 +6,53 @@ This page defines the professional multi-agent delivery model for Weave. It tran
 
 ## Operating principle
 
-`weave-co-leader` owns decomposition, integration, and evidence. It does **not** become a mega-coder.
+`weave-co-leader` owns sprint decomposition, issue/PR orchestration, merge sequencing, integration, and evidence. It does **not** become a mega-coder and it must not declare a sprint complete just because one PR is green.
 
-Use this loop until no material optimization remains:
+Use this sprint loop until the issue DAG is integrated or a product-core blocker stops safe progress:
 
-1. Recover truth from this repo, GitHub issues/PRs, and CI/evidence.
-2. Identify the governing issue/spec/acceptance contract.
-3. Build a small task DAG; parallelize only independent file/contract areas.
-4. Spawn a scoped specialist with exact files, inputs, stop conditions, and a required gate.
-5. Integrate only from returned evidence and inspected diffs.
-6. Run an adversarial Integration-Gate review.
-7. Repeat implementation/review for material findings.
-8. Stop only when the reviewer reports no material optimization opportunity or a product-core clarification blocks safe progress.
+1. Recover truth from `main`, repo specs/docs/tasks, GitHub issues/PRs, and CI/evidence.
+2. Identify the governing spec and decide whether it is ready for implementation. Keep unresolved product-core questions in `draft`/`proposed`.
+3. Convert the spec plan/tasks into a GitHub issue DAG. Label independent work `parallel`; label ordered work `sequential`; link issues/PRs back to the spec.
+4. Cut short-lived branches from updated `main` and open reviewable PRs in dependency order.
+5. Spawn scoped specialists only for narrow issue slices, each with exact files, inputs, stop conditions, and a required gate.
+6. Integrate only from returned evidence and inspected diffs, then run an adversarial Integration-Gate review.
+7. Merge dependency-free PRs once CI/gates/review evidence pass and the sprint brief authorizes merge; otherwise surface the exact missing approval.
+8. After every merge, update `main`, re-evaluate the remaining DAG, and continue the next slice.
+9. Stop only when all sprint issues/PRs are merged or when a product-core clarification, live-infra/destructive approval, or failed gate blocks safe progress.
+10. Produce the sprint closure report from repo/GitHub/CI evidence.
 
 Material optimization means improved correctness, traceability, security/privacy, accessibility, supportability, deployability, CI/evidence quality, or reviewability without hidden scope expansion.
+
+## Sprint management responsibilities
+
+The co-leader keeps durable sprint state in GitHub and repo files, not chat transcripts:
+
+- Specification stewarding lives in `specs/<id>/spec.md`, `plan.md`, `tasks.md`, and traceability files.
+- Work tracking lives in GitHub issues with dependency notes and `parallel`/`sequential` labels.
+- Implementation state lives in PRs and CI artifacts.
+- Release impact lives in exactly one release-notes label per PR.
+- Sprint closure lives in a checked-in report or PR comment that cites merged PRs, gates, and remaining decisions.
+
+If the sprint brief authorizes autonomous merge, `weave-co-leader` may merge green, reviewed PRs in DAG order. If not, it reports merge-ready PRs and asks for the one missing merge decision.
 
 ## Recommended roles
 
 Use native OpenClaw subagents for these repo-aware specialists by default:
 
-- `weave-product-spec`: product-core wording, lifecycle status, frontmatter, non-goals, clarification markers.
-- `weave-client-a11y`: Flutter member/admin UX, accessibility semantics, keyboard/screen-reader behavior, l10n, widget tests.
+- `weave-product-spec`: product-core wording, lifecycle status, frontmatter, non-goals, clarification markers, issue slicing.
+- `weave-architecture-contract`: provider-neutral domain boundaries, contract drift, spec/plan architecture consistency.
+- `weave-client-ui`: Flutter member/admin UX implementation, navigation, state handling, widget tests.
+- `weave-client-a11y`: accessibility semantics, keyboard/screen-reader behavior, l10n, deterministic screenshots.
+- `weave-admin-console`: Admin Console, workspace health, IDM/RBAC, policy previews, readiness, whitelisting.
 - `weave-server-domain`: domain facades, authorization, audit, provider boundaries, backend contract tests.
-- `weave-admin-policy`: Admin Console, workspace health, IDM/RBAC, policy previews, readiness, whitelisting.
+- `weave-server-auth-audit`: identity, authz, audit ordering, support-safe audit payloads.
+- `weave-provider-adapters`: provider-neutral adapter facades and canonical model mapping.
 - `weave-provider-infra`: OpenTofu, adapters, runner/environment posture, backup/restore, support bundles.
-- `weave-qa-evidence`: Gherkin, `scenario_mappings.json`, Live Stack evidence, sanitized artifacts.
+- `weave-e2e-acceptance`: Gherkin, live-stack acceptance flow coverage, scenario intent.
+- `weave-qa-evidence`: `scenario_mappings.json`, sanitized artifacts, CI/evidence completeness.
 - `weave-docs-release`: docs navigation, handbooks, release notes, PR templates, closure reports.
 - `weave-security-privacy`: secrets, raw provider payloads, audit, support-safe diagnostics, external-provider risk.
+- `weave-devex-ci`: Gradle tasks, CI workflows, dependency/tooling checks, evidence upload.
 - `weave-integration-reviewer`: final diff/spec/PR readiness, evidence strength, scope creep, release-label and CI posture.
 
 Use ACP harnesses only when explicitly requested or intentionally selected for a coding-harness run:

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -108,6 +108,22 @@ Use protected `main` plus short-lived PR branches; do not introduce long-lived `
 
 Release notes are generated from merged PR labels, not manually reconstructed later. The CI `Release Notes Label Check` runs on every pull-request update and fails PRs with zero or multiple release-notes labels; label-only changes run that lightweight check without re-running the full Gradle CI job. See [Weave operating model](weave-operating-model.md) for the delivery contract and [Trunk-based PR and release workflow](gitflow-pr-workflow.md) for label semantics and merge rules.
 
+## Spec-driven sprint contract
+
+A Weave sprint is not one green PR. A sprint starts from an accepted or explicitly proposed specification and ends only after the planned issue/PR train has been integrated or a product-core blocker is recorded.
+
+Required sprint shape:
+
+1. Recover truth from `main`, `specs/`, GitHub issues/PRs, and CI artifacts.
+2. Select or create the governing spec, then keep product-core ambiguity in `draft`/`proposed` with explicit `[NEEDS CLARIFICATION: ...]` markers.
+3. Break the spec plan/tasks into a GitHub issue DAG with `parallel`/`sequential` labels where ordering matters.
+4. For each implementation slice, open a short-lived branch and one reviewable PR with exactly one release-notes label.
+5. Merge PRs in dependency order after green CI, required local gates, and fallback human/agent review evidence. Copilot review is optional while premium review requests are exhausted.
+6. After each merge, update local `main` before cutting the next dependent branch.
+7. Finish with a sprint closure report that lists the spec, issue DAG, merged PRs in order, gates/CI evidence, unresolved decisions, release/RC follow-up, and next safe action.
+
+The `weave-co-leader` is expected to drive this loop autonomously when given a sprint goal. It should ask Massimo only for product-core decisions, destructive/live-infra approval, or merge/release decisions not already authorized by the sprint brief.
+
 ## Documentation site
 
 Weave docs are published as a MkDocs site configured by `mkdocs.yml`. The site uses MkDocs Material; its MIT license was verified from upstream on 2026-05-24 and is safe for project use.

--- a/docs/spec-driven-development.md
+++ b/docs/spec-driven-development.md
@@ -77,6 +77,20 @@ Product-core questions that require Massimo/team confirmation include:
 - when Weaver moves from placeholder category to governed runtime implementation;
 - which agentic developer-assistance capability, if any, is allowed inside Weave policy.
 
+## Sprint orchestration
+
+A sprint is the execution of a spec-backed issue DAG, not a single implementation PR. The expected autonomous flow is:
+
+1. `weave-co-leader` recovers current truth from repo/GitHub/CI.
+2. `weave-product-spec` and `weave-architecture-contract` confirm whether the governing spec is implementable or needs clarification.
+3. The co-leader creates or updates GitHub issues for the spec tasks, labels them `parallel` or `sequential`, and records dependencies in issue bodies.
+4. Specialists implement narrow issues on short-lived branches.
+5. The co-leader opens PRs, assigns exactly one release-notes label, waits for green CI/gates, runs Integration-Gate, and merges in dependency order when authorized.
+6. After each merge, the co-leader updates `main`, revises remaining tasks if necessary, and continues.
+7. Sprint closure records the spec, issue DAG, merged PR train, gates, evidence artifacts, unresolved product decisions, and next release/RC action.
+
+Durable sprint state belongs in specs, issues, PRs, and checked-in reports. Agent chat/session state is disposable.
+
 ## DevOps traceability
 
 Every implementation PR should connect:

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -635,6 +635,15 @@
       ],
       "additionalEvidence": [
         {
+          "path": "server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java",
+          "fragments": [
+            "taskWritesPublishSupportSafeWorkspaceAuditEvents",
+            "preWriteAuditRedactsUnsafeResourceReferencesBeforeRepositoryValidation",
+            "updateStatusFailsClosedBeforeMutationWhenAuditPublisherIsMissing",
+            "linkDecisionFailsClosedBeforeMutationWhenAuditPublisherIsMissing"
+          ]
+        },
+        {
           "path": "docs/release-v0.1-dogfood-plan.md",
           "fragments": [
             "Boards with user writes",
@@ -664,6 +673,12 @@
           ]
         },
         {
+          "path": "server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java",
+          "fragments": [
+            "createMeetingCapsuleFailsClosedBeforeMutationWhenAuditPublisherIsMissing"
+          ]
+        },
+        {
           "path": "docs/release-v0.1-dogfood-plan.md",
           "fragments": [
             "Meeting Capsule includes agenda, files, decisions, and follow-up tasks",
@@ -688,6 +703,12 @@
             "/api/v1/chat/conversations/channel-general/decisions",
             "source-linked",
             "DECISION_LEDGER_RECORD_CREATED"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java",
+          "fragments": [
+            "createDecisionFailsClosedBeforeMutationWhenAuditPublisherIsMissing"
           ]
         },
         {

--- a/server/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
@@ -172,11 +172,12 @@ public class BoardsFacadeService {
         PrincipalContext principal = requireContextPermission(jwt, ContextPermission.EDIT);
         TaskStatus status = parseStatus(request.status());
         try {
-            TaskItem task = boardsRepository.updateTaskStatus(taskId, status, request.targetColumnId());
-            publishTaskAudit(principal, AuditAction.TASK_STATUS_UPDATED, task, Map.of(
+            publishTaskWriteAudit(principal, AuditAction.TASK_STATUS_UPDATED, "update_task_status:" + taskId, Map.of(
                     "command", "update_task_status",
-                    "status", status.contractName()));
-            return task;
+                    "taskId", taskId,
+                    "status", status.contractName(),
+                    "targetColumnId", request.targetColumnId() == null ? "" : request.targetColumnId()));
+            return boardsRepository.updateTaskStatus(taskId, status, request.targetColumnId());
         } catch (BoardsException exception) {
             throw apiError(exception);
         }
@@ -185,11 +186,11 @@ public class BoardsFacadeService {
     public TaskItem linkDecision(Jwt jwt, String taskId, BoardsLinkDecisionRequest request) {
         PrincipalContext principal = requireContextPermission(jwt, ContextPermission.EDIT);
         try {
-            TaskItem task = boardsRepository.linkDecision(taskId, request.decisionRef());
-            publishTaskAudit(principal, AuditAction.TASK_DECISION_LINKED, task, Map.of(
+            publishTaskWriteAudit(principal, AuditAction.TASK_DECISION_LINKED, "link_decision:" + taskId, Map.of(
                     "command", "link_decision",
-                    "decisionRef", request.decisionRef()));
-            return task;
+                    "taskId", taskId,
+                    "decisionRef", request.decisionRef() == null ? "" : request.decisionRef()));
+            return boardsRepository.linkDecision(taskId, request.decisionRef());
         } catch (BoardsException exception) {
             throw apiError(exception);
         }
@@ -304,28 +305,9 @@ public class BoardsFacadeService {
                 Map.of("field", "status", "supportSafe", "true")));
     }
 
-    private void publishTaskAudit(PrincipalContext principal, AuditAction action, TaskItem task, Map<String, Object> payload) {
-        Map<String, Object> auditPayload = new LinkedHashMap<>(payload);
-        auditPayload.put("boardId", task.boardId());
-        auditPayload.put("taskId", task.id());
-        auditPayload.put("columnId", task.columnId());
-        auditPayload.put("status", task.status().contractName());
-        auditPayload.put("supportSafe", true);
-        AuditWriteGate.publishRequired(auditEventPublisher, new AuditEvent(
-                principal.tenantId(),
-                principal.contextId(),
-                principal.principalRef(),
-                "weave:boards-workspace",
-                action,
-                task.updatedAt(),
-                action.wireName() + ":" + task.id() + ":" + task.updatedAt(),
-                AuditRedactionLevel.SUPPORT_SAFE,
-                auditPayload));
-    }
-
     private void publishTaskWriteAudit(PrincipalContext principal, AuditAction action, String subject, Map<String, Object> payload) {
         Instant timestamp = Instant.now();
-        Map<String, Object> auditPayload = new LinkedHashMap<>(payload);
+        Map<String, Object> auditPayload = supportSafeAuditPayload(payload);
         auditPayload.put("supportSafe", true);
         AuditWriteGate.publishRequired(auditEventPublisher, new AuditEvent(
                 principal.tenantId(),
@@ -334,9 +316,36 @@ public class BoardsFacadeService {
                 "weave:boards-workspace",
                 action,
                 timestamp,
-                action.wireName() + ":" + subject + ":" + timestamp,
+                action.wireName() + ":" + supportSafeAuditString(subject) + ":" + timestamp,
                 AuditRedactionLevel.SUPPORT_SAFE,
                 auditPayload));
+    }
+
+    private Map<String, Object> supportSafeAuditPayload(Map<String, Object> payload) {
+        Map<String, Object> safePayload = new LinkedHashMap<>();
+        payload.forEach((key, value) -> safePayload.put(key,
+                value instanceof String stringValue ? supportSafeAuditString(stringValue) : value));
+        return safePayload;
+    }
+
+    private String supportSafeAuditString(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim();
+        String normalized = trimmed.toLowerCase(Locale.ROOT);
+        if (trimmed.length() > 160
+                || normalized.contains("://")
+                || normalized.contains("authorization")
+                || normalized.contains("token")
+                || normalized.contains("secret")
+                || normalized.contains("password")
+                || normalized.contains("apikey")
+                || normalized.contains("api_key")
+                || normalized.contains("cookie")) {
+            return "[redacted:unsafe-ref]";
+        }
+        return trimmed;
     }
 
     private String sourceFor(ProviderKind provider) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
@@ -214,13 +214,13 @@ public class ChatFacadeService {
                 sanitizeTextList(request.openQuestions(), 120),
                 sanitizeReferenceList(request.followUpRefs()),
                 true);
-        decisionsFor(conversation.id()).add(decision);
         publishAudit(principal, AuditAction.DECISION_LEDGER_RECORD_CREATED, decision.id(), timestamp, Map.of(
                 "command", "create_decision",
                 "conversationId", conversation.id(),
                 "status", decision.status(),
                 "referenceCount", references.size(),
                 "supportSafe", true));
+        decisionsFor(conversation.id()).add(decision);
         return decision;
     }
 
@@ -265,12 +265,12 @@ public class ChatFacadeService {
                 false,
                 false,
                 true);
-        meetingCapsulesFor(conversation.id()).add(capsule);
         publishAudit(principal, AuditAction.MEETING_CAPSULE_CREATED, capsule.id(), timestamp, Map.of(
                 "command", "create_meeting_capsule",
                 "conversationId", conversation.id(),
                 "failClosed", true,
                 "supportSafe", true));
+        meetingCapsulesFor(conversation.id()).add(capsule);
         return capsule;
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
@@ -1,6 +1,7 @@
 package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.AuditRequiredException;
 import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
 import com.massimotter.weave.backend.boards.domain.Board;
 import com.massimotter.weave.backend.boards.domain.BoardColumn;
@@ -204,6 +205,75 @@ class BoardsFacadeServiceTest {
     }
 
     @Test
+    void preWriteAuditRedactsUnsafeResourceReferencesBeforeRepositoryValidation() {
+        var auditPublisher = new InMemoryAuditEventPublisher();
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsRuntimeGuard(true),
+                new LocalWorkspaceBoardsRepository(),
+                request -> ContextAuthorizationDecision.allow("edit allowed"),
+                contextAuthorizationProperties(),
+                workspaceCapabilityService(),
+                auditPublisher);
+
+        assertThatThrownBy(() -> service.moveTask(jwt(), "https://provider.example/tasks/42?token=secret",
+                new com.massimotter.weave.backend.model.boards.BoardsMoveTaskRequest(
+                        "https://provider.example/columns/1?token=secret",
+                        0)))
+                .isInstanceOf(ApiErrorException.class);
+
+        assertThat(auditPublisher.events()).hasSize(1);
+        assertThat(auditPublisher.events().get(0).idempotencyKey())
+                .contains("[redacted:unsafe-ref]")
+                .doesNotContain("provider.example")
+                .doesNotContain("secret");
+        assertThat(auditPublisher.events().get(0).payload().toString())
+                .contains("[redacted:unsafe-ref]")
+                .doesNotContain("provider.example")
+                .doesNotContain("secret");
+    }
+
+    @Test
+    void updateStatusFailsClosedBeforeMutationWhenAuditPublisherIsMissing() {
+        LocalWorkspaceBoardsRepository repository = new LocalWorkspaceBoardsRepository();
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsRuntimeGuard(true),
+                repository,
+                request -> ContextAuthorizationDecision.allow("edit allowed"),
+                contextAuthorizationProperties(),
+                workspaceCapabilityService(),
+                null);
+
+        assertThat(task(repository, "local-task-contract").status()).isEqualTo(TaskStatus.OPEN);
+
+        assertThatThrownBy(() -> service.updateTaskStatus(jwt(), "local-task-contract",
+                new com.massimotter.weave.backend.model.boards.BoardsUpdateTaskStatusRequest("blocked", null)))
+                .isInstanceOf(AuditRequiredException.class);
+
+        assertThat(task(repository, "local-task-contract").status()).isEqualTo(TaskStatus.OPEN);
+        assertThat(task(repository, "local-task-contract").columnId()).isEqualTo("local-column-todo");
+    }
+
+    @Test
+    void linkDecisionFailsClosedBeforeMutationWhenAuditPublisherIsMissing() {
+        LocalWorkspaceBoardsRepository repository = new LocalWorkspaceBoardsRepository();
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsRuntimeGuard(true),
+                repository,
+                request -> ContextAuthorizationDecision.allow("edit allowed"),
+                contextAuthorizationProperties(),
+                workspaceCapabilityService(),
+                null);
+
+        assertThat(task(repository, "local-task-contract").decisionRefs()).isEmpty();
+
+        assertThatThrownBy(() -> service.linkDecision(jwt(), "local-task-contract",
+                new com.massimotter.weave.backend.model.boards.BoardsLinkDecisionRequest("decision:release-v0.1")))
+                .isInstanceOf(AuditRequiredException.class);
+
+        assertThat(task(repository, "local-task-contract").decisionRefs()).isEmpty();
+    }
+
+    @Test
     void workspaceSourceReflectsOpenProjectReadSyncWhenProviderAdapterIsSelected() {
         BoardsFacadeService service = new BoardsFacadeService(
                 new BoardsRuntimeGuard(true),
@@ -264,6 +334,13 @@ class BoardsFacadeServiceTest {
                             .containsEntry("cursorKey", "projects")
                             .containsEntry("supportSafe", "true");
                 });
+    }
+
+    private TaskItem task(LocalWorkspaceBoardsRepository repository, String taskId) {
+        return repository.listTasks("local-board-1", TaskQuery.all()).items().stream()
+                .filter(task -> task.id().equals(taskId))
+                .findFirst()
+                .orElseThrow();
     }
 
     private ContextAuthorizationProperties contextAuthorizationProperties() {

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
@@ -1,0 +1,99 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.audit.AuditRequiredException;
+import com.massimotter.weave.backend.config.ContextAuthorizationProperties;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.context.authz.ContextAuthorizationDecision;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.chat.DecisionLedgerCreateRequest;
+import com.massimotter.weave.backend.model.chat.DecisionLedgerReferenceRequest;
+import com.massimotter.weave.backend.model.chat.MeetingCapsuleCreateRequest;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ChatFacadeServiceTest {
+
+    @Test
+    void createDecisionFailsClosedBeforeMutationWhenAuditPublisherIsMissing() {
+        ChatFacadeService service = serviceWithMissingAuditPublisher();
+
+        assertThat(service.decisions(jwt(), "channel-general").records()).isEmpty();
+
+        assertThatThrownBy(() -> service.createDecision(jwt(), "channel-general", decisionRequest()))
+                .isInstanceOf(AuditRequiredException.class);
+
+        assertThat(service.decisions(jwt(), "channel-general").records()).isEmpty();
+    }
+
+    @Test
+    void createMeetingCapsuleFailsClosedBeforeMutationWhenAuditPublisherIsMissing() {
+        ChatFacadeService service = serviceWithMissingAuditPublisher();
+
+        assertThat(service.meetingCapsules(jwt(), "channel-general").capsules()).isEmpty();
+
+        assertThatThrownBy(() -> service.createMeetingCapsule(jwt(), "channel-general",
+                new MeetingCapsuleCreateRequest("Sprint planning", List.of("Review scope"), List.of("decision:sprint"))))
+                .isInstanceOf(AuditRequiredException.class);
+
+        assertThat(service.meetingCapsules(jwt(), "channel-general").capsules()).isEmpty();
+    }
+
+    private ChatFacadeService serviceWithMissingAuditPublisher() {
+        WorkspaceCapabilityProperties properties = new WorkspaceCapabilityProperties(
+                null,
+                new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
+                null,
+                null,
+                null,
+                null);
+        return new ChatFacadeService(
+                properties,
+                workspaceCapabilityService(properties),
+                request -> ContextAuthorizationDecision.allow("test allow"),
+                new ContextAuthorizationProperties(null, null, null, null, null, null, null, null),
+                null);
+    }
+
+    private WorkspaceCapabilityService workspaceCapabilityService(WorkspaceCapabilityProperties properties) {
+        OAuth2ResourceServerProperties resourceServerProperties = new OAuth2ResourceServerProperties();
+        resourceServerProperties.getJwt().setIssuerUri("https://auth.example.invalid/realms/acme");
+        return new WorkspaceCapabilityService(
+                resourceServerProperties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                properties);
+    }
+
+    private DecisionLedgerCreateRequest decisionRequest() {
+        return new DecisionLedgerCreateRequest(
+                "Accept support-safe channel records",
+                "accepted",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(new DecisionLedgerReferenceRequest(
+                        "chat-message",
+                        "message:msg-seed-welcome",
+                        "Seed message",
+                        "Provider details stay behind the backend facade.")));
+    }
+
+    private Jwt jwt() {
+        Instant now = Instant.parse("2026-05-25T12:00:00Z");
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("user-123")
+                .issuer("https://auth.example.invalid/realms/acme")
+                .claim("weave_tenant_id", "tenant-default")
+                .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .build();
+    }
+}

--- a/specs/0001-organization-embedding-product-core/plan.md
+++ b/specs/0001-organization-embedding-product-core/plan.md
@@ -1,0 +1,76 @@
+# Implementation plan: Organization embedding and provider-neutral product core
+
+**Spec**: `specs/0001-organization-embedding-product-core/spec.md`  
+**Branch**: `spec/weave-0001-org-embedding`  
+**Date**: 2026-05-28
+
+## Summary
+
+Draft the first product-core spec around organization embedding, provider-neutral categories, IDM/RBAC capability policy, readiness states, and support-safe evidence. No product implementation should start until Massimo/team resolves the open product-core questions in the spec and issue #381.
+
+## Constitution check
+
+- Repo truth recovered from `main`, docs, GitHub issue/PR state, and CI evidence: yes
+- Product-first/provider-neutral boundary preserved: yes
+- Acceptance/evidence path identified before implementation: partial; blocked by product-scope clarification
+- Accessibility/supportability/auditability/deployability addressed: partial; draft requirements included, concrete gates pending
+- Provider secrets/raw diagnostics remain admin/operator-only: yes
+- Weaver/OpenClaw runtime remains governed and disabled-by-default unless explicitly in scope: yes
+
+Any `no` requires a blocker or a documented exception before implementation.
+
+## Affected areas
+
+- `client/`: possible future member/admin capability-state UX; no draft implementation.
+- `server/`: possible future policy/readiness/domain contracts; no draft implementation.
+- `admin-console/`: possible future provider-category readiness UX; no draft implementation.
+- `infra/`: possible future provider/bootstrap evidence; no draft implementation.
+- `e2e/`: future product-language acceptance once scope is confirmed.
+- `docs/`: spec and issue traceability only in this draft slice.
+- `release/`: no release behavior while draft.
+- `tools/`: no tool changes while draft.
+
+## Contracts and tests first
+
+1. Product acceptance/Gherkin: blocked on first-slice confirmation.
+2. Mapping/evidence marker: blocked on story split.
+3. API/event/schema contracts: blocked on selected surface.
+4. Unit/widget/backend/admin tests: blocked on selected implementation area.
+5. CI/evidence artifacts: `./gradlew specContract` and `./gradlew acceptanceContract` for draft PR.
+
+## Agent work breakdown
+
+Use specialists only when they reduce risk or parallelize independent files. Each brief must include allowed files, stop conditions, and a required gate.
+
+- Product/spec steward: refine wording after #381 decisions.
+- Client/accessibility: only after member/admin UX scope is selected.
+- Server/domain facade: only after capability/policy contract scope is selected.
+- Admin/policy: likely first implementation specialist if Admin/Provider Control Plane is confirmed.
+- Provider/infra: only if bootstrap/readiness evidence changes enter scope.
+- QA/evidence: create Gherkin/mappings after story split.
+- Docs/release: keep docs aligned with accepted scope.
+- Security/privacy review: validate no raw provider/secret leakage and audit posture.
+
+## Rollout and migration
+
+- Backward compatibility: draft/spec-only, no runtime changes.
+- Data migration: none until concrete domain model changes are accepted.
+- Feature flag/capability gate: to be defined after product-core decision.
+- Rollback plan: revert draft spec PR.
+- Release evidence: spec/acceptance gates only while draft.
+
+## Risks and mitigations
+
+- Risk: Agents invent product-core decisions to make implementation easier.
+  - Mitigation: keep spec `draft` with explicit `[NEEDS CLARIFICATION: ...]` markers.
+  - Evidence gate: `./gradlew specContract` must allow draft markers but block them once status changes.
+- Risk: Weaver runtime scope leaks into v0.1 before organization policy exists.
+  - Mitigation: keep Weaver disabled/default placeholder unless Massimo/team explicitly accepts runtime scope.
+  - Evidence gate: acceptance scenarios must distinguish placeholder/category from runtime behavior.
+
+## Final gates
+
+- `./gradlew specContract`
+- `./gradlew acceptanceContract`
+- Smallest area gate(s): none until implementation area selected
+- `./gradlew ci` when cross-stack or release-relevant

--- a/specs/0001-organization-embedding-product-core/plan.md
+++ b/specs/0001-organization-embedding-product-core/plan.md
@@ -1,4 +1,4 @@
-# Implementation plan: Organization embedding and provider-neutral product core
+# Implementation plan: Admin-Suite and provider-neutral product core
 
 **Spec**: `specs/0001-organization-embedding-product-core/spec.md`  
 **Branch**: `spec/weave-0001-org-embedding`  
@@ -6,71 +6,91 @@
 
 ## Summary
 
-Draft the first product-core spec around organization embedding, provider-neutral categories, IDM/RBAC capability policy, readiness states, and support-safe evidence. No product implementation should start until Massimo/team resolves the open product-core questions in the spec and issue #381.
+Integrate Massimo's WEAVE-SPEC-0001 product decisions into an accepted product-core baseline. The sprint establishes Weave as a provider-neutral collaboration platform whose Admin-Suite owns provider/adapter setup, readiness, switching, and recovery while member clients see stable Weave capabilities only.
+
+This PR remains spec/issue-DAG work. Implementation follows in short PRs from the recorded issue DAG.
 
 ## Constitution check
 
-- Repo truth recovered from `main`, docs, GitHub issue/PR state, and CI evidence: yes
+- Repo truth recovered from `main`, docs, GitHub issues/PRs, and CI evidence: yes
 - Product-first/provider-neutral boundary preserved: yes
-- Acceptance/evidence path identified before implementation: partial; blocked by product-scope clarification
-- Accessibility/supportability/auditability/deployability addressed: partial; draft requirements included, concrete gates pending
+- Acceptance/evidence path identified before implementation: yes (#389)
+- Accessibility/supportability/auditability/deployability addressed: yes as release blockers
 - Provider secrets/raw diagnostics remain admin/operator-only: yes
-- Weaver/OpenClaw runtime remains governed and disabled-by-default unless explicitly in scope: yes
+- Weaver/OpenClaw runtime remains out of scope for Spec 0001: yes
 
-Any `no` requires a blocker or a documented exception before implementation.
+Any future `no` requires a blocker or documented exception before implementation.
 
 ## Affected areas
 
-- `client/`: possible future member/admin capability-state UX; no draft implementation.
-- `server/`: possible future policy/readiness/domain contracts; no draft implementation.
-- `admin-console/`: possible future provider-category readiness UX; no draft implementation.
-- `infra/`: possible future provider/bootstrap evidence; no draft implementation.
-- `e2e/`: future product-language acceptance once scope is confirmed.
-- `docs/`: spec and issue traceability only in this draft slice.
-- `release/`: no release behavior while draft.
-- `tools/`: no tool changes while draft.
+- `specs/0001-organization-embedding-product-core/`: accepted product-core baseline.
+- GitHub #381: decision record source.
+- GitHub #386-#389: implementation/acceptance issue DAG.
+- `client/`: future member-safe capability manifest consumption and invite/SSO/passkey flow evidence.
+- `server/`: future provider-neutral facade, capability manifest, switch/evidence contracts.
+- `admin-console/`: future Admin-Suite readiness/setup/switch UX contracts.
+- `infra/`: future provider bootstrap/readiness evidence only when needed.
+- `e2e/`: future acceptance scenario mapping (#389).
+- `docs/`: future closure/release documentation as implementation lands.
+- `release/`: no tag/publish from this spec-only PR.
+
+## Issue DAG / PR train
+
+1. #386 — provider-neutral domain and capability model. Sequential root.
+2. #387 — Admin-Suite readiness and setup UX contract. Depends on #386.
+3. #388 — provider switch and portable export/import contract. Depends on #386 and #387.
+4. #389 — acceptance and evidence mapping. Can run in parallel after #386 contract shape is stable.
+
+Preferred PR train:
+
+1. Spec update and decision record (`release-notes-skip`).
+2. Capability/domain model contracts (`release-notes-feature` once behavior changes).
+3. Admin readiness/setup UX contract.
+4. Provider switch/export-import/rollback contract.
+5. Acceptance/evidence mapping and sprint closure.
 
 ## Contracts and tests first
 
-1. Product acceptance/Gherkin: blocked on first-slice confirmation.
-2. Mapping/evidence marker: blocked on story split.
-3. API/event/schema contracts: blocked on selected surface.
-4. Unit/widget/backend/admin tests: blocked on selected implementation area.
-5. CI/evidence artifacts: `./gradlew specContract` and `./gradlew acceptanceContract` for draft PR.
+1. Product acceptance/Gherkin: tracked by #389.
+2. Mapping/evidence marker: tracked by #389.
+3. API/event/schema contracts: tracked by #386 and #388.
+4. Admin/member UX contracts: tracked by #387.
+5. CI/evidence artifacts: every PR runs the smallest meaningful local gate and inspects GitHub CI.
 
 ## Agent work breakdown
 
-Use specialists only when they reduce risk or parallelize independent files. Each brief must include allowed files, stop conditions, and a required gate.
+Use specialists only for narrow slices with explicit files, stop conditions, and evidence gates.
 
-- Product/spec steward: refine wording after #381 decisions.
-- Client/accessibility: only after member/admin UX scope is selected.
-- Server/domain facade: only after capability/policy contract scope is selected.
-- Admin/policy: likely first implementation specialist if Admin/Provider Control Plane is confirmed.
-- Provider/infra: only if bootstrap/readiness evidence changes enter scope.
-- QA/evidence: create Gherkin/mappings after story split.
-- Docs/release: keep docs aligned with accepted scope.
-- Security/privacy review: validate no raw provider/secret leakage and audit posture.
+- Product/spec steward: keep WEAVE-SPEC-0001 wording aligned with Massimo's decision record.
+- Server/domain facade: own #386 capability/domain contracts and backend-owned provider-neutral manifests.
+- Admin/policy: own #387 setup assistant/readiness/switch UX contracts.
+- Provider/infra: assist #388 only for portable export/import and readiness evidence boundaries.
+- QA/evidence: own #389 Gherkin/mappings/evidence.
+- Security/privacy review: validate no raw provider/secret leakage and safe adapter/switch posture.
+- Docs/release: closure reports and release notes only after integrated evidence.
 
 ## Rollout and migration
 
-- Backward compatibility: draft/spec-only, no runtime changes.
-- Data migration: none until concrete domain model changes are accepted.
-- Feature flag/capability gate: to be defined after product-core decision.
-- Rollback plan: revert draft spec PR.
-- Release evidence: spec/acceptance gates only while draft.
+- Backward compatibility: spec-only baseline; no runtime behavior changes in this PR.
+- Data migration: v0.1 promises portable export/import contracts; full migration automation is later work.
+- Feature flag/capability gate: implementation PRs must define capability state behavior before member exposure.
+- Rollback plan: revert spec-only PR or individual implementation PRs; switch/cutover PRs require explicit rollback evidence.
+- Release evidence: spec/acceptance gates for this PR; implementation PRs add area gates and CI.
 
 ## Risks and mitigations
 
-- Risk: Agents invent product-core decisions to make implementation easier.
-  - Mitigation: keep spec `draft` with explicit `[NEEDS CLARIFICATION: ...]` markers.
-  - Evidence gate: `./gradlew specContract` must allow draft markers but block them once status changes.
-- Risk: Weaver runtime scope leaks into v0.1 before organization policy exists.
-  - Mitigation: keep Weaver disabled/default placeholder unless Massimo/team explicitly accepts runtime scope.
-  - Evidence gate: acceptance scenarios must distinguish placeholder/category from runtime behavior.
+- Risk: Provider-neutrality becomes a thin settings UI with hidden lock-in.
+  - Mitigation: #388 requires portable export/import, cutover, and rollback contract.
+- Risk: Normal members are exposed to provider/admin details.
+  - Mitigation: member-safe capability manifest and Admin-Suite boundary are hard requirements.
+- Risk: Weaver/AI runtime sneaks into first product-core scope.
+  - Mitigation: Weaver/AI runtime is explicit non-goal for WEAVE-SPEC-0001.
+- Risk: Dynamic adapters become unsafe arbitrary plugins.
+  - Mitigation: validated adapter packages and rollback, not uncontrolled runtime plugin model.
 
 ## Final gates
 
 - `./gradlew specContract`
+- `./gradlew specContractTest`
 - `./gradlew acceptanceContract`
-- Smallest area gate(s): none until implementation area selected
-- `./gradlew ci` when cross-stack or release-relevant
+- `./gradlew ci` only once implementation becomes cross-stack/release-relevant.

--- a/specs/0001-organization-embedding-product-core/spec.md
+++ b/specs/0001-organization-embedding-product-core/spec.md
@@ -1,8 +1,8 @@
 ---
 id: WEAVE-SPEC-0001
-title: Organization embedding and provider-neutral product core
+title: Admin-Suite and provider-neutral product core
 version: 0.1.0
-status: draft
+status: accepted
 domain: product-core
 owner: weave-co-leader
 github_issue: 381
@@ -12,118 +12,235 @@ depends_on:
 acceptance_features: []
 evidence_gates:
   - ./gradlew specContract
+  - ./gradlew specContractTest
   - ./gradlew acceptanceContract
 ---
 
-# Feature specification: Organization embedding and provider-neutral product core
+# Feature specification: Admin-Suite and provider-neutral product core
+
+## Decision record
+
+Massimo decided the `WEAVE-SPEC-0001` product core through the Nextcloud Forms response submitted on 2026-05-28.
+
+Weave is a provider-neutral collaboration platform. Its first product-core slice is the first-class Admin-Suite plus provider-neutral domain/capability contracts. Admins bind, unbind, validate, switch, and detach provider adapters per domain. Normal members do not manage providers, status, reachability, diagnostics, OIDC setup, secrets, or repair flows. Members join an already configured organization through invite/SSO/passkey and then see stable Weave capabilities.
+
+Weaver/AI runtime is explicitly out of scope for this spec. It may appear later as a governed domain, but it must not be introduced accidentally or before admin/provider governance is mature.
 
 ## Intent
 
-Define Weave's first real product-core slice after the spec framework: how an organization is embedded into Weave through provider-neutral identity, policy, readiness, and capability-state contracts.
+Define the product contract that lets Weave stay provider-neutral while still being operationally usable:
 
-This draft intentionally does **not** choose product-core behavior beyond the currently documented direction. It captures the recommended first slice and the decisions Massimo/team must make before implementation.
+- admins get a comfortable control plane for provider setup, readiness, switching, and recovery;
+- the backend owns provider facades/adapters and support-safe evidence;
+- member clients consume provider-agnostic capability manifests;
+- provider switching is planned and auditable, with v0.1 guaranteeing portable export/import contracts before full automation.
 
 ## Product boundaries
 
 ### In scope
 
-- Organization/tenant embedding vocabulary and non-human identity boundaries.
-- IDM/RBAC/capability-policy relationship at product level.
-- Provider-category readiness states for member/admin/operator surfaces.
-- Stable member-facing Weave capability states that avoid raw provider configuration.
-- Admin/operator support-safe evidence for missing/degraded providers.
-- Weaver as a governed, disabled-by-default capability category unless explicitly promoted by a later decision.
+- First-class Admin-Suite as provider/adapter control plane.
+- Provider-neutral domain and capability model for v0.1.
+- Backend-owned provider facade/adapter boundaries.
+- Member-safe capability manifest with no provider internals.
+- Guided admin setup assistant and readiness dashboard.
+- Provider switch contract: plan, preflight, portable export/import, cutover, rollback/recovery, and support-safe audit evidence.
+- Invite/SSO/passkey member join flow after admin setup.
+- Admin/operator support-safe evidence and repair guidance.
+- Accessibility, supportability, auditability, and deployability as release blockers.
 
 ### Out of scope
 
-- Implementing a concrete Chat facade, Files facade, Boards facade, or Weaver runtime.
-- Selecting one provider stack as the product model.
-- Exposing raw provider secrets, endpoints, diagnostics, or setup flows to normal members.
-- Changing live infrastructure or production environments.
+- Weaver/AI runtime behavior.
+- Public third-party adapter marketplace or uncontrolled runtime plugin installation.
+- Full automated cross-provider migration for every domain in v0.1.
+- Normal-member provider configuration, provider diagnostics, endpoint management, or status cockpit.
+- Live production provider migration or release/tag/publish action without explicit release evidence and signoff.
+- Selecting one provider stack as Weave's product model.
 
 ### Non-negotiable constraints
 
 - Weave remains product-first and provider-neutral.
-- Normal members must not configure raw providers or see provider secrets/diagnostics.
-- Accessibility, supportability, auditability, and deployability are release blockers.
-- Weaver remains disabled by default unless this spec explicitly and safely changes a governed placeholder/runtime contract.
+- No provider vendor lock-in.
+- Domain models must fit their domain; do not force all domains into one unsuitable model.
+- Normal members must not be confronted with admin/provider burden.
+- No raw provider secrets, endpoints, diagnostic payloads, or provider-specific repair instructions leak to normal members.
+- Irreversible admin actions require preview, preflight, clear consequences, rollback/recovery, and understandable errors.
+- Self-hosted infrastructure remains the recommended sovereignty path; managed/external providers are choices behind Weave contracts, not the product model.
+
+## v0.1 domains and capability states
+
+### Required v0.1 domains
+
+- IDM/RBAC
+- Chat/Channels
+- Files/Docs
+- Boards/Tasks
+- Calendar/Events
+- Meetings
+- Forms/Contacts
+
+### Cross-cutting admin capability
+
+- Health/Readiness: admin/operator-only setup, readiness, repair, evidence, and migration state across all domains.
+
+### Capability vocabulary
+
+Weave uses this stable vocabulary for member-safe capability manifests and admin/operator readiness correlation:
+
+- `available`: capability can be used now.
+- `disabled_by_policy`: organization policy or RBAC disables it for this user/scope.
+- `not_configured`: no provider/adapter is configured for the domain.
+- `degraded`: partially working; admin/operator action may be required.
+- `unavailable`: configured capability cannot currently be used.
+- `coming_later`: intentionally outside current release scope.
 
 ## User/admin/operator stories
 
-### US1 - Admin embeds an organization by provider category (Priority: P1)
+### US1 - Admin embeds an organization through provider-neutral domains (Priority: P1)
 
 **Actor**: Organization admin  
-**Story**: As an admin, I can define which organization providers back Weave categories such as IDM, chat, files/docs, calendar, boards/tasks, meetings, decisions, health, and Weaver.  
-**Why now**: Weave must be a provider-neutral suite before feature facades or Weaver runtime can safely depend on capability policy.  
-**Independent test**: [NEEDS CLARIFICATION: confirm whether WEAVE-SPEC-0001 starts with Admin/Provider Control Plane, Member capability states, or both.]
+**Story**: As an admin, I can choose, validate, bind, unbind, and detach providers/adapters per Weave domain from one Admin-Suite.  
+**Why now**: Provider-neutrality is not credible unless admins can operate domains without changing the member product model.  
+**Independent test**: Admin readiness output lists configured domains, missing domains, degraded domains, and next actions without leaking secrets or raw provider payloads.
 
 **Acceptance scenarios**:
 
-1. Given an organization has selected providers by category, when an admin reviews readiness, then Weave shows category-level readiness without exposing secrets or raw provider payloads.
-2. Given a category is not configured, when a member reaches a dependent surface, then Weave shows a stable capability state rather than raw provider setup.
+1. Given an admin configures IDM/RBAC, Chat/Channels, Files/Docs, Boards/Tasks, Calendar/Events, Meetings, and Forms/Contacts, when readiness is reviewed, then Weave reports domain readiness using provider-neutral language.
+2. Given a provider is missing or degraded, when the admin opens readiness, then Weave shows action-oriented repair state and support-safe evidence.
+3. Given a normal member opens Weave, when a domain is not configured or degraded, then the member sees only stable capability state and humane product copy, not provider setup or diagnostics.
 
-### US2 - IDM/RBAC policy decides capability profiles (Priority: P1)
+### US2 - Member joins a configured organization without provider burden (Priority: P1)
 
-**Actor**: Admin/operator  
-**Story**: As an admin/operator, I can connect identity roles/groups to Weave capability profiles before member/provider access occurs.  
-**Why now**: Provider-neutral capability states and future Weaver permissions must derive from organization policy instead of per-call user prompts.  
-**Independent test**: [NEEDS CLARIFICATION: decide whether initial acceptance is product-language only or must include server policy contract tests.]
-
-**Acceptance scenarios**:
-
-1. Given IDM role or group membership changes, when Weave evaluates capabilities, then the resulting member capability state follows the configured policy profile.
-2. Given Weaver is disabled or not configured, when capability profiles are generated, then Weaver remains unavailable and auditable rather than implied as shipped runtime.
-
-### US3 - Operator evidence stays support-safe (Priority: P2)
-
-**Actor**: Operator/support reviewer  
-**Story**: As an operator, I can collect readiness and diagnostic evidence that proves category state without leaking provider secrets or raw payloads.  
-**Why now**: Evidence must be trustworthy enough for CI/release review but safe enough for support artifacts.  
-**Independent test**: [NEEDS CLARIFICATION: decide whether this slice includes concrete evidence artifact schema changes.]
+**Actor**: Normal member  
+**Story**: As a member, I can follow an invite or organization URL, complete SSO/passkey authentication, and land in my assigned organization/workspaces with capabilities already resolved.  
+**Why now**: Weave's provider-neutral promise fails if members must understand OIDC, endpoints, provider health, or admin setup.  
+**Independent test**: A member onboarding scenario proves invite/SSO/passkey entry and stable capability display with no provider setup affordance.
 
 **Acceptance scenarios**:
 
-1. Given a provider is degraded, when evidence is exported, then the artifact identifies category/readiness impact and redacts secrets/provider payloads.
-2. Given a capability is unavailable, when docs/support output is reviewed, then the reason is actionable for admins/operators and not shown as member-facing provider internals.
+1. Given an admin has configured organization providers and policy, when a member follows an invite, then the member completes authentication and sees assigned teams/workspaces/capabilities.
+2. Given a capability is disabled by policy, when the member reaches that surface, then Weave explains the product state without exposing provider internals.
+3. Given a provider switch is in progress, when the member uses unaffected surfaces, then Weave preserves stable member-facing capability language.
+
+### US3 - Admin switches providers safely (Priority: P1)
+
+**Actor**: Organization admin/operator  
+**Story**: As an admin/operator, I can plan a provider switch, run preflight, understand data portability, execute cutover, and recover or rollback if needed.  
+**Why now**: Provider neutrality requires a credible path away from a provider, not just a different logo in settings.  
+**Independent test**: A provider switch contract proves planned steps, export/import manifest, cutover state, rollback/recovery guidance, and support-safe audit evidence.
+
+**Acceptance scenarios**:
+
+1. Given an admin starts a provider switch, when preflight runs, then Weave shows what will move, what will not, risks, required permissions, and rollback path before any irreversible action.
+2. Given v0.1 supports portable export/import rather than full automation, when a domain switch is planned, then Weave produces or references a domain export/import contract and evidence manifest.
+3. Given cutover fails, when recovery is needed, then Weave provides support-safe status, audit trail, and rollback/recovery guidance without leaking secrets.
+
+### US4 - Backend and Admin-Suite own provider facades and evidence (Priority: P2)
+
+**Actor**: Backend/admin/operator  
+**Story**: As the product platform, Weave keeps provider-specific details behind backend facades and Admin-Suite workflows while exposing stable capability manifests to clients.  
+**Why now**: This is the architectural seam that prevents provider lock-in and member-client leakage.  
+**Independent test**: Server/admin contracts prove raw provider errors, endpoints, secrets, and diagnostics are not returned to member clients.
+
+**Acceptance scenarios**:
+
+1. Given member client requests organization capabilities, when the backend responds, then the manifest contains only provider-agnostic domains and capability states.
+2. Given admin/operator requests readiness evidence, when the backend responds, then evidence is actionable and redacted.
+3. Given a provider adapter package is enabled or replaced, when validation fails, then Admin-Suite blocks activation and explains recovery.
 
 ## Functional requirements
 
-- **FR-001**: Weave MUST model organization embedding by provider-neutral categories rather than a fixed vendor stack.
-- **FR-002**: Weave MUST separate member capability states from admin/operator provider configuration and diagnostics.
-- **FR-003**: Weave MUST derive member and Weaver capability profiles from organization policy and IDM/RBAC constraints.
-- **FR-004**: Weave MUST keep Weaver disabled by default unless a later accepted spec promotes concrete governed runtime behavior.
-- **FR-005**: Weave MUST produce support-safe readiness/evidence language that does not leak secrets or raw provider payloads.
-- **FR-006**: Weave MUST NOT implement product behavior while any `[NEEDS CLARIFICATION: ...]` marker remains in this spec.
+- **FR-001**: Weave MUST model organization product capabilities by provider-neutral domains, not vendor-specific surfaces.
+- **FR-002**: Weave MUST provide a first-class Admin-Suite for provider/adapter bind, unbind, readiness, switch, and detach workflows.
+- **FR-003**: Weave MUST keep provider reachability, diagnostics, repair, endpoint configuration, secrets, and raw provider errors admin/operator-only.
+- **FR-004**: Weave MUST expose member-safe capability manifests using `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, and `coming_later`.
+- **FR-005**: Weave MUST let members join configured organizations through invite/SSO/passkey without raw provider setup.
+- **FR-006**: Weave MUST define v0.1 portable export/import contracts for provider switching before claiming full automated provider migration.
+- **FR-007**: Weave MUST require preflight, preview, clear consequences, rollback/recovery, and understandable errors for irreversible admin actions.
+- **FR-008**: Weave MUST keep Weaver/AI runtime out of WEAVE-SPEC-0001 acceptance and implementation.
+- **FR-009**: Weave MUST support validated adapter packages with safe rollback rather than uncontrolled arbitrary runtime plugins.
+- **FR-010**: Weave MUST produce support-safe audit/evidence for provider readiness and switching without secrets/raw provider payloads.
 
 ## Domain model and contracts
 
-- Canonical Weave entities affected: Organization, Workspace, ProviderCategory, CapabilityProfile, ReadinessState, PolicyProfile, AuditEvent, SupportEvidence.
-- Provider/category contracts affected: IDM, chat, files/docs, calendar, boards/tasks, meetings, decisions, health, Weaver.
-- API/event contracts affected: [NEEDS CLARIFICATION: identify first API/event contract after product-scope decision.]
-- Policy/RBAC/capability keys affected: [NEEDS CLARIFICATION: decide minimal v0.1 capability vocabulary.]
-- Audit/support evidence affected: readiness summary, provider category state, policy evaluation trace, redacted diagnostics.
+Canonical entities:
+
+- Organization
+- Workspace
+- Member
+- Admin
+- Operator
+- ProviderDomain
+- ProviderAdapter
+- AdapterPackage
+- CapabilityManifest
+- CapabilityState
+- ReadinessState
+- PolicyProfile
+- SwitchPlan
+- ExportImportManifest
+- CutoverRecord
+- RollbackPlan
+- SupportEvidence
+- AuditEvent
+
+Provider domains:
+
+- `idm-rbac`
+- `chat-channels`
+- `files-docs`
+- `boards-tasks`
+- `calendar-events`
+- `meetings`
+- `forms-contacts`
+
+Admin/readiness domains:
+
+- `health-readiness`
+- `provider-switch`
+- `support-evidence`
+
+Implementation issue DAG:
+
+- #386 — provider-neutral domain and capability model (sequential root)
+- #387 — Admin-Suite readiness and setup UX contract (depends on #386)
+- #388 — provider switch and portable export/import contract (depends on #386 and #387)
+- #389 — acceptance and evidence mapping (parallel after #386 contract shape)
 
 ## Acceptance and evidence mapping
 
-- Gherkin feature path(s): [NEEDS CLARIFICATION: create new `e2e/features/organization_embedding.feature` or extend existing product acceptance flows?]
-- `e2e/scenario_mappings.json` marker(s): [NEEDS CLARIFICATION: choose stable markers after story split.]
-- Unit/widget/backend/admin/contract test path(s): [NEEDS CLARIFICATION: depends on selected first implementation surface.]
-- Live Stack E2E required? no for draft/spec-only PR; yes once provider/control-plane behavior changes.
-- Support-safe evidence artifact(s): [NEEDS CLARIFICATION: decide whether this spec creates or references a readiness/evidence schema.]
+Initial acceptance work is tracked in #389. Implementation PRs must map product-language scenarios to stable executable evidence before claiming release readiness.
+
+Required scenario families:
+
+- Member joins configured organization through invite/SSO/passkey and sees stable capabilities.
+- Admin configures domains and reviews readiness in support-safe language.
+- Admin plans provider switch with preflight/export-import/cutover/rollback evidence.
+- Backend/member capability manifest proves provider-agnostic capability states.
+- Weaver/AI runtime remains out of scope and cannot be accidentally implied as shipped.
+
+Required gates for this spec baseline:
+
+- `./gradlew specContract`
+- `./gradlew specContractTest`
+- `./gradlew acceptanceContract`
+
+Implementation PRs add the smallest relevant area gate, for example `serverCi`, `clientCi`, `adminCi`, `infraStatic`, or `ci` depending on changed files.
 
 ## Release and migration impact
 
-- Member impact: future stable capability states; no direct runtime change while draft.
-- Admin/operator impact: future provider-category readiness and policy workflows.
-- Developer/API impact: future canonical product contracts for provider-neutral categories and capability policy.
-- Data migration/backfill: none while draft; [NEEDS CLARIFICATION: assess once concrete model/API changes are chosen.]
-- Rollback/reversibility: revert spec-only PR while draft; implementation PRs need area-specific rollback plans.
-- Release-notes label expected: `release-notes-skip` for draft/spec-only PR; `release-notes-feature` once product behavior changes.
+- Member impact: simpler join flow and stable product capability language; no provider/admin burden.
+- Admin/operator impact: Admin-Suite becomes the product surface for provider setup, readiness, switching, and recovery.
+- Developer/API impact: backend/admin contracts must preserve provider neutrality and member-safe capability manifests.
+- Data migration/backfill: v0.1 defines portable export/import contracts and switch evidence; full automation is later work.
+- Rollback/reversibility: spec baseline can be reverted; implementation PRs need per-area rollback plans.
+- Release-notes label expected: `release-notes-skip` for spec-only PRs; `release-notes-feature` for product behavior changes.
 
-## Open questions
+## Closed questions
 
-- [ ] Is Organization embedding / IDM / Policy / Readiness the first `WEAVE-SPEC-0001` slice, or should the first product spec be Chat facade, Identity policy only, Admin/Provider Control Plane, or another foundation?
-- [ ] Does `product-core` for this first spec cover Member Client only, Admin/Provider Control Plane only, or the provider-neutral suite contract across Member + Admin + Operator?
-- [ ] Should Weaver remain a governed placeholder category here, or should concrete per-user runtime profile generation acceptance be included?
-- [ ] Which provider categories are mandatory in v0.1/v0.2, and which may be optional/degraded/provider-not-configured?
-- [ ] What is the minimal stable capability vocabulary for the first user-visible release?
+- First product-core slice: Admin-Suite plus provider-neutral domain/capability model.
+- First-spec surface: provider-neutral suite contract across Member + Admin + Operator, with Admin-Suite first-class and member surface provider-agnostic.
+- Weaver scope: out of scope for WEAVE-SPEC-0001; no runtime profile generation acceptance here.
+- Mandatory v0.1 domains: IDM/RBAC, Chat/Channels, Files/Docs, Boards/Tasks, Calendar/Events, Meetings, Forms/Contacts; Health/Readiness is cross-cutting admin capability.
+- Minimal capability vocabulary: `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, `coming_later`.

--- a/specs/0001-organization-embedding-product-core/spec.md
+++ b/specs/0001-organization-embedding-product-core/spec.md
@@ -1,0 +1,129 @@
+---
+id: WEAVE-SPEC-0001
+title: Organization embedding and provider-neutral product core
+version: 0.1.0
+status: draft
+domain: product-core
+owner: weave-co-leader
+github_issue: 381
+supersedes: []
+depends_on:
+  - WEAVE-SPEC-0000
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew acceptanceContract
+---
+
+# Feature specification: Organization embedding and provider-neutral product core
+
+## Intent
+
+Define Weave's first real product-core slice after the spec framework: how an organization is embedded into Weave through provider-neutral identity, policy, readiness, and capability-state contracts.
+
+This draft intentionally does **not** choose product-core behavior beyond the currently documented direction. It captures the recommended first slice and the decisions Massimo/team must make before implementation.
+
+## Product boundaries
+
+### In scope
+
+- Organization/tenant embedding vocabulary and non-human identity boundaries.
+- IDM/RBAC/capability-policy relationship at product level.
+- Provider-category readiness states for member/admin/operator surfaces.
+- Stable member-facing Weave capability states that avoid raw provider configuration.
+- Admin/operator support-safe evidence for missing/degraded providers.
+- Weaver as a governed, disabled-by-default capability category unless explicitly promoted by a later decision.
+
+### Out of scope
+
+- Implementing a concrete Chat facade, Files facade, Boards facade, or Weaver runtime.
+- Selecting one provider stack as the product model.
+- Exposing raw provider secrets, endpoints, diagnostics, or setup flows to normal members.
+- Changing live infrastructure or production environments.
+
+### Non-negotiable constraints
+
+- Weave remains product-first and provider-neutral.
+- Normal members must not configure raw providers or see provider secrets/diagnostics.
+- Accessibility, supportability, auditability, and deployability are release blockers.
+- Weaver remains disabled by default unless this spec explicitly and safely changes a governed placeholder/runtime contract.
+
+## User/admin/operator stories
+
+### US1 - Admin embeds an organization by provider category (Priority: P1)
+
+**Actor**: Organization admin  
+**Story**: As an admin, I can define which organization providers back Weave categories such as IDM, chat, files/docs, calendar, boards/tasks, meetings, decisions, health, and Weaver.  
+**Why now**: Weave must be a provider-neutral suite before feature facades or Weaver runtime can safely depend on capability policy.  
+**Independent test**: [NEEDS CLARIFICATION: confirm whether WEAVE-SPEC-0001 starts with Admin/Provider Control Plane, Member capability states, or both.]
+
+**Acceptance scenarios**:
+
+1. Given an organization has selected providers by category, when an admin reviews readiness, then Weave shows category-level readiness without exposing secrets or raw provider payloads.
+2. Given a category is not configured, when a member reaches a dependent surface, then Weave shows a stable capability state rather than raw provider setup.
+
+### US2 - IDM/RBAC policy decides capability profiles (Priority: P1)
+
+**Actor**: Admin/operator  
+**Story**: As an admin/operator, I can connect identity roles/groups to Weave capability profiles before member/provider access occurs.  
+**Why now**: Provider-neutral capability states and future Weaver permissions must derive from organization policy instead of per-call user prompts.  
+**Independent test**: [NEEDS CLARIFICATION: decide whether initial acceptance is product-language only or must include server policy contract tests.]
+
+**Acceptance scenarios**:
+
+1. Given IDM role or group membership changes, when Weave evaluates capabilities, then the resulting member capability state follows the configured policy profile.
+2. Given Weaver is disabled or not configured, when capability profiles are generated, then Weaver remains unavailable and auditable rather than implied as shipped runtime.
+
+### US3 - Operator evidence stays support-safe (Priority: P2)
+
+**Actor**: Operator/support reviewer  
+**Story**: As an operator, I can collect readiness and diagnostic evidence that proves category state without leaking provider secrets or raw payloads.  
+**Why now**: Evidence must be trustworthy enough for CI/release review but safe enough for support artifacts.  
+**Independent test**: [NEEDS CLARIFICATION: decide whether this slice includes concrete evidence artifact schema changes.]
+
+**Acceptance scenarios**:
+
+1. Given a provider is degraded, when evidence is exported, then the artifact identifies category/readiness impact and redacts secrets/provider payloads.
+2. Given a capability is unavailable, when docs/support output is reviewed, then the reason is actionable for admins/operators and not shown as member-facing provider internals.
+
+## Functional requirements
+
+- **FR-001**: Weave MUST model organization embedding by provider-neutral categories rather than a fixed vendor stack.
+- **FR-002**: Weave MUST separate member capability states from admin/operator provider configuration and diagnostics.
+- **FR-003**: Weave MUST derive member and Weaver capability profiles from organization policy and IDM/RBAC constraints.
+- **FR-004**: Weave MUST keep Weaver disabled by default unless a later accepted spec promotes concrete governed runtime behavior.
+- **FR-005**: Weave MUST produce support-safe readiness/evidence language that does not leak secrets or raw provider payloads.
+- **FR-006**: Weave MUST NOT implement product behavior while any `[NEEDS CLARIFICATION: ...]` marker remains in this spec.
+
+## Domain model and contracts
+
+- Canonical Weave entities affected: Organization, Workspace, ProviderCategory, CapabilityProfile, ReadinessState, PolicyProfile, AuditEvent, SupportEvidence.
+- Provider/category contracts affected: IDM, chat, files/docs, calendar, boards/tasks, meetings, decisions, health, Weaver.
+- API/event contracts affected: [NEEDS CLARIFICATION: identify first API/event contract after product-scope decision.]
+- Policy/RBAC/capability keys affected: [NEEDS CLARIFICATION: decide minimal v0.1 capability vocabulary.]
+- Audit/support evidence affected: readiness summary, provider category state, policy evaluation trace, redacted diagnostics.
+
+## Acceptance and evidence mapping
+
+- Gherkin feature path(s): [NEEDS CLARIFICATION: create new `e2e/features/organization_embedding.feature` or extend existing product acceptance flows?]
+- `e2e/scenario_mappings.json` marker(s): [NEEDS CLARIFICATION: choose stable markers after story split.]
+- Unit/widget/backend/admin/contract test path(s): [NEEDS CLARIFICATION: depends on selected first implementation surface.]
+- Live Stack E2E required? no for draft/spec-only PR; yes once provider/control-plane behavior changes.
+- Support-safe evidence artifact(s): [NEEDS CLARIFICATION: decide whether this spec creates or references a readiness/evidence schema.]
+
+## Release and migration impact
+
+- Member impact: future stable capability states; no direct runtime change while draft.
+- Admin/operator impact: future provider-category readiness and policy workflows.
+- Developer/API impact: future canonical product contracts for provider-neutral categories and capability policy.
+- Data migration/backfill: none while draft; [NEEDS CLARIFICATION: assess once concrete model/API changes are chosen.]
+- Rollback/reversibility: revert spec-only PR while draft; implementation PRs need area-specific rollback plans.
+- Release-notes label expected: `release-notes-skip` for draft/spec-only PR; `release-notes-feature` once product behavior changes.
+
+## Open questions
+
+- [ ] Is Organization embedding / IDM / Policy / Readiness the first `WEAVE-SPEC-0001` slice, or should the first product spec be Chat facade, Identity policy only, Admin/Provider Control Plane, or another foundation?
+- [ ] Does `product-core` for this first spec cover Member Client only, Admin/Provider Control Plane only, or the provider-neutral suite contract across Member + Admin + Operator?
+- [ ] Should Weaver remain a governed placeholder category here, or should concrete per-user runtime profile generation acceptance be included?
+- [ ] Which provider categories are mandatory in v0.1/v0.2, and which may be optional/degraded/provider-not-configured?
+- [ ] What is the minimal stable capability vocabulary for the first user-visible release?

--- a/specs/0001-organization-embedding-product-core/tasks.md
+++ b/specs/0001-organization-embedding-product-core/tasks.md
@@ -1,4 +1,4 @@
-# Tasks: Organization embedding and provider-neutral product core
+# Tasks: Admin-Suite and provider-neutral product core
 
 **Spec**: `specs/0001-organization-embedding-product-core/spec.md`  
 **Plan**: `specs/0001-organization-embedding-product-core/plan.md`
@@ -7,33 +7,40 @@ Task format: `- [ ] T001 [P?] [US?/Area] Description with exact path and gate`
 
 ## Phase 0: Truth recovery
 
-- [x] T001 [Spec] Re-read `AGENTS.md`, `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and `docs/product-line-and-weaver-plan.md` orientation.
-- [x] T002 [Spec] Verify branch starts from current `origin/main` and no unrelated local changes are present.
-- [x] T003 [Spec] Create/verify linked GitHub issue #381 and release-notes label expectation.
+- [x] T001 [Spec] Re-read repo specs/docs and recover current GitHub issue/PR state.
+- [x] T002 [Spec] Rebase `spec/weave-0001-org-embedding` onto current `origin/main`.
+- [x] T003 [Spec] Verify release-notes label expectation: `release-notes-skip` for this spec-only PR.
 
-## Phase 1: Product-core clarification
+## Phase 1: Product-core decisions
 
-- [ ] T010 [Decision] Confirm whether `WEAVE-SPEC-0001` starts with Organization embedding / IDM / Policy / Readiness or another first slice.
-- [ ] T011 [Decision] Confirm first-spec product-core surface: Member Client, Admin/Provider Control Plane, or provider-neutral suite contract across Member + Admin + Operator.
-- [ ] T012 [Decision] Confirm Weaver scope: placeholder category vs concrete runtime profile generation acceptance.
-- [ ] T013 [Decision] Confirm mandatory vs optional provider categories for v0.1/v0.2.
-- [ ] T014 [Decision] Confirm minimal stable capability vocabulary for first user-visible release.
+- [x] T010 [Decision] Resolve first product-core slice from Massimo's Forms response: Admin-Suite + provider neutrality.
+- [x] T011 [Decision] Resolve first-spec product surface: provider-neutral suite contract across Member + Admin + Operator, with Admin-Suite first-class.
+- [x] T012 [Decision] Resolve Weaver scope: Weaver/AI runtime is out of scope for WEAVE-SPEC-0001.
+- [x] T013 [Decision] Resolve mandatory v0.1 domains: IDM/RBAC, Chat/Channels, Files/Docs, Boards/Tasks, Calendar/Events, Meetings, Forms/Contacts; Health/Readiness cross-cutting.
+- [x] T014 [Decision] Resolve capability vocabulary: `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, `coming_later`.
 
-## Phase 2: Acceptance and contracts first
+## Phase 2: Issue DAG and contracts first
 
-- [ ] T020 [Acceptance] Add or update product-language Gherkin after T010-T014.
-- [ ] T021 [Acceptance] Update `e2e/scenario_mappings.json` with stable markers after story split.
-- [ ] T022 [Contracts] Add API/event/provider contract files for the selected first implementation surface.
-- [ ] T023 [Evidence] Run `./gradlew specContract` and `./gradlew acceptanceContract`; document expected draft/proposed state.
+- [x] T020 [DAG] Create #386 for provider-neutral domain and capability model.
+- [x] T021 [DAG] Create #387 for Admin-Suite readiness/setup UX contract.
+- [x] T022 [DAG] Create #388 for provider switch and portable export/import contract.
+- [x] T023 [DAG] Create #389 for acceptance and evidence mapping.
+- [x] T024 [Spec] Update `spec.md`, `plan.md`, `tasks.md`, and `traceability.yaml` with decisions and DAG.
 
 ## Phase 3: Implementation slices
 
-Implementation tasks are intentionally blocked until the spec moves from draft to proposed/accepted with product-core decisions resolved.
+Implementation tasks are intentionally split into follow-up PRs from the issue DAG:
+
+- [ ] T030 [#386] Add provider-neutral domain/capability contracts and smallest relevant server/client/admin gate.
+- [ ] T031 [#387] Add Admin-Suite readiness/setup UX contract and gate.
+- [ ] T032 [#388] Add provider switch/export-import/cutover/rollback contract and gate.
+- [ ] T033 [#389] Add product-language acceptance/evidence mapping and gate.
 
 ## Phase 4: Integration and handoff
 
-- [ ] T040 Run required area gates.
-- [ ] T041 Run Integration-Gate or Optimization-Review; loop on material findings.
-- [ ] T042 Fill PR body with spec ID, acceptance/evidence, risks, and fallback review evidence.
-- [ ] T043 Update spec status/version or document why it remains draft/proposed.
-- [ ] T044 Agent handoff: preserve durable decisions, evidence, blockers, and next safe action only.
+- [ ] T040 Run `./gradlew specContract specContractTest acceptanceContract --console=plain`.
+- [ ] T041 Push branch and update PR #382 to non-draft only if gates pass.
+- [ ] T042 Update #381 with decision record and link the integrated PR/DAG.
+- [ ] T043 Inspect GitHub CI for #382.
+- [ ] T044 Merge PR #382 when CI/labels/branch protection permit.
+- [ ] T045 Fast-forward `main`, close/confirm #381, and update sprint closure/release evidence.

--- a/specs/0001-organization-embedding-product-core/tasks.md
+++ b/specs/0001-organization-embedding-product-core/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: Organization embedding and provider-neutral product core
+
+**Spec**: `specs/0001-organization-embedding-product-core/spec.md`  
+**Plan**: `specs/0001-organization-embedding-product-core/plan.md`
+
+Task format: `- [ ] T001 [P?] [US?/Area] Description with exact path and gate`
+
+## Phase 0: Truth recovery
+
+- [x] T001 [Spec] Re-read `AGENTS.md`, `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and `docs/product-line-and-weaver-plan.md` orientation.
+- [x] T002 [Spec] Verify branch starts from current `origin/main` and no unrelated local changes are present.
+- [x] T003 [Spec] Create/verify linked GitHub issue #381 and release-notes label expectation.
+
+## Phase 1: Product-core clarification
+
+- [ ] T010 [Decision] Confirm whether `WEAVE-SPEC-0001` starts with Organization embedding / IDM / Policy / Readiness or another first slice.
+- [ ] T011 [Decision] Confirm first-spec product-core surface: Member Client, Admin/Provider Control Plane, or provider-neutral suite contract across Member + Admin + Operator.
+- [ ] T012 [Decision] Confirm Weaver scope: placeholder category vs concrete runtime profile generation acceptance.
+- [ ] T013 [Decision] Confirm mandatory vs optional provider categories for v0.1/v0.2.
+- [ ] T014 [Decision] Confirm minimal stable capability vocabulary for first user-visible release.
+
+## Phase 2: Acceptance and contracts first
+
+- [ ] T020 [Acceptance] Add or update product-language Gherkin after T010-T014.
+- [ ] T021 [Acceptance] Update `e2e/scenario_mappings.json` with stable markers after story split.
+- [ ] T022 [Contracts] Add API/event/provider contract files for the selected first implementation surface.
+- [ ] T023 [Evidence] Run `./gradlew specContract` and `./gradlew acceptanceContract`; document expected draft/proposed state.
+
+## Phase 3: Implementation slices
+
+Implementation tasks are intentionally blocked until the spec moves from draft to proposed/accepted with product-core decisions resolved.
+
+## Phase 4: Integration and handoff
+
+- [ ] T040 Run required area gates.
+- [ ] T041 Run Integration-Gate or Optimization-Review; loop on material findings.
+- [ ] T042 Fill PR body with spec ID, acceptance/evidence, risks, and fallback review evidence.
+- [ ] T043 Update spec status/version or document why it remains draft/proposed.
+- [ ] T044 Agent handoff: preserve durable decisions, evidence, blockers, and next safe action only.

--- a/specs/0001-organization-embedding-product-core/traceability.yaml
+++ b/specs/0001-organization-embedding-product-core/traceability.yaml
@@ -1,15 +1,56 @@
 spec_id: WEAVE-SPEC-0001
 version: 0.1.0
-status: draft
+status: accepted
 github_issue: 381
 release_notes_label: release-notes-skip
+decision_source:
+  nextcloud_form_id: 9
+  submitted_at: 2026-05-28T21:30:35+02:00
+issue_dag:
+  sequential:
+    - issue: 386
+      title: WEAVE-SPEC-0001: define provider-neutral domain and capability model
+    - issue: 387
+      title: WEAVE-SPEC-0001: specify Admin-Suite readiness and setup UX contract
+      depends_on: [386]
+    - issue: 388
+      title: WEAVE-SPEC-0001: specify provider switch and portable export/import contract
+      depends_on: [386, 387]
+  parallel:
+    - issue: 389
+      title: WEAVE-SPEC-0001: add acceptance and evidence mapping for admin/provider-neutral flow
+      depends_on: [386]
+accepted_product_decisions:
+  product_core: first-class Admin-Suite plus provider neutrality
+  member_boundary: members see stable Weave capabilities only, not provider/status/admin internals
+  admin_boundary: admins bind/unbind/validate/switch/detach providers and adapters per domain
+  provider_switch_minimum: guided plan, preflight, portable export/import, cutover, rollback/recovery
+  data_portability_v0_1: portable export/import contract before full migration automation
+  join_flow: invite/SSO/passkey and done after admin setup
+  capability_vocabulary:
+    - available
+    - disabled_by_policy
+    - not_configured
+    - degraded
+    - unavailable
+    - coming_later
+  v0_1_domains:
+    - IDM/RBAC
+    - Chat/Channels
+    - Files/Docs
+    - Boards/Tasks
+    - Calendar/Events
+    - Meetings
+    - Forms/Contacts
+  cross_cutting_admin_capability: Health/Readiness
+  explicit_non_goals:
+    - Weaver/AI runtime
+    - provider vendor lock-in
+    - user-facing admin/provider burden
+    - uncontrolled runtime plugin model
 acceptance_features: []
 evidence_gates:
   - ./gradlew specContract
+  - ./gradlew specContractTest
   - ./gradlew acceptanceContract
-open_product_core_decisions:
-  - first product-core slice
-  - first-spec product surface
-  - Weaver placeholder vs runtime scope
-  - mandatory provider categories
-  - minimal capability vocabulary
+open_product_core_decisions: []

--- a/specs/0001-organization-embedding-product-core/traceability.yaml
+++ b/specs/0001-organization-embedding-product-core/traceability.yaml
@@ -1,0 +1,15 @@
+spec_id: WEAVE-SPEC-0001
+version: 0.1.0
+status: draft
+github_issue: 381
+release_notes_label: release-notes-skip
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew acceptanceContract
+open_product_core_decisions:
+  - first product-core slice
+  - first-spec product surface
+  - Weaver placeholder vs runtime scope
+  - mandatory provider categories
+  - minimal capability vocabulary


### PR DESCRIPTION
## Summary

- Accept `WEAVE-SPEC-0001` as the Admin-Suite + provider-neutral product-core baseline from Massimo's Forms decision record.
- Remove answered clarification blockers: product core, surface scope, Weaver scope, v0.1 domains, capability vocabulary.
- Add the implementation issue DAG for the ordered PR train: #386 -> #387 -> #388, with #389 as acceptance/evidence mapping.

Closes #381 once merged.

## Product decisions encoded

- Admin-Suite is first-class control plane for provider/adapter bind, unbind, readiness, switch, and detach.
- Weave remains provider-neutral; backend owns provider facades/adapters; member client consumes provider-agnostic capability manifests.
- Members join via invite/SSO/passkey and never manage provider/status/admin details.
- Provider switch minimum: plan, preflight, portable export/import, cutover, rollback/recovery.
- Weaver/AI runtime is explicitly out of scope for Spec 0001.

## Issue DAG

- #386 provider-neutral domain/capability model
- #387 Admin-Suite readiness/setup UX contract
- #388 provider switch + portable export/import contract
- #389 acceptance/evidence mapping

## Gates

- `./gradlew specContract specContractTest acceptanceContract --console=plain`

## Release notes

- Label: `release-notes-skip`
- Reason: spec/issue-DAG only; behavior changes follow in implementation PRs.
