### PR TITLE
Fail closed before audited workspace writes

### DIFF
--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -635,6 +635,15 @@
       ],
       "additionalEvidence": [
         {
+          "path": "server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java",
+          "fragments": [
+            "taskWritesPublishSupportSafeWorkspaceAuditEvents",
+            "preWriteAuditRedactsUnsafeResourceReferencesBeforeRepositoryValidation",
+            "updateStatusFailsClosedBeforeMutationWhenAuditPublisherIsMissing",
+            "linkDecisionFailsClosedBeforeMutationWhenAuditPublisherIsMissing"
+          ]
+        },
+        {
           "path": "docs/release-v0.1-dogfood-plan.md",
           "fragments": [
             "Boards with user writes",
@@ -664,6 +673,12 @@
           ]
         },
         {
+          "path": "server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java",
+          "fragments": [
+            "createMeetingCapsuleFailsClosedBeforeMutationWhenAuditPublisherIsMissing"
+          ]
+        },
+        {
           "path": "docs/release-v0.1-dogfood-plan.md",
           "fragments": [
             "Meeting Capsule includes agenda, files, decisions, and follow-up tasks",
@@ -688,6 +703,12 @@
             "/api/v1/chat/conversations/channel-general/decisions",
             "source-linked",
             "DECISION_LEDGER_RECORD_CREATED"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java",
+          "fragments": [
+            "createDecisionFailsClosedBeforeMutationWhenAuditPublisherIsMissing"
           ]
         },
         {

--- a/server/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
@@ -172,11 +172,12 @@ public class BoardsFacadeService {
         PrincipalContext principal = requireContextPermission(jwt, ContextPermission.EDIT);
         TaskStatus status = parseStatus(request.status());
         try {
-            TaskItem task = boardsRepository.updateTaskStatus(taskId, status, request.targetColumnId());
-            publishTaskAudit(principal, AuditAction.TASK_STATUS_UPDATED, task, Map.of(
+            publishTaskWriteAudit(principal, AuditAction.TASK_STATUS_UPDATED, "update_task_status:" + taskId, Map.of(
                     "command", "update_task_status",
-                    "status", status.contractName()));
-            return task;
+                    "taskId", taskId,
+                    "status", status.contractName(),
+                    "targetColumnId", request.targetColumnId() == null ? "" : request.targetColumnId()));
+            return boardsRepository.updateTaskStatus(taskId, status, request.targetColumnId());
         } catch (BoardsException exception) {
             throw apiError(exception);
         }
@@ -185,11 +186,11 @@ public class BoardsFacadeService {
     public TaskItem linkDecision(Jwt jwt, String taskId, BoardsLinkDecisionRequest request) {
         PrincipalContext principal = requireContextPermission(jwt, ContextPermission.EDIT);
         try {
-            TaskItem task = boardsRepository.linkDecision(taskId, request.decisionRef());
-            publishTaskAudit(principal, AuditAction.TASK_DECISION_LINKED, task, Map.of(
+            publishTaskWriteAudit(principal, AuditAction.TASK_DECISION_LINKED, "link_decision:" + taskId, Map.of(
                     "command", "link_decision",
-                    "decisionRef", request.decisionRef()));
-            return task;
+                    "taskId", taskId,
+                    "decisionRef", request.decisionRef() == null ? "" : request.decisionRef()));
+            return boardsRepository.linkDecision(taskId, request.decisionRef());
         } catch (BoardsException exception) {
             throw apiError(exception);
         }
@@ -304,28 +305,9 @@ public class BoardsFacadeService {
                 Map.of("field", "status", "supportSafe", "true")));
     }
 
-    private void publishTaskAudit(PrincipalContext principal, AuditAction action, TaskItem task, Map<String, Object> payload) {
-        Map<String, Object> auditPayload = new LinkedHashMap<>(payload);
-        auditPayload.put("boardId", task.boardId());
-        auditPayload.put("taskId", task.id());
-        auditPayload.put("columnId", task.columnId());
-        auditPayload.put("status", task.status().contractName());
-        auditPayload.put("supportSafe", true);
-        AuditWriteGate.publishRequired(auditEventPublisher, new AuditEvent(
-                principal.tenantId(),
-                principal.contextId(),
-                principal.principalRef(),
-                "weave:boards-workspace",
-                action,
-                task.updatedAt(),
-                action.wireName() + ":" + task.id() + ":" + task.updatedAt(),
-                AuditRedactionLevel.SUPPORT_SAFE,
-                auditPayload));
-    }
-
     private void publishTaskWriteAudit(PrincipalContext principal, AuditAction action, String subject, Map<String, Object> payload) {
         Instant timestamp = Instant.now();
-        Map<String, Object> auditPayload = new LinkedHashMap<>(payload);
+        Map<String, Object> auditPayload = supportSafeAuditPayload(payload);
         auditPayload.put("supportSafe", true);
         AuditWriteGate.publishRequired(auditEventPublisher, new AuditEvent(
                 principal.tenantId(),
@@ -334,9 +316,36 @@ public class BoardsFacadeService {
                 "weave:boards-workspace",
                 action,
                 timestamp,
-                action.wireName() + ":" + subject + ":" + timestamp,
+                action.wireName() + ":" + supportSafeAuditString(subject) + ":" + timestamp,
                 AuditRedactionLevel.SUPPORT_SAFE,
                 auditPayload));
+    }
+
+    private Map<String, Object> supportSafeAuditPayload(Map<String, Object> payload) {
+        Map<String, Object> safePayload = new LinkedHashMap<>();
+        payload.forEach((key, value) -> safePayload.put(key,
+                value instanceof String stringValue ? supportSafeAuditString(stringValue) : value));
+        return safePayload;
+    }
+
+    private String supportSafeAuditString(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.trim();
+        String normalized = trimmed.toLowerCase(Locale.ROOT);
+        if (trimmed.length() > 160
+                || normalized.contains("://")
+                || normalized.contains("authorization")
+                || normalized.contains("token")
+                || normalized.contains("secret")
+                || normalized.contains("password")
+                || normalized.contains("apikey")
+                || normalized.contains("api_key")
+                || normalized.contains("cookie")) {
+            return "[redacted:unsafe-ref]";
+        }
+        return trimmed;
     }
 
     private String sourceFor(ProviderKind provider) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
@@ -214,13 +214,13 @@ public class ChatFacadeService {
                 sanitizeTextList(request.openQuestions(), 120),
                 sanitizeReferenceList(request.followUpRefs()),
                 true);
-        decisionsFor(conversation.id()).add(decision);
         publishAudit(principal, AuditAction.DECISION_LEDGER_RECORD_CREATED, decision.id(), timestamp, Map.of(
                 "command", "create_decision",
                 "conversationId", conversation.id(),
                 "status", decision.status(),
                 "referenceCount", references.size(),
                 "supportSafe", true));
+        decisionsFor(conversation.id()).add(decision);
         return decision;
     }
 
@@ -265,12 +265,12 @@ public class ChatFacadeService {
                 false,
                 false,
                 true);
-        meetingCapsulesFor(conversation.id()).add(capsule);
         publishAudit(principal, AuditAction.MEETING_CAPSULE_CREATED, capsule.id(), timestamp, Map.of(
                 "command", "create_meeting_capsule",
                 "conversationId", conversation.id(),
                 "failClosed", true,
                 "supportSafe", true));
+        meetingCapsulesFor(conversation.id()).add(capsule);
         return capsule;
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
@@ -1,6 +1,7 @@
 package com.massimotter.weave.backend.service;
 
 import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.AuditRequiredException;
 import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
 import com.massimotter.weave.backend.boards.domain.Board;
 import com.massimotter.weave.backend.boards.domain.BoardColumn;
@@ -204,6 +205,75 @@ class BoardsFacadeServiceTest {
     }
 
     @Test
+    void preWriteAuditRedactsUnsafeResourceReferencesBeforeRepositoryValidation() {
+        var auditPublisher = new InMemoryAuditEventPublisher();
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsRuntimeGuard(true),
+                new LocalWorkspaceBoardsRepository(),
+                request -> ContextAuthorizationDecision.allow("edit allowed"),
+                contextAuthorizationProperties(),
+                workspaceCapabilityService(),
+                auditPublisher);
+
+        assertThatThrownBy(() -> service.moveTask(jwt(), "https://provider.example/tasks/42?token=secret",
+                new com.massimotter.weave.backend.model.boards.BoardsMoveTaskRequest(
+                        "https://provider.example/columns/1?token=secret",
+                        0)))
+                .isInstanceOf(ApiErrorException.class);
+
+        assertThat(auditPublisher.events()).hasSize(1);
+        assertThat(auditPublisher.events().get(0).idempotencyKey())
+                .contains("[redacted:unsafe-ref]")
+                .doesNotContain("provider.example")
+                .doesNotContain("secret");
+        assertThat(auditPublisher.events().get(0).payload().toString())
+                .contains("[redacted:unsafe-ref]")
+                .doesNotContain("provider.example")
+                .doesNotContain("secret");
+    }
+
+    @Test
+    void updateStatusFailsClosedBeforeMutationWhenAuditPublisherIsMissing() {
+        LocalWorkspaceBoardsRepository repository = new LocalWorkspaceBoardsRepository();
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsRuntimeGuard(true),
+                repository,
+                request -> ContextAuthorizationDecision.allow("edit allowed"),
+                contextAuthorizationProperties(),
+                workspaceCapabilityService(),
+                null);
+
+        assertThat(task(repository, "local-task-contract").status()).isEqualTo(TaskStatus.OPEN);
+
+        assertThatThrownBy(() -> service.updateTaskStatus(jwt(), "local-task-contract",
+                new com.massimotter.weave.backend.model.boards.BoardsUpdateTaskStatusRequest("blocked", null)))
+                .isInstanceOf(AuditRequiredException.class);
+
+        assertThat(task(repository, "local-task-contract").status()).isEqualTo(TaskStatus.OPEN);
+        assertThat(task(repository, "local-task-contract").columnId()).isEqualTo("local-column-todo");
+    }
+
+    @Test
+    void linkDecisionFailsClosedBeforeMutationWhenAuditPublisherIsMissing() {
+        LocalWorkspaceBoardsRepository repository = new LocalWorkspaceBoardsRepository();
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsRuntimeGuard(true),
+                repository,
+                request -> ContextAuthorizationDecision.allow("edit allowed"),
+                contextAuthorizationProperties(),
+                workspaceCapabilityService(),
+                null);
+
+        assertThat(task(repository, "local-task-contract").decisionRefs()).isEmpty();
+
+        assertThatThrownBy(() -> service.linkDecision(jwt(), "local-task-contract",
+                new com.massimotter.weave.backend.model.boards.BoardsLinkDecisionRequest("decision:release-v0.1")))
+                .isInstanceOf(AuditRequiredException.class);
+
+        assertThat(task(repository, "local-task-contract").decisionRefs()).isEmpty();
+    }
+
+    @Test
     void workspaceSourceReflectsOpenProjectReadSyncWhenProviderAdapterIsSelected() {
         BoardsFacadeService service = new BoardsFacadeService(
                 new BoardsRuntimeGuard(true),
@@ -264,6 +334,13 @@ class BoardsFacadeServiceTest {
                             .containsEntry("cursorKey", "projects")
                             .containsEntry("supportSafe", "true");
                 });
+    }
+
+    private TaskItem task(LocalWorkspaceBoardsRepository repository, String taskId) {
+        return repository.listTasks("local-board-1", TaskQuery.all()).items().stream()
+                .filter(task -> task.id().equals(taskId))
+                .findFirst()
+                .orElseThrow();
     }
 
     private ContextAuthorizationProperties contextAuthorizationProperties() {

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
@@ -1,0 +1,99 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.audit.AuditRequiredException;
+import com.massimotter.weave.backend.config.ContextAuthorizationProperties;
+import com.massimotter.weave.backend.config.WeaveSecurityProperties;
+import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.context.authz.ContextAuthorizationDecision;
+import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.model.chat.DecisionLedgerCreateRequest;
+import com.massimotter.weave.backend.model.chat.DecisionLedgerReferenceRequest;
+import com.massimotter.weave.backend.model.chat.MeetingCapsuleCreateRequest;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ChatFacadeServiceTest {
+
+    @Test
+    void createDecisionFailsClosedBeforeMutationWhenAuditPublisherIsMissing() {
+        ChatFacadeService service = serviceWithMissingAuditPublisher();
+
+        assertThat(service.decisions(jwt(), "channel-general").records()).isEmpty();
+
+        assertThatThrownBy(() -> service.createDecision(jwt(), "channel-general", decisionRequest()))
+                .isInstanceOf(AuditRequiredException.class);
+
+        assertThat(service.decisions(jwt(), "channel-general").records()).isEmpty();
+    }
+
+    @Test
+    void createMeetingCapsuleFailsClosedBeforeMutationWhenAuditPublisherIsMissing() {
+        ChatFacadeService service = serviceWithMissingAuditPublisher();
+
+        assertThat(service.meetingCapsules(jwt(), "channel-general").capsules()).isEmpty();
+
+        assertThatThrownBy(() -> service.createMeetingCapsule(jwt(), "channel-general",
+                new MeetingCapsuleCreateRequest("Sprint planning", List.of("Review scope"), List.of("decision:sprint"))))
+                .isInstanceOf(AuditRequiredException.class);
+
+        assertThat(service.meetingCapsules(jwt(), "channel-general").capsules()).isEmpty();
+    }
+
+    private ChatFacadeService serviceWithMissingAuditPublisher() {
+        WorkspaceCapabilityProperties properties = new WorkspaceCapabilityProperties(
+                null,
+                new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
+                null,
+                null,
+                null,
+                null);
+        return new ChatFacadeService(
+                properties,
+                workspaceCapabilityService(properties),
+                request -> ContextAuthorizationDecision.allow("test allow"),
+                new ContextAuthorizationProperties(null, null, null, null, null, null, null, null),
+                null);
+    }
+
+    private WorkspaceCapabilityService workspaceCapabilityService(WorkspaceCapabilityProperties properties) {
+        OAuth2ResourceServerProperties resourceServerProperties = new OAuth2ResourceServerProperties();
+        resourceServerProperties.getJwt().setIssuerUri("https://auth.example.invalid/realms/acme");
+        return new WorkspaceCapabilityService(
+                resourceServerProperties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                properties);
+    }
+
+    private DecisionLedgerCreateRequest decisionRequest() {
+        return new DecisionLedgerCreateRequest(
+                "Accept support-safe channel records",
+                "accepted",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(new DecisionLedgerReferenceRequest(
+                        "chat-message",
+                        "message:msg-seed-welcome",
+                        "Seed message",
+                        "Provider details stay behind the backend facade.")));
+    }
+
+    private Jwt jwt() {
+        Instant now = Instant.parse("2026-05-25T12:00:00Z");
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .subject("user-123")
+                .issuer("https://auth.example.invalid/realms/acme")
+                .claim("weave_tenant_id", "tenant-default")
+                .claim("realm_access", java.util.Map.of("roles", java.util.List.of("member")))
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(300))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- move boards write audit publication before repository mutation and redact unsafe resource references in audit payload/idempotency keys
- move Decision Ledger and Meeting Capsule audit publication before in-memory mutation
- map v0.1 board/decision/meeting scenarios to the new fail-closed service evidence

## Evidence
- ./gradlew acceptanceContract
- ./gradlew specContract
- ./gradlew serverCi
- git diff --cached --check

Related: #381