### PR TITLE
Define autonomous sprint orchestration

### DIFF
--- a/.specify/templates/weave-agent-briefs.md
+++ b/.specify/templates/weave-agent-briefs.md
@@ -96,6 +96,52 @@ Return:
 - If no findings: final evidence needed before commit/PR
 ```
 
+## Sprint-Planning
+
+```text
+You are weave-co-leader. Plan a real Weave sprint from the governing spec.
+Inputs: <spec.md/plan.md/tasks.md/docs/issues>.
+Do first: recover truth from main, specs, GitHub issues/PRs, CI/evidence.
+Output: sprint goal, issue DAG, PR train order, specialist roles, required gates, merge authorization status, product-core blockers.
+If issues are missing and GitHub access is available, create/update them with dependency notes and parallel/sequential labels.
+Do not implement yet.
+```
+
+## Issue-DAG
+
+```text
+Create or update GitHub issues for the sprint.
+Each issue must include: spec id, user/admin/operator value, allowed scope, dependencies, acceptance/gate, release-notes expectation, and whether it is parallel or sequential.
+Do not create vague umbrella tasks unless they link concrete implementation/review issues.
+Return: issue numbers, dependency order, blockers.
+```
+
+## PR-Train
+
+```text
+For the next unblocked issue in the DAG, cut/update a short-lived branch from current main, implement the smallest reviewable slice, open a PR, set exactly one release-notes label, and run the required local gate.
+After CI and Integration-Gate pass, merge only if the sprint brief authorizes autonomous merge; otherwise report merge-ready with the one missing decision.
+After merge, fetch/fast-forward main before continuing dependent PRs.
+Return: issue, branch, PR, gates, CI, merge status, next unblocked issue.
+```
+
+## Sprint-Closure
+
+```text
+Close the sprint only after all planned issues/PRs are merged or an explicit blocker is recorded.
+Report exactly:
+- Verdict
+- Governing spec(s)
+- Issue DAG with final state
+- Merged PRs in order
+- Gates and CI evidence
+- Release notes / RC impact
+- Product decisions made or still blocked
+- Docs/spec updates
+- Next safe action
+A green unmerged PR is not a completed sprint.
+```
+
 ## Session-Handoff
 
 ```text

--- a/.specify/templates/weave-agent-team-config.example.json5
+++ b/.specify/templates/weave-agent-team-config.example.json5
@@ -31,17 +31,24 @@
         id: "weave-co-leader",
         name: "Weave co-leader / integrator",
         workspace: "/Users/flotterotter/code/weave",
+        systemPromptOverride: "You are weave-co-leader for the Weave monorepo. A sprint means spec -> issue DAG -> ordered PR train -> merges -> closure report; never treat one green PR as a completed sprint. Recover truth from repo/GitHub/CI first. Create/update issues when missing. Spawn scoped specialists from the allowlist for narrow slices. Enforce exactly one release-notes label per PR, green gates/CI, Integration-Gate review, and merge in dependency order when authorized. Keep durable state in specs/issues/PRs/reports, not chat transcripts. Stop for product-core ambiguity, live-infra/destructive actions, secrets, or missing merge authorization.",
         subagents: {
           requireAgentId: true,
           allowAgents: [
             "weave-product-spec",
+            "weave-architecture-contract",
+            "weave-client-ui",
             "weave-client-a11y",
+            "weave-admin-console",
             "weave-server-domain",
-            "weave-admin-policy",
+            "weave-server-auth-audit",
+            "weave-provider-adapters",
             "weave-provider-infra",
+            "weave-e2e-acceptance",
             "weave-qa-evidence",
             "weave-docs-release",
             "weave-security-privacy",
+            "weave-devex-ci",
             "weave-integration-reviewer",
             "weave-codex-acp",
             "weave-claude-acp",
@@ -56,8 +63,23 @@
         workspace: "/Users/flotterotter/code/weave",
       },
       {
+        id: "weave-architecture-contract",
+        name: "Weave architecture/contract specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-client-ui",
+        name: "Weave client/UI specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
         id: "weave-client-a11y",
         name: "Weave client/accessibility specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-admin-console",
+        name: "Weave admin console/policy specialist",
         workspace: "/Users/flotterotter/code/weave",
       },
       {
@@ -66,13 +88,23 @@
         workspace: "/Users/flotterotter/code/weave",
       },
       {
-        id: "weave-admin-policy",
-        name: "Weave admin/policy specialist",
+        id: "weave-server-auth-audit",
+        name: "Weave server auth/audit specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-provider-adapters",
+        name: "Weave provider adapter specialist",
         workspace: "/Users/flotterotter/code/weave",
       },
       {
         id: "weave-provider-infra",
         name: "Weave provider/infra specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-e2e-acceptance",
+        name: "Weave E2E/acceptance specialist",
         workspace: "/Users/flotterotter/code/weave",
       },
       {
@@ -88,6 +120,11 @@
       {
         id: "weave-security-privacy",
         name: "Weave security/privacy specialist",
+        workspace: "/Users/flotterotter/code/weave",
+      },
+      {
+        id: "weave-devex-ci",
+        name: "Weave DevEx/CI specialist",
         workspace: "/Users/flotterotter/code/weave",
       },
       {

--- a/docs/agent-team-orchestration.md
+++ b/docs/agent-team-orchestration.md
@@ -6,33 +6,53 @@ This page defines the professional multi-agent delivery model for Weave. It tran
 
 ## Operating principle
 
-`weave-co-leader` owns decomposition, integration, and evidence. It does **not** become a mega-coder.
+`weave-co-leader` owns sprint decomposition, issue/PR orchestration, merge sequencing, integration, and evidence. It does **not** become a mega-coder and it must not declare a sprint complete just because one PR is green.
 
-Use this loop until no material optimization remains:
+Use this sprint loop until the issue DAG is integrated or a product-core blocker stops safe progress:
 
-1. Recover truth from this repo, GitHub issues/PRs, and CI/evidence.
-2. Identify the governing issue/spec/acceptance contract.
-3. Build a small task DAG; parallelize only independent file/contract areas.
-4. Spawn a scoped specialist with exact files, inputs, stop conditions, and a required gate.
-5. Integrate only from returned evidence and inspected diffs.
-6. Run an adversarial Integration-Gate review.
-7. Repeat implementation/review for material findings.
-8. Stop only when the reviewer reports no material optimization opportunity or a product-core clarification blocks safe progress.
+1. Recover truth from `main`, repo specs/docs/tasks, GitHub issues/PRs, and CI/evidence.
+2. Identify the governing spec and decide whether it is ready for implementation. Keep unresolved product-core questions in `draft`/`proposed`.
+3. Convert the spec plan/tasks into a GitHub issue DAG. Label independent work `parallel`; label ordered work `sequential`; link issues/PRs back to the spec.
+4. Cut short-lived branches from updated `main` and open reviewable PRs in dependency order.
+5. Spawn scoped specialists only for narrow issue slices, each with exact files, inputs, stop conditions, and a required gate.
+6. Integrate only from returned evidence and inspected diffs, then run an adversarial Integration-Gate review.
+7. Merge dependency-free PRs once CI/gates/review evidence pass and the sprint brief authorizes merge; otherwise surface the exact missing approval.
+8. After every merge, update `main`, re-evaluate the remaining DAG, and continue the next slice.
+9. Stop only when all sprint issues/PRs are merged or when a product-core clarification, live-infra/destructive approval, or failed gate blocks safe progress.
+10. Produce the sprint closure report from repo/GitHub/CI evidence.
 
 Material optimization means improved correctness, traceability, security/privacy, accessibility, supportability, deployability, CI/evidence quality, or reviewability without hidden scope expansion.
+
+## Sprint management responsibilities
+
+The co-leader keeps durable sprint state in GitHub and repo files, not chat transcripts:
+
+- Specification stewarding lives in `specs/<id>/spec.md`, `plan.md`, `tasks.md`, and traceability files.
+- Work tracking lives in GitHub issues with dependency notes and `parallel`/`sequential` labels.
+- Implementation state lives in PRs and CI artifacts.
+- Release impact lives in exactly one release-notes label per PR.
+- Sprint closure lives in a checked-in report or PR comment that cites merged PRs, gates, and remaining decisions.
+
+If the sprint brief authorizes autonomous merge, `weave-co-leader` may merge green, reviewed PRs in DAG order. If not, it reports merge-ready PRs and asks for the one missing merge decision.
 
 ## Recommended roles
 
 Use native OpenClaw subagents for these repo-aware specialists by default:
 
-- `weave-product-spec`: product-core wording, lifecycle status, frontmatter, non-goals, clarification markers.
-- `weave-client-a11y`: Flutter member/admin UX, accessibility semantics, keyboard/screen-reader behavior, l10n, widget tests.
+- `weave-product-spec`: product-core wording, lifecycle status, frontmatter, non-goals, clarification markers, issue slicing.
+- `weave-architecture-contract`: provider-neutral domain boundaries, contract drift, spec/plan architecture consistency.
+- `weave-client-ui`: Flutter member/admin UX implementation, navigation, state handling, widget tests.
+- `weave-client-a11y`: accessibility semantics, keyboard/screen-reader behavior, l10n, deterministic screenshots.
+- `weave-admin-console`: Admin Console, workspace health, IDM/RBAC, policy previews, readiness, whitelisting.
 - `weave-server-domain`: domain facades, authorization, audit, provider boundaries, backend contract tests.
-- `weave-admin-policy`: Admin Console, workspace health, IDM/RBAC, policy previews, readiness, whitelisting.
+- `weave-server-auth-audit`: identity, authz, audit ordering, support-safe audit payloads.
+- `weave-provider-adapters`: provider-neutral adapter facades and canonical model mapping.
 - `weave-provider-infra`: OpenTofu, adapters, runner/environment posture, backup/restore, support bundles.
-- `weave-qa-evidence`: Gherkin, `scenario_mappings.json`, Live Stack evidence, sanitized artifacts.
+- `weave-e2e-acceptance`: Gherkin, live-stack acceptance flow coverage, scenario intent.
+- `weave-qa-evidence`: `scenario_mappings.json`, sanitized artifacts, CI/evidence completeness.
 - `weave-docs-release`: docs navigation, handbooks, release notes, PR templates, closure reports.
 - `weave-security-privacy`: secrets, raw provider payloads, audit, support-safe diagnostics, external-provider risk.
+- `weave-devex-ci`: Gradle tasks, CI workflows, dependency/tooling checks, evidence upload.
 - `weave-integration-reviewer`: final diff/spec/PR readiness, evidence strength, scope creep, release-label and CI posture.
 
 Use ACP harnesses only when explicitly requested or intentionally selected for a coding-harness run:

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -108,6 +108,22 @@ Use protected `main` plus short-lived PR branches; do not introduce long-lived `
 
 Release notes are generated from merged PR labels, not manually reconstructed later. The CI `Release Notes Label Check` runs on every pull-request update and fails PRs with zero or multiple release-notes labels; label-only changes run that lightweight check without re-running the full Gradle CI job. See [Weave operating model](weave-operating-model.md) for the delivery contract and [Trunk-based PR and release workflow](gitflow-pr-workflow.md) for label semantics and merge rules.
 
+## Spec-driven sprint contract
+
+A Weave sprint is not one green PR. A sprint starts from an accepted or explicitly proposed specification and ends only after the planned issue/PR train has been integrated or a product-core blocker is recorded.
+
+Required sprint shape:
+
+1. Recover truth from `main`, `specs/`, GitHub issues/PRs, and CI artifacts.
+2. Select or create the governing spec, then keep product-core ambiguity in `draft`/`proposed` with explicit `[NEEDS CLARIFICATION: ...]` markers.
+3. Break the spec plan/tasks into a GitHub issue DAG with `parallel`/`sequential` labels where ordering matters.
+4. For each implementation slice, open a short-lived branch and one reviewable PR with exactly one release-notes label.
+5. Merge PRs in dependency order after green CI, required local gates, and fallback human/agent review evidence. Copilot review is optional while premium review requests are exhausted.
+6. After each merge, update local `main` before cutting the next dependent branch.
+7. Finish with a sprint closure report that lists the spec, issue DAG, merged PRs in order, gates/CI evidence, unresolved decisions, release/RC follow-up, and next safe action.
+
+The `weave-co-leader` is expected to drive this loop autonomously when given a sprint goal. It should ask Massimo only for product-core decisions, destructive/live-infra approval, or merge/release decisions not already authorized by the sprint brief.
+
 ## Documentation site
 
 Weave docs are published as a MkDocs site configured by `mkdocs.yml`. The site uses MkDocs Material; its MIT license was verified from upstream on 2026-05-24 and is safe for project use.

--- a/docs/spec-driven-development.md
+++ b/docs/spec-driven-development.md
@@ -77,6 +77,20 @@ Product-core questions that require Massimo/team confirmation include:
 - when Weaver moves from placeholder category to governed runtime implementation;
 - which agentic developer-assistance capability, if any, is allowed inside Weave policy.
 
+## Sprint orchestration
+
+A sprint is the execution of a spec-backed issue DAG, not a single implementation PR. The expected autonomous flow is:
+
+1. `weave-co-leader` recovers current truth from repo/GitHub/CI.
+2. `weave-product-spec` and `weave-architecture-contract` confirm whether the governing spec is implementable or needs clarification.
+3. The co-leader creates or updates GitHub issues for the spec tasks, labels them `parallel` or `sequential`, and records dependencies in issue bodies.
+4. Specialists implement narrow issues on short-lived branches.
+5. The co-leader opens PRs, assigns exactly one release-notes label, waits for green CI/gates, runs Integration-Gate, and merges in dependency order when authorized.
+6. After each merge, the co-leader updates `main`, revises remaining tasks if necessary, and continues.
+7. Sprint closure records the spec, issue DAG, merged PR train, gates, evidence artifacts, unresolved product decisions, and next release/RC action.
+
+Durable sprint state belongs in specs, issues, PRs, and checked-in reports. Agent chat/session state is disposable.
+
 ## DevOps traceability
 
 Every implementation PR should connect:


### PR DESCRIPTION
## Summary
- define a real Weave sprint as spec -> issue DAG -> ordered PR train -> merges -> closure
- add issue-DAG, PR-train, and sprint-closure briefing templates
- align the example OpenClaw team config with the current granular Weave specialist roles

Closes #384

## Gates
- `./gradlew docsStructureCheck specContract --console=plain`
- `./gradlew docsCheck specContract --console=plain`

## Notes
- This is a process/config-template foundation change; no member-facing behavior.
- Live OpenClaw agent config was patched separately with the same sprint model and validated via OpenClaw config patch dry-run.
