### PR TITLE
docs: align RC2 release evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ The point is not to re-skin a fixed vendor bundle. The point is to let an organi
 
 Current maturity is honest and evidence-scoped:
 
+- **Published as dogfood-production release candidate:** `v0.1.0-rc.2` is a prerelease on protected `main` with green PR-safe CI, credentialed Live Stack E2E, release-owner signoff, and no open `release-blocker` issues at publication.
 - **Ready for dogfood-production foundation:** repository orchestration, documentation site, release-note automation, provider-neutral domain contracts, admin/operator readiness boundaries, policy enforcement, and support-safe evidence checks.
-- **In progress / guarded:** richer daily-work surfaces for calendars, boards/tasks, meetings, provider replacement, and release-candidate live-stack evidence. These stay fail-closed unless configured and evidenced.
+- **In progress / guarded:** richer daily-work surfaces for calendars, boards/tasks, meetings, provider replacement, and the WEAVE-SPEC-0001 implementation DAG. These stay fail-closed unless configured and evidenced.
 - **Not shipped as v0.1 product scope:** broad marketplace administration, autonomous agent/team writes, public connector SDK, and the optional Weaver personal-assistant runtime.
 
 ## v0.1 Golden Path quick read
@@ -21,6 +22,7 @@ Current maturity is honest and evidence-scoped:
 - [Weave product line and Weaver integration plan](docs/product-line-and-weaver-plan.md) for current product ordering.
 - [Sprint 5 closure report](docs/sprint-5-closure-report.md) for project-readiness evidence and release-candidate gaps.
 - [Enterprise release foundation](docs/enterprise-release-foundation.md) for Sprint 6 release lanes, RC evidence, waiver rules, and support-safe artifacts.
+- [v0.1.0-rc.2 release evidence](docs/release-v0.1-rc2-evidence.md) for the published RC2 candidate, exact commit, gates, and signoff.
 
 ## Product architecture
 
@@ -38,7 +40,7 @@ Weaver/AI PA positioning is deliberately later. Weaver is Weave's optional, gove
 
 ## Release notes
 
-The managed block below is the README-facing draft of merged but unreleased changes. It is a review artifact, not proof that a release was published. Maintainers update it with the checked-in release-note tooling; do not edit inside the markers by hand.
+The managed block below is the README-facing draft of merged changes after the latest tagged prerelease. The published `v0.1.0-rc.2` notes live in [v0.1 release notes](docs/release-notes/v0.1.md). Maintainers update this block with the checked-in release-note tooling; do not edit inside the markers by hand.
 
 <!-- WEAVE_RELEASE_NOTES_START -->
 _Generated release notes are review artifacts. A release maintainer may update this block with `python3 tools/readme_release_notes.py --update --source <generated-notes>` before opening the release-draft review._
@@ -47,27 +49,11 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Added
 
-- Repeatable RC readiness check with Markdown/JSON output, Gradle fixture tests, Live Stack evidence validation, release-blocker gating, and explicit waiver marker handling.
-- MkDocs documentation site foundation with handbook navigation, diagrams, GitFlow/PR workflow, and release notes process.
-- Root Gradle wrapper and orchestration tasks for delegated server, client, admin, infra, docs, acceptance, CI, and release-notes checks.
-- Local release notes generator for merged PR metadata grouped by release-notes labels.
-- Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
-- Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
-- Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
-- Admin/operator effective policy simulation endpoint with support-safe capability impact output, fail-closed unknown identity inputs, Weaver disabled-by-default evidence, and audited counts before provider or realm changes apply.
-- Guarded identity realm apply decision path with explicit confirmation, retained-admin lockout protection, risky/destructive rollback evidence gates, support-safe audit counts, and decision-only provider mutation semantics.
-- Sprint 6 epic closure map for admin-owned OIDC setup (#212) and Keycloak realm dry-run/apply architecture (#233), linking role/setup contracts, realm baseline fixtures, Workspace Health readiness, policy simulation, and guarded apply evidence.
-- Sprint 6 final closure report recording the RC/provider-ops foundation, post-merge main CI, credentialed Live Stack evidence scope, residual risks, and first-release entry criteria without claiming a public release.
+- Nothing yet.
 
 ## Changed
 
-- Repositioned the root README as a Sprint 6 readiness/kickoff enterprise product entry point with audience-directed documentation navigation, explicit maturity status, Java 21 gate guidance, E2E/release-candidate evidence boundaries, and governed Weaver/AI PA boundaries.
-- Added organization-embedding, identity-provisioning, and provider-replacement strategy contracts to make provider neutrality, mixed self-hosted/cloud/external deployments, and adapter replacement explicit before new feature slices.
-- Documentation validation now has a dedicated docs check/build path.
-- PR CI now enforces exactly one release-notes label before review/merge.
-- `make release-notes-check` now verifies release-notes label edge cases and generator fixture output.
-- Live Stack acceptance artifacts now include `release-evidence-manifest.json` with commit/run metadata, artifact list, support-safe exclusions, and the RC promotion rule.
-- Admin Console treats missing identity readiness contracts as `admin-action-required` and keeps member flows provider-neutral/fail-closed during version skew.
+- Nothing yet.
 
 ## Fixed
 
@@ -83,7 +69,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Migration/Operator Notes
 
-- Operators can build the documentation site locally with `python3 -m pip install -r docs/requirements.txt` and `make docs-build`.
+- Nothing yet.
 
 ## Known Issues
 

--- a/docs/enterprise-release-foundation.md
+++ b/docs/enterprise-release-foundation.md
@@ -96,17 +96,17 @@ This makes evidence portable: a release owner can inspect one artifact directory
 
 ## Repeatable RC readiness check
 
-Use the local/CI-safe readiness check before creating or promoting an RC tag:
+Use the local/CI-safe readiness check before creating or promoting an RC tag. The latest published audit is [`v0.1.0-rc.2`](release-v0.1-rc2-evidence.md); the command below is an example shape and each promotion must pass explicit candidate values:
 
 ```sh
 ./gradlew releaseReadinessCheck \
-  -PcandidateVersion=0.1.0-rc.1 \
-  -PcandidateTag=v0.1.0-rc.1 \
+  -PcandidateVersion=<candidate-version> \
+  -PcandidateTag=<candidate-tag> \
   -PcandidateCommit=<sha>
 # or pass explicit evidence paths when reviewing downloaded artifacts:
 python3 tools/release_readiness_check.py \
-  --candidate-version 0.1.0-rc.1 \
-  --candidate-tag v0.1.0-rc.1 \
+  --candidate-version <candidate-version> \
+  --candidate-tag <candidate-tag> \
   --candidate-commit <sha> \
   --ci-summary build/evidence/ci-summary.json \
   --live-evidence-dir weave-live-stack-acceptance-evidence \

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,11 @@ Start with:
 1. [v0.1 Golden Path readiness](v0.1-golden-path.md) — what is ready, guarded, disabled, degraded, or future.
 2. Root README — public product entry point and architecture-at-a-glance.
 3. [Product acceptance flows](product-acceptance-flows.md) — product-language acceptance paths.
-4. [Sprint 6 closure report](sprint-6-closure-report.md) — final RC/provider-ops foundation evidence and first-release entry criteria.
-5. [Sprint 5 closure report](sprint-5-closure-report.md) — project-readiness evidence and release-candidate gaps.
-6. [Enterprise release foundation](enterprise-release-foundation.md) — release lanes, RC gate, waiver semantics, and support-safe artifacts.
-7. [Sprint 6 epic closure report](sprint-6-epic-closure-report.md) — #212/#233 acceptance evidence after the merged identity/admin slices.
+4. [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md) — exact candidate commit, gates, signoff, and post-release documentation corrections.
+5. [Sprint 6 closure report](sprint-6-closure-report.md) — final RC/provider-ops foundation evidence and first-release entry criteria, with a post-closure pointer to RC2.
+6. [Sprint 5 closure report](sprint-5-closure-report.md) — project-readiness evidence and release-candidate gaps.
+7. [Enterprise release foundation](enterprise-release-foundation.md) — release lanes, RC gate, waiver semantics, and support-safe artifacts.
+8. [Sprint 6 epic closure report](sprint-6-epic-closure-report.md) — #212/#233 acceptance evidence after the merged identity/admin slices.
 
 ### Member / user
 
@@ -94,6 +95,7 @@ Release and evidence docs:
 - [Sprint 5 closure report](sprint-5-closure-report.md)
 - [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md)
 - [Sprint 6 epic closure report](sprint-6-epic-closure-report.md)
+- [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md)
 - [Sprint 6 closure report](sprint-6-closure-report.md)
 
 Historical/context docs:
@@ -108,7 +110,7 @@ The active product direction is [Weave product line and Weaver integration plan]
 
 Weaver remains optional, governed, auditable, support-safe, and disabled by default. Any future per-user PA runtime must be generated from Weave organization policy as an isolated OpenClaw-derived profile and follow the rule: user-rights, organization-whitelisted capabilities.
 
-v0.1 is dogfood-production, not a preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets. The shortest status summary for reviewers is [v0.1 Golden Path readiness](v0.1-golden-path.md).
+v0.1 is dogfood-production, not a preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets. The shortest status summary for reviewers is [v0.1 Golden Path readiness](v0.1-golden-path.md). The latest published prerelease audit is [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md).
 
 ## Documentation stack
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -5,7 +5,7 @@ Release notes are the durable, user/admin/operator-facing record of what changed
 ## Files
 
 - [Unreleased](unreleased.md) collects changes that have merged but are not cut into a tagged release yet.
-- [v0.1](v0.1.md) records the dogfood-production release notes.
+- [v0.1](v0.1.md) records the dogfood-production release notes, including the published `v0.1.0-rc.2` prerelease facts and evidence links.
 
 ## Categories
 
@@ -39,6 +39,6 @@ GH_TOKEN=... python3 tools/release_notes_generate.py --repo masssi164/weave --si
 
 Use `--dry-run` to inspect output without writing, and use `--input tools/fixtures/release_notes_prs.json` for deterministic local checks. Issue #293 tracks the remaining automation to publish GitHub release drafts from this source of truth. Checked-in release notes pages remain concise, user/admin/operator-oriented drafts linked to deeper docs when needed.
 
-At release cut, generated notes should move into the versioned release notes file and `unreleased.md` should reset to empty category headings. Run `make release-notes-check` or `make docs-check` before requesting review.
+At release cut, generated notes should move into the versioned release notes file and `unreleased.md` should reset to empty category headings. `v0.1.0-rc.2` follows this pattern: versioned notes hold the release facts, while Unreleased is reset for later changes. Run `make release-notes-check` or `make docs-check` before requesting review.
 
 Release notes must stay honest about shipped, gated, disabled, degraded, or future behavior. Do not describe preview-only or guarded surfaces as generally available.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -4,27 +4,11 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Added
 
-- Repeatable RC readiness check with Markdown/JSON output, Gradle fixture tests, Live Stack evidence validation, release-blocker gating, and explicit waiver marker handling.
-- MkDocs documentation site foundation with handbook navigation, diagrams, GitFlow/PR workflow, and release notes process.
-- Root Gradle wrapper and orchestration tasks for delegated server, client, admin, infra, docs, acceptance, CI, and release-notes checks.
-- Local release notes generator for merged PR metadata grouped by release-notes labels.
-- Sprint 6 kickoff plan and initial Keycloak realm dry-run provider contract scaffold for admin-owned identity/provider operations.
-- Enterprise release foundation with machine-checked release lanes, support-safe Live Stack evidence manifest, RC promotion/waiver contract, and required runtime marker policy.
-- Workspace Health identity provider readiness facade with realm import, OIDC client, roles/groups, login, and policy cards backed only by backend Admin Console APIs.
-- Admin/operator effective policy simulation endpoint with support-safe capability impact output, fail-closed unknown identity inputs, Weaver disabled-by-default evidence, and audited counts before provider or realm changes apply.
-- Guarded identity realm apply decision path with explicit confirmation, retained-admin lockout protection, risky/destructive rollback evidence gates, support-safe audit counts, and decision-only provider mutation semantics.
-- Sprint 6 epic closure map for admin-owned OIDC setup (#212) and Keycloak realm dry-run/apply architecture (#233), linking role/setup contracts, realm baseline fixtures, Workspace Health readiness, policy simulation, and guarded apply evidence.
-- Sprint 6 final closure report recording the RC/provider-ops foundation, post-merge main CI, credentialed Live Stack evidence scope, residual risks, and first-release entry criteria without claiming a public release.
+- Nothing yet.
 
 ## Changed
 
-- Repositioned the root README as a Sprint 6 readiness/kickoff enterprise product entry point with audience-directed documentation navigation, explicit maturity status, Java 21 gate guidance, E2E/release-candidate evidence boundaries, and governed Weaver/AI PA boundaries.
-- Added organization-embedding, identity-provisioning, and provider-replacement strategy contracts to make provider neutrality, mixed self-hosted/cloud/external deployments, and adapter replacement explicit before new feature slices.
-- Documentation validation now has a dedicated docs check/build path.
-- PR CI now enforces exactly one release-notes label before review/merge.
-- `make release-notes-check` now verifies release-notes label edge cases and generator fixture output.
-- Live Stack acceptance artifacts now include `release-evidence-manifest.json` with commit/run metadata, artifact list, support-safe exclusions, and the RC promotion rule.
-- Admin Console treats missing identity readiness contracts as `admin-action-required` and keeps member flows provider-neutral/fail-closed during version skew.
+- Nothing yet.
 
 ## Fixed
 
@@ -40,7 +24,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Migration/Operator Notes
 
-- Operators can build the documentation site locally with `python3 -m pip install -r docs/requirements.txt` and `make docs-build`.
+- Nothing yet.
 
 ## Known Issues
 

--- a/docs/release-notes/v0.1.md
+++ b/docs/release-notes/v0.1.md
@@ -1,20 +1,41 @@
 # v0.1 release notes
 
-v0.1 is the dogfood-production release line. Entries below should reflect shipped, evidence-backed behavior only. Guarded, disabled, or future surfaces must be named as such.
+v0.1 is the dogfood-production release line. Entries below reflect shipped, evidence-backed behavior only. Guarded, disabled, or future surfaces are named as such.
+
+Latest published prerelease: [`v0.1.0-rc.2`](https://github.com/masssi164/weave/releases/tag/v0.1.0-rc.2), published on 2026-05-28 from `9409ae44a07f38864a45a203d90a842b22c6a82d` on protected `main`.
+
+Evidence for `v0.1.0-rc.2`:
+
+- Main CI: [`26598506323`](https://github.com/masssi164/weave/actions/runs/26598506323), success.
+- Credentialed Live Stack E2E: [`26598646805`](https://github.com/masssi164/weave/actions/runs/26598646805), success, artifact `weave-live-stack-acceptance-evidence`.
+- Release draft workflow: [`26599654278`](https://github.com/masssi164/weave/actions/runs/26599654278), success.
+- Tag CI: [`26599820660`](https://github.com/masssi164/weave/actions/runs/26599820660), success.
+- Release-owner signoff and blocker closure: issue #379.
+- Detailed audit: [v0.1.0-rc.2 release evidence](../release-v0.1-rc2-evidence.md).
 
 ## Added
 
+- Identity realm dry-run contracts for admin-owned provider setup and review.
+- Repeatable RC readiness checks for candidate input, CI summary, release notes, Live Stack evidence, release blockers, support-safety, and explicit waivers.
+- Workspace Health identity provider readiness facade through backend Admin Console APIs.
+- Admin/operator effective policy simulation before provider or realm changes apply.
+- Guarded identity realm apply decision path with explicit confirmation, last-admin protection, rollback evidence gates, and support-safe audit counts.
+- Sprint 6 identity epic closure evidence for #212 and #233.
+- Sprint 6 closure report for the release-candidate/provider-ops foundation.
 - Provider-neutral Weave product positioning for identity, chat, files, calendar, boards/tasks, meetings, documents/collaboration, and later Weaver runtime.
 - Canonical feature model and facade architecture documentation for server/admin/infra implementation planning.
 - Quality and acceptance evidence documentation for release gating.
 
 ## Changed
 
+- WEAVE-SPEC-0001 is accepted as the product-core baseline for a first-class Admin-Suite plus provider neutrality. It is included in the candidate as specification and issue-DAG work, not runtime implementation.
+- PRs #344 and #382 are present in the RC2 candidate; #382 uses `release-notes-skip` because it is spec-only and follow-up implementation remains in #386-#389.
 - Normal member setup is admin-provisioned: members join with an organization auth URL, invite, or deep link rather than configuring raw providers.
 
 ## Fixed
 
-- Nothing yet.
+- Live Stack E2E failure diagnostics now generate support-safe manifests, marker summaries, and redacted failure artifacts.
+- Audited workspace writes fail closed before provider mutation when required evidence is missing.
 
 ## Security
 
@@ -31,4 +52,6 @@ v0.1 is the dogfood-production release line. Entries below should reflect shippe
 
 ## Known Issues
 
-- Live-stack E2E requires the dedicated self-hosted live runner and configured test credentials; power/storage budget is no longer a standing gate for scheduled or manual release evidence.
+- Live-stack E2E requires the dedicated self-hosted live runner and configured test credentials.
+- The WEAVE-SPEC-0001 implementation DAG remains follow-up work: #386, #387, #388, and #389.
+- Weaver/AI runtime remains out of WEAVE-SPEC-0001 and is still disabled/future scope.

--- a/docs/release-v0.1-dogfood-plan.md
+++ b/docs/release-v0.1-dogfood-plan.md
@@ -2,6 +2,8 @@
 
 Status: implementation baseline for the monorepo refoundation.
 
+Latest prerelease audit: `v0.1.0-rc.2` was published on 2026-05-28 from `9409ae44a07f38864a45a203d90a842b22c6a82d` with green PR-safe CI, credentialed Live Stack E2E, release-owner signoff, and no open release blockers. See [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md).
+
 ## Goal
 
 Ship Weave as a daily work tool for a real project, not as a demo stack.
@@ -162,6 +164,7 @@ Deliverables:
 - Secret/certificate handling.
 - Release notes with honest limitations.
 - Support bundle and smoke-test artifacts.
+- Exact-candidate RC evidence with tag, commit, CI, credentialed Live Stack E2E, blocker state, release-owner signoff, and rollback note.
 
 Exit gate:
 
@@ -170,6 +173,7 @@ Exit gate:
 - restore smoke passes
 - support bundle is redacted
 - Live Stack E2E passes against release manifest
+- `./gradlew releaseReadinessCheck` is ready for the exact candidate, with support-safe CI, Live Stack, release notes, and blocker evidence
 
 ### IDM/RBAC and capability whitelisting acceptance
 

--- a/docs/release-v0.1-rc2-evidence.md
+++ b/docs/release-v0.1-rc2-evidence.md
@@ -1,0 +1,62 @@
+# v0.1.0-rc.2 release evidence
+
+Status: published prerelease evidence, 2026-05-28.
+
+## Release facts
+
+- Release: [`v0.1.0-rc.2`](https://github.com/masssi164/weave/releases/tag/v0.1.0-rc.2)
+- Published at: `2026-05-28T20:18:18Z`
+- Candidate commit: `9409ae44a07f38864a45a203d90a842b22c6a82d` on protected `main`
+- Tag target: `v0.1.0-rc.2` -> `9409ae44a07f38864a45a203d90a842b22c6a82d`
+- Draft: `false`
+- Prerelease: `true`
+- Release-blocker state at publication: no open issues labeled `release-blocker`
+
+## Requirement audit
+
+The release-owner request was to merge the appropriate PRs and not call the work finished until a release existed. The audited state for `v0.1.0-rc.2` is:
+
+- PR #344 was merged before the final candidate and is present on `main` as `2849c4b06cc75c1bc656c897d351050d33cbd281`.
+- PR #382 was merged into `main` as `9409ae44a07f38864a45a203d90a842b22c6a82d` and is the RC2 candidate commit.
+- Issue #381 was closed after the WEAVE-SPEC-0001 decision record was posted.
+- Issue #379 recorded release-owner signoff for `v0.1.0-rc.2`, then closed after publication.
+- No open PRs remained when the release audit was performed.
+
+## Evidence reviewed
+
+- PR-safe CI on `main`: [`26598506323`](https://github.com/masssi164/weave/actions/runs/26598506323), `success`, for `9409ae44a07f38864a45a203d90a842b22c6a82d`.
+- Credentialed Live Stack E2E: [`26598646805`](https://github.com/masssi164/weave/actions/runs/26598646805), `success`, for `9409ae44a07f38864a45a203d90a842b22c6a82d`, artifact `weave-live-stack-acceptance-evidence`.
+- Release draft workflow: [`26599654278`](https://github.com/masssi164/weave/actions/runs/26599654278), `success`, for `9409ae44a07f38864a45a203d90a842b22c6a82d`.
+- Tag CI: [`26599820660`](https://github.com/masssi164/weave/actions/runs/26599820660), `success`, for `v0.1.0-rc.2` / `9409ae44a07f38864a45a203d90a842b22c6a82d`.
+- Local release readiness check: `python3 tools/release_readiness_check.py --candidate-version 0.1.0-rc.2 --candidate-tag v0.1.0-rc.2 --candidate-commit 9409ae44a07f38864a45a203d90a842b22c6a82d --ci-summary build/evidence/ci-summary.json --live-evidence-dir /tmp/weave-live-stack-acceptance-evidence-26598646805 --release-notes docs/release-notes/v0.1.md --blockers-json build/evidence/release-blockers.json` returned `# RC readiness: ready` after the versioned release notes were updated.
+
+## WEAVE-SPEC-0001 audit
+
+The RC2 candidate includes the accepted WEAVE-SPEC-0001 baseline:
+
+- product core: first-class Admin-Suite plus provider neutrality;
+- member boundary: members see stable Weave capabilities only, not provider/status/admin internals;
+- admin boundary: admins bind, unbind, validate, switch, and detach providers/adapters per domain;
+- provider switching: guided plan, preflight, portable export/import, cutover, rollback/recovery;
+- Weaver/AI runtime: explicitly out of scope for WEAVE-SPEC-0001.
+
+The follow-up implementation DAG remains open by design and is not claimed as implemented by RC2:
+
+- #386 — provider-neutral domain and capability model;
+- #387 — Admin-Suite readiness and setup UX contract;
+- #388 — provider switch and portable export/import contract;
+- #389 — acceptance and evidence mapping.
+
+## Documentation corrections from the RC2 audit
+
+Tracking issue: #390.
+
+The release itself was valid, but the post-release documentation needed tightening:
+
+- versioned v0.1 notes now record the `v0.1.0-rc.2` publication facts and evidence links;
+- `docs/release-notes/unreleased.md` is reset for post-RC2 work;
+- README release-note markers are refreshed from the reset Unreleased page;
+- Sprint 6 closure now has a post-closure note pointing to the actual RC2 release evidence;
+- WEAVE-SPEC-0001 handoff tasks are marked complete for the spec PR merge/issue closure/release-evidence update.
+
+This page is the compact audit trail for those corrections; the GitHub release remains the release artifact of record.

--- a/docs/sprint-6-closure-report.md
+++ b/docs/sprint-6-closure-report.md
@@ -8,6 +8,8 @@ Sprint 6 closes the release-candidate and provider-operations foundation for Wea
 
 This report does **not** publish, tag, or claim a final v0.1 release. It records the evidence state after PR #377 merged and issues #212 and #233 were closed.
 
+Post-closure update: the first later prerelease with exact-candidate signoff is `v0.1.0-rc.2`, published on 2026-05-28. See [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md) for the release facts; this Sprint 6 report remains historical foundation evidence.
+
 ## Final closure status
 
 - Sprint 6 milestone: `Sprint 6 — Release Candidate & Provider Operations`.
@@ -66,7 +68,7 @@ Sprint 6 freezes these release-candidate/provider-ops rules for the next sprint:
 - The docs-only epic closure for #212/#233 does not add a live Keycloak mutation executor.
 - Sprint 6 does not claim broad provider marketplace support, generic migrations, SCIM/LDAP/Entra reconciliation, or autonomous Weaver writes.
 - Admin Console dashboard composition and richer operator UX remain follow-up work on top of the Sprint 6 backend/control-plane contracts.
-- Release readiness still depends on exact-candidate evidence and release-owner signoff, not on this report alone.
+- Release readiness still depends on exact-candidate evidence and release-owner signoff, not on this report alone. The later `v0.1.0-rc.2` prerelease records that evidence separately in [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md).
 
 ## Next-sprint entry criteria for the first real release
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
       - Sprint 6 kickoff plan: sprint-6-kickoff-plan.md
       - Sprint 6 epic closure report: sprint-6-epic-closure-report.md
       - Sprint 6 closure report: sprint-6-closure-report.md
+      - v0.1.0-rc.2 release evidence: release-v0.1-rc2-evidence.md
       - Accessibility release gate: accessibility-release-gate.md
       - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md
   - Product and Release Scope:

--- a/specs/0001-organization-embedding-product-core/plan.md
+++ b/specs/0001-organization-embedding-product-core/plan.md
@@ -8,7 +8,7 @@
 
 Integrate Massimo's WEAVE-SPEC-0001 product decisions into an accepted product-core baseline. The sprint establishes Weave as a provider-neutral collaboration platform whose Admin-Suite owns provider/adapter setup, readiness, switching, and recovery while member clients see stable Weave capabilities only.
 
-This PR remains spec/issue-DAG work. Implementation follows in short PRs from the recorded issue DAG.
+This PR remained spec/issue-DAG work and merged as PR #382 into `main` at `9409ae44a07f38864a45a203d90a842b22c6a82d`. Implementation follows in short PRs from the recorded issue DAG (#386-#389).
 
 ## Constitution check
 
@@ -32,7 +32,7 @@ Any future `no` requires a blocker or documented exception before implementation
 - `infra/`: future provider bootstrap/readiness evidence only when needed.
 - `e2e/`: future acceptance scenario mapping (#389).
 - `docs/`: future closure/release documentation as implementation lands.
-- `release/`: no tag/publish from this spec-only PR.
+- `release/`: no tag/publish from this spec-only PR itself; the later `v0.1.0-rc.2` release candidate uses the merged spec commit as its exact candidate.
 
 ## Issue DAG / PR train
 

--- a/specs/0001-organization-embedding-product-core/tasks.md
+++ b/specs/0001-organization-embedding-product-core/tasks.md
@@ -38,9 +38,9 @@ Implementation tasks are intentionally split into follow-up PRs from the issue D
 
 ## Phase 4: Integration and handoff
 
-- [ ] T040 Run `./gradlew specContract specContractTest acceptanceContract --console=plain`.
-- [ ] T041 Push branch and update PR #382 to non-draft only if gates pass.
-- [ ] T042 Update #381 with decision record and link the integrated PR/DAG.
-- [ ] T043 Inspect GitHub CI for #382.
-- [ ] T044 Merge PR #382 when CI/labels/branch protection permit.
-- [ ] T045 Fast-forward `main`, close/confirm #381, and update sprint closure/release evidence.
+- [x] T040 Run `./gradlew specContract specContractTest acceptanceContract --console=plain`.
+- [x] T041 Push branch and update PR #382 to non-draft only if gates pass.
+- [x] T042 Update #381 with decision record and link the integrated PR/DAG.
+- [x] T043 Inspect GitHub CI for #382.
+- [x] T044 Merge PR #382 when CI/labels/branch protection permit.
+- [x] T045 Fast-forward `main`, close/confirm #381, and update sprint closure/release evidence.

--- a/specs/0001-organization-embedding-product-core/traceability.yaml
+++ b/specs/0001-organization-embedding-product-core/traceability.yaml
@@ -2,6 +2,9 @@ spec_id: WEAVE-SPEC-0001
 version: 0.1.0
 status: accepted
 github_issue: 381
+github_pr: 382
+merge_commit: 9409ae44a07f38864a45a203d90a842b22c6a82d
+release_candidate: v0.1.0-rc.2
 release_notes_label: release-notes-skip
 decision_source:
   nextcloud_form_id: 9


### PR DESCRIPTION
## Summary

- Fixes #390.
- Adds a durable `v0.1.0-rc.2` release evidence page with exact tag, commit, CI, Live Stack, release draft, tag CI, signoff, and blocker facts.
- Moves RC2 facts into versioned `docs/release-notes/v0.1.md`, resets `docs/release-notes/unreleased.md`, and refreshes the README release-note block.
- Updates docs nav and WEAVE-SPEC-0001 handoff traceability after #382/#381.

## Scope and user impact

- Release/operator/docs auditability only; no runtime behavior change.
- Corrects the DevOps/process gap where local post-release docs fixes were not backed by an issue/milestone/PR.

## Spec / acceptance link

- Issue: #390
- Repo spec or spec note: `specs/0001-organization-embedding-product-core/*`
- Acceptance scenario / mapping marker when product behavior changed: no product behavior change
- Product-core questions intentionally left unresolved: none

## Branch, target, and release path

- [x] Branch started from current `origin/main`
- [x] PR targets protected `main`
- [x] No long-lived `dev`/`testing`/`staging` branch involved
- [x] Production release is not implied by this merge

## Screenshots or docs impact

- Docs-only release evidence/navigation/release-notes update.

## Accessibility and localization

- Screen-reader friendly Markdown; no tables added to the main evidence page.
- No localization impact.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: WEAVE-SPEC-0001 traceability/tasks updated for #382 merge, #381 closure, and RC2 evidence handoff
- [x] `./gradlew specContract` run for spec/product-contract changes

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [ ] `release-notes-feature`
- [x] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [x] Copilot review not requested: Copilot premium review requests are exhausted; fallback evidence is local gates + CI + human/agent review.
- [x] Copilot findings addressed or fallback human/agent review evidence documented

## Checks run

- [x] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [x] `make docs-check` / `make docs-build` equivalent: `./gradlew docsCheck`
- [x] `make release-notes-check` equivalent: `./gradlew releaseEvidenceCheck`
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [x] Live-stack validation: cites successful RC2 run 26598646805; no new live-stack run required for docs-only correction

Exact commands run:

```sh
./gradlew docsCheck releaseEvidenceCheck specContract specContractTest acceptanceContract --console=plain
python3 tools/release_readiness_check.py --candidate-version 0.1.0-rc.2 --candidate-tag v0.1.0-rc.2 --candidate-commit 9409ae44a07f38864a45a203d90a842b22c6a82d --ci-summary build/evidence/ci-summary.json --live-evidence-dir /tmp/weave-live-stack-acceptance-evidence-26598646805 --release-notes docs/release-notes/v0.1.md --blockers-json build/evidence/release-blockers.json
```

## Notes for reviewers

- The RC2 release itself was already published; this PR fixes checked-in documentation/process traceability.
- `docs/release-notes/unreleased.md` is intentionally reset after the release cut.
