### PR TITLE
docs: enforce autonomous Weave agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,25 +4,71 @@ Weave is one monorepo. `client/`, `server/`, `infra/`, `e2e/`, `docs/`, and `rel
 
 Old `weave-backend` and `weave-infra` checkouts are stale. Ignore them.
 
-Current truth: this repo, README/docs, GitHub issues/PRs, repo-local `specs/`, and executable evidence. `~/code/specs` is orientation/cross-session contract context; repo-local specs/docs remain the implementation authority when they are more current.
+Current truth: this repo, README/docs, GitHub issues/PRs/milestones, repo-local `specs/`, and executable evidence. `~/code/specs` is orientation/cross-session contract context; repo-local specs/docs remain the implementation authority when they are more current.
+
+Language policy: every `AGENTS.md`, agent prompt, checked-in project instruction, PR body, issue body, code comment, and documentation change must be written in English unless a user-facing localization file explicitly requires another language.
 
 Product-line truth: read `docs/product-line-and-weaver-plan.md` before product direction, admin/provider, RBAC/whitelist, or Weaver work. Preserve the order: Weave provider-neutral organization suite first; admin portal/IDM/RBAC/readiness/whitelisting second; Weaver governed per-user PA runtime later. Do not regress to agent-first planning or a fixed Nextcloud/Matrix-only product boundary.
 
 v0.1 is dogfood-production, not preview. No scaffold, roadmap, or coming-soon UX in normal member paths.
 
-Work spec-driven: intent → issue/spec note or repo-local `specs/NNNN-slug/spec.md` → acceptance/evidence → implementation → review. Use `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and `docs/weave-operating-model.md` as the delivery/agent orchestration contract.
+## Required project standards
 
-Route work:
+Before coding, opening PRs, merging, or declaring work complete, read and follow:
+
+- `docs/developer-handbook.md` for coding conventions, Gradle gates, generated code, accessibility/i18n, and evidence expectations.
+- `docs/gitflow-pr-workflow.md` for protected `main`, short-lived branches, PR readiness, merge rules, and release-notes labels.
+- `docs/weave-operating-model.md` for delivery lifecycle and governance.
+- `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and relevant repo-local `specs/` for spec-driven delivery.
+- Domain docs near the changed area (`client/`, `server/`, `infra/`, `e2e/`, `docs/`).
+
+Default gates: `./gradlew acceptanceContract`, `./gradlew clientCi`, `./gradlew serverCi`, `./gradlew adminCi`, `./gradlew infraStatic`, `./gradlew docsCheck`, and `./gradlew releaseEvidenceCheck`; use the smallest meaningful subset and `./gradlew ci` for cross-stack changes.
+
+## Autonomous sprint ownership
+
+`weave-co-leader` is the only autonomous Weave team leader. Main/Flotto delegates Weave sprint or milestone work to `weave-co-leader`; specialists are accessed and managed only by `weave-co-leader`, never directly by the main session.
+
+A user request such as “finish Sprint N”, “take this milestone”, or “close the sprint” is sufficient. The user does not need to repeat acceptance criteria. The co-leader must derive acceptance from GitHub milestone/issues, linked PRs, repo-local specs/tasks, developer docs, CI policy, and existing evidence.
+
+A sprint-finish request authorizes normal repository delivery actions needed to finish the sprint: creating/updating issues, labels, branches, PRs, checked-in docs/evidence, PR comments, fallback agent reviews, merges into protected `main` when gates pass, issue closure, and milestone closure. It does not authorize secrets disclosure, destructive data loss, live infrastructure mutation, history rewrite, production release publication, or unresolved product-core decisions.
+
+## Autonomous sprint loop
+
+When assigned a sprint or milestone, `weave-co-leader` must run this loop without handing decomposition back to main:
+
+1. **Truth recovery**: fetch current `origin/main`, inspect GitHub milestone/issues/PRs/checks, read linked specs/tasks/docs, and identify the governing sprint lifecycle.
+2. **Acceptance derivation**: turn each issue/spec/task into testable acceptance criteria and evidence gates. If an issue lacks acceptance, infer it from linked specs/docs and update the issue or sprint plan instead of asking the user for restatement.
+3. **Issue DAG**: build or repair the dependency graph; mark independent work parallel and ordered work sequential.
+4. **Delegation**: spawn scoped specialists with strict briefs: task id, allowed files/globs, relevant docs, derived acceptance, required gates, output contract, and stop conditions.
+5. **File ownership**: never let parallel specialists edit the same files without explicit sequencing or separate worktrees/branches.
+6. **PR train**: create short-lived branches from current `origin/main`, open issue-scoped PRs, fill the PR template, and apply exactly one `release-notes-*` label.
+7. **Quality gates**: run local gates, inspect GitHub CI, use fallback human/agent review when Copilot review is unavailable, and fix failures before continuing.
+8. **Merge progression**: merge PRs in dependency order when gates pass and the sprint-finish authorization covers normal merges; after each merge, fetch/fast-forward `main` before the next dependent branch.
+9. **Closure report**: create/update `docs/sprint-<n>-closure-report.md` with governing specs, issue DAG final state, merged PRs in order, gates/CI evidence, release/RC impact, unresolved decisions, and next safe action.
+10. **GitHub closure gate**: verify via GitHub that the target milestone has zero open issues, all sprint issues are closed, the closure report exists on `origin/main`, and the final `main` CI after the last merge is green.
+
+Do not stop after one PR. Do not report success from local git state, a green branch, or a raw diff. If the closure gate fails, report `BLOCKED` with the exact issue, PR, command, check, missing decision, or permission that prevents progress.
+
+## Work routing
+
 - `client/`: Flutter UX, accessibility, l10n.
 - `server/`: facades, authz, audit, provider boundaries.
+- `admin-console/`: admin UX, readiness, policy preview, setup flows.
 - `infra/`: OpenTofu, deploy, backup/restore, support bundles.
 - `e2e/`: Gherkin contracts and evidence mapping.
-- `docs/`: current product truth.
+- `docs/`: current product truth, release notes, handbooks, closure reports.
 
-Default gates: `./gradlew acceptanceContract`, `./gradlew clientCi`, `./gradlew serverCi`, `./gradlew infraStatic`; use `./gradlew ci` for cross-stack changes.
+Use compact templates from `.specify/templates/weave-agent-briefs.md`: Truth-Recovery, Specialist-Brief, ACP-Harness-Brief, Evidence-Return, Integration-Gate, Optimization-Review, and Session-Handoff. Use `docs/agent-team-orchestration.md` for the professional optimization loop.
 
-`weave-co-leader` coordinates specialists using compact templates: Truth-Recovery, Specialist-Brief, ACP-Harness-Brief, Evidence-Return, Integration-Gate, Optimization-Review, and Session-Handoff. Use `.specify/templates/weave-agent-briefs.md` for role/runtime constraints and `docs/agent-team-orchestration.md` for the professional optimization loop. Copilot review is fallback-only while premium requests are exhausted; do not block PRs on Copilot review during that period.
+## Hard stops
 
-Stop before secrets, data loss, live infra mutation, history rewrite, or hidden scope expansion.
+Stop and ask only for product-core decisions not inferable from issues/specs, external communication, destructive data loss, live infra mutation, secrets/raw provider payloads, history rewrite, production release publication, hidden scope expansion, or gates that fail after a concrete fix attempt.
 
 Accessibility, supportability, auditability, and deployability are release blockers.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -43,3 +43,10 @@ Monorepo alignment:
 - Product acceptance features live in `../e2e/features/`; keep `../e2e/scenario_mappings.json` updated with client evidence.
 - Use `../infra/weave-workspace/.generated/bootstrap.env` for live-stack bootstrap defaults.
 - Do not reintroduce client-side provider secrets or direct provider calls.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/client/lib/features/auth/AGENTS.md
+++ b/client/lib/features/auth/AGENTS.md
@@ -24,3 +24,10 @@ Infrastructure-aligned app OIDC defaults:
 - keep the app-native redirect scheme aligned to infrastructure: `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout`
 - keep the app client ID aligned to infrastructure: `weave-app`
 - treat the app client as infra-managed by default; the server config flow may expose the client ID with `weave-app` as the default and allow override for custom issuers
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/client/lib/features/calendar/AGENTS.md
+++ b/client/lib/features/calendar/AGENTS.md
@@ -17,3 +17,10 @@ Accessibility:
 - agenda and list rows must read date, time, and title in a sensible spoken order
 - recurring, all-day, and timezone-shifted events should remain understandable to screen reader users
 - group row semantics when separate labels would cause fragmented announcements
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/client/lib/features/chat/AGENTS.md
+++ b/client/lib/features/chat/AGENTS.md
@@ -27,3 +27,10 @@ Accessibility:
 - merge semantics for a message bubble when separate child announcements would be noisy
 - avoid duplicate spoken output for decorative avatars, timestamps, or status icons
 - security actions and verification dialogs must preserve `48x48` tap targets and expose clear button semantics because they are high-risk recovery flows
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/client/lib/features/files/AGENTS.md
+++ b/client/lib/features/files/AGENTS.md
@@ -24,3 +24,10 @@ Accessibility:
 - each file row should be understandable as one unit when appropriate
 - screen readers must get clear file or folder naming plus relevant state
 - nested navigation must remain traversable without losing context in deep directory trees
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/client/lib/integrations/AGENTS.md
+++ b/client/lib/integrations/AGENTS.md
@@ -12,3 +12,10 @@ Ownership guidance:
 - keep feature-specific mapping and user-facing state inside the owning feature
 - keep server/session/account lifecycle rules in the integration when those rules are not feature-specific
 - if a new integration becomes large enough to guide contributors, add an `AGENTS.md` inside that integration subtree
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/client/lib/integrations/nextcloud/AGENTS.md
+++ b/client/lib/integrations/nextcloud/AGENTS.md
@@ -23,3 +23,10 @@ Boundary rules:
 Default endpoint expectations:
 - the user-facing default files endpoint now derives from `files.<tenant_domain>` to match infrastructure, even though some internal compatibility-safe field names still refer to Nextcloud
 - do not assume the browser-facing default host is `nextcloud.<tenant_domain>` when updating setup or endpoint-derivation behavior
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -9,3 +9,10 @@ Gherkin in this directory is the Weave product contract.
 - Do not add aspirational scenarios without executable mappings; use roadmap docs or issues for future intent.
 - Live-stack evidence must be sparse, sanitized, and deterministic.
 - Never write tokens, cookies, private keys, raw provider errors, room IDs, event IDs, filenames, usernames, or display names into evidence artifacts.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/.github/AGENTS.md
+++ b/infra/.github/AGENTS.md
@@ -6,3 +6,10 @@ This directory owns repository automation and GitHub-native workflows.
 
 - `workflows/ci.yml`: continuous integration workflow for Terraform formatting, init/validate checks, and shell script linting.
 - `workflows/AGENTS.md`: workflow-level maintenance summary.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/.github/workflows/AGENTS.md
+++ b/infra/.github/workflows/AGENTS.md
@@ -11,3 +11,10 @@ This directory contains GitHub Actions workflows for repository validation.
 - Keep the validation job focused on deterministic repository checks that can run without local Docker state.
 - Prefer validating both Terraform stages with `init -backend=false` before heavier integration steps.
 - The smoke job is allowed to use Docker when manually dispatched to validate release-critical stack contracts end to end. Do not make it a normal PR/push requirement unless the cross-repo CI/E2E spec changes.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -34,3 +34,10 @@ This repository contains one runnable workspace under `weave-workspace/`.
 - Any destructive operation must require typed confirmation and must preserve backup/rollback guidance.
 - Keep support bundles redacted and deterministic; never leak secrets, tokens, cookies, raw provider errors, generated private keys, room IDs, event IDs, filenames, usernames, or display names.
 - Map release-critical infra behavior to `../e2e/scenario_mappings.json` when it affects product acceptance.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/01-infrastructure/AGENTS.md
+++ b/infra/weave-workspace/01-infrastructure/AGENTS.md
@@ -21,3 +21,10 @@ This stage owns Docker networking, generated runtime config files, local contain
 - `modules/backend`: Weave backend container, OIDC environment, healthcheck, and Caddy routing.
 - `modules/matrix`: MAS and Synapse containers plus local CA trust for MAS.
 - `modules/nextcloud`: Nextcloud container and storage.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/01-infrastructure/modules/AGENTS.md
+++ b/infra/weave-workspace/01-infrastructure/modules/AGENTS.md
@@ -34,3 +34,10 @@ These child modules keep the root stage orchestration-only.
   - `main.tf`: Nextcloud image, volume, container, reverse proxy trust, and local CA mount.
   - `variables.tf`: database, hostname, and admin inputs.
   - `outputs.tf`: container and volume identifiers.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/01-infrastructure/modules/backend/AGENTS.md
+++ b/infra/weave-workspace/01-infrastructure/modules/backend/AGENTS.md
@@ -7,3 +7,10 @@ This module owns the local Weave backend runtime consumed by the Caddy product g
 - `main.tf`: Weave backend image, container, healthcheck, OIDC environment, and Docker network aliases.
 - `variables.tf`: image, port, hostname, and OIDC contract inputs.
 - `outputs.tf`: exported backend container identifier.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/01-infrastructure/modules/keycloak/AGENTS.md
+++ b/infra/weave-workspace/01-infrastructure/modules/keycloak/AGENTS.md
@@ -7,3 +7,10 @@ This module runs the local Keycloak container behind the Caddy reverse proxy.
 - `main.tf`: Keycloak image, persistent volume, database wiring, admin bootstrap, and public URL wiring.
 - `variables.tf`: image, storage, database, port, hostname, and admin inputs.
 - `outputs.tf`: exported container and volume identifiers.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/01-infrastructure/modules/matrix/AGENTS.md
+++ b/infra/weave-workspace/01-infrastructure/modules/matrix/AGENTS.md
@@ -7,3 +7,10 @@ This module owns Matrix Authentication Service and Synapse. Public Matrix routin
 - `main.tf`: MAS and Synapse images, Synapse volume, generated config uploads, containers, and MAS local CA trust.
 - `variables.tf`: ports, hostname, generated-file paths, TLS CA mount, and image inputs.
 - `outputs.tf`: exported MAS and Synapse container identifiers plus Synapse storage metadata.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/01-infrastructure/modules/nextcloud/AGENTS.md
+++ b/infra/weave-workspace/01-infrastructure/modules/nextcloud/AGENTS.md
@@ -7,3 +7,10 @@ This module owns the local Nextcloud runtime behind the Caddy reverse proxy.
 - `main.tf`: Nextcloud image, persistent volume, database wiring, admin bootstrap, proxy trust, and local CA mount.
 - `variables.tf`: image, storage, database, hostname, URL, proxy trust, TLS CA mount, and admin inputs.
 - `outputs.tf`: exported container and volume identifiers.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/01-infrastructure/modules/postgres/AGENTS.md
+++ b/infra/weave-workspace/01-infrastructure/modules/postgres/AGENTS.md
@@ -11,3 +11,10 @@ This module owns the shared PostgreSQL runtime used by Keycloak, MAS, Synapse, a
 ## Maintenance Notes
 
 - Per-service roles and databases are created by the root stage bootstrap in `01-infrastructure/main.tf`, not inside this child module.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/01-infrastructure/modules/reverse-proxy/AGENTS.md
+++ b/infra/weave-workspace/01-infrastructure/modules/reverse-proxy/AGENTS.md
@@ -7,3 +7,10 @@ This module owns the Caddy edge container for local HTTPS hostname-based routing
 - `main.tf`: Caddy image, Caddyfile mount, TLS cert directory mount, runtime volumes, published HTTP/HTTPS ports, and container.
 - `variables.tf`: network, image, host-port, Caddyfile, TLS cert, and hostname inputs.
 - `outputs.tf`: exported proxy container and volume identifiers.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/02-keycloak-setup/AGENTS.md
+++ b/infra/weave-workspace/02-keycloak-setup/AGENTS.md
@@ -15,3 +15,10 @@ This stage owns tenant-level identity configuration after Keycloak is already ru
 - This stage configures Keycloak only.
 - It does not mutate Docker resources or rerender infrastructure assets.
 - Nextcloud app bootstrap remains in `install.sh`, using outputs from this stage.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/02-keycloak-setup/modules/AGENTS.md
+++ b/infra/weave-workspace/02-keycloak-setup/modules/AGENTS.md
@@ -7,3 +7,10 @@
   - `main.tf`: tenant realm, optional integration test user, OIDC clients, Weave workspace scope and audience mapper, and the Nextcloud group mapper.
   - `variables.tf`: public URLs, shared client-secret inputs, and optional test user flag.
   - `outputs.tf`: realm, Weave, Nextcloud client, and optional test user outputs returned to the root stage.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/AGENTS.md
+++ b/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/AGENTS.md
@@ -7,3 +7,10 @@ This module owns tenant-specific Keycloak configuration after the server is alre
 - `main.tf`: tenant realm, optional integration test user, OIDC client definitions, Weave workspace scope and audience mapper, and the Nextcloud group membership mapper.
 - `variables.tf`: tenant slug, public URLs, shared secret inputs, and optional test user flag.
 - `outputs.tf`: realm, client, and optional test user outputs returned to the stage root.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/infra/weave-workspace/AGENTS.md
+++ b/infra/weave-workspace/AGENTS.md
@@ -21,3 +21,10 @@
 - Keep stage root modules thin and orchestration-focused.
 - Put tightly coupled resources inside the existing child modules under each stage’s `modules/` directory.
 - Update the corresponding stage `AGENTS.md` when files or responsibilities move.
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -13,3 +13,10 @@ The server owns Weave product facades, authorization, audit, provider boundaries
 Validation from `server/`:
 
 - `./gradlew test`
+
+## Global Weave agent baseline
+
+- Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
+- Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
+- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.


### PR DESCRIPTION
## Summary
- rewrites the root Weave agent rules around autonomous sprint ownership instead of main-session babysitting
- makes "finish this sprint/milestone" sufficient: weave-co-leader must derive acceptance from GitHub milestones/issues, repo specs/tasks/docs, CI policy, and evidence
- documents sprint-finish authorization for normal repo delivery actions: branches, PRs, fallback reviews, green-gated merges, issue/milestone closure, and closure report
- propagates the English + handbook/Git workflow/operating-model baseline into all AGENTS.md files

## Checks
- git diff --check
- AGENTS.md language scan: 25 files checked, 0 German-rule suspects
- NLM notebook checked: OpenClaw Multi-Agent Orchestration and Configuration Guide (`9db80505-488e-4792-b209-37b02449c921`)

## Release notes
- release-notes-skip: agent instruction/configuration only; no product/runtime behavior shipped to users