### PR TITLE
WEAVE-SPEC-0001: add Admin-Suite readiness setup contract

### DIFF
--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -24,7 +24,7 @@ function mockApi(
       targetAdapter: 'keycloak-realm',
       readinessState: 'ready',
       migrationDryRunRequired: true,
-      memberImpactStates: ['usable', 'degraded', 'policy-blocked'],
+      memberImpactStates: ['available', 'degraded', 'disabled_by_policy'],
       supportSafe: true,
       providerDiagnosticsRedacted: true,
       cutoverGates: ['Run backend migration dry-run before apply'],
@@ -74,6 +74,12 @@ describe('Admin Console MVP', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: /provider categories/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /guided setup assistant/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /readiness dashboard/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: /identity provider readiness/i }),
@@ -141,6 +147,29 @@ describe('Admin Console MVP', () => {
       screen.getByText(/member provider setup:/i),
     ).toHaveTextContent(/blocked/i);
     expect(document.body).not.toHaveTextContent(/client_secret|access_token/i);
+  });
+
+  it('specifies guided setup and per-domain readiness before member go-live', async () => {
+    render(<App api={mockApi()} />);
+
+    expect(
+      await screen.findByRole('heading', { name: /guided setup assistant/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/admin setup assistant steps/i),
+    ).toHaveTextContent(/identity \/ idm: ready for member go-live/i);
+    expect(
+      screen.getByLabelText(/admin setup assistant steps/i),
+    ).toHaveTextContent(/meetings \/ calls: repair before inviting affected members/i);
+    expect(
+      screen.getByText(/requires dry-run\/preflight, member impact preview/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/domain readiness dashboard/i),
+    ).toHaveTextContent(/next action: run a readiness test/i);
+    expect(
+      screen.getByLabelText(/domain readiness dashboard/i),
+    ).toHaveTextContent(/member preview: degraded/i);
   });
 
   it('keeps admin/provider setup separate from the member client and direct providers', async () => {
@@ -255,7 +284,7 @@ describe('Admin Console MVP', () => {
     expect(screen.getByText(/diagnostics redacted: yes/i)).toBeInTheDocument();
     expect(
       screen.getByText(
-        /member impact states: usable, degraded, policy-blocked/i,
+        /member impact states: available, degraded, disabled_by_policy/i,
       ),
     ).toBeInTheDocument();
   });
@@ -275,7 +304,7 @@ describe('Admin Console MVP', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        /use weave product capabilities with only usable, disabled, degraded, or policy-blocked states/i,
+        /use weave product capabilities with only available, disabled_by_policy, not_configured, degraded, unavailable, or coming_later states/i,
       ),
     ).toBeInTheDocument();
     unmount();
@@ -284,7 +313,7 @@ describe('Admin Console MVP', () => {
     const memberPreview = await screen.findByLabelText(
       /member-visible capability states/i,
     );
-    expect(memberPreview).toHaveTextContent(/Member state: usable/i);
+    expect(memberPreview).toHaveTextContent(/Member state: available/i);
     expect(memberPreview).not.toHaveTextContent(/secretref:\/\//i);
     expect(document.body).not.toHaveTextContent(/secretref:\/\//i);
     expect(document.body).not.toHaveTextContent(

--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -19,7 +19,7 @@ function mockApi(
     dryRunProviderReplacement: vi.fn().mockResolvedValue({
       dryRunId: 'chat-slack-dry-run',
       status: 'dry_run_ready',
-      category: 'identity-idm',
+      category: 'idm-rbac',
       currentAdapter: 'keycloak-realm',
       targetAdapter: 'keycloak-realm',
       readinessState: 'ready',
@@ -110,7 +110,7 @@ describe('Admin Console MVP', () => {
       screen.getByRole('heading', { name: /audit trail/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByLabelText(/identity \/ idm status is ready/i),
+      screen.getByLabelText(/idm \/ rbac status is ready/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/provider source of truth/i)).toBeInTheDocument();
     expect(screen.getByText(/backend-owned facade/i)).toBeInTheDocument();
@@ -157,10 +157,10 @@ describe('Admin Console MVP', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByLabelText(/admin setup assistant steps/i),
-    ).toHaveTextContent(/identity \/ idm: ready for member go-live/i);
+    ).toHaveTextContent(/idm \/ rbac: ready for member go-live/i);
     expect(
       screen.getByLabelText(/admin setup assistant steps/i),
-    ).toHaveTextContent(/meetings \/ calls: repair before inviting affected members/i);
+    ).toHaveTextContent(/meetings: repair before inviting affected members/i);
     expect(
       screen.getByText(/requires dry-run\/preflight, member impact preview/i),
     ).toBeInTheDocument();
@@ -224,7 +224,7 @@ describe('Admin Console MVP', () => {
 
     await waitFor(() =>
       expect(api.selectProvider).toHaveBeenCalledWith(
-        'identity-idm',
+        'idm-rbac',
         'keycloak-realm',
         'recommended_self_hosted_default',
         false,
@@ -248,7 +248,7 @@ describe('Admin Console MVP', () => {
 
     await waitFor(() =>
       expect(api.selectProvider).toHaveBeenCalledWith(
-        'identity-idm',
+        'idm-rbac',
         'keycloak-realm',
         'recommended_self_hosted_default',
         true,
@@ -272,7 +272,7 @@ describe('Admin Console MVP', () => {
 
     await waitFor(() =>
       expect(api.dryRunProviderReplacement).toHaveBeenCalledWith(
-        expect.objectContaining({ key: 'identity-idm' }),
+        expect.objectContaining({ key: 'idm-rbac' }),
         'keycloak-realm',
         'recommended_self_hosted_default',
       ),

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -36,7 +36,13 @@ import {
 import { AdminConsoleLocale, adminCopy } from './copy';
 
 type ViewerRole = 'owner' | 'admin' | 'operator' | 'member';
-type MemberStableState = 'usable' | 'disabled' | 'degraded' | 'policy-blocked';
+type MemberStableState =
+  | 'available'
+  | 'disabled_by_policy'
+  | 'not_configured'
+  | 'degraded'
+  | 'unavailable'
+  | 'coming_later';
 
 const stateColor: Record<
   CapabilityState,
@@ -61,19 +67,59 @@ function memberStableState(state: CapabilityState): MemberStableState {
   switch (state) {
     case 'ready':
     case 'configured':
-      return 'usable';
+      return 'available';
     case 'policy-blocked':
-      return 'policy-blocked';
-    case 'admin-action-required':
-      return 'degraded';
     case 'disabled':
-    case 'unsupported':
+      return 'disabled_by_policy';
     case 'not_configured':
-      return 'disabled';
+      return 'not_configured';
+    case 'unsupported':
+      return 'unavailable';
+    case 'admin-action-required':
     case 'degraded':
     case 'misconfigured':
     default:
       return 'degraded';
+  }
+}
+
+function setupStage(state: CapabilityState): string {
+  switch (state) {
+    case 'ready':
+    case 'configured':
+      return 'Ready for member go-live';
+    case 'policy-blocked':
+    case 'disabled':
+      return 'Disabled by policy';
+    case 'not_configured':
+    case 'admin-action-required':
+      return 'Admin setup required';
+    case 'unsupported':
+      return 'Unavailable for this adapter';
+    case 'degraded':
+    case 'misconfigured':
+    default:
+      return 'Repair before inviting affected members';
+  }
+}
+
+function setupNextAction(category: ProviderCategory): string {
+  switch (category.state) {
+    case 'ready':
+    case 'configured':
+      return 'Keep monitoring audit evidence and invite members when policy simulation is green.';
+    case 'policy-blocked':
+    case 'disabled':
+      return 'Review deny-by-default policy before exposing this domain to members.';
+    case 'not_configured':
+    case 'admin-action-required':
+      return 'Select and dry-run a provider adapter, then test readiness through the backend.';
+    case 'unsupported':
+      return 'Choose a supported adapter or keep the member state unavailable.';
+    case 'degraded':
+    case 'misconfigured':
+    default:
+      return 'Run a readiness test, review support-safe diagnostics, and repair before member go-live.';
   }
 }
 
@@ -308,6 +354,37 @@ export default function App({
             </CardContent>
           </Card>
 
+          {viewerRole !== 'member' ? (
+            <Card component="section" aria-labelledby="setup-assistant-heading">
+              <CardContent>
+                <Typography
+                  id="setup-assistant-heading"
+                  variant="h2"
+                  sx={{ fontSize: '1.35rem', mb: 1 }}
+                >
+                  Guided setup assistant
+                </Typography>
+                <Alert severity="info" sx={{ mb: 2 }}>
+                  Admins bind, unbind, validate, switch, or detach provider
+                  adapters only through backend admin APIs. Every apply path
+                  requires dry-run/preflight, member impact preview, clear
+                  consequences, and recovery guidance before an irreversible
+                  change.
+                </Alert>
+                <List aria-label="Admin setup assistant steps">
+                  {controlPlane.providerCategories.map((category) => (
+                    <ListItem key={`setup-${category.key}`} alignItems="flex-start">
+                      <ListItemText
+                        primary={`${category.label}: ${setupStage(category.state)}`}
+                        secondary={setupNextAction(category)}
+                      />
+                    </ListItem>
+                  ))}
+                </List>
+              </CardContent>
+            </Card>
+          ) : null}
+
           <Card component="section" aria-labelledby="member-preview-heading">
             <CardContent>
               <Typography
@@ -445,6 +522,36 @@ export default function App({
                       </Card>
                     ))}
                   </Stack>
+                </CardContent>
+              </Card>
+
+              <Card component="section" aria-labelledby="readiness-dashboard-heading">
+                <CardContent>
+                  <Typography
+                    id="readiness-dashboard-heading"
+                    variant="h2"
+                    sx={{ fontSize: '1.35rem', mb: 2 }}
+                  >
+                    Readiness dashboard
+                  </Typography>
+                  <Typography sx={{ mb: 2 }}>
+                    Domain readiness is actionable for admins and operators but
+                    support-safe by default: provider diagnostics are redacted,
+                    SecretRef handles stay out of member contracts, and member
+                    preview states remain provider-neutral.
+                  </Typography>
+                  <List aria-label="Domain readiness dashboard">
+                    {controlPlane.providerCategories.map((category) => (
+                      <ListItem key={`readiness-${category.key}`} alignItems="flex-start">
+                        <ListItemText
+                          primary={`${category.label}: ${readableState(category.state)}`}
+                          secondary={`Member preview: ${memberStableState(
+                            category.state,
+                          )}. Next action: ${setupNextAction(category)}`}
+                        />
+                      </ListItem>
+                    ))}
+                  </List>
                 </CardContent>
               </Card>
 

--- a/admin-console/src/api.test.ts
+++ b/admin-console/src/api.test.ts
@@ -97,10 +97,9 @@ describe('AdminControlPlaneApi provider boundary', () => {
     expect(identityReadiness.cards[0]?.memberImpact).toBe('degraded');
     expect(report.supportSafe).toBe(true);
     expect(report.memberImpactStates).toEqual([
-      'usable',
-      'disabled',
+      'available',
+      'disabled_by_policy',
       'degraded',
-      'policy-blocked',
     ]);
     expect(calls).toEqual([
       'https://api.example.invalid/api/admin/providers/selections',

--- a/admin-console/src/api.test.ts
+++ b/admin-console/src/api.test.ts
@@ -11,7 +11,7 @@ describe('AdminControlPlaneApi provider boundary', () => {
       const body = path.includes('/identity/readiness')
         ? {
             contractVersion: 'identity-provider-readiness-v1',
-            category: 'identity-idm',
+            category: 'idm-rbac',
             providerKey: 'keycloak-realm',
             overallState: 'admin-action-required',
             supportSafe: true,
@@ -43,7 +43,7 @@ describe('AdminControlPlaneApi provider boundary', () => {
         : path.includes('/replacements/dry-run')
           ? {
             status: 'dry_run_ready',
-            category: 'chat',
+            category: 'chat-channels',
             currentAdapter: 'synapse-homeserver',
             targetAdapter: 'slack',
             readinessState: 'degraded',
@@ -87,7 +87,7 @@ describe('AdminControlPlaneApi provider boundary', () => {
       selectedAdapter: 'synapse-homeserver',
     };
 
-    await api.selectProvider('chat', 'slack');
+    await api.selectProvider('chat-channels', 'slack');
     const identityReadiness = await api.getIdentityProviderReadiness();
     await api.testProviderReadiness('slack');
     const report = await api.dryRunProviderReplacement(category, 'slack');

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -64,6 +64,14 @@ export interface AuditEvent {
   summary: string;
 }
 
+export type MemberCapabilityState =
+  | 'available'
+  | 'disabled_by_policy'
+  | 'not_configured'
+  | 'degraded'
+  | 'unavailable'
+  | 'coming_later';
+
 export interface ProviderReplacementDryRunReport {
   dryRunId: string;
   status: string;
@@ -72,9 +80,7 @@ export interface ProviderReplacementDryRunReport {
   targetAdapter: string;
   readinessState: CapabilityState;
   migrationDryRunRequired: boolean;
-  memberImpactStates: Array<
-    'usable' | 'disabled' | 'degraded' | 'policy-blocked'
-  >;
+  memberImpactStates: MemberCapabilityState[];
   supportSafe: boolean;
   providerDiagnosticsRedacted: boolean;
   cutoverGates: string[];
@@ -603,21 +609,40 @@ function normalizeIdentityMemberImpact(
   }
 }
 
-function normalizeMemberImpactStates(
-  values?: string[],
-): Array<'usable' | 'disabled' | 'degraded' | 'policy-blocked'> {
+function normalizeMemberImpactStates(values?: string[]): MemberCapabilityState[] {
   const normalized = (values ?? [])
-    .map((value) => (value === 'ready' ? 'usable' : value))
-    .filter(
-      (value): value is 'usable' | 'disabled' | 'degraded' | 'policy-blocked' =>
-        value === 'usable' ||
-        value === 'disabled' ||
-        value === 'degraded' ||
-        value === 'policy-blocked',
-    );
+    .map(normalizeMemberCapabilityState)
+    .filter((value): value is MemberCapabilityState => value !== null);
   return normalized.length > 0
     ? Array.from(new Set(normalized))
-    : ['usable', 'disabled', 'degraded', 'policy-blocked'];
+    : ['available', 'disabled_by_policy', 'not_configured', 'degraded'];
+}
+
+function normalizeMemberCapabilityState(value?: string): MemberCapabilityState | null {
+  switch (value) {
+    case 'available':
+    case 'not_configured':
+    case 'degraded':
+    case 'unavailable':
+    case 'coming_later':
+      return value;
+    case 'disabled_by_policy':
+    case 'policy-blocked':
+    case 'policy_blocked':
+    case 'disabled':
+      return 'disabled_by_policy';
+    case 'ready':
+    case 'usable':
+      return 'available';
+    case 'admin-action-required':
+    case 'admin_action_required':
+    case 'misconfigured':
+      return 'degraded';
+    case 'unsupported':
+      return 'unavailable';
+    default:
+      return null;
+  }
 }
 
 function normalizeState(value?: string): CapabilityState {

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -461,7 +461,7 @@ function normalizeIdentityProviderReadiness(
   return {
     contractVersion:
       readiness?.contractVersion ?? 'identity-provider-readiness-v1',
-    category: readiness?.category ?? 'identity-idm',
+    category: readiness?.category ?? 'idm-rbac',
     providerKey: readiness?.providerKey ?? 'awaiting_admin_selection',
     overallState: normalizeState(
       readiness?.overallState ?? 'admin-action-required',
@@ -536,7 +536,7 @@ function normalizeWhitelist(
     blockedCapabilities: [
       'provider.direct_call',
       'provider.secret_export',
-      'weaver.exec_without_policy',
+      'provider.unapproved_runtime_execution',
     ],
   };
 }
@@ -688,8 +688,8 @@ export const sampleControlPlane: ControlPlaneResponse = {
   bootstrapDefaultsAreSuggestionsOnly: true,
   providerCategories: [
     {
-      key: 'identity-idm',
-      label: 'Identity / IDM',
+      key: 'idm-rbac',
+      label: 'IDM / RBAC',
       selectedAdapter: 'keycloak-realm',
       state: 'ready',
       summary:
@@ -711,8 +711,8 @@ export const sampleControlPlane: ControlPlaneResponse = {
       secretRefs: ['secretref://weave/provider/keycloak-realm/client-secret'],
     },
     {
-      key: 'chat',
-      label: 'Chat',
+      key: 'chat-channels',
+      label: 'Chat / channels',
       selectedAdapter: 'synapse-homeserver',
       state: 'ready',
       summary: 'Chat is available through Weave conversations.',
@@ -724,8 +724,8 @@ export const sampleControlPlane: ControlPlaneResponse = {
       secretRefs: ['secretref://weave/provider/synapse-homeserver'],
     },
     {
-      key: 'files',
-      label: 'Files',
+      key: 'files-docs',
+      label: 'Files / docs',
       selectedAdapter: 'nextcloud-files',
       state: 'degraded',
       summary:
@@ -743,8 +743,8 @@ export const sampleControlPlane: ControlPlaneResponse = {
       secretRefs: ['secretref://weave/provider/nextcloud-files'],
     },
     {
-      key: 'calendar',
-      label: 'Calendar',
+      key: 'calendar-events',
+      label: 'Calendar / events',
       selectedAdapter: 'nextcloud-caldav',
       state: 'degraded',
       summary:
@@ -781,8 +781,8 @@ export const sampleControlPlane: ControlPlaneResponse = {
       secretRefs: ['secretref://weave/provider/openproject-primary'],
     },
     {
-      key: 'meetings-calls',
-      label: 'Meetings / calls',
+      key: 'meetings',
+      label: 'Meetings',
       selectedAdapter: 'livekit',
       state: 'misconfigured',
       summary:
@@ -799,42 +799,27 @@ export const sampleControlPlane: ControlPlaneResponse = {
       secretRefs: ['secretref://weave/provider/livekit'],
     },
     {
-      key: 'documents-collaboration',
-      label: 'Documents / collaboration',
-      selectedAdapter: 'onlyoffice-community',
+      key: 'forms-contacts',
+      label: 'Forms / contacts',
+      selectedAdapter: 'weave-managed-forms-contacts',
       state: 'disabled',
       summary:
-        'Documents use Weave/WOPI collaboration contracts; Nextcloud/SharePoint/WOPI providers are not member-facing setup.',
+        'Forms and contacts use Weave canonical contracts; provider-specific address book or form backends stay admin/operator-side.',
       supportSafe: true,
       selectedByAdmin: true,
       bootstrapSuggestionOnly: false,
       choiceModel: 'recommended_self_hosted_default',
       providerCandidates: [
-        'onlyoffice-community',
-        'collabora-code',
-        'wopi-host',
-        'microsoft-365-office-graph',
+        'weave-managed-forms-contacts',
+        'nextcloud-forms-contacts',
+        'google-workspace-contacts',
       ],
-      secretRefs: ['secretref://weave/provider/onlyoffice-community'],
-    },
-    {
-      key: 'weaver',
-      label: 'Weaver runtime',
-      selectedAdapter: 'awaiting_admin_selection',
-      state: 'policy-blocked',
-      summary:
-        'Governed per-user PA runtime remains disabled by default and Weave-owned decisions stay backend-policy controlled.',
-      supportSafe: true,
-      selectedByAdmin: false,
-      bootstrapSuggestionOnly: true,
-      choiceModel: 'not_selected',
-      providerCandidates: ['openclaw-governed-runtime'],
-      secretRefs: [],
+      secretRefs: ['secretref://weave/provider/weave-managed-forms-contacts'],
     },
   ],
   identityProviderReadiness: {
     contractVersion: 'identity-provider-readiness-v1',
-    category: 'identity-idm',
+    category: 'idm-rbac',
     providerKey: 'keycloak-realm',
     overallState: 'ready',
     supportSafe: true,
@@ -911,7 +896,7 @@ export const sampleControlPlane: ControlPlaneResponse = {
   whitelistPolicy: {
     denyByDefault: true,
     allowedCapabilities: ['chat.read', 'files.read'],
-    blockedCapabilities: ['weaver.exec', 'provider.direct_call'],
+    blockedCapabilities: ['provider.direct_call', 'provider.secret_export'],
   },
   auditEvents: [
     {

--- a/admin-console/src/copy.ts
+++ b/admin-console/src/copy.ts
@@ -12,7 +12,7 @@ export const adminConsoleMessages = {
       'Inspect readiness, audit evidence, and support-safe diagnostics without seeing raw provider secrets or downstream bodies.',
     memberRole: 'Member',
     memberDescription:
-      'Use Weave product capabilities with only usable, disabled, degraded, or policy-blocked states.',
+      'Use Weave product capabilities with only available, disabled_by_policy, not_configured, degraded, unavailable, or coming_later states.',
     memberPreviewHeading: 'Member capability preview',
     memberPreviewDescription:
       'This preview intentionally hides provider adapters, SecretRefs, tenant URLs, raw diagnostics, and admin-only controls.',

--- a/docs/admin-provisioned-first-use.md
+++ b/docs/admin-provisioned-first-use.md
@@ -4,7 +4,7 @@ Status: v0.1 release contract for issues #259, #250, and #212.
 
 ## Product rule
 
-The detailed strategic contracts are [Organization embedding contract](organization-embedding-contract.md), [Identity provisioning strategy](identity-provisioning-strategy.md), and [Provider replacement and anti-silo contract](provider-replacement-and-anti-silo-contract.md). This page remains the v0.1 first-use boundary for member/admin separation.
+The detailed strategic contracts are [Organization embedding contract](organization-embedding-contract.md), [Identity provisioning strategy](identity-provisioning-strategy.md), [Admin-Suite readiness and setup contract](admin-suite-readiness-setup-contract.md), and [Provider replacement and anti-silo contract](provider-replacement-and-anti-silo-contract.md). This page remains the v0.1 first-use boundary for member/admin separation.
 
 Normal organization members land in an admin-provisioned workspace. They sign in with Weave SSO, use Weave-owned chat, files, calendar, boards, meetings, and decisions surfaces, and see either complete capabilities or simple impact/fallback states.
 
@@ -16,7 +16,7 @@ Admins and operators provision identity, domains, provider stack, policy, backup
 
 Members enter or open only an organization auth URL, invite link, or deep link. After SSO, the Weave Client consumes the support-safe organization manifest and effective capability states, then renders member work surfaces. Member-visible manifest states are limited to `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, or `coming_later`.
 
-The Admin Console owns organization creation/bootstrap, IDM/provider setup, provider/category selection, endpoint URL management and rotation, readiness and diagnostics, users/groups/roles, RBAC/capability profiles, deny-by-default policy, org-wide defaults, audit logs, and privacy/compliance/risk notes. Whitelisting belongs to the Admin Console: provider, tool, and agent allowlists are configured there, while the client only consumes effective policy/capabilities.
+The Admin Console owns organization creation/bootstrap, IDM/provider setup, guided setup assistant, per-domain readiness dashboard, provider/category selection, endpoint URL management and rotation, readiness and diagnostics, users/groups/roles, RBAC/capability profiles, deny-by-default policy, org-wide defaults, audit logs, and privacy/compliance/risk notes. Whitelisting belongs to the Admin Console: provider, tool, and agent allowlists are configured there, while the client only consumes effective policy/capabilities.
 
 ## Provider-category admin boundary
 

--- a/docs/admin-suite-readiness-setup-contract.md
+++ b/docs/admin-suite-readiness-setup-contract.md
@@ -1,0 +1,53 @@
+# Admin-Suite readiness and setup contract
+
+Status: WEAVE-SPEC-0001 issue #387 contract.
+
+## Product rule
+
+The Admin-Suite is the owner/admin/operator control plane for organization setup, provider readiness, policy, diagnostics, and repair. Normal members enter an already-provisioned organization and consume only provider-neutral capability states from the organization manifest.
+
+This contract extends the [Admin-provisioned first use boundary](admin-provisioned-first-use.md) and [Weave product line and Weaver integration plan](product-line-and-weaver-plan.md) for WEAVE-SPEC-0001. It does not add member-facing provider setup and it does not claim full provider migration automation; portable switch/export/import details remain in the provider replacement contract.
+
+## Guided setup assistant
+
+The Admin-Suite setup assistant must lead an owner/admin through these steps before member go-live:
+
+1. Choose or confirm provider categories: identity/IDM, chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver-disabled-by-default.
+2. Bind the selected adapter through backend admin APIs only; never call provider admin APIs directly from the browser client.
+3. Keep secrets as `SecretRef` handles and reject raw secrets, bearer tokens, credential-bearing URLs, raw downstream payloads, or provider diagnostics in form fields and evidence.
+4. Run dry-run/preflight validation before apply.
+5. Show an effective member preview using only `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, or `coming_later`.
+6. Explain consequences, recovery path, and rollback/support boundary before any irreversible bind, unbind, switch, detach, or policy change.
+7. Write support-safe audit evidence for every setup, readiness, and policy action.
+
+## Readiness dashboard
+
+The Admin-Suite readiness dashboard is per domain, not vendor-first. Every domain row must include:
+
+| Field | Contract |
+| --- | --- |
+| Domain | Canonical Weave domain/category label. |
+| Admin readiness | Admin/operator status and next action from backend readiness/policy. |
+| Member preview | Provider-neutral member state only: `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, or `coming_later`. |
+| Selected adapter | Visible only to owner/admin/operator roles. |
+| Evidence | Support-safe references, never raw provider payloads or secrets. |
+| Recovery | Repair or rollback guidance before irreversible actions. |
+
+Admin/operator readiness may use implementation states such as ready, configured, degraded, misconfigured, policy-blocked, admin-action-required, disabled, unsupported, or not_configured, but those states must be translated before reaching normal member contracts.
+
+## Role and action boundary
+
+- `owner` and delegated `admin`: may configure provider categories, policy, readiness, setup, preflight, and guarded apply paths.
+- `operator`: may inspect readiness, run delegated tests/preflight, collect support-safe evidence, and execute delegated repair actions.
+- `member` and `guest`: must not see provider setup controls, diagnostics, selected adapters, `SecretRef` handles, raw provider names in core workflows, or recovery internals.
+
+Bind, unbind, switch, and detach are admin-side actions. They must be unavailable or blocked until preflight evidence, member impact preview, consequence copy, and recovery guidance exist. Switch/export/import/cutover details are governed by [Provider replacement and anti-silo contract](provider-replacement-and-anti-silo-contract.md).
+
+## Evidence and gates
+
+#387 evidence is satisfied when:
+
+- the Admin Console exposes a guided setup assistant and per-domain readiness dashboard for owner/admin/operator roles;
+- member preview remains provider-neutral and hides provider/admin controls;
+- backend/admin API contracts remain support-safe and redacted;
+- `./gradlew specContract acceptanceContract adminCi --console=plain` passes for the slice.

--- a/docs/admin-suite-readiness-setup-contract.md
+++ b/docs/admin-suite-readiness-setup-contract.md
@@ -12,7 +12,7 @@ This contract extends the [Admin-provisioned first use boundary](admin-provision
 
 The Admin-Suite setup assistant must lead an owner/admin through these steps before member go-live:
 
-1. Choose or confirm provider categories: identity/IDM, chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver-disabled-by-default.
+1. Choose or confirm WEAVE-SPEC-0001 provider domains: IDM/RBAC, Chat/Channels, Files/Docs, Boards/Tasks, Calendar/Events, Meetings, and Forms/Contacts.
 2. Bind the selected adapter through backend admin APIs only; never call provider admin APIs directly from the browser client.
 3. Keep secrets as `SecretRef` handles and reject raw secrets, bearer tokens, credential-bearing URLs, raw downstream payloads, or provider diagnostics in form fields and evidence.
 4. Run dry-run/preflight validation before apply.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,9 +30,10 @@ Start with:
 Start with:
 
 1. [Admin/Operator Handbook](admin-operator-handbook.md) — setup, provider categories, policy, readiness, audit, backup/restore, and support bundles.
-2. [Admin-provisioned first use](admin-provisioned-first-use.md) — member/admin boundary and setup acceptance.
-3. [Organization embedding contract](organization-embedding-contract.md) — identity, tenant, roles/groups, non-human identities, and future Weaver category boundaries.
-4. [Identity provisioning strategy](identity-provisioning-strategy.md) — LDAP/AD/OIDC/SAML/SCIM-oriented identity planning.
+2. [Admin-Suite readiness and setup contract](admin-suite-readiness-setup-contract.md) — guided setup assistant, readiness dashboard, action boundary, and support-safe evidence.
+3. [Admin-provisioned first use](admin-provisioned-first-use.md) — member/admin boundary and setup acceptance.
+4. [Organization embedding contract](organization-embedding-contract.md) — identity, tenant, roles/groups, non-human identities, and future Weaver category boundaries.
+5. [Identity provisioning strategy](identity-provisioning-strategy.md) — LDAP/AD/OIDC/SAML/SCIM-oriented identity planning.
 
 ### Operator
 
@@ -76,6 +77,7 @@ Canonical product docs:
 - [Canonical feature models](canonical-feature-models.md)
 - [Architecture](architecture.md)
 - [Organization embedding contract](organization-embedding-contract.md)
+- [Admin-Suite readiness and setup contract](admin-suite-readiness-setup-contract.md)
 - [Provider replacement and anti-silo contract](provider-replacement-and-anti-silo-contract.md)
 
 Canonical handbooks:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - "Strategy sprint: organization embedding": strategy-sprint-org-embedding-plan.md
       - Organization embedding contract: organization-embedding-contract.md
       - Identity provisioning strategy: identity-provisioning-strategy.md
+      - Admin-Suite readiness and setup contract: admin-suite-readiness-setup-contract.md
       - Provider replacement and anti-silo contract: provider-replacement-and-anti-silo-contract.md
       - Manuals and release notes integration: manuals-and-release-notes-integration.md
       - v0.1 dogfood plan: release-v0.1-dogfood-plan.md

--- a/specs/0001-organization-embedding-product-core/spec.md
+++ b/specs/0001-organization-embedding-product-core/spec.md
@@ -215,7 +215,7 @@ Initial acceptance work is tracked in #389. Implementation PRs must map product-
 Required scenario families:
 
 - Member joins configured organization through invite/SSO/passkey and sees stable capabilities.
-- Admin configures domains and reviews readiness in support-safe language.
+- Admin configures domains through the guided setup assistant and reviews per-domain readiness in support-safe language.
 - Admin plans provider switch with preflight/export-import/cutover/rollback evidence.
 - Backend/member capability manifest proves provider-agnostic capability states.
 - Weaver/AI runtime remains out of scope and cannot be accidentally implied as shipped.

--- a/specs/0001-organization-embedding-product-core/tasks.md
+++ b/specs/0001-organization-embedding-product-core/tasks.md
@@ -32,7 +32,7 @@ Task format: `- [ ] T001 [P?] [US?/Area] Description with exact path and gate`
 Implementation tasks are intentionally split into follow-up PRs from the issue DAG:
 
 - [x] T030 [#386] Add provider-neutral domain/capability contracts and smallest relevant server/client/admin gate.
-- [ ] T031 [#387] Add Admin-Suite readiness/setup UX contract and gate.
+- [x] T031 [#387] Add Admin-Suite readiness/setup UX contract and gate.
 - [ ] T032 [#388] Add provider switch/export-import/cutover/rollback contract and gate.
 - [ ] T033 [#389] Add product-language acceptance/evidence mapping and gate.
 

--- a/specs/0001-organization-embedding-product-core/traceability.yaml
+++ b/specs/0001-organization-embedding-product-core/traceability.yaml
@@ -56,4 +56,18 @@ evidence_gates:
   - ./gradlew specContract
   - ./gradlew specContractTest
   - ./gradlew acceptanceContract
+implementation_slices:
+  - issue: 386
+    task: T030
+    evidence:
+      - server member capability manifest state enum
+      - Flutter organization manifest DTO/domain parsing
+      - member capability vocabulary docs and acceptance wording
+  - issue: 387
+    task: T031
+    evidence:
+      - docs/admin-suite-readiness-setup-contract.md
+      - admin-console guided setup assistant
+      - admin-console per-domain readiness dashboard
+      - support-safe member/admin boundary tests
 open_product_core_decisions: []


### PR DESCRIPTION
## Summary
- Adds the WEAVE-SPEC-0001 Admin-Suite readiness/setup contract for issue #387.
- Adds owner/admin/operator guided setup assistant and per-domain readiness dashboard evidence in the Admin Console.
- Keeps member preview provider-neutral with `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, and `coming_later` member states while hiding provider/admin controls from member view.

Closes #387

## Spec / issue
- Spec: WEAVE-SPEC-0001 (`specs/0001-organization-embedding-product-core/spec.md`)
- Issue: #387
- Depends on merged #386 / PR #392

## Test plan
- `./gradlew specContract acceptanceContract adminCi --console=plain`
- `./gradlew docsCheck --console=plain`

## CI / Integration-Gate
- Release notes: exactly one release-notes label (`release-notes-feature`).
- Copilot review unavailable due exhausted premium requests; use fallback agent/human review plus green CI per operating model.
- No secrets/raw provider payloads; admin evidence is support-safe and member preview hides provider/admin internals.

## Risks / rollback
- Scope is admin-console contract/UI evidence plus docs/spec traceability; revert this PR to remove the #387 slice if needed.
