### PR TITLE
feat: add provider switch portability evidence

### DIFF
--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -32,16 +32,40 @@ function mockApi(
         canonicalObjects: ['IdentitySubject', 'GroupMembership'],
         contractRisks: ['External claims need mapping review'],
         adminNotes: ['Support-safe dry-run'],
-        conflicts: [],
+        conflicts: ['Group owner claim needs operator approval'],
         replacementRequirement: 'Review before apply',
       },
       lifecycleExpectations: {
-        sourceOfTruthPolicy: 'Weave effective policy remains source of truth',
+        sourceOfTruthPolicy:
+          'Backend declares source of truth per IDM subject and group object',
         exportExpectation: 'Export evidence is required before cutover.',
         deleteExpectation:
           'Delete/deprovision evidence is required after cutover.',
         deprovisionExpectation: 'Deactivate old adapter after verification.',
         rollbackSupportBoundary: 'Rollback bounded by provider export support.',
+      },
+      portableExportImportContract: {
+        exportManifestRef: 'idm-rbac-portable-export-manifest-v0.1',
+        importManifestRef: 'idm-rbac-portable-import-manifest-v0.1',
+        portabilityGuarantee:
+          'v0.1 guarantees portable export/import before automated migration.',
+        excludedAutomation: ['full automated migration'],
+        evidenceRefs: [
+          'provider-switch-preflight',
+          'portable-export-import-contract',
+          'rollback-recovery-plan',
+        ],
+      },
+      switchPlan: {
+        planRef: 'idm-rbac-switch-plan-v0.1',
+        preflightRequired: true,
+        cutoverWindowRequired: true,
+        rollbackRequired: true,
+        memberFacingStateDuringSwitch: 'degraded',
+        recoveryActions: [
+          'keep current adapter active until evidence passes',
+          'block apply until rollback evidence passes',
+        ],
       },
     }),
     testProviderReadiness: vi.fn().mockResolvedValue({
@@ -259,6 +283,7 @@ describe('Admin Console MVP', () => {
     );
   });
 
+  // V01_PROVIDER_SWITCH_PORTABILITY: admin provider switch requires preflight, portable export/import, cutover, rollback, recovery, and support-safe evidence.
   it('renders support-safe provider replacement dry-run evidence', async () => {
     const api = mockApi();
     const user = userEvent.setup();
@@ -286,6 +311,30 @@ describe('Admin Console MVP', () => {
       screen.getByText(
         /member impact states: available, degraded, disabled_by_policy/i,
       ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/source of truth: backend declares source of truth/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/what moves: identitysubject, groupmembership/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/what will not move: full automated migration/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/risks: external claims/i)).toBeInTheDocument();
+    expect(screen.getByText(/conflicts: group owner claim/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/portable export\/import: idm-rbac-portable-export/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/evidence refs: provider-switch-preflight/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/switch plan: idm-rbac-switch-plan-v0.1/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/cutover window required: yes/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/recovery actions: keep current adapter active/i),
     ).toBeInTheDocument();
   });
 

--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -28,6 +28,7 @@ function mockApi(
       supportSafe: true,
       providerDiagnosticsRedacted: true,
       cutoverGates: ['Run backend migration dry-run before apply'],
+      auditRefs: ['provider-replacement-dry-run-idm-rbac'],
       lossyMappingReport: {
         canonicalObjects: ['IdentitySubject', 'GroupMembership'],
         contractRisks: ['External claims need mapping review'],
@@ -328,6 +329,9 @@ describe('Admin Console MVP', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(/evidence refs: provider-switch-preflight/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/audit refs: provider-replacement-dry-run-idm-rbac/i),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/switch plan: idm-rbac-switch-plan-v0.1/i),

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -821,10 +821,34 @@ export default function App({
                         {dryRunReport.memberImpactStates.join(', ')}
                       </Typography>
                       <Typography>
-                        Canonical objects:{' '}
+                        Source of truth:{' '}
+                        {
+                          dryRunReport.lifecycleExpectations
+                            .sourceOfTruthPolicy
+                        }
+                      </Typography>
+                      <Typography>
+                        What moves:{' '}
                         {dryRunReport.lossyMappingReport.canonicalObjects.join(
                           ', ',
                         ) || 'reported by backend contract'}
+                      </Typography>
+                      <Typography>
+                        What will not move:{' '}
+                        {dryRunReport.portableExportImportContract.excludedAutomation.join(
+                          '; ',
+                        ) || 'none reported by backend dry-run'}
+                      </Typography>
+                      <Typography>
+                        Risks:{' '}
+                        {dryRunReport.lossyMappingReport.contractRisks.join(
+                          '; ',
+                        ) || 'none reported by backend dry-run'}
+                      </Typography>
+                      <Typography>
+                        Conflicts:{' '}
+                        {dryRunReport.lossyMappingReport.conflicts.join('; ') ||
+                          'none reported by backend dry-run'}
                       </Typography>
                       <Typography>
                         Cutover gates:{' '}
@@ -836,6 +860,58 @@ export default function App({
                       </Typography>
                       <Typography>
                         {dryRunReport.lifecycleExpectations.deleteExpectation}
+                      </Typography>
+                      <Typography>
+                        Rollback boundary:{' '}
+                        {
+                          dryRunReport.lifecycleExpectations
+                            .rollbackSupportBoundary
+                        }
+                      </Typography>
+                      <Typography>
+                        Portable export/import:{' '}
+                        {
+                          dryRunReport.portableExportImportContract
+                            .exportManifestRef
+                        }{' '}
+                        →{' '}
+                        {
+                          dryRunReport.portableExportImportContract
+                            .importManifestRef
+                        }
+                        ; guarantee:{' '}
+                        {
+                          dryRunReport.portableExportImportContract
+                            .portabilityGuarantee
+                        }
+                      </Typography>
+                      <Typography>
+                        Evidence refs:{' '}
+                        {dryRunReport.portableExportImportContract.evidenceRefs.join(
+                          ', ',
+                        )}
+                      </Typography>
+                      <Typography>
+                        Switch plan: {dryRunReport.switchPlan.planRef};
+                        preflight required:{' '}
+                        {dryRunReport.switchPlan.preflightRequired
+                          ? 'yes'
+                          : 'no'}
+                        ; cutover window required:{' '}
+                        {dryRunReport.switchPlan.cutoverWindowRequired
+                          ? 'yes'
+                          : 'no'}
+                        ; rollback required:{' '}
+                        {dryRunReport.switchPlan.rollbackRequired
+                          ? 'yes'
+                          : 'no'}
+                        ; member state during switch:{' '}
+                        {dryRunReport.switchPlan.memberFacingStateDuringSwitch}
+                        .
+                      </Typography>
+                      <Typography>
+                        Recovery actions:{' '}
+                        {dryRunReport.switchPlan.recoveryActions.join('; ')}
                       </Typography>
                     </Stack>
                   ) : (

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -892,6 +892,11 @@ export default function App({
                         )}
                       </Typography>
                       <Typography>
+                        Audit refs:{' '}
+                        {dryRunReport.auditRefs.join(', ') ||
+                          'backend audit ref required before apply'}
+                      </Typography>
+                      <Typography>
                         Switch plan: {dryRunReport.switchPlan.planRef};
                         preflight required:{' '}
                         {dryRunReport.switchPlan.preflightRequired

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -98,6 +98,21 @@ export interface ProviderReplacementDryRunReport {
     deprovisionExpectation: string;
     rollbackSupportBoundary: string;
   };
+  portableExportImportContract: {
+    exportManifestRef: string;
+    importManifestRef: string;
+    portabilityGuarantee: string;
+    excludedAutomation: string[];
+    evidenceRefs: string[];
+  };
+  switchPlan: {
+    planRef: string;
+    preflightRequired: boolean;
+    cutoverWindowRequired: boolean;
+    rollbackRequired: boolean;
+    memberFacingStateDuringSwitch: MemberCapabilityState;
+    recoveryActions: string[];
+  };
 }
 
 interface ServerProviderReplacementDryRunReport {
@@ -118,6 +133,10 @@ interface ServerProviderReplacementDryRunReport {
   lifecycleExpectations?: Partial<
     ProviderReplacementDryRunReport['lifecycleExpectations']
   >;
+  portableExportImportContract?: Partial<
+    ProviderReplacementDryRunReport['portableExportImportContract']
+  >;
+  switchPlan?: Partial<ProviderReplacementDryRunReport['switchPlan']>;
 }
 
 export interface ControlPlaneResponse {
@@ -316,6 +335,13 @@ export class AdminControlPlaneApi {
           lossyMappingNotes: [
             'Admin Console requested support-safe preflight; backend redaction owns provider diagnostics.',
           ],
+          portableExportImportRequired: true,
+          requestedSwitchPlan: {
+            plan: 'guided-plan-preflight-export-import-cutover-rollback',
+            memberFacingStateDuringSwitch: 'degraded',
+            automationBoundary:
+              'v0.1 requires portable export/import evidence; full automated migration remains future work.',
+          },
           reason:
             'Evaluate provider replacement before activation through Organization/Admin Console',
         }),
@@ -548,6 +574,8 @@ function normalizeProviderReplacementDryRun(
 ): ProviderReplacementDryRunReport {
   const lossyMapping = response.lossyMappingReport ?? {};
   const lifecycle = response.lifecycleExpectations ?? {};
+  const portability = response.portableExportImportContract ?? {};
+  const switchPlan = response.switchPlan ?? {};
   return {
     dryRunId: response.dryRunId ?? `${category.key}-replacement-dry-run`,
     status: response.status ?? 'dry_run_ready',
@@ -574,7 +602,7 @@ function normalizeProviderReplacementDryRun(
     lifecycleExpectations: {
       sourceOfTruthPolicy:
         lifecycle.sourceOfTruthPolicy ??
-        'Weave remains source of truth for canonical member state.',
+        'Source of truth is declared per provider-backed category/object by the backend dry-run; Weave preserves provider-neutral member capability state only.',
       exportExpectation:
         lifecycle.exportExpectation ??
         'Export expectations are evaluated by backend migration contracts.',
@@ -587,6 +615,39 @@ function normalizeProviderReplacementDryRun(
       rollbackSupportBoundary:
         lifecycle.rollbackSupportBoundary ??
         'Rollback is bounded by provider export/delete support.',
+    },
+    portableExportImportContract: {
+      exportManifestRef:
+        portability.exportManifestRef ??
+        `${category.key}-portable-export-manifest-v0.1`,
+      importManifestRef:
+        portability.importManifestRef ??
+        `${category.key}-portable-import-manifest-v0.1`,
+      portabilityGuarantee:
+        portability.portabilityGuarantee ??
+        'v0.1 guarantees a documented portable export/import contract before claiming automated migration.',
+      excludedAutomation: portability.excludedAutomation ?? [
+        'no full cross-provider automated migration promise in v0.1',
+      ],
+      evidenceRefs: portability.evidenceRefs ?? [
+        'provider-switch-preflight',
+        'portable-export-import-contract',
+        'rollback-recovery-plan',
+      ],
+    },
+    switchPlan: {
+      planRef: switchPlan.planRef ?? `${category.key}-switch-plan-v0.1`,
+      preflightRequired: switchPlan.preflightRequired ?? true,
+      cutoverWindowRequired: switchPlan.cutoverWindowRequired ?? true,
+      rollbackRequired: switchPlan.rollbackRequired ?? true,
+      memberFacingStateDuringSwitch:
+        normalizeMemberCapabilityState(
+          switchPlan.memberFacingStateDuringSwitch,
+        ) ?? 'degraded',
+      recoveryActions: switchPlan.recoveryActions ?? [
+        'keep current adapter active until export/import evidence is accepted',
+        'block apply when rollback evidence or support-safe audit refs are missing',
+      ],
     },
   };
 }

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -84,6 +84,7 @@ export interface ProviderReplacementDryRunReport {
   supportSafe: boolean;
   providerDiagnosticsRedacted: boolean;
   cutoverGates: string[];
+  auditRefs: string[];
   lossyMappingReport: {
     canonicalObjects: string[];
     contractRisks: string[];
@@ -127,6 +128,7 @@ interface ServerProviderReplacementDryRunReport {
   supportSafe?: boolean;
   providerDiagnosticsRedacted?: boolean;
   cutoverGates?: string[];
+  auditRefs?: string[];
   lossyMappingReport?: Partial<
     ProviderReplacementDryRunReport['lossyMappingReport']
   >;
@@ -590,6 +592,7 @@ function normalizeProviderReplacementDryRun(
     supportSafe: response.supportSafe ?? true,
     providerDiagnosticsRedacted: response.providerDiagnosticsRedacted ?? true,
     cutoverGates: response.cutoverGates ?? [],
+    auditRefs: response.auditRefs ?? [`provider-replacement-dry-run-${category.key}`],
     lossyMappingReport: {
       canonicalObjects: lossyMapping.canonicalObjects ?? [],
       contractRisks: lossyMapping.contractRisks ?? [],

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -49,6 +49,7 @@ void main() {
         'Server control plane owns provider policy and audit',
         'Infra bootstrap feeds the backend control plane safely',
         'Organization admins manage provider policy in a separate console',
+        'Admin plans a provider switch with portable export/import evidence',
         'Operators can deploy, verify, back up, restore, and diagnose safely',
       ]),
     );

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -155,6 +155,14 @@ Feature: Weave v0.1 dogfood production release
     And no raw provider calls, provider secrets, or admin diagnostics are exposed to member clients
     And the console remains keyboard reachable with semantic headings, forms, and status text
 
+  @weave-v01-provider-switch-portability
+  Scenario: Admin plans a provider switch with portable export/import evidence
+    Given an admin has an active provider adapter and a candidate replacement for a domain
+    When the admin runs the provider switch dry-run before applying the replacement
+    Then the Admin Console shows backend-declared source-of-truth policy, what will move, what will not move, risks, conflicts, and required permissions
+    And preflight, export/import manifests, cutover gates, rollback boundary, recovery actions, and support-safe audit evidence are required before irreversible action
+    And member-facing surfaces keep provider-neutral available, disabled_by_policy, not_configured, degraded, unavailable, or coming_later states during the switch
+
   @weave-v01-operator-release-path
   Scenario: Operators can deploy, verify, back up, restore, and diagnose safely
     Given an operator installs or updates a Weave stack

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -789,6 +789,43 @@
           ]
         }
       ]
+    },
+    {
+      "tag": "@weave-v01-provider-switch-portability",
+      "scenario": "Admin plans a provider switch with portable export/import evidence",
+      "feature": "e2e/features/v0_1_dogfood_release.feature",
+      "executableTest": "admin-console/src/App.test.tsx",
+      "evidenceMarkers": [
+        "V01_PROVIDER_SWITCH_PORTABILITY"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "specs/0001-organization-embedding-product-core/spec.md",
+          "fragments": [
+            "Provider switch contract: plan, preflight, portable export/import, cutover, rollback/recovery, and support-safe audit evidence.",
+            "v0.1 guaranteeing portable export/import contracts before full automation"
+          ]
+        },
+        {
+          "path": "admin-console/src/App.tsx",
+          "fragments": [
+            "Source of truth:",
+            "What moves:",
+            "What will not move:",
+            "Rollback boundary:",
+            "Recovery actions:"
+          ]
+        },
+        {
+          "path": "admin-console/src/api.ts",
+          "fragments": [
+            "Source of truth is declared per provider-backed category/object by the backend dry-run",
+            "provider-switch-preflight",
+            "portable-export-import-contract",
+            "rollback-recovery-plan"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -813,13 +813,33 @@
             "What moves:",
             "What will not move:",
             "Rollback boundary:",
-            "Recovery actions:"
+            "Recovery actions:",
+            "Audit refs:"
           ]
         },
         {
           "path": "admin-console/src/api.ts",
           "fragments": [
             "Source of truth is declared per provider-backed category/object by the backend dry-run",
+            "auditRefs",
+            "provider-switch-preflight",
+            "portable-export-import-contract",
+            "rollback-recovery-plan"
+          ]
+        },
+        {
+          "path": "server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunResponse.java",
+          "fragments": [
+            "PortableExportImportContract",
+            "SwitchPlan",
+            "supportSafe",
+            "providerDiagnosticsRedacted"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java",
+          "fragments": [
+            "providerReplacementDryRunReturnsBackendOwnedPortableSwitchContract",
             "provider-switch-preflight",
             "portable-export-import-contract",
             "rollback-recovery-plan"

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunRequest.java
@@ -3,6 +3,7 @@ package com.massimotter.weave.backend.model.admin;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
+import java.util.Map;
 
 @Schema(description = "Support-safe provider replacement preflight. This validates an adapter swap without applying provider state.")
 public record ProviderReplacementDryRunRequest(
@@ -13,8 +14,11 @@ public record ProviderReplacementDryRunRequest(
         @NotBlank String secretRef,
         @NotBlank String sourceOfTruth,
         List<String> lossyMappingNotes,
+        boolean portableExportImportRequired,
+        Map<String, String> requestedSwitchPlan,
         String reason) {
     public ProviderReplacementDryRunRequest {
         lossyMappingNotes = lossyMappingNotes == null ? List.of() : List.copyOf(lossyMappingNotes);
+        requestedSwitchPlan = requestedSwitchPlan == null ? Map.of() : Map.copyOf(requestedSwitchPlan);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/ProviderReplacementDryRunResponse.java
@@ -18,6 +18,8 @@ public record ProviderReplacementDryRunResponse(
         boolean migrationDryRunRequired,
         LossyMappingReport lossyMappingReport,
         LifecycleExpectations lifecycleExpectations,
+        PortableExportImportContract portableExportImportContract,
+        SwitchPlan switchPlan,
         List<String> cutoverGates,
         List<String> memberImpactStates,
         boolean supportSafe,
@@ -49,5 +51,29 @@ public record ProviderReplacementDryRunResponse(
             String deleteExpectation,
             String deprovisionExpectation,
             String rollbackSupportBoundary) {
+    }
+
+    public record PortableExportImportContract(
+            String exportManifestRef,
+            String importManifestRef,
+            String portabilityGuarantee,
+            List<String> excludedAutomation,
+            List<String> evidenceRefs) {
+        public PortableExportImportContract {
+            excludedAutomation = excludedAutomation == null ? List.of() : List.copyOf(excludedAutomation);
+            evidenceRefs = evidenceRefs == null ? List.of() : List.copyOf(evidenceRefs);
+        }
+    }
+
+    public record SwitchPlan(
+            String planRef,
+            boolean preflightRequired,
+            boolean cutoverWindowRequired,
+            boolean rollbackRequired,
+            String memberFacingStateDuringSwitch,
+            List<String> recoveryActions) {
+        public SwitchPlan {
+            recoveryActions = recoveryActions == null ? List.of() : List.copyOf(recoveryActions);
+        }
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -269,6 +269,7 @@ public class AdminControlPlaneService {
                         Map.entry("secretRefPresent", true),
                         Map.entry("secretRef", safeSecretRef(request.secretRef())),
                         Map.entry("migrationDryRunRequired", migrationRequired),
+                        Map.entry("portableExportImportRequired", request.portableExportImportRequired()),
                         Map.entry("lossyMappingNoteCount", adminNotes.size()),
                         Map.entry("rawProviderError", "redacted before audit"),
                         Map.entry("token", "not-stored"))));
@@ -296,6 +297,21 @@ public class AdminControlPlaneService {
                         ProviderCapabilityContracts.exportDeleteExpectation(category),
                         "deprovision source identities, groups, memberships, grants, and service principals through the authoritative provider before capability cutover",
                         "rollback is an admin decision boundary; dry-run does not mutate provider state and apply must preserve mapping history"),
+                new ProviderReplacementDryRunResponse.PortableExportImportContract(
+                        category + "-portable-export-manifest-v0.1",
+                        category + "-portable-import-manifest-v0.1",
+                        "v0.1 guarantees a documented portable export/import contract before claiming automated migration.",
+                        List.of("full automated cross-provider migration is not claimed in v0.1"),
+                        List.of("provider-switch-preflight", "portable-export-import-contract", "rollback-recovery-plan", auditRef)),
+                new ProviderReplacementDryRunResponse.SwitchPlan(
+                        category + "-switch-plan-v0.1",
+                        true,
+                        true,
+                        true,
+                        "degraded",
+                        List.of(
+                                "keep current adapter active until export/import evidence is accepted",
+                                "block apply when rollback evidence or support-safe audit refs are missing")),
                 List.of(
                         "SecretRef exists and remains backend-only; raw credentials are never returned.",
                         "Admin confirms source-of-truth, export/delete, lossy mapping, and rollback/support notes.",

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -244,6 +244,55 @@ class AdminControlPlaneControllerTest {
     }
 
     @Test
+    void providerReplacementDryRunReturnsBackendOwnedPortableSwitchContract() throws Exception {
+        String request = """
+                {
+                  "category": "identity-idm",
+                  "currentAdapter": "keycloak-realm",
+                  "targetAdapter": "authentik",
+                  "choiceModel": "external_existing_provider",
+                  "secretRef": "secretref://weave/provider/authentik",
+                  "sourceOfTruth": "Admin Console-selected provider category remains Weave source of truth until apply.",
+                  "lossyMappingNotes": ["support-safe preflight only"],
+                  "portableExportImportRequired": true,
+                  "requestedSwitchPlan": {
+                    "plan": "guided-plan-preflight-export-import-cutover-rollback",
+                    "memberFacingStateDuringSwitch": "degraded"
+                  },
+                  "reason": "dry-run with Bearer token-that-must-not-leak and client_secret"
+                }
+                """;
+
+        mockMvc.perform(post("/api/admin/providers/replacements/dry-run")
+                        .with(adminJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(request))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.category").value("identity-idm"))
+                .andExpect(jsonPath("$.currentAdapter").value("keycloak-realm"))
+                .andExpect(jsonPath("$.targetAdapter").value("authentik"))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.providerDiagnosticsRedacted").value(true))
+                .andExpect(jsonPath("$.lossyMappingReport.canonicalObjects[*]", hasItems("UserAccount", "Group", "CapabilityPolicy")))
+                .andExpect(jsonPath("$.lifecycleExpectations.sourceOfTruthPolicy", containsString("authoritative IdP")))
+                .andExpect(jsonPath("$.portableExportImportContract.exportManifestRef").value("identity-idm-portable-export-manifest-v0.1"))
+                .andExpect(jsonPath("$.portableExportImportContract.importManifestRef").value("identity-idm-portable-import-manifest-v0.1"))
+                .andExpect(jsonPath("$.portableExportImportContract.portabilityGuarantee", containsString("documented portable export/import contract")))
+                .andExpect(jsonPath("$.portableExportImportContract.excludedAutomation[*]", hasItems(containsString("full automated cross-provider migration"))))
+                .andExpect(jsonPath("$.portableExportImportContract.evidenceRefs[*]", hasItems("provider-switch-preflight", "portable-export-import-contract", "rollback-recovery-plan")))
+                .andExpect(jsonPath("$.switchPlan.planRef").value("identity-idm-switch-plan-v0.1"))
+                .andExpect(jsonPath("$.switchPlan.preflightRequired").value(true))
+                .andExpect(jsonPath("$.switchPlan.cutoverWindowRequired").value(true))
+                .andExpect(jsonPath("$.switchPlan.rollbackRequired").value(true))
+                .andExpect(jsonPath("$.switchPlan.memberFacingStateDuringSwitch").value("degraded"))
+                .andExpect(jsonPath("$.switchPlan.recoveryActions[*]", hasItems(containsString("keep current adapter active"), containsString("block apply"))))
+                .andExpect(jsonPath("$.memberImpactStates[*]", hasItems("usable", "disabled", "degraded", "policy-blocked")))
+                .andExpect(content().string(not(containsString("token-that-must-not-leak"))))
+                .andExpect(content().string(not(containsString("client_secret"))))
+                .andExpect(content().string(not(containsString("secretref://"))));
+    }
+
+    @Test
     void identityProviderReadinessIsBackendOwnedAndMembersCannotReadIt() throws Exception {
         mockMvc.perform(get("/api/admin/identity/readiness").with(adminJwt()))
                 .andExpect(status().isOk())


### PR DESCRIPTION
Closes #388

## Summary
- adds provider replacement dry-run portability data to the Admin Console API contract
- surfaces source-of-truth, what moves/does not move, risks, conflicts, cutover, rollback, recovery, and evidence refs in the Admin Console
- maps V01_PROVIDER_SWITCH_PORTABILITY to Gherkin and acceptance evidence

## Gates
- npm run ci (admin-console)
- ./gradlew specContract acceptanceContract

## Veto evidence
- Product/spec clarity: issue #388 acceptance mapped in e2e/scenario_mappings.json
- Architecture/contract: backend-admin-only replacement dry-run contract in admin-console/src/api.ts
- QA/evidence: V01_PROVIDER_SWITCH_PORTABILITY in e2e/features/v0_1_dogfood_release.feature and admin-console/src/App.test.tsx
- DevOps/reproducibility: local gates above

No release tag, publish, or production mutation.