### PR TITLE
WEAVE-SPEC-0001: map acceptance evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,26 @@ jobs:
           (cd client && flutter pub get)
       - name: Run root Gradle CI
         env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
+          PR_ACTION: ${{ github.event_name == 'pull_request' && github.event.action || '' }}
           PR_LABELS_JSON: ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.labels.*.name) || '' }}
-        run: ./gradlew ci
+        run: |
+          labels_json="$PR_LABELS_JSON"
+          if [ -n "$PR_NUMBER" ]; then
+            labels_json="$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name]')"
+            if [ "$PR_ACTION" = "opened" ] && [ "$labels_json" = "[]" ]; then
+              # `gh pr create --label ...` can emit the opened event before the label
+              # is visible to the workflow. Give GitHub a short propagation window,
+              # then validate the live PR labels instead of the stale event payload.
+              for _ in 1 2 3; do
+                sleep 10
+                labels_json="$(gh pr view "$PR_NUMBER" --json labels --jq '[.labels[].name]')"
+                [ "$labels_json" != "[]" ] && break
+              done
+            fi
+          fi
+          PR_LABELS_JSON="$labels_json" ./gradlew ci
       - name: Upload sanitized CI evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -51,6 +51,11 @@ void main() {
         'Organization admins manage provider policy in a separate console',
         'Admin plans a provider switch with portable export/import evidence',
         'Operators can deploy, verify, back up, restore, and diagnose safely',
+        'Member joins a configured organization through invite SSO or passkey',
+        'Member sees stable capabilities only after joining',
+        'Admin configures domains through setup and reviews readiness evidence',
+        'Provider switch evidence distinguishes spec acceptance from live migration',
+        'Weaver AI runtime stays excluded from Spec 0001 acceptance',
       ]),
     );
   });

--- a/client/test/release_1/spec_0001_acceptance_mapping_test.dart
+++ b/client/test/release_1/spec_0001_acceptance_mapping_test.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('WEAVE-SPEC-0001 acceptance evidence mapping', () {
+    final spec = File(
+      '../specs/0001-organization-embedding-product-core/spec.md',
+    );
+    final traceability = File(
+      '../specs/0001-organization-embedding-product-core/traceability.yaml',
+    );
+    final feature = File('../e2e/features/weave_spec_0001_acceptance.feature');
+    final mapping = File('../e2e/scenario_mappings.json');
+    final adminSetup = File('../docs/admin-suite-readiness-setup-contract.md');
+    final providerSwitch = File(
+      '../docs/provider-replacement-and-anti-silo-contract.md',
+    );
+
+    test('maps member join and stable capability promises', () {
+      // SPEC_0001_MEMBER_JOIN_INVITE_SSO_PASSKEY
+      // SPEC_0001_STABLE_MEMBER_CAPABILITIES
+      expect(spec.existsSync(), isTrue);
+      expect(feature.existsSync(), isTrue);
+
+      final specText = spec.readAsStringSync();
+      final featureText = feature.readAsStringSync();
+
+      for (final required in <String>[
+        'Members join an already configured organization through invite/SSO/passkey',
+        'member-safe capability manifests',
+        'FR-004',
+        'FR-005',
+        'available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, and `coming_later`',
+        'Normal members must not be confronted with admin/provider burden',
+      ]) {
+        expect(specText, contains(required));
+      }
+
+      for (final required in <String>[
+        '@weave-spec-0001-member-join-invite-sso-passkey',
+        '@weave-spec-0001-stable-member-capabilities',
+        'the member never configures OIDC, provider endpoints, secrets, readiness, or repair flows',
+        'raw provider diagnostics, endpoint details, provider setup, and admin controls remain absent',
+      ]) {
+        expect(featureText, contains(required));
+      }
+
+      for (final marker in <String>[
+        'SPEC_0001_MEMBER_JOIN_INVITE_SSO_PASSKEY',
+        'SPEC_0001_STABLE_MEMBER_CAPABILITIES',
+      ]) {
+        // ignore: avoid_print
+        print(marker);
+      }
+    });
+
+    test('maps admin setup readiness and provider switch evidence', () {
+      // SPEC_0001_ADMIN_READINESS_SETUP
+      // SPEC_0001_PROVIDER_SWITCH_PORTABILITY_EVIDENCE
+      expect(adminSetup.existsSync(), isTrue);
+      expect(providerSwitch.existsSync(), isTrue);
+
+      final specText = spec.readAsStringSync();
+      final adminSetupText = adminSetup.readAsStringSync();
+      final providerSwitchText = providerSwitch.readAsStringSync();
+      final featureText = feature.readAsStringSync();
+
+      for (final required in <String>[
+        'Guided admin setup assistant and readiness dashboard',
+        'Provider switch contract: plan, preflight, portable export/import, cutover, rollback/recovery',
+        'Full automated cross-provider migration for every domain in v0.1',
+        'Live production provider migration or release/tag/publish action without explicit release evidence and signoff',
+        'Accessibility, supportability, auditability, and deployability as release blockers',
+      ]) {
+        expect(specText, contains(required));
+      }
+
+      for (final required in <String>[
+        'Guided setup assistant',
+        'Readiness dashboard',
+        'support-safe',
+      ]) {
+        expect(adminSetupText, contains(required));
+      }
+
+      for (final required in <String>[
+        'Provider replacement workflow',
+        'preflight',
+        'rollback',
+        'audit events',
+      ]) {
+        expect(providerSwitchText, contains(required));
+      }
+
+      for (final required in <String>[
+        '@weave-spec-0001-admin-readiness-setup',
+        '@weave-spec-0001-provider-switch-evidence',
+        'does not claim full automated live production migration',
+      ]) {
+        expect(featureText, contains(required));
+      }
+
+      for (final marker in <String>[
+        'SPEC_0001_ADMIN_READINESS_SETUP',
+        'SPEC_0001_PROVIDER_SWITCH_PORTABILITY_EVIDENCE',
+      ]) {
+        // ignore: avoid_print
+        print(marker);
+      }
+    });
+
+    test('keeps Weaver AI runtime excluded from Spec 0001 acceptance', () {
+      // SPEC_0001_WEAVER_AI_RUNTIME_EXCLUDED
+      expect(traceability.existsSync(), isTrue);
+
+      final specText = spec.readAsStringSync();
+      final traceabilityText = traceability.readAsStringSync();
+      final featureText = feature.readAsStringSync();
+
+      for (final required in <String>[
+        'Weaver/AI runtime is explicitly out of scope for this spec',
+        'FR-008',
+        'Weaver/AI runtime remains out of scope and cannot be accidentally implied as shipped.',
+        'Weaver scope: out of scope for WEAVE-SPEC-0001',
+      ]) {
+        expect(specText, contains(required));
+      }
+
+      expect(traceabilityText, contains('Weaver/AI runtime'));
+      expect(
+        featureText,
+        contains('@weave-spec-0001-weaver-ai-runtime-excluded'),
+      );
+      expect(
+        featureText,
+        contains(
+          'runtime profiles, agent tools, and uncontrolled plugin installation cannot be implied as shipped',
+        ),
+      );
+
+      // ignore: avoid_print
+      print('SPEC_0001_WEAVER_AI_RUNTIME_EXCLUDED');
+    });
+
+    test(
+      'scenario mappings keep Spec 0001 evidence explicit and executable',
+      () {
+        final decoded =
+            jsonDecode(mapping.readAsStringSync()) as Map<String, Object?>;
+        final scenarios = (decoded['scenarios'] as List<Object?>)
+            .cast<Map<String, Object?>>();
+        final tags = scenarios
+            .map((scenario) => scenario['tag'] as String)
+            .toSet();
+
+        for (final tag in <String>[
+          '@weave-spec-0001-member-join-invite-sso-passkey',
+          '@weave-spec-0001-stable-member-capabilities',
+          '@weave-spec-0001-admin-readiness-setup',
+          '@weave-spec-0001-provider-switch-evidence',
+          '@weave-spec-0001-weaver-ai-runtime-excluded',
+        ]) {
+          expect(tags, contains(tag));
+        }
+      },
+    );
+  });
+}

--- a/e2e/features/weave_spec_0001_acceptance.feature
+++ b/e2e/features/weave_spec_0001_acceptance.feature
@@ -1,0 +1,39 @@
+Feature: WEAVE-SPEC-0001 acceptance and evidence mapping
+
+  WEAVE-SPEC-0001 acceptance must prove the admin/provider-neutral product core
+  without implying live production migration or Weaver/AI runtime delivery.
+
+  @weave-spec-0001-member-join-invite-sso-passkey
+  Scenario: Member joins a configured organization through invite SSO or passkey
+    Given an admin has configured organization providers and policy before inviting members
+    When a normal member follows an invite, organization URL, or passkey-capable SSO entry
+    Then the member lands in assigned Weave workspaces with capabilities already resolved
+    And the member never configures OIDC, provider endpoints, secrets, readiness, or repair flows
+
+  @weave-spec-0001-stable-member-capabilities
+  Scenario: Member sees stable capabilities only after joining
+    Given backend readiness and policy have been evaluated for the organization
+    When a normal member opens Weave feature surfaces
+    Then every member capability uses available, disabled_by_policy, not_configured, degraded, unavailable, or coming_later
+    And raw provider diagnostics, endpoint details, provider setup, and admin controls remain absent from member surfaces
+
+  @weave-spec-0001-admin-readiness-setup
+  Scenario: Admin configures domains through setup and reviews readiness evidence
+    Given an owner admin or operator opens the Admin Suite before member use
+    When they bind domains, validate adapters, and review the readiness dashboard
+    Then readiness is shown per provider-neutral domain with support-safe next actions and evidence
+    And accessibility, supportability, auditability, and deployability remain release blockers
+
+  @weave-spec-0001-provider-switch-evidence
+  Scenario: Provider switch evidence distinguishes spec acceptance from live migration
+    Given an admin plans a provider switch for a configured domain
+    When preflight and portable export import evidence are requested
+    Then Weave records plan, cutover gates, rollback recovery, support-safe audit evidence, and export import contracts
+    And the evidence does not claim full automated live production migration without separate release signoff
+
+  @weave-spec-0001-weaver-ai-runtime-excluded
+  Scenario: Weaver AI runtime stays excluded from Spec 0001 acceptance
+    Given WEAVE-SPEC-0001 defines the Admin Suite and provider-neutral product core
+    When acceptance evidence is collected for this spec
+    Then Weaver and AI runtime behavior is treated as out of scope
+    And runtime profiles, agent tools, and uncontrolled plugin installation cannot be implied as shipped by this spec

--- a/e2e/features/weave_spec_0001_acceptance.feature
+++ b/e2e/features/weave_spec_0001_acceptance.feature
@@ -27,8 +27,8 @@ Feature: WEAVE-SPEC-0001 acceptance and evidence mapping
   @weave-spec-0001-provider-switch-evidence
   Scenario: Provider switch evidence distinguishes spec acceptance from live migration
     Given an admin plans a provider switch for a configured domain
-    When preflight and portable export import evidence are requested
-    Then Weave records plan, cutover gates, rollback recovery, support-safe audit evidence, and export import contracts
+    When preflight and portable export/import evidence are requested
+    Then Weave records plan, cutover gates, rollback/recovery, support-safe audit evidence, and export/import contracts
     And the evidence does not claim full automated live production migration without separate release signoff
 
   @weave-spec-0001-weaver-ai-runtime-excluded

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -846,6 +846,136 @@
           ]
         }
       ]
+    },
+    {
+      "tag": "@weave-spec-0001-member-join-invite-sso-passkey",
+      "scenario": "Member joins a configured organization through invite SSO or passkey",
+      "feature": "e2e/features/weave_spec_0001_acceptance.feature",
+      "executableTest": "client/test/release_1/spec_0001_acceptance_mapping_test.dart",
+      "evidenceMarkers": [
+        "SPEC_0001_MEMBER_JOIN_INVITE_SSO_PASSKEY"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "specs/0001-organization-embedding-product-core/spec.md",
+          "fragments": [
+            "Members join an already configured organization through invite/SSO/passkey",
+            "FR-005",
+            "Normal members must not be confronted with admin/provider burden"
+          ]
+        },
+        {
+          "path": "specs/0001-organization-embedding-product-core/traceability.yaml",
+          "fragments": [
+            "join_flow: invite/SSO/passkey and done after admin setup"
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "@weave-spec-0001-stable-member-capabilities",
+      "scenario": "Member sees stable capabilities only after joining",
+      "feature": "e2e/features/weave_spec_0001_acceptance.feature",
+      "executableTest": "client/test/release_1/spec_0001_acceptance_mapping_test.dart",
+      "evidenceMarkers": [
+        "SPEC_0001_STABLE_MEMBER_CAPABILITIES"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "specs/0001-organization-embedding-product-core/spec.md",
+          "fragments": [
+            "member-safe capability manifests",
+            "FR-004",
+            "No raw provider secrets, endpoints, diagnostic payloads, or provider-specific repair instructions leak to normal members"
+          ]
+        },
+        {
+          "path": "docs/admin-provisioned-first-use.md",
+          "fragments": [
+            "Member-visible manifest states are limited to `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, or `coming_later`.",
+            "Normal members never configure raw providers"
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "@weave-spec-0001-admin-readiness-setup",
+      "scenario": "Admin configures domains through setup and reviews readiness evidence",
+      "feature": "e2e/features/weave_spec_0001_acceptance.feature",
+      "executableTest": "client/test/release_1/spec_0001_acceptance_mapping_test.dart",
+      "evidenceMarkers": [
+        "SPEC_0001_ADMIN_READINESS_SETUP"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "specs/0001-organization-embedding-product-core/spec.md",
+          "fragments": [
+            "Guided admin setup assistant and readiness dashboard",
+            "Accessibility, supportability, auditability, and deployability as release blockers"
+          ]
+        },
+        {
+          "path": "docs/admin-suite-readiness-setup-contract.md",
+          "fragments": [
+            "Guided setup assistant",
+            "Readiness dashboard",
+            "support-safe audit evidence"
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "@weave-spec-0001-provider-switch-evidence",
+      "scenario": "Provider switch evidence distinguishes spec acceptance from live migration",
+      "feature": "e2e/features/weave_spec_0001_acceptance.feature",
+      "executableTest": "client/test/release_1/spec_0001_acceptance_mapping_test.dart",
+      "evidenceMarkers": [
+        "SPEC_0001_PROVIDER_SWITCH_PORTABILITY_EVIDENCE"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "specs/0001-organization-embedding-product-core/spec.md",
+          "fragments": [
+            "Provider switch contract: plan, preflight, portable export/import, cutover, rollback/recovery",
+            "Full automated cross-provider migration for every domain in v0.1",
+            "Live production provider migration or release/tag/publish action without explicit release evidence and signoff"
+          ]
+        },
+        {
+          "path": "docs/provider-replacement-and-anti-silo-contract.md",
+          "fragments": [
+            "No data is mutated during preflight.",
+            "export/delete/deprovision expectations",
+            "rollback/restore notes"
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "@weave-spec-0001-weaver-ai-runtime-excluded",
+      "scenario": "Weaver AI runtime stays excluded from Spec 0001 acceptance",
+      "feature": "e2e/features/weave_spec_0001_acceptance.feature",
+      "executableTest": "client/test/release_1/spec_0001_acceptance_mapping_test.dart",
+      "evidenceMarkers": [
+        "SPEC_0001_WEAVER_AI_RUNTIME_EXCLUDED"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "specs/0001-organization-embedding-product-core/spec.md",
+          "fragments": [
+            "Weaver/AI runtime is explicitly out of scope for this spec",
+            "FR-008",
+            "Weaver/AI runtime remains out of scope and cannot be accidentally implied as shipped."
+          ]
+        },
+        {
+          "path": "specs/0001-organization-embedding-product-core/traceability.yaml",
+          "fragments": [
+            "explicit_non_goals:",
+            "Weaver/AI runtime"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/specs/0001-organization-embedding-product-core/spec.md
+++ b/specs/0001-organization-embedding-product-core/spec.md
@@ -9,7 +9,8 @@ github_issue: 381
 supersedes: []
 depends_on:
   - WEAVE-SPEC-0000
-acceptance_features: []
+acceptance_features:
+  - e2e/features/weave_spec_0001_acceptance.feature
 evidence_gates:
   - ./gradlew specContract
   - ./gradlew specContractTest

--- a/specs/0001-organization-embedding-product-core/traceability.yaml
+++ b/specs/0001-organization-embedding-product-core/traceability.yaml
@@ -51,7 +51,8 @@ accepted_product_decisions:
     - provider vendor lock-in
     - user-facing admin/provider burden
     - uncontrolled runtime plugin model
-acceptance_features: []
+acceptance_features:
+  - e2e/features/weave_spec_0001_acceptance.feature
 evidence_gates:
   - ./gradlew specContract
   - ./gradlew specContractTest


### PR DESCRIPTION
Closes #389

## Summary
- adds explicit WEAVE-SPEC-0001 acceptance feature scenarios for member join, stable capability states, admin readiness/setup, provider-switch evidence, and Weaver/AI runtime exclusion
- maps each scenario to executable evidence markers in `client/test/release_1/spec_0001_acceptance_mapping_test.dart`
- records the acceptance feature in spec metadata and traceability

## Gates
- `./gradlew specContract acceptanceContract`
- `./gradlew specContractTest`
- `cd client && flutter test test/release_1/spec_0001_acceptance_mapping_test.dart test/live_stack_feature_mapping_test.dart`

## Release
- release-notes-bugfix: includes acceptance/spec evidence mapping plus a CI label-propagation fix for reliable release-note gate execution; no release tag, no publish, no production mutation.

