### PR TITLE
tech-debt(android): harden release identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,11 @@ app.*.map.json
 **/android/app/profile
 **/android/app/release
 
+# Android release signing material must stay local/secret.
+**/android/key.properties
+**/android/*.jks
+**/android/*.keystore
+
 # AI Agent Skills
 .dart_skills/
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build
 registerRootCommandTask('releaseNotesLabelCheck', ['bash', '-lc', 'if [ -n "${PR_LABELS_JSON:-}" ]; then python3 tools/release_notes_label_check.py; else echo "release-notes-label-check: skipped (PR_LABELS_JSON is not set)"; fi'], 'Validate the current PR release-notes label set from PR_LABELS_JSON when available.')
 registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.py'], 'Validate repo-local Weave specs, lifecycle metadata, and implementation-ready clarification state.')
 registerRootCommandTask('specContractTest', ['python3', 'tools/spec_contract_check_test.py'], 'Run fixture tests for the repo-local Weave spec contract guard.')
+registerRootCommandTask('androidReleaseIdentityCheck', ['python3', 'tools/android_release_identity_check.py'], 'Validate Android package identity and release-signing fail-safe posture.')
 registerRootCommandTask('generateReleaseNotes', ['python3', 'tools/release_notes_generate.py', '--input', 'tools/fixtures/release_notes_prs.json'], 'Generate reviewable release notes under build/release-notes by default.')
 registerRootCommandTask('updateReadmeReleaseNotes', ['python3', 'tools/readme_release_notes.py', '--update'], 'Explicitly update the managed README release-notes evidence block.')
 registerRootCommandTask('projectReadinessEvidenceCheck', ['python3', 'tools/project_readiness_evidence_check.py'], 'Validate Sprint 5 project-readiness evidence remains mapped and support-safe.')
@@ -99,6 +100,7 @@ ext.ciEvidenceGates = [
     'releaseNotesLabelCheck',
     'specContract',
     'specContractTest',
+    'androidReleaseIdentityCheck',
     'releaseEvidenceCheck',
     'projectReadinessEvidenceCheck',
     'enterpriseReleaseGateCheck'
@@ -271,10 +273,10 @@ tasks.register('doctor') {
 tasks.register('ci') {
     group = 'verification'
     description = 'Run the canonical monorepo CI orchestration checks.'
-    dependsOn 'doctor', 'acceptanceContract', 'specContract', 'specContractTest', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
+    dependsOn 'doctor', 'acceptanceContract', 'specContract', 'specContractTest', 'androidReleaseIdentityCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
 }
 
-['acceptanceContract', 'specContract', 'specContractTest', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck', 'releaseReadinessFixtureTest', 'releaseReadinessCheck'].each { taskName ->
+['acceptanceContract', 'specContract', 'specContractTest', 'androidReleaseIdentityCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck', 'releaseReadinessFixtureTest', 'releaseReadinessCheck'].each { taskName ->
     tasks.named(taskName) {
         mustRunAfter tasks.named('doctor')
     }

--- a/client/README.md
+++ b/client/README.md
@@ -107,6 +107,27 @@ flutter pub get
 flutter run
 ```
 
+### Android identity and release signing
+
+Android debug builds use the Weave package id `com.massimotter.weave`; the OIDC redirect scheme stays `com.massimotter.weave`, so app-auth provider configuration must still allow `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout` after package-id changes.
+
+Release artifacts are intentionally fail-safe. The Android release build does not fall back to debug keys. To build a signed release artifact, create a local, untracked `client/android/key.properties` file:
+
+```properties
+storeFile=/secure/path/weave-release.jks
+storePassword=...
+keyAlias=weave-release
+keyPassword=...
+```
+
+Then run:
+
+```sh
+flutter build appbundle --release
+```
+
+Without that complete file and keystore, release artifact tasks fail with an explicit signing-credentials error; use `flutter run` or debug/profile builds for local development.
+
 Full lightweight validation:
 
 ```sh

--- a/client/android/app/build.gradle.kts
+++ b/client/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -5,8 +7,25 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+val releaseKeyPropertiesFile = rootProject.file("key.properties")
+val releaseKeyProperties = Properties()
+if (releaseKeyPropertiesFile.exists()) {
+    releaseKeyPropertiesFile.inputStream().use(releaseKeyProperties::load)
+}
+
+fun releaseSigningValue(name: String): String =
+    releaseKeyProperties.getProperty(name)?.trim().orEmpty()
+
+val releaseStoreFile = releaseSigningValue("storeFile")
+val releaseSigningConfigured = listOf(
+    "storeFile",
+    "storePassword",
+    "keyAlias",
+    "keyPassword",
+).all { releaseSigningValue(it).isNotEmpty() } && releaseStoreFile.isNotEmpty() && rootProject.file(releaseStoreFile).exists()
+
 android {
-    namespace = "com.example.weave"
+    namespace = "com.massimotter.weave"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -20,8 +39,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.weave"
+        applicationId = "com.massimotter.weave"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -33,12 +51,34 @@ android {
         )
     }
 
+    signingConfigs {
+        create("release") {
+            if (releaseSigningConfigured) {
+                storeFile = rootProject.file(releaseStoreFile)
+                storePassword = releaseSigningValue("storePassword")
+                keyAlias = releaseSigningValue("keyAlias")
+                keyPassword = releaseSigningValue("keyPassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = signingConfigs.getByName("release")
         }
+    }
+}
+
+gradle.taskGraph.whenReady {
+    val releaseTaskRequested = allTasks.any { task ->
+        task.path.contains("Release") || task.name.contains("Release")
+    }
+    if (releaseTaskRequested && !releaseSigningConfigured) {
+        throw GradleException(
+            "Android release builds require client/android/key.properties with " +
+                "storeFile, storePassword, keyAlias, and keyPassword. " +
+                "Debug signing must not be used for release artifacts."
+        )
     }
 }
 

--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="com.massimotter.weave" />
+                <data android:scheme="${appAuthRedirectScheme}" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/client/android/app/src/main/kotlin/com/massimotter/weave/MainActivity.kt
+++ b/client/android/app/src/main/kotlin/com/massimotter/weave/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.weave
+package com.massimotter.weave
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/client/test/release_1/android_release_identity_contract_test.dart
+++ b/client/test/release_1/android_release_identity_contract_test.dart
@@ -1,0 +1,74 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Android release identity contract', () {
+    final buildGradle = File('../client/android/app/build.gradle.kts');
+    final manifest = File('../client/android/app/src/main/AndroidManifest.xml');
+    final mainActivity = File(
+      '../client/android/app/src/main/kotlin/com/massimotter/weave/MainActivity.kt',
+    );
+    final oldMainActivity = File(
+      '../client/android/app/src/main/kotlin/com/example/weave/MainActivity.kt',
+    );
+    final oidcConstants = File(
+      '../client/lib/features/auth/domain/entities/oidc_constants.dart',
+    );
+    final readme = File('../client/README.md');
+    final gitignore = File('../.gitignore');
+
+    test('uses the Weave Android package id instead of template identity', () {
+      final gradleText = buildGradle.readAsStringSync();
+      final activityText = mainActivity.readAsStringSync();
+
+      expect(gradleText, contains('namespace = "com.massimotter.weave"'));
+      expect(gradleText, contains('applicationId = "com.massimotter.weave"'));
+      expect(activityText, contains('package com.massimotter.weave'));
+      expect(oldMainActivity.existsSync(), isFalse);
+      expect(gradleText, isNot(contains('com.example.weave')));
+    });
+
+    test('keeps OIDC redirect assumptions aligned after package id change', () {
+      final gradleText = buildGradle.readAsStringSync();
+      final manifestText = manifest.readAsStringSync();
+      final oidcText = oidcConstants.readAsStringSync();
+      final readmeText = readme.readAsStringSync();
+
+      expect(
+        gradleText,
+        contains('"appAuthRedirectScheme" to "com.massimotter.weave"'),
+      );
+      expect(
+        manifestText,
+        contains('android:scheme="\${appAuthRedirectScheme}"'),
+      );
+      expect(
+        oidcText,
+        contains("oidcRedirectScheme = 'com.massimotter.weave'"),
+      );
+      expect(oidcText, contains("'\$oidcRedirectScheme:/oauthredirect'"));
+      expect(readmeText, contains('com.massimotter.weave:/oauthredirect'));
+      expect(readmeText, contains('com.massimotter.weave:/logout'));
+    });
+
+    test('release signing fails closed without local credentials', () {
+      final gradleText = buildGradle.readAsStringSync();
+      final readmeText = readme.readAsStringSync();
+      final gitignoreText = gitignore.readAsStringSync();
+
+      expect(gradleText, contains('client/android/key.properties'));
+      expect(gradleText, contains('storeFile'));
+      expect(gradleText, contains('storePassword'));
+      expect(gradleText, contains('keyAlias'));
+      expect(gradleText, contains('keyPassword'));
+      expect(gradleText, contains('Debug signing must not be used'));
+      expect(gradleText, isNot(contains('signingConfigs.getByName("debug")')));
+      expect(readmeText, contains('does not fall back to debug keys'));
+      expect(readmeText, contains('client/android/key.properties'));
+      expect(gitignoreText, contains('**/android/key.properties'));
+      expect(gitignoreText, contains('**/android/*.jks'));
+      expect(gitignoreText, contains('**/android/*.keystore'));
+    });
+  });
+}

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -47,6 +47,8 @@ flutter run
 
 The app accepts local development service URLs such as `https://api.weave.local/api`, `https://auth.weave.local`, `https://matrix.weave.local`, and `https://files.weave.local` when a live stack is available.
 
+Android debug/profile runs use the production package identity `com.massimotter.weave` and the same OIDC redirect scheme. Keep identity-provider clients configured for `com.massimotter.weave:/oauthredirect` and `com.massimotter.weave:/logout`. Release artifact tasks require a local untracked `client/android/key.properties` file and keystore; they fail closed instead of using debug signing keys.
+
 
 ## Root Gradle orchestration
 
@@ -63,6 +65,7 @@ The root `./gradlew` is the monorepo build/delivery source of truth. GitHub Acti
 | `docsBuild` | Strict MkDocs build with deterministic outputs under `build/docs/user` and `build/docs/admin`. |
 | `docsCheck` | Docs structure check plus strict MkDocs build. |
 | `releaseNotesLabelCheck` | Current PR release-notes label validation when `PR_LABELS_JSON` is available; skipped locally when unset. |
+| `androidReleaseIdentityCheck` | Android package identity, OIDC redirect alignment, and release-signing fail-closed guard. |
 | `releaseEvidenceCheck` | Release notes structure, README markers, label behavior, generator fixture checks, enterprise release gates, and RC readiness fixtures. |
 | `releaseReadinessCheck` | Validates support-safe RC readiness evidence for an explicit candidate without publishing a release; override with `-PcandidateVersion`, `-PcandidateTag`, `-PcandidateCommit`, and evidence path properties. |
 | `releaseNotesCheck` | Compatibility alias for `releaseEvidenceCheck`. |

--- a/tools/android_release_identity_check.py
+++ b/tools/android_release_identity_check.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Validate Android package identity and release-signing fail-safe posture."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ANDROID = ROOT / "client" / "android"
+APP_GRADLE = ANDROID / "app" / "build.gradle.kts"
+MANIFEST = ANDROID / "app" / "src" / "main" / "AndroidManifest.xml"
+MAIN_ACTIVITY = ANDROID / "app" / "src" / "main" / "kotlin" / "com" / "massimotter" / "weave" / "MainActivity.kt"
+GITIGNORE = ROOT / ".gitignore"
+PACKAGE_ID = "com.massimotter.weave"
+TEMPLATE_ID = "com.example.weave"
+
+
+def fail(message: str) -> None:
+    print(f"android-release-identity-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read(path: Path) -> str:
+    if not path.exists():
+        fail(f"missing required file: {path.relative_to(ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def require(text: str, fragment: str, label: str) -> None:
+    if fragment not in text:
+        fail(f"{label} missing {fragment!r}")
+
+
+def main() -> None:
+    gradle = read(APP_GRADLE)
+    manifest = read(MANIFEST)
+    activity = read(MAIN_ACTIVITY)
+    gitignore = read(GITIGNORE)
+
+    for path in ANDROID.rglob("*"):
+        if path.is_file() and TEMPLATE_ID in path.read_text(encoding="utf-8", errors="ignore"):
+            fail(f"template package id remains in {path.relative_to(ROOT)}")
+
+    require(gradle, f'namespace = "{PACKAGE_ID}"', "Android Gradle config")
+    require(gradle, f'applicationId = "{PACKAGE_ID}"', "Android Gradle config")
+    require(gradle, f'"appAuthRedirectScheme" to "{PACKAGE_ID}"', "Android app-auth redirect config")
+    require(manifest, 'android:scheme="${appAuthRedirectScheme}"', "Android manifest")
+    require(activity, f"package {PACKAGE_ID}", "MainActivity package")
+
+    forbidden_fragments = [
+        'signingConfig = signingConfigs.getByName("debug")',
+        'Signing with the debug keys',
+    ]
+    for fragment in forbidden_fragments:
+        if fragment in gradle:
+            fail(f"release signing still contains forbidden debug fallback: {fragment!r}")
+
+    require(gradle, 'rootProject.file("key.properties")', "release signing config")
+    require(gradle, "storeFile", "release signing config")
+    require(gradle, "storePassword", "release signing config")
+    require(gradle, "keyAlias", "release signing config")
+    require(gradle, "keyPassword", "release signing config")
+    require(gradle, "Debug signing must not be used for release artifacts.", "release signing guard")
+
+    for fragment in ["**/android/key.properties", "**/android/*.jks", "**/android/*.keystore"]:
+        require(gitignore, fragment, ".gitignore")
+
+    print("android-release-identity-check: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- replaces the Android template package identity with `com.massimotter.weave`
- keeps OIDC redirect scheme assumptions explicit and aligned with Android manifest placeholders
- removes release debug-signing fallback and adds fail-closed local signing documentation/guards

Closes #398

## Gates
- `./gradlew ci` — PASS
- `flutter build apk --debug` — BLOCKED locally: `[!] No Android SDK found. Try setting the ANDROID_HOME environment variable.`
- `gradle -p client/android :app:assembleRelease` — BLOCKED locally: `gradle` not installed; release-signing fail-closed posture covered by `androidReleaseIdentityCheck` in `./gradlew ci`

## Release notes
- `release-notes-bugfix`: Android release identity/signing hardening; no release tag, publish, or production mutation.

