### PR TITLE
tech-debt(admin-console): pin dependency versions

### DIFF
--- a/admin-console/README.md
+++ b/admin-console/README.md
@@ -20,6 +20,10 @@ npm install
 npm run ci
 ```
 
+## Dependency update policy
+
+`package.json` uses exact dependency versions that match the reviewed `package-lock.json`; do not use `latest` ranges. To refresh Admin Console dependencies, intentionally edit the versions or run a targeted npm update, then refresh the lockfile with `npm install --package-lock-only` and validate with `npm ci` plus `npm run ci` before opening a PR.
+
 Configure with Vite env vars when needed:
 
 ```bash

--- a/admin-console/package-lock.json
+++ b/admin-console/package-lock.json
@@ -8,24 +8,24 @@
       "name": "@weave/admin-console",
       "version": "0.1.0",
       "dependencies": {
-        "@emotion/react": "latest",
-        "@emotion/styled": "latest",
-        "@mui/icons-material": "latest",
-        "@mui/material": "latest",
-        "@vitejs/plugin-react": "latest",
-        "react": "latest",
-        "react-dom": "latest",
-        "vite": "latest"
+        "@emotion/react": "11.14.0",
+        "@emotion/styled": "11.14.1",
+        "@mui/icons-material": "9.0.1",
+        "@mui/material": "9.0.1",
+        "@vitejs/plugin-react": "6.0.2",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "vite": "8.0.14"
       },
       "devDependencies": {
-        "@testing-library/jest-dom": "latest",
-        "@testing-library/react": "latest",
-        "@testing-library/user-event": "latest",
-        "@types/react": "^19.2.15",
-        "@types/react-dom": "^19.2.3",
-        "jsdom": "latest",
-        "typescript": "latest",
-        "vitest": "latest"
+        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/react": "16.3.2",
+        "@testing-library/user-event": "14.6.1",
+        "@types/react": "19.2.15",
+        "@types/react-dom": "19.2.3",
+        "jsdom": "29.1.1",
+        "typescript": "6.0.3",
+        "vitest": "4.1.7"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/admin-console/package.json
+++ b/admin-console/package.json
@@ -9,23 +9,23 @@
     "ci": "npm run build && npm run test"
   },
   "dependencies": {
-    "@emotion/react": "latest",
-    "@emotion/styled": "latest",
-    "@mui/icons-material": "latest",
-    "@mui/material": "latest",
-    "@vitejs/plugin-react": "latest",
-    "react": "latest",
-    "react-dom": "latest",
-    "vite": "latest"
+    "@emotion/react": "11.14.0",
+    "@emotion/styled": "11.14.1",
+    "@mui/icons-material": "9.0.1",
+    "@mui/material": "9.0.1",
+    "@vitejs/plugin-react": "6.0.2",
+    "react": "19.2.6",
+    "react-dom": "19.2.6",
+    "vite": "8.0.14"
   },
   "devDependencies": {
-    "@testing-library/jest-dom": "latest",
-    "@testing-library/react": "latest",
-    "@testing-library/user-event": "latest",
-    "@types/react": "^19.2.15",
-    "@types/react-dom": "^19.2.3",
-    "jsdom": "latest",
-    "typescript": "latest",
-    "vitest": "latest"
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
+    "@testing-library/user-event": "14.6.1",
+    "@types/react": "19.2.15",
+    "@types/react-dom": "19.2.3",
+    "jsdom": "29.1.1",
+    "typescript": "6.0.3",
+    "vitest": "4.1.7"
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ registerRootCommandTask('releaseNotesLabelCheck', ['bash', '-lc', 'if [ -n "${PR
 registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.py'], 'Validate repo-local Weave specs, lifecycle metadata, and implementation-ready clarification state.')
 registerRootCommandTask('specContractTest', ['python3', 'tools/spec_contract_check_test.py'], 'Run fixture tests for the repo-local Weave spec contract guard.')
 registerRootCommandTask('androidReleaseIdentityCheck', ['python3', 'tools/android_release_identity_check.py'], 'Validate Android package identity and release-signing fail-safe posture.')
+registerRootCommandTask('adminDependencyPolicyCheck', ['python3', 'tools/admin_console_dependency_policy_check.py'], 'Validate Admin Console dependency pins and lockfile policy.')
 registerRootCommandTask('generateReleaseNotes', ['python3', 'tools/release_notes_generate.py', '--input', 'tools/fixtures/release_notes_prs.json'], 'Generate reviewable release notes under build/release-notes by default.')
 registerRootCommandTask('updateReadmeReleaseNotes', ['python3', 'tools/readme_release_notes.py', '--update'], 'Explicitly update the managed README release-notes evidence block.')
 registerRootCommandTask('projectReadinessEvidenceCheck', ['python3', 'tools/project_readiness_evidence_check.py'], 'Validate Sprint 5 project-readiness evidence remains mapped and support-safe.')
@@ -101,6 +102,7 @@ ext.ciEvidenceGates = [
     'specContract',
     'specContractTest',
     'androidReleaseIdentityCheck',
+    'adminDependencyPolicyCheck',
     'releaseEvidenceCheck',
     'projectReadinessEvidenceCheck',
     'enterpriseReleaseGateCheck'
@@ -273,10 +275,10 @@ tasks.register('doctor') {
 tasks.register('ci') {
     group = 'verification'
     description = 'Run the canonical monorepo CI orchestration checks.'
-    dependsOn 'doctor', 'acceptanceContract', 'specContract', 'specContractTest', 'androidReleaseIdentityCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
+    dependsOn 'doctor', 'acceptanceContract', 'specContract', 'specContractTest', 'androidReleaseIdentityCheck', 'adminDependencyPolicyCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
 }
 
-['acceptanceContract', 'specContract', 'specContractTest', 'androidReleaseIdentityCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck', 'releaseReadinessFixtureTest', 'releaseReadinessCheck'].each { taskName ->
+['acceptanceContract', 'specContract', 'specContractTest', 'androidReleaseIdentityCheck', 'adminDependencyPolicyCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck', 'releaseReadinessFixtureTest', 'releaseReadinessCheck'].each { taskName ->
     tasks.named(taskName) {
         mustRunAfter tasks.named('doctor')
     }

--- a/tools/admin_console_dependency_policy_check.py
+++ b/tools/admin_console_dependency_policy_check.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Validate Admin Console dependency version policy."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ADMIN = ROOT / "admin-console"
+PACKAGE_JSON = ADMIN / "package.json"
+PACKAGE_LOCK = ADMIN / "package-lock.json"
+README = ADMIN / "README.md"
+SECTIONS = ("dependencies", "devDependencies")
+
+
+def fail(message: str) -> None:
+    print(f"admin-console-dependency-policy-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_json(path: Path) -> dict:
+    if not path.exists():
+        fail(f"missing required file: {path.relative_to(ROOT)}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> None:
+    package = read_json(PACKAGE_JSON)
+    lock = read_json(PACKAGE_LOCK)
+    lock_root = lock.get("packages", {}).get("", {})
+    readme = README.read_text(encoding="utf-8")
+
+    for section in SECTIONS:
+        manifest_versions = package.get(section, {})
+        lock_versions = lock_root.get(section, {})
+        if set(manifest_versions) != set(lock_versions):
+            fail(f"{section} entries differ between package.json and package-lock.json")
+        for name, version in manifest_versions.items():
+            if version == "latest" or "latest" in version.lower():
+                fail(f"{name} in {section} uses non-reproducible version {version!r}")
+            if lock_versions.get(name) != version:
+                fail(f"{name} version differs between package.json and package-lock.json")
+            package_entry = lock.get("packages", {}).get(f"node_modules/{name}", {})
+            if package_entry.get("version") != version:
+                fail(f"{name} root pin {version!r} does not match locked package version {package_entry.get('version')!r}")
+
+    for fragment in (
+        "exact dependency versions",
+        "do not use `latest` ranges",
+        "npm install --package-lock-only",
+        "npm ci",
+        "npm run ci",
+    ):
+        if fragment not in readme:
+            fail(f"README dependency policy missing {fragment!r}")
+
+    print("admin-console-dependency-policy-check: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #397\n\n## Summary\n- replaces Admin Console `latest` dependency ranges with exact versions from the reviewed lockfile\n- refreshes `package-lock.json` with `npm install --package-lock-only`\n- documents the Admin Console dependency update policy\n- adds `adminDependencyPolicyCheck` to guard manifest/lockfile pin drift\n\n## Gates\n- `./gradlew adminDependencyPolicyCheck releaseNotesLabelCheck`\n- `cd admin-console && npm ci`\n- `cd admin-console && npm run ci`\n\n## Release notes\n- `release-notes-skip`\n