### PR TITLE
feat(workflows): define context-driven workflow contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Added
 
-- Nothing yet.
+- Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
 
 ## Changed
 

--- a/client/lib/features/workflows/domain/entities/workflow_preview.dart
+++ b/client/lib/features/workflows/domain/entities/workflow_preview.dart
@@ -122,10 +122,34 @@ class WorkflowStepPreview {
       state == WorkflowStepState.blocked ||
       state == WorkflowStepState.waitingForApproval;
 
+  bool get hasTraceableEvidence {
+    final contextReferenceIds = contextReferences
+        .where((reference) => reference.isExplicit)
+        .map((reference) => reference.id)
+        .toSet();
+
+    return evidence.isNotEmpty &&
+        evidence.every(
+          (reference) =>
+              contextReferenceIds.contains(reference.contextReferenceId),
+        );
+  }
+
+  bool get hasTraceableBlockers {
+    final evidenceIds = evidence.map((reference) => reference.id).toSet();
+
+    return blockers.every(
+      (blocker) =>
+          blocker.evidenceIds.isNotEmpty &&
+          blocker.evidenceIds.every(evidenceIds.contains),
+    );
+  }
+
   bool get isExplainable =>
       contextReferences.isNotEmpty &&
       contextReferences.every((reference) => reference.isExplicit) &&
-      evidence.isNotEmpty;
+      hasTraceableEvidence &&
+      hasTraceableBlockers;
 }
 
 class WorkflowRunPreview {

--- a/client/lib/features/workflows/domain/entities/workflow_preview.dart
+++ b/client/lib/features/workflows/domain/entities/workflow_preview.dart
@@ -1,5 +1,7 @@
 enum WorkflowContextReferenceKind {
   channel,
+  project,
+  event,
   task,
   decision,
   file,
@@ -12,6 +14,23 @@ enum WorkflowStepKind { step, gate, approval }
 enum WorkflowStepState { ready, inProgress, blocked, waitingForApproval, done }
 
 enum WorkflowAssigneeKind { person, agent }
+
+class WorkflowTemplatePreview {
+  const WorkflowTemplatePreview({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.attachableContextKinds,
+  });
+
+  final String id;
+  final String title;
+  final String description;
+  final List<WorkflowContextReferenceKind> attachableContextKinds;
+
+  bool canAttachTo(WorkflowContextReferenceKind kind) =>
+      attachableContextKinds.contains(kind);
+}
 
 class WorkflowContextReference {
   const WorkflowContextReference({
@@ -111,7 +130,7 @@ class WorkflowStepPreview {
 
 class WorkflowRunPreview {
   const WorkflowRunPreview({
-    required this.templateId,
+    required this.template,
     required this.runId,
     required this.title,
     required this.contextLabel,
@@ -121,7 +140,7 @@ class WorkflowRunPreview {
     required this.auditTrailRequired,
   });
 
-  final String templateId;
+  final WorkflowTemplatePreview template;
   final String runId;
   final String title;
   final String contextLabel;

--- a/client/lib/features/workflows/presentation/providers/workflow_preview_provider.dart
+++ b/client/lib/features/workflows/presentation/providers/workflow_preview_provider.dart
@@ -25,21 +25,145 @@ class WorkflowPreviewFacade {
   WorkflowPreviewSnapshot previewForWorkspace({
     List<WorkflowContextSeed> contexts = const <WorkflowContextSeed>[],
   }) {
-    final context =
-        contexts
-            .where((seed) => seed.kind == WorkflowContextSeedKind.channel)
-            .firstOrNull ??
-        const WorkflowContextSeed(
-          id: 'channel:general',
-          kind: WorkflowContextSeedKind.channel,
-          label: 'general',
-        );
+    final channel = _contextOrDefault(
+      contexts,
+      WorkflowContextSeedKind.channel,
+      const WorkflowContextSeed(
+        id: 'channel:general',
+        kind: WorkflowContextSeedKind.channel,
+        label: 'general',
+      ),
+    );
+    final project = _contextOrDefault(
+      contexts,
+      WorkflowContextSeedKind.project,
+      const WorkflowContextSeed(
+        id: 'project:workspace-launch',
+        kind: WorkflowContextSeedKind.project,
+        label: 'Workspace launch',
+      ),
+    );
+    final incident = _contextOrDefault(
+      contexts,
+      WorkflowContextSeedKind.event,
+      const WorkflowContextSeed(
+        id: 'event:support-incident',
+        kind: WorkflowContextSeedKind.event,
+        label: 'Support incident',
+      ),
+    );
 
-    final channelReference = WorkflowContextReference(
-      id: 'channel:${context.id}',
-      kind: WorkflowContextReferenceKind.channel,
-      label: context.label,
-      sourceLabel: 'Selected chat channel',
+    return WorkflowPreviewSnapshot(
+      runs: <WorkflowRunPreview>[
+        _workspaceOnboardingRun(project),
+        _releasePreparationRun(channel),
+        _supportIncidentRun(incident),
+      ],
+    );
+  }
+
+  WorkflowContextSeed _contextOrDefault(
+    List<WorkflowContextSeed> contexts,
+    WorkflowContextSeedKind kind,
+    WorkflowContextSeed fallback,
+  ) {
+    return contexts.where((seed) => seed.kind == kind).firstOrNull ?? fallback;
+  }
+
+  WorkflowRunPreview _workspaceOnboardingRun(WorkflowContextSeed project) {
+    final projectReference = _contextReference(project, 'Selected project');
+    const taskReference = WorkflowContextReference(
+      id: 'task:onboarding-checklist',
+      kind: WorkflowContextReferenceKind.task,
+      label: 'Workspace onboarding checklist',
+      sourceLabel: 'Linked board task',
+    );
+    const fileReference = WorkflowContextReference(
+      id: 'file:welcome-pack',
+      kind: WorkflowContextReferenceKind.file,
+      label: 'Welcome pack',
+      sourceLabel: 'Selected file',
+    );
+    const checklistEvidence = WorkflowEvidenceReference(
+      id: 'evidence:onboarding-checklist',
+      label: 'Checklist has owners for first-day tasks',
+      sourceLabel: 'Linked task state',
+      contextReferenceId: 'task:onboarding-checklist',
+    );
+    const welcomePackEvidence = WorkflowEvidenceReference(
+      id: 'evidence:welcome-pack',
+      label: 'Welcome pack is ready for member review',
+      sourceLabel: 'Selected file metadata',
+      contextReferenceId: 'file:welcome-pack',
+    );
+
+    return WorkflowRunPreview(
+      template: const WorkflowTemplatePreview(
+        id: 'template:workspace-onboarding',
+        title: 'Onboard a workspace',
+        description:
+            'Attach project context, checklist evidence, and owner approval before inviting members.',
+        attachableContextKinds: <WorkflowContextReferenceKind>[
+          WorkflowContextReferenceKind.project,
+        ],
+      ),
+      runId: 'run:workspace-onboarding-preview',
+      title: 'Onboard a workspace',
+      contextLabel: project.label,
+      backgroundRoomReadingEnabled: false,
+      agentActionsEnabled: false,
+      auditTrailRequired: true,
+      steps: <WorkflowStepPreview>[
+        WorkflowStepPreview(
+          id: 'step:assign-onboarding-owners',
+          kind: WorkflowStepKind.step,
+          title: 'Assign onboarding owners',
+          state: WorkflowStepState.ready,
+          ownerLabel: 'Workspace owner',
+          assignee: const WorkflowAssignee(
+            label: 'Workspace owner',
+            kind: WorkflowAssigneeKind.person,
+          ),
+          nextAction: 'Confirm task owners before sending invitations.',
+          dueLabel: 'Before invite',
+          contextReferences: <WorkflowContextReference>[
+            projectReference,
+            taskReference,
+          ],
+          evidence: const <WorkflowEvidenceReference>[checklistEvidence],
+          blockers: const <WorkflowBlocker>[],
+          requiresApproval: false,
+          agentDryRunOnly: true,
+        ),
+        WorkflowStepPreview(
+          id: 'step:review-welcome-pack',
+          kind: WorkflowStepKind.approval,
+          title: 'Review welcome pack',
+          state: WorkflowStepState.waitingForApproval,
+          ownerLabel: 'Workspace owner',
+          assignee: const WorkflowAssignee(
+            label: 'Onboarding coach',
+            kind: WorkflowAssigneeKind.agent,
+          ),
+          nextAction: 'Ask the owner to approve the welcome pack draft.',
+          dueLabel: 'Before invite',
+          contextReferences: <WorkflowContextReference>[
+            projectReference,
+            fileReference,
+          ],
+          evidence: const <WorkflowEvidenceReference>[welcomePackEvidence],
+          blockers: const <WorkflowBlocker>[],
+          requiresApproval: true,
+          agentDryRunOnly: true,
+        ),
+      ],
+    );
+  }
+
+  WorkflowRunPreview _releasePreparationRun(WorkflowContextSeed channel) {
+    final channelReference = _contextReference(
+      channel,
+      'Selected chat channel',
     );
     const decisionReference = WorkflowContextReference(
       id: 'decision:release-readiness',
@@ -85,94 +209,231 @@ class WorkflowPreviewFacade {
       contextReferenceId: 'file:release-notes-draft',
     );
 
-    return WorkflowPreviewSnapshot(
-      runs: <WorkflowRunPreview>[
-        WorkflowRunPreview(
-          templateId: 'template:release-prep',
-          runId: 'run:release-prep-preview',
-          title: 'Prepare a release',
-          contextLabel: context.label,
-          backgroundRoomReadingEnabled: false,
-          agentActionsEnabled: false,
-          auditTrailRequired: true,
-          steps: <WorkflowStepPreview>[
-            WorkflowStepPreview(
-              id: 'step:confirm-readiness',
-              kind: WorkflowStepKind.gate,
-              title: 'Confirm release readiness',
-              state: WorkflowStepState.done,
-              ownerLabel: 'Product owner',
-              assignee: const WorkflowAssignee(
-                label: 'Product owner',
-                kind: WorkflowAssigneeKind.person,
-              ),
-              nextAction: 'Decision is captured and linked.',
-              dueLabel: 'Done',
-              contextReferences: <WorkflowContextReference>[
-                channelReference,
-                decisionReference,
-              ],
-              evidence: const <WorkflowEvidenceReference>[
-                releaseDecisionEvidence,
-              ],
-              blockers: const <WorkflowBlocker>[],
-              requiresApproval: false,
-              agentDryRunOnly: true,
-            ),
-            WorkflowStepPreview(
-              id: 'step:clear-blockers',
-              kind: WorkflowStepKind.step,
-              title: 'Clear release blockers',
-              state: WorkflowStepState.blocked,
+    return WorkflowRunPreview(
+      template: const WorkflowTemplatePreview(
+        id: 'template:release-prep',
+        title: 'Prepare a release',
+        description:
+            'Attach channel decisions, release tasks, and release-note evidence before publish.',
+        attachableContextKinds: <WorkflowContextReferenceKind>[
+          WorkflowContextReferenceKind.channel,
+        ],
+      ),
+      runId: 'run:release-prep-preview',
+      title: 'Prepare a release',
+      contextLabel: channel.label,
+      backgroundRoomReadingEnabled: false,
+      agentActionsEnabled: false,
+      auditTrailRequired: true,
+      steps: <WorkflowStepPreview>[
+        WorkflowStepPreview(
+          id: 'step:confirm-readiness',
+          kind: WorkflowStepKind.gate,
+          title: 'Confirm release readiness',
+          state: WorkflowStepState.done,
+          ownerLabel: 'Product owner',
+          assignee: const WorkflowAssignee(
+            label: 'Product owner',
+            kind: WorkflowAssigneeKind.person,
+          ),
+          nextAction: 'Decision is captured and linked.',
+          dueLabel: 'Done',
+          contextReferences: <WorkflowContextReference>[
+            channelReference,
+            decisionReference,
+          ],
+          evidence: const <WorkflowEvidenceReference>[releaseDecisionEvidence],
+          blockers: const <WorkflowBlocker>[],
+          requiresApproval: false,
+          agentDryRunOnly: true,
+        ),
+        WorkflowStepPreview(
+          id: 'step:clear-blockers',
+          kind: WorkflowStepKind.step,
+          title: 'Clear release blockers',
+          state: WorkflowStepState.blocked,
+          ownerLabel: 'Engineering lead',
+          assignee: const WorkflowAssignee(
+            label: 'Engineering lead',
+            kind: WorkflowAssigneeKind.person,
+          ),
+          nextAction: 'Review the linked checklist and assign the open item.',
+          dueLabel: 'Next working day',
+          contextReferences: <WorkflowContextReference>[
+            channelReference,
+            taskReference,
+          ],
+          evidence: const <WorkflowEvidenceReference>[checklistEvidence],
+          blockers: const <WorkflowBlocker>[
+            WorkflowBlocker(
+              id: 'blocker:open-checklist-item',
+              description: 'One checklist item still needs an owner.',
               ownerLabel: 'Engineering lead',
-              assignee: const WorkflowAssignee(
-                label: 'Engineering lead',
-                kind: WorkflowAssigneeKind.person,
-              ),
-              nextAction:
-                  'Review the linked checklist and assign the open item.',
-              dueLabel: 'Next working day',
-              contextReferences: <WorkflowContextReference>[
-                channelReference,
-                taskReference,
-              ],
-              evidence: const <WorkflowEvidenceReference>[checklistEvidence],
-              blockers: const <WorkflowBlocker>[
-                WorkflowBlocker(
-                  id: 'blocker:open-checklist-item',
-                  description: 'One checklist item still needs an owner.',
-                  ownerLabel: 'Engineering lead',
-                  evidenceIds: <String>['evidence:release-checklist'],
-                ),
-              ],
-              requiresApproval: false,
-              agentDryRunOnly: true,
-            ),
-            const WorkflowStepPreview(
-              id: 'step:approve-notes',
-              kind: WorkflowStepKind.approval,
-              title: 'Approve release notes',
-              state: WorkflowStepState.waitingForApproval,
-              ownerLabel: 'Workspace owner',
-              assignee: WorkflowAssignee(
-                label: 'Release coach',
-                kind: WorkflowAssigneeKind.agent,
-              ),
-              nextAction:
-                  'Ask the owner to review the draft before any agent action.',
-              dueLabel: 'Before publish',
-              contextReferences: <WorkflowContextReference>[
-                fileReference,
-                agentReference,
-              ],
-              evidence: <WorkflowEvidenceReference>[draftEvidence],
-              blockers: <WorkflowBlocker>[],
-              requiresApproval: true,
-              agentDryRunOnly: true,
+              evidenceIds: <String>['evidence:release-checklist'],
             ),
           ],
+          requiresApproval: false,
+          agentDryRunOnly: true,
+        ),
+        const WorkflowStepPreview(
+          id: 'step:approve-notes',
+          kind: WorkflowStepKind.approval,
+          title: 'Approve release notes',
+          state: WorkflowStepState.waitingForApproval,
+          ownerLabel: 'Workspace owner',
+          assignee: WorkflowAssignee(
+            label: 'Release coach',
+            kind: WorkflowAssigneeKind.agent,
+          ),
+          nextAction:
+              'Ask the owner to review the draft before any agent action.',
+          dueLabel: 'Before publish',
+          contextReferences: <WorkflowContextReference>[
+            fileReference,
+            agentReference,
+          ],
+          evidence: <WorkflowEvidenceReference>[draftEvidence],
+          blockers: <WorkflowBlocker>[],
+          requiresApproval: true,
+          agentDryRunOnly: true,
         ),
       ],
+    );
+  }
+
+  WorkflowRunPreview _supportIncidentRun(WorkflowContextSeed event) {
+    final eventReference = _contextReference(event, 'Selected event');
+    const meetingReference = WorkflowContextReference(
+      id: 'meeting:support-triage',
+      kind: WorkflowContextReferenceKind.meeting,
+      label: 'Support triage call',
+      sourceLabel: 'Linked meeting',
+    );
+    const taskReference = WorkflowContextReference(
+      id: 'task:support-follow-up',
+      kind: WorkflowContextReferenceKind.task,
+      label: 'Support follow-up task',
+      sourceLabel: 'Linked board task',
+    );
+    const agentReference = WorkflowContextReference(
+      id: 'agent-run:support-summary-dry-run',
+      kind: WorkflowContextReferenceKind.agentRun,
+      label: 'Support summary dry-run',
+      sourceLabel: 'Governed agent preview',
+    );
+    const triageEvidence = WorkflowEvidenceReference(
+      id: 'evidence:support-triage',
+      label: 'Triage notes are linked to the incident',
+      sourceLabel: 'Linked meeting summary',
+      contextReferenceId: 'meeting:support-triage',
+    );
+    const followUpEvidence = WorkflowEvidenceReference(
+      id: 'evidence:support-follow-up',
+      label: 'Follow-up task has owner and next action',
+      sourceLabel: 'Linked task state',
+      contextReferenceId: 'task:support-follow-up',
+    );
+    const summaryEvidence = WorkflowEvidenceReference(
+      id: 'evidence:support-summary-dry-run',
+      label: 'Agent summary is ready for owner approval',
+      sourceLabel: 'Governed agent preview',
+      contextReferenceId: 'agent-run:support-summary-dry-run',
+    );
+
+    return WorkflowRunPreview(
+      template: const WorkflowTemplatePreview(
+        id: 'template:support-incident',
+        title: 'Resolve a support incident',
+        description:
+            'Attach incident event, meeting, task, and governed agent summary evidence.',
+        attachableContextKinds: <WorkflowContextReferenceKind>[
+          WorkflowContextReferenceKind.event,
+        ],
+      ),
+      runId: 'run:support-incident-preview',
+      title: 'Resolve a support incident',
+      contextLabel: event.label,
+      backgroundRoomReadingEnabled: false,
+      agentActionsEnabled: false,
+      auditTrailRequired: true,
+      steps: <WorkflowStepPreview>[
+        WorkflowStepPreview(
+          id: 'step:capture-triage',
+          kind: WorkflowStepKind.gate,
+          title: 'Capture triage decision',
+          state: WorkflowStepState.done,
+          ownerLabel: 'Support lead',
+          assignee: const WorkflowAssignee(
+            label: 'Support lead',
+            kind: WorkflowAssigneeKind.person,
+          ),
+          nextAction: 'Triage decision is captured and linked.',
+          dueLabel: 'Done',
+          contextReferences: <WorkflowContextReference>[
+            eventReference,
+            meetingReference,
+          ],
+          evidence: const <WorkflowEvidenceReference>[triageEvidence],
+          blockers: const <WorkflowBlocker>[],
+          requiresApproval: false,
+          agentDryRunOnly: true,
+        ),
+        WorkflowStepPreview(
+          id: 'step:assign-follow-up',
+          kind: WorkflowStepKind.step,
+          title: 'Assign follow-up owner',
+          state: WorkflowStepState.inProgress,
+          ownerLabel: 'Support lead',
+          assignee: const WorkflowAssignee(
+            label: 'Support lead',
+            kind: WorkflowAssigneeKind.person,
+          ),
+          nextAction: 'Confirm the follow-up owner and customer-safe action.',
+          dueLabel: 'Today',
+          contextReferences: <WorkflowContextReference>[
+            eventReference,
+            taskReference,
+          ],
+          evidence: const <WorkflowEvidenceReference>[followUpEvidence],
+          blockers: const <WorkflowBlocker>[],
+          requiresApproval: false,
+          agentDryRunOnly: true,
+        ),
+        const WorkflowStepPreview(
+          id: 'step:approve-support-summary',
+          kind: WorkflowStepKind.approval,
+          title: 'Approve support summary',
+          state: WorkflowStepState.waitingForApproval,
+          ownerLabel: 'Support lead',
+          assignee: WorkflowAssignee(
+            label: 'Support coach',
+            kind: WorkflowAssigneeKind.agent,
+          ),
+          nextAction: 'Approve the agent summary before it is shared.',
+          dueLabel: 'Before customer update',
+          contextReferences: <WorkflowContextReference>[agentReference],
+          evidence: <WorkflowEvidenceReference>[summaryEvidence],
+          blockers: <WorkflowBlocker>[],
+          requiresApproval: true,
+          agentDryRunOnly: true,
+        ),
+      ],
+    );
+  }
+
+  WorkflowContextReference _contextReference(
+    WorkflowContextSeed seed,
+    String sourceLabel,
+  ) {
+    return WorkflowContextReference(
+      id: seed.id,
+      kind: switch (seed.kind) {
+        WorkflowContextSeedKind.channel => WorkflowContextReferenceKind.channel,
+        WorkflowContextSeedKind.project => WorkflowContextReferenceKind.project,
+        WorkflowContextSeedKind.event => WorkflowContextReferenceKind.event,
+      },
+      label: seed.label,
+      sourceLabel: sourceLabel,
     );
   }
 }

--- a/client/lib/features/workflows/presentation/widgets/workflow_preview_panel.dart
+++ b/client/lib/features/workflows/presentation/widgets/workflow_preview_panel.dart
@@ -302,12 +302,15 @@ class _WorkflowStepTile extends StatelessWidget {
                   runSpacing: 8,
                   children: [
                     OutlinedButton.icon(
-                      onPressed: null,
+                      onPressed: () => _showStepSnackBar(
+                        context,
+                        '${step.title}: ${step.nextAction}',
+                      ),
                       icon: const Icon(Icons.open_in_new_outlined),
                       label: Text(l10n.workflowPreviewOpenStepButton),
                     ),
                     OutlinedButton.icon(
-                      onPressed: null,
+                      onPressed: () => _showStepSnackBar(context, evidenceText),
                       icon: const Icon(Icons.fact_check_outlined),
                       label: Text(l10n.workflowPreviewReviewEvidenceButton),
                     ),
@@ -344,6 +347,12 @@ class _WorkflowStepFact extends StatelessWidget {
       ),
     );
   }
+}
+
+void _showStepSnackBar(BuildContext context, String message) {
+  ScaffoldMessenger.of(context)
+    ..hideCurrentSnackBar()
+    ..showSnackBar(SnackBar(content: Text(message)));
 }
 
 String _kindLabel(AppLocalizations l10n, WorkflowStepKind kind) {

--- a/client/test/architecture/workflow_context_contract_test.dart
+++ b/client/test/architecture/workflow_context_contract_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('workflow context contract maps issue 218 acceptance', () async {
+    final contract = await File(
+      '../docs/workflow-context-contract.md',
+    ).readAsString();
+    final domain = await File(
+      'lib/features/workflows/domain/entities/workflow_preview.dart',
+    ).readAsString();
+    final provider = await File(
+      'lib/features/workflows/presentation/providers/workflow_preview_provider.dart',
+    ).readAsString();
+
+    for (final required in <String>[
+      'Workflow template',
+      'Workflow run',
+      'Step',
+      'Gate',
+      'Approval',
+      'Evidence',
+      'Blocker',
+      'Assignee',
+      'Context Graph references',
+      'Agent participation rules',
+      'MVP slice before a visual builder',
+      'Onboard a workspace',
+      'Prepare a release',
+      'Resolve a support incident',
+    ]) {
+      expect(contract, contains(required));
+    }
+
+    for (final forbidden in <String>[
+      'background room scanning',
+      'autonomous agent execution',
+      'direct provider-control-plane calls from member UI',
+    ]) {
+      expect(contract, contains(forbidden));
+    }
+
+    expect(domain, contains('class WorkflowTemplatePreview'));
+    expect(domain, contains('class WorkflowRunPreview'));
+    expect(domain, contains('class WorkflowStepPreview'));
+    expect(domain, contains('class WorkflowEvidenceReference'));
+    expect(domain, contains('class WorkflowBlocker'));
+    expect(domain, contains('class WorkflowAssignee'));
+
+    expect(provider, contains('backgroundRoomReadingEnabled: false'));
+    expect(provider, contains('agentActionsEnabled: false'));
+    expect(provider, contains('auditTrailRequired: true'));
+    expect(provider, contains('agentDryRunOnly: true'));
+    expect(provider, contains('WorkflowContextReferenceKind.project'));
+    expect(provider, contains('WorkflowContextReferenceKind.event'));
+    expect(provider, contains('WorkflowContextReferenceKind.meeting'));
+  });
+}

--- a/client/test/features/workflows/workflow_preview_panel_test.dart
+++ b/client/test/features/workflows/workflow_preview_panel_test.dart
@@ -11,9 +11,19 @@ void main() {
     final snapshot = const WorkflowPreviewFacade().previewForWorkspace(
       contexts: const <WorkflowContextSeed>[
         WorkflowContextSeed(
-          id: '!release:home.internal',
+          id: 'channel:release',
           kind: WorkflowContextSeedKind.channel,
           label: 'Release channel',
+        ),
+        WorkflowContextSeed(
+          id: 'project:workspace-launch',
+          kind: WorkflowContextSeedKind.project,
+          label: 'Workspace launch',
+        ),
+        WorkflowContextSeed(
+          id: 'event:support-incident',
+          kind: WorkflowContextSeedKind.event,
+          label: 'Support incident',
         ),
       ],
     );
@@ -36,14 +46,17 @@ void main() {
       expect(find.text('Linear view first'), findsOneWidget);
       expect(find.text('Explicit context only'), findsOneWidget);
       expect(find.text('Governed actions'), findsOneWidget);
+      expect(find.text('Onboard a workspace'), findsOneWidget);
       expect(find.text('Prepare a release'), findsOneWidget);
+      expect(find.text('Resolve a support incident'), findsOneWidget);
       expect(find.text('Clear release blockers'), findsOneWidget);
+      expect(find.text('Approve support summary'), findsOneWidget);
       expect(
         find.textContaining('One checklist item still needs an owner'),
         findsOneWidget,
       );
-      expect(find.text('Open step'), findsNWidgets(3));
-      expect(find.text('Review evidence'), findsNWidgets(3));
+      expect(find.text('Open step'), findsNWidgets(8));
+      expect(find.text('Review evidence'), findsNWidgets(8));
       expect(
         find.textContaining('does not continuously read rooms'),
         findsOneWidget,
@@ -52,7 +65,7 @@ void main() {
       final panelSemantics = tester
           .getSemantics(find.byType(WorkflowPreviewPanel))
           .getSemanticsData();
-      expect(panelSemantics.label, contains('1 active workflow'));
+      expect(panelSemantics.label, contains('3 active workflows'));
     } finally {
       semantics.dispose();
     }

--- a/client/test/features/workflows/workflow_preview_panel_test.dart
+++ b/client/test/features/workflows/workflow_preview_panel_test.dart
@@ -57,6 +57,25 @@ void main() {
       );
       expect(find.text('Open step'), findsNWidgets(8));
       expect(find.text('Review evidence'), findsNWidgets(8));
+      final actions = tester.widgetList<OutlinedButton>(
+        find.byType(OutlinedButton),
+      );
+      expect(actions.length, 16);
+      expect(actions.every((button) => button.onPressed != null), isTrue);
+
+      await tester.ensureVisible(find.text('Open step').first);
+      await tester.tap(find.text('Open step').first);
+      await tester.pump();
+      expect(find.textContaining('Assign onboarding owners'), findsWidgets);
+
+      await tester.ensureVisible(find.text('Review evidence').first);
+      await tester.tap(find.text('Review evidence').first);
+      await tester.pump();
+      expect(
+        find.textContaining('Checklist has owners for first-day tasks'),
+        findsWidgets,
+      );
+
       expect(
         find.textContaining('does not continuously read rooms'),
         findsOneWidget,

--- a/client/test/features/workflows/workflow_preview_provider_test.dart
+++ b/client/test/features/workflows/workflow_preview_provider_test.dart
@@ -7,9 +7,19 @@ void main() {
     final snapshot = const WorkflowPreviewFacade().previewForWorkspace(
       contexts: const <WorkflowContextSeed>[
         WorkflowContextSeed(
-          id: '!release:home.internal',
+          id: 'channel:release',
           kind: WorkflowContextSeedKind.channel,
           label: 'Release channel',
+        ),
+        WorkflowContextSeed(
+          id: 'project:workspace-launch',
+          kind: WorkflowContextSeedKind.project,
+          label: 'Workspace launch',
+        ),
+        WorkflowContextSeed(
+          id: 'event:support-incident',
+          kind: WorkflowContextSeedKind.event,
+          label: 'Support incident',
         ),
       ],
     );
@@ -18,27 +28,59 @@ void main() {
     expect(snapshot.isLinearAccessiblePreview, isTrue);
     expect(snapshot.usesOnlyExplicitContext, isTrue);
     expect(snapshot.keepsAgentsGoverned, isTrue);
+    expect(snapshot.runs.map((run) => run.title), <String>[
+      'Onboard a workspace',
+      'Prepare a release',
+      'Resolve a support incident',
+    ]);
 
-    final run = snapshot.runs.single;
-    expect(run.title, 'Prepare a release');
-    expect(run.contextLabel, 'Release channel');
-    expect(run.backgroundRoomReadingEnabled, isFalse);
-    expect(run.agentActionsEnabled, isFalse);
-    expect(run.auditTrailRequired, isTrue);
-    expect(run.steps.map((step) => step.kind), <WorkflowStepKind>[
+    final onboarding = snapshot.runs.first;
+    expect(onboarding.template.id, 'template:workspace-onboarding');
+    expect(
+      onboarding.template.canAttachTo(WorkflowContextReferenceKind.project),
+      isTrue,
+    );
+    expect(onboarding.contextLabel, 'Workspace launch');
+
+    final release = snapshot.runs[1];
+    expect(release.template.id, 'template:release-prep');
+    expect(
+      release.template.canAttachTo(WorkflowContextReferenceKind.channel),
+      isTrue,
+    );
+    expect(release.contextLabel, 'Release channel');
+    expect(release.backgroundRoomReadingEnabled, isFalse);
+    expect(release.agentActionsEnabled, isFalse);
+    expect(release.auditTrailRequired, isTrue);
+    expect(release.steps.map((step) => step.kind), <WorkflowStepKind>[
       WorkflowStepKind.gate,
       WorkflowStepKind.step,
       WorkflowStepKind.approval,
     ]);
-    expect(run.steps.any((step) => step.requiresApproval), isTrue);
-    expect(run.steps.any((step) => step.blockers.isNotEmpty), isTrue);
+
+    final support = snapshot.runs.last;
+    expect(support.template.id, 'template:support-incident');
     expect(
-      run.steps.expand((step) => step.contextReferences).map((ref) => ref.kind),
+      support.template.canAttachTo(WorkflowContextReferenceKind.event),
+      isTrue,
+    );
+    expect(support.contextLabel, 'Support incident');
+
+    final steps = snapshot.runs.expand((run) => run.steps).toList();
+    expect(steps.any((step) => step.requiresApproval), isTrue);
+    expect(steps.any((step) => step.blockers.isNotEmpty), isTrue);
+    expect(steps.every((step) => step.agentDryRunOnly), isTrue);
+
+    expect(
+      steps.expand((step) => step.contextReferences).map((ref) => ref.kind),
       containsAll(<WorkflowContextReferenceKind>{
         WorkflowContextReferenceKind.channel,
+        WorkflowContextReferenceKind.project,
+        WorkflowContextReferenceKind.event,
         WorkflowContextReferenceKind.task,
         WorkflowContextReferenceKind.decision,
         WorkflowContextReferenceKind.file,
+        WorkflowContextReferenceKind.meeting,
         WorkflowContextReferenceKind.agentRun,
       }),
     );

--- a/client/test/features/workflows/workflow_preview_provider_test.dart
+++ b/client/test/features/workflows/workflow_preview_provider_test.dart
@@ -70,6 +70,9 @@ void main() {
     expect(steps.any((step) => step.requiresApproval), isTrue);
     expect(steps.any((step) => step.blockers.isNotEmpty), isTrue);
     expect(steps.every((step) => step.agentDryRunOnly), isTrue);
+    expect(steps.every((step) => step.hasTraceableEvidence), isTrue);
+    expect(steps.every((step) => step.hasTraceableBlockers), isTrue);
+    expect(steps.every((step) => step.isExplainable), isTrue);
 
     expect(
       steps.expand((step) => step.contextReferences).map((ref) => ref.kind),
@@ -84,5 +87,108 @@ void main() {
         WorkflowContextReferenceKind.agentRun,
       }),
     );
+  });
+
+  test('workflow steps reject unlinked evidence and blocker references', () {
+    const context = WorkflowContextReference(
+      id: 'task:ready',
+      kind: WorkflowContextReferenceKind.task,
+      label: 'Ready task',
+      sourceLabel: 'Linked task',
+    );
+    const evidence = WorkflowEvidenceReference(
+      id: 'evidence:ready',
+      label: 'Ready evidence',
+      sourceLabel: 'Task state',
+      contextReferenceId: 'task:ready',
+    );
+
+    const linked = WorkflowStepPreview(
+      id: 'step:linked',
+      kind: WorkflowStepKind.step,
+      title: 'Linked step',
+      state: WorkflowStepState.ready,
+      ownerLabel: 'Owner',
+      assignee: WorkflowAssignee(
+        label: 'Owner',
+        kind: WorkflowAssigneeKind.person,
+      ),
+      nextAction: 'Continue.',
+      dueLabel: 'Today',
+      contextReferences: <WorkflowContextReference>[context],
+      evidence: <WorkflowEvidenceReference>[evidence],
+      blockers: <WorkflowBlocker>[
+        WorkflowBlocker(
+          id: 'blocker:ready',
+          description: 'Needs evidence.',
+          ownerLabel: 'Owner',
+          evidenceIds: <String>['evidence:ready'],
+        ),
+      ],
+      requiresApproval: false,
+      agentDryRunOnly: true,
+    );
+
+    const evidenceWithoutContext = WorkflowStepPreview(
+      id: 'step:unlinked-evidence',
+      kind: WorkflowStepKind.step,
+      title: 'Unlinked evidence',
+      state: WorkflowStepState.ready,
+      ownerLabel: 'Owner',
+      assignee: WorkflowAssignee(
+        label: 'Owner',
+        kind: WorkflowAssigneeKind.person,
+      ),
+      nextAction: 'Stop.',
+      dueLabel: 'Today',
+      contextReferences: <WorkflowContextReference>[context],
+      evidence: <WorkflowEvidenceReference>[
+        WorkflowEvidenceReference(
+          id: 'evidence:missing-context',
+          label: 'Missing context evidence',
+          sourceLabel: 'Unknown state',
+          contextReferenceId: 'task:missing',
+        ),
+      ],
+      blockers: <WorkflowBlocker>[],
+      requiresApproval: false,
+      agentDryRunOnly: true,
+    );
+
+    const blockerWithoutEvidence = WorkflowStepPreview(
+      id: 'step:unlinked-blocker',
+      kind: WorkflowStepKind.step,
+      title: 'Unlinked blocker',
+      state: WorkflowStepState.blocked,
+      ownerLabel: 'Owner',
+      assignee: WorkflowAssignee(
+        label: 'Owner',
+        kind: WorkflowAssigneeKind.person,
+      ),
+      nextAction: 'Stop.',
+      dueLabel: 'Today',
+      contextReferences: <WorkflowContextReference>[context],
+      evidence: <WorkflowEvidenceReference>[evidence],
+      blockers: <WorkflowBlocker>[
+        WorkflowBlocker(
+          id: 'blocker:missing-evidence',
+          description: 'Missing evidence link.',
+          ownerLabel: 'Owner',
+          evidenceIds: <String>['evidence:missing'],
+        ),
+      ],
+      requiresApproval: false,
+      agentDryRunOnly: true,
+    );
+
+    expect(linked.hasTraceableEvidence, isTrue);
+    expect(linked.hasTraceableBlockers, isTrue);
+    expect(linked.isExplainable, isTrue);
+
+    expect(evidenceWithoutContext.hasTraceableEvidence, isFalse);
+    expect(evidenceWithoutContext.isExplainable, isFalse);
+
+    expect(blockerWithoutEvidence.hasTraceableBlockers, isFalse);
+    expect(blockerWithoutEvidence.isExplainable, isFalse);
   });
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,8 @@ Start with:
 3. [Spec-driven development for Weave](spec-driven-development.md) — repo-local specs, lifecycle, evidence gates, and agent orchestration.
 4. [Weave agent-team orchestration](agent-team-orchestration.md) — `weave-co-leader`, native subagents, ACP specialists, briefs, and optimization loop.
 5. [Canonical feature models](canonical-feature-models.md) — provider-neutral domain vocabulary.
-6. [Architecture](architecture.md) and [Diagrams](diagrams/index.md) — facades, data flow, and domain diagrams.
+6. [Accessible workflow context contract](workflow-context-contract.md) — linear workflow primitives, context references, agent dry-run rules, and the MVP slice before a visual builder.
+7. [Architecture](architecture.md) and [Diagrams](diagrams/index.md) — facades, data flow, and domain diagrams.
 
 ### Security / compliance reviewer
 
@@ -75,6 +76,7 @@ Canonical product docs:
 - [Spec-driven development for Weave](spec-driven-development.md)
 - [Weave agent-team orchestration](agent-team-orchestration.md)
 - [Canonical feature models](canonical-feature-models.md)
+- [Accessible workflow context contract](workflow-context-contract.md)
 - [Architecture](architecture.md)
 - [Organization embedding contract](organization-embedding-contract.md)
 - [Admin-Suite readiness and setup contract](admin-suite-readiness-setup-contract.md)

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -4,7 +4,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Added
 
-- Nothing yet.
+- Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
 
 ## Changed
 

--- a/docs/workflow-context-contract.md
+++ b/docs/workflow-context-contract.md
@@ -1,0 +1,100 @@
+# Accessible workflow context contract
+
+Status: companion contract projection for `specs/0002-context-driven-workflows/spec.md` and issue #218. The repo-local spec remains the canonical source; this page explains the workflow model before any visual builder.
+
+Weave workflows are linear, context-driven work records. They help people and governed agents coordinate work without turning the primary experience into a visual-only diagram canvas. A diagram can be added later, but the accessible linear view is the source of truth.
+
+## Primitives
+
+| Primitive | Contract |
+| --- | --- |
+| Workflow template | A reusable workflow definition that declares which Context Graph node kinds it can attach to. Initial attach points are `channel`, `project`, and `event`. |
+| Workflow run | One started instance of a template. It stores the selected context node, ordered steps, current blockers, and audit requirement. |
+| Step | A linear unit of work with a type, status, owner, assignee, next action, due label, context references, and evidence references. |
+| Gate | A step that records a decision or readiness check before later work may be treated as complete. |
+| Approval | A step that must be approved by the owning person before a suggested action can run or be shared. |
+| Evidence | A support-safe pointer to an existing context node or artifact. It explains why the step is in its current state. |
+| Blocker | A named condition preventing progress, with an owner and linked evidence ids. |
+| Assignee | A person or governed agent assigned to the step. Agent assignment never grants autonomous execution by itself. |
+
+## Context Graph references
+
+Workflows do not duplicate chat messages, files, tasks, meetings, decisions, events, or agent outputs. They store references to Context Graph nodes and short display labels only.
+
+Required node reference behavior:
+
+- Context references use stable ids such as `channel:*`, `project:*`, `event:*`, `task:*`, `decision:*`, `file:*`, `meeting:*`, and `agent-run:*`.
+- A workflow step may cite several context references, but every reference must be explicit and visible to the user.
+- Evidence points back to a context reference id so reviewers can understand the source without exposing raw provider payloads.
+- Background room reading is off for the MVP contract; users attach context intentionally.
+- Provider-specific state stays behind existing Weave facades and support-safe evidence boundaries.
+
+## Accessible linear view
+
+The first workflow UI is a linear list, not a drag-only board or diagram.
+
+The view must expose:
+
+- workflow title, selected context, step count, blocker count, and next action;
+- each step's type, status, owner, due label, next action, blockers, and evidence;
+- the same status and blocker information through screen-reader semantics;
+- keyboard-reachable actions for opening a step and reviewing evidence;
+- non-color-only status indicators.
+
+The client contract lives in:
+
+- `client/lib/features/workflows/domain/entities/workflow_preview.dart`
+- `client/lib/features/workflows/presentation/providers/workflow_preview_provider.dart`
+- `client/lib/features/workflows/presentation/widgets/workflow_preview_panel.dart`
+- `client/test/features/workflows/workflow_preview_provider_test.dart`
+- `client/test/features/workflows/workflow_preview_panel_test.dart`
+
+## Agent participation rules
+
+Agents can be assignees, but the MVP workflow slice is dry-run only.
+
+Rules:
+
+1. Agent steps must show the agent assignee, context references, evidence, and next action before any owner decision.
+2. `agentDryRunOnly` remains true for every MVP step.
+3. `agentActionsEnabled` remains false at workflow-run level until admin policy, permissions, audit, and approvals are connected.
+4. Approval steps require the owning person before generated summaries, drafts, or suggested actions are shared.
+5. `auditTrailRequired` remains true for every workflow run.
+6. Agent outputs are represented as `agent-run:*` context references, not hidden side effects.
+
+## Sample workflows
+
+| Sample workflow | Attach point | Purpose | MVP behavior |
+| --- | --- | --- | --- |
+| Onboard a workspace | `project` | Coordinate owners, checklist evidence, and welcome-pack approval before inviting members. | Linear steps with task and file evidence; agent help is approval-gated. |
+| Prepare a release | `channel` | Link release decisions, checklist blockers, and release-note approval. | Linear gate/step/approval sequence with visible blocker evidence. |
+| Resolve a support incident | `event` | Link incident triage, meeting notes, follow-up task, and support-summary approval. | Agent summary is dry-run only and must be approved before sharing. |
+
+## MVP slice before a visual builder
+
+The shippable MVP slice is the accessible workflow preview contract:
+
+- domain primitives for templates, runs, steps, gates, approvals, evidence, blockers, and assignees;
+- explicit Context Graph node references instead of duplicated data;
+- linear screen-reader-friendly workflow panel;
+- sample workflow fixtures for onboarding, release preparation, and support incident resolution;
+- tests proving explicit context, governed agent dry-run behavior, and accessible semantics.
+
+Not in the MVP slice:
+
+- visual workflow builder;
+- drag-only diagram editing;
+- autonomous agent execution;
+- background room scanning;
+- direct provider-control-plane calls from member UI.
+
+## Acceptance mapping
+
+Issue #218 acceptance is satisfied by this contract and the client workflow preview evidence:
+
+- primitives: `WorkflowTemplatePreview`, `WorkflowRunPreview`, `WorkflowStepPreview`, `WorkflowEvidenceReference`, `WorkflowBlocker`, and `WorkflowAssignee`;
+- linear view: `WorkflowPreviewPanel` and its widget test;
+- Context Graph references: `WorkflowContextReference` and evidence `contextReferenceId` links;
+- agent rules: dry-run, approval, and audit flags in `WorkflowRunPreview` and `WorkflowStepPreview`;
+- sample workflows: onboarding a workspace, preparing a release, resolving a support incident;
+- MVP slice: accessible preview contract before any visual builder.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Trunk-based PR and release workflow: gitflow-pr-workflow.md
       - Architecture: architecture.md
       - Canonical feature models: canonical-feature-models.md
+      - Accessible workflow context contract: workflow-context-contract.md
       - Acceptance contracts: acceptance-contracts.md
       - Quality and evidence: quality-and-evidence.md
       - Build, evidence, and delivery system: build-evidence-delivery-system.md

--- a/specs/0002-context-driven-workflows/plan.md
+++ b/specs/0002-context-driven-workflows/plan.md
@@ -1,0 +1,75 @@
+# Implementation plan: Context-driven workflow primitives
+
+**Spec**: `specs/0002-context-driven-workflows/spec.md`  
+**Branch**: `issue-218-workflow-contract`  
+**Date**: 2026-05-29
+
+## Summary
+
+Add a preview-only workflow contract that keeps workflows provider-neutral, linear-first, Context Graph based, and agent-governed. The first implementation stays in client domain/presentation preview code and documents the required backend/server ownership before any persisted workflow execution.
+
+## Constitution check
+
+- Repo truth recovered from `main`, docs, GitHub issue/PR state, and CI evidence: yes
+- Product-first/provider-neutral boundary preserved: yes
+- Acceptance/evidence path identified before implementation: yes
+- Accessibility/supportability/auditability/deployability addressed: yes
+- Provider secrets/raw diagnostics remain admin/operator-only: yes
+- Weaver/OpenClaw runtime remains governed and disabled-by-default unless explicitly in scope: yes
+
+## Affected areas
+
+- `client/`: workflow preview domain entities, preview facade, provider/widget tests.
+- `server/`: not changed in MVP; must own future persisted templates/runs and Context Graph authorization.
+- `admin-console/`: not changed in MVP; future policy preview may expose workflow execution controls.
+- `infra/`: not changed.
+- `e2e/`: not changed for preview-only MVP.
+- `docs/`: repo-local spec under `specs/0002-context-driven-workflows/`.
+- `release/`: not changed.
+- `tools/`: not changed.
+
+## Contracts and tests first
+
+1. Product acceptance/Gherkin: deferred until persisted backend/user journey slice.
+2. Mapping/evidence marker: deferred until product journey is executable.
+3. API/event/schema contracts: future backend workflow/context endpoint required before execution.
+4. Unit/widget/backend/admin tests: `client/test/features/workflows/workflow_preview_provider_test.dart`, `client/test/features/workflows/workflow_preview_panel_test.dart`.
+5. CI/evidence artifacts: local Flutter workflow tests and `./gradlew specContract`.
+
+## Agent work breakdown
+
+- Product/spec steward: validate `specs/0002-context-driven-workflows/spec.md` issue #218 acceptance coverage.
+- Client/accessibility: keep `WorkflowPreviewPanel` linear, semantic, non-drag, and text-first.
+- Server/domain facade: later define persisted workflow endpoint and Context Graph authorization.
+- Admin/policy: later define workflow execution and agent dry-run policy keys.
+- Provider/infra: no MVP work.
+- QA/evidence: add Gherkin/mapping when backend journey exists.
+- Docs/release: link PR to issue #218 and use `release-notes-feature`.
+- Security/privacy review: confirm no raw provider payloads or silent agent writes.
+
+## Rollout and migration
+
+- Backward compatibility: preview-only domain classes; no stored data.
+- Data migration: none.
+- Feature flag/capability gate: future workflow capability before persisted rollout.
+- Rollback plan: remove preview surface/classes; no provider migration.
+- Release evidence: local workflow tests and spec contract gate.
+
+## Risks and mitigations
+
+- Risk: client preview becomes product contract without server-owned canonical ids.
+  - Mitigation: spec marks backend ownership and fail-closed Context Graph resolution as required before execution.
+  - Evidence gate: architecture review plus future backend contract tests.
+- Risk: agent workflows imply autonomous writes.
+  - Mitigation: MVP flags agent steps as dry-run/proposal-only with approval and audit requirements.
+  - Evidence gate: workflow provider tests.
+- Risk: workflow UI regresses to visual-only builder assumptions.
+  - Mitigation: linear preview first; widget test covers non-drag accessible panel.
+  - Evidence gate: workflow panel widget test.
+
+## Final gates
+
+- `./gradlew specContract`
+- `./gradlew acceptanceContract` when Gherkin/mappings change or before PR review
+- `flutter test test/features/workflows/workflow_preview_provider_test.dart test/features/workflows/workflow_preview_panel_test.dart`
+- `./gradlew clientCi` before merge for client changes

--- a/specs/0002-context-driven-workflows/plan.md
+++ b/specs/0002-context-driven-workflows/plan.md
@@ -1,7 +1,7 @@
 # Implementation plan: Context-driven workflow primitives
 
-**Spec**: `specs/0002-context-driven-workflows/spec.md`  
-**Branch**: `issue-218-workflow-contract`  
+**Spec**: `specs/0002-context-driven-workflows/spec.md`
+**Branch**: `issue-218-workflow-contract`
 **Date**: 2026-05-29
 
 ## Summary

--- a/specs/0002-context-driven-workflows/spec.md
+++ b/specs/0002-context-driven-workflows/spec.md
@@ -55,9 +55,9 @@ Define the provider-neutral workflow primitives that let teams run expert proces
 
 ### US1 - Linear workflow preview (Priority: P1)
 
-**Actor**: Member  
-**Story**: As a member, I can open active workflows for my workspace context as a linear list of steps with owners, state, blockers, evidence, and next actions.  
-**Why now**: Issue #218 requires expert-grade workflows without inaccessible visual spaghetti.  
+**Actor**: Member
+**Story**: As a member, I can open active workflows for my workspace context as a linear list of steps with owners, state, blockers, evidence, and next actions.
+**Why now**: Issue #218 requires expert-grade workflows without inaccessible visual spaghetti.
 **Independent test**: `flutter test test/features/workflows/workflow_preview_provider_test.dart test/features/workflows/workflow_preview_panel_test.dart`
 
 **Acceptance scenarios**:
@@ -67,9 +67,9 @@ Define the provider-neutral workflow primitives that let teams run expert proces
 
 ### US2 - Context Graph references instead of duplicated data (Priority: P1)
 
-**Actor**: Developer  
-**Story**: As a developer, I can model workflow step references as canonical Context Graph node references instead of copying task, decision, file, meeting, or agent-run data into workflows.  
-**Why now**: Workflows must remain portable across provider swaps and domain facades.  
+**Actor**: Developer
+**Story**: As a developer, I can model workflow step references as canonical Context Graph node references instead of copying task, decision, file, meeting, or agent-run data into workflows.
+**Why now**: Workflows must remain portable across provider swaps and domain facades.
 **Independent test**: Domain/unit tests verify reference kind, explicitness, evidence linkage, and fail-closed assumptions before backend execution exists.
 
 **Acceptance scenarios**:
@@ -79,9 +79,9 @@ Define the provider-neutral workflow primitives that let teams run expert proces
 
 ### US3 - Governed agent participation (Priority: P1)
 
-**Actor**: Admin and member  
-**Story**: As an admin/member, I can see when an agent is assigned only to prepare a dry-run/proposal and when owner approval is required before action.  
-**Why now**: Agent participation is useful only if it preserves user rights, organization-whitelisted capabilities, and auditability.  
+**Actor**: Admin and member
+**Story**: As an admin/member, I can see when an agent is assigned only to prepare a dry-run/proposal and when owner approval is required before action.
+**Why now**: Agent participation is useful only if it preserves user rights, organization-whitelisted capabilities, and auditability.
 **Independent test**: Provider tests assert agent actions disabled, dry-run-only steps, approval flags, and audit requirements.
 
 **Acceptance scenarios**:

--- a/specs/0002-context-driven-workflows/spec.md
+++ b/specs/0002-context-driven-workflows/spec.md
@@ -1,0 +1,140 @@
+---
+id: WEAVE-SPEC-0002
+title: Context-driven workflow primitives
+version: 0.1.0
+status: proposed
+domain: product-core
+owner: weave-co-leader
+github_issue: 218
+supersedes: []
+depends_on:
+  - WEAVE-SPEC-0001
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew acceptanceContract
+  - flutter test test/features/workflows/workflow_preview_provider_test.dart test/features/workflows/workflow_preview_panel_test.dart
+---
+
+# Feature specification: Context-driven workflow primitives
+
+## Intent
+
+Define the provider-neutral workflow primitives that let teams run expert processes from Weave context objects without requiring a visual-only workflow builder. The first slice is a linear, accessible preview contract that can attach workflow templates to channels, projects, and events; reference existing Weave context nodes; and keep agent participation proposal-first, approval-gated, and auditable.
+
+## Product boundaries
+
+### In scope
+
+- Workflow templates attachable to channel, project, and event contexts.
+- Workflow runs that present ordered steps in a linear, screen-reader-friendly view.
+- Step references to tasks, decisions, files, meetings, and agent runs through Context Graph node references.
+- Agent participation rules for dry-run proposals, explicit approval, and audit evidence.
+- Sample workflow templates for workspace onboarding, release preparation, and support incident resolution.
+- MVP slice before any visual builder: preview/read-only workflow runs with explicit context and governed action metadata.
+
+### Out of scope
+
+- Visual workflow builder, drag-only workflow editing, or pointer-only execution paths.
+- Silent agent writes, continuous room reading, or autonomous execution outside organization policy.
+- Provider-specific workflow engines as the product model.
+- Raw provider payloads, endpoints, credentials, or diagnostics in member workflow views.
+- Cross-provider workflow migration automation beyond stable identifiers and support-safe evidence references.
+
+### Non-negotiable constraints
+
+- Weave remains product-first and provider-neutral.
+- Normal members see Weave workflow objects and capability states, not provider workflow internals.
+- Workflow steps must be operable and understandable without drag/drop or visual diagrams.
+- Every context reference must resolve to a server-owned canonical Context Graph node or fail closed.
+- Agent-assigned steps are dry-run/proposal-only until explicit approval and audit receipt exist.
+- Accessibility, supportability, auditability, and deployability are release blockers.
+- Weaver/OpenClaw runtime remains governed and disabled-by-default unless a later accepted spec enables runtime execution.
+
+## User/admin/operator stories
+
+### US1 - Linear workflow preview (Priority: P1)
+
+**Actor**: Member  
+**Story**: As a member, I can open active workflows for my workspace context as a linear list of steps with owners, state, blockers, evidence, and next actions.  
+**Why now**: Issue #218 requires expert-grade workflows without inaccessible visual spaghetti.  
+**Independent test**: `flutter test test/features/workflows/workflow_preview_provider_test.dart test/features/workflows/workflow_preview_panel_test.dart`
+
+**Acceptance scenarios**:
+
+1. Given a selected channel, project, or event context, when workflows are previewed, then each run shows a template, run id, title, context label, ordered steps, explicit context references, evidence, blockers, and next action copy.
+2. Given a workflow contains blocked or approval steps, when the member reviews the linear view, then blockers and approval needs are exposed in text and not by color alone.
+
+### US2 - Context Graph references instead of duplicated data (Priority: P1)
+
+**Actor**: Developer  
+**Story**: As a developer, I can model workflow step references as canonical Context Graph node references instead of copying task, decision, file, meeting, or agent-run data into workflows.  
+**Why now**: Workflows must remain portable across provider swaps and domain facades.  
+**Independent test**: Domain/unit tests verify reference kind, explicitness, evidence linkage, and fail-closed assumptions before backend execution exists.
+
+**Acceptance scenarios**:
+
+1. Given a workflow step references a task, decision, file, meeting, or agent run, when the workflow is rendered, then the workflow stores the node reference id/kind/label/source label and not raw provider data.
+2. Given a reference is implicit or missing evidence, when explainability is evaluated, then the run is not considered explainable.
+
+### US3 - Governed agent participation (Priority: P1)
+
+**Actor**: Admin and member  
+**Story**: As an admin/member, I can see when an agent is assigned only to prepare a dry-run/proposal and when owner approval is required before action.  
+**Why now**: Agent participation is useful only if it preserves user rights, organization-whitelisted capabilities, and auditability.  
+**Independent test**: Provider tests assert agent actions disabled, dry-run-only steps, approval flags, and audit requirements.
+
+**Acceptance scenarios**:
+
+1. Given a step is assigned to an agent, when the workflow is shown, then the step states whether approval is required and whether the agent action is dry-run-only.
+2. Given a workflow allows background room reading or direct agent actions without audit, when governance is evaluated, then it is not acceptable for the MVP preview.
+
+## Functional requirements
+
+- **FR-001**: Weave MUST model workflow templates with stable ids, titles, descriptions, and attachable context kinds.
+- **FR-002**: Weave MUST model workflow runs with stable run ids, template references, context labels, ordered steps, and audit/governance flags.
+- **FR-003**: Workflow steps MUST include id, kind, state, owner, assignee, next action, due label, context references, evidence, blockers, approval requirement, and agent dry-run state.
+- **FR-004**: Workflow context references MUST use canonical node ids and kinds for channel, project, event, task, decision, file, meeting, and agent run references.
+- **FR-005**: Workflow evidence MUST link back to explicit context references and remain support-safe.
+- **FR-006**: The MVP member view MUST provide a linear, accessible path before any visual builder.
+- **FR-007**: Agent workflow participation MUST be dry-run/proposal-only unless a later accepted spec defines approval receipts, audit persistence, and runtime execution.
+- **FR-008**: Weave MUST NOT duplicate raw provider records, provider secrets, endpoints, or diagnostics into workflow objects.
+- **FR-009**: Weave MUST include sample templates for onboarding a workspace, preparing a release, and resolving a support incident.
+- **FR-010**: Workflow references that cannot be authorized or resolved through server-owned context contracts MUST fail closed before execution or provider access.
+
+## Domain model and contracts
+
+- Canonical Weave entities affected: WorkflowTemplate, WorkflowRun, WorkflowStep, WorkflowContextReference, WorkflowEvidenceReference, WorkflowBlocker, WorkflowAssignee.
+- Provider/category contracts affected: none directly in MVP; later execution must use server facades for chat, files, boards/tasks, calendar/events, meetings, decisions, and governed Weaver runtime.
+- API/event contracts affected: future backend contract must expose workflow previews/runs with Context Graph node references; no provider-specific payloads in member responses.
+- Policy/RBAC/capability keys affected: workflow preview availability, workflow execution approval, agent dry-run/proposal, audit receipt requirements.
+- Audit/support evidence affected: workflow run id, step id, approval requirement, context reference ids, evidence ids, and support-safe source labels.
+
+## Sample workflows
+
+- Workspace onboarding: attaches to a project, references onboarding tasks and welcome-pack files, requires owner review before invites or agent-written copy.
+- Release preparation: attaches to a channel, references decisions, release checklist tasks, release-note files, and dry-run agent review before publication.
+- Support incident resolution: attaches to an incident event, references meeting notes, follow-up tasks, and dry-run agent summaries before owner approval.
+
+## Acceptance and evidence mapping
+
+- Gherkin feature path(s): none for proposed MVP preview; add before backend execution or user journey expansion.
+- `e2e/scenario_mappings.json` marker(s): none for proposed MVP preview.
+- Unit/widget/backend/admin/contract test path(s): `client/test/features/workflows/workflow_preview_provider_test.dart`, `client/test/features/workflows/workflow_preview_panel_test.dart`.
+- Live Stack E2E required? no; MVP is local preview/domain contract only.
+- Support-safe evidence artifact(s): local Flutter test output; later CI summary under `build/evidence/**` when merged through PR.
+
+## Release and migration impact
+
+- Member impact: accessible preview of workflow runs and blockers.
+- Admin/operator impact: no provider setup surface in MVP; later policy/audit controls required for execution.
+- Developer/API impact: establishes client/domain primitives that must be backed by server-owned context references before persistence/execution.
+- Data migration/backfill: none for preview-only MVP.
+- Rollback/reversibility: remove preview feature without provider/data migration.
+- Release-notes label expected: `release-notes-feature`
+
+## Open questions
+
+- [ ] Which backend endpoint owns persisted workflow templates/runs after preview-only MVP?
+- [ ] Which policy key names govern workflow execution approval and agent dry-run visibility?
+- [ ] Which acceptance feature should cover first persisted workflow execution after preview-only MVP?

--- a/specs/0002-context-driven-workflows/tasks.md
+++ b/specs/0002-context-driven-workflows/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Context-driven workflow primitives
 
-**Spec**: `specs/0002-context-driven-workflows/spec.md`  
+**Spec**: `specs/0002-context-driven-workflows/spec.md`
 **Plan**: `specs/0002-context-driven-workflows/plan.md`
 
 ## Phase 0: Truth recovery

--- a/specs/0002-context-driven-workflows/tasks.md
+++ b/specs/0002-context-driven-workflows/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Context-driven workflow primitives
+
+**Spec**: `specs/0002-context-driven-workflows/spec.md`  
+**Plan**: `specs/0002-context-driven-workflows/plan.md`
+
+## Phase 0: Truth recovery
+
+- [x] T001 [Spec] Re-read `AGENTS.md`, `.specify/memory/constitution.md`, product-line direction, and issue #218.
+- [x] T002 [Spec] Verify branch and local diff state for `issue-218-workflow-contract`.
+- [x] T003 [Spec] Verify issue #218 acceptance asks for templates, Context Graph references, agent rules, sample workflows, and MVP slice.
+
+## Phase 1: Acceptance and contracts first
+
+- [x] T010 [Spec] Add repo-local proposed workflow contract in `specs/0002-context-driven-workflows/spec.md`.
+- [x] T011 [Acceptance] Record that Gherkin/mapping is deferred until persisted backend workflow/user journey exists.
+- [x] T012 [Contracts] Keep Context Graph/server ownership as a required future contract before execution.
+- [ ] T013 [Evidence] Run `./gradlew specContract`.
+
+## Phase 2: Implementation slices
+
+- [x] T020 [US1] Extend preview primitives in `client/lib/features/workflows/domain/entities/workflow_preview.dart`.
+- [x] T021 [US1] Add sample workflow previews in `client/lib/features/workflows/presentation/providers/workflow_preview_provider.dart`.
+- [x] T022 [US1] Update workflow preview provider/widget tests.
+- [x] T023 [US1] Run targeted Flutter workflow tests.
+
+## Phase 3: Cross-cutting quality
+
+- [x] T030 [A11y] Keep workflow preview linear, non-drag, text-first, and semantics-covered.
+- [x] T031 [Support] Keep context references support-safe and provider-neutral.
+- [x] T032 [Audit] Model approval, dry-run, and audit-required flags.
+- [x] T033 [Docs] Document release-notes expectation in the spec.
+
+## Phase 4: Integration and handoff
+
+- [ ] T040 Run required area gates.
+- [ ] T041 Run `./gradlew clientCi` before merge.
+- [x] T042 Run architecture-contract review and resolve API/domain drift.
+- [ ] T043 Fill PR body with spec ID, acceptance/evidence, risks, and fallback review evidence.
+- [x] T044 Keep spec status `proposed` until backend execution and policy names are accepted.
+- [x] T045 Agent handoff: preserve durable decisions, evidence, blockers, and next safe action only.

--- a/specs/0002-context-driven-workflows/tasks.md
+++ b/specs/0002-context-driven-workflows/tasks.md
@@ -14,7 +14,7 @@
 - [x] T010 [Spec] Add repo-local proposed workflow contract in `specs/0002-context-driven-workflows/spec.md`.
 - [x] T011 [Acceptance] Record that Gherkin/mapping is deferred until persisted backend workflow/user journey exists.
 - [x] T012 [Contracts] Keep Context Graph/server ownership as a required future contract before execution.
-- [ ] T013 [Evidence] Run `./gradlew specContract`.
+- [x] T013 [Evidence] Run `./gradlew specContract`.
 
 ## Phase 2: Implementation slices
 
@@ -32,8 +32,8 @@
 
 ## Phase 4: Integration and handoff
 
-- [ ] T040 Run required area gates.
-- [ ] T041 Run `./gradlew clientCi` before merge.
+- [x] T040 Run required area gates.
+- [ ] T041 Run `./gradlew clientCi` before merge after branch changes are committed; local uncommitted-diff check fails while this patch is still unstaged.
 - [x] T042 Run architecture-contract review and resolve API/domain drift.
 - [ ] T043 Fill PR body with spec ID, acceptance/evidence, risks, and fallback review evidence.
 - [x] T044 Keep spec status `proposed` until backend execution and policy names are accepted.

--- a/specs/0002-context-driven-workflows/traceability.yaml
+++ b/specs/0002-context-driven-workflows/traceability.yaml
@@ -1,0 +1,38 @@
+spec_id: WEAVE-SPEC-0002
+version: 0.1.0
+status: proposed
+github_issue: 218
+release_notes_label: release-notes-feature
+depends_on:
+  - WEAVE-SPEC-0001
+issue_dag:
+  sequential:
+    - issue: 218
+      title: Context-driven workflows
+domain_entities:
+  - WorkflowTemplate
+  - WorkflowRun
+  - WorkflowStep
+  - WorkflowContextReference
+  - WorkflowEvidenceReference
+  - WorkflowBlocker
+  - WorkflowAssignee
+provider_neutral_invariants:
+  - workflow objects reference Context Graph nodes instead of duplicating provider records
+  - member workflow views do not expose raw provider payloads, endpoints, secrets, or diagnostics
+  - unresolved or unauthorized context references fail closed before execution/provider access
+  - agent steps are dry-run/proposal-only until explicit approval and audit receipt exist
+  - linear accessible view ships before any visual workflow builder
+sample_workflows:
+  - workspace onboarding
+  - release preparation
+  - support incident resolution
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew acceptanceContract
+  - flutter test test/features/workflows/workflow_preview_provider_test.dart test/features/workflows/workflow_preview_panel_test.dart
+open_product_core_decisions:
+  - backend endpoint ownership for persisted workflow templates and runs
+  - policy key names for workflow execution approval and agent dry-run visibility
+  - first Gherkin feature for persisted workflow execution


### PR DESCRIPTION
Closes #218.

## Summary
- define WEAVE-SPEC-0002 for context-driven workflow primitives and traceability
- extend workflow preview primitives for templates, runs, steps, gates, approvals, evidence, blockers, assignees, and explicit Context Graph references
- add linear-first sample workflow previews for workspace onboarding, release preparation, and support incident resolution
- document dry-run-only governed agent participation, accessible linear view requirements, and MVP boundaries before any visual builder

## Evidence
- `flutter test test/features/workflows/workflow_preview_provider_test.dart test/features/workflows/workflow_preview_panel_test.dart test/architecture/workflow_context_contract_test.dart`
- `./gradlew specContract acceptanceContract --console=plain`
- `make docs-check`
- `PR_LABELS_JSON='["area:ux","release-notes-feature","track:interop"]' ./gradlew releaseNotesLabelCheck --console=plain`
- `./gradlew clientCi --console=plain`

## Veto / risk notes
- No provider secrets, raw provider payloads, or production mutations.
- Agent workflow steps remain dry-run/proposal-only; execution, policy keys, persisted backend endpoints, and approval receipts are future accepted-spec work.
- Visual workflow builder and background room scanning are explicitly out of scope.
