### PR TITLE
feat(meetings): define contextual meeting contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Use this page for release-affecting changes that have merged but are not include
 ## Added
 
 - Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
-- Contextual meetings now have a fail-closed architecture contract covering MatrixRTC/Element Call vs LiveKit-style SFU trade-offs, encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
+- Contextual meetings now have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
 
 ## Changed
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Use this page for release-affecting changes that have merged but are not include
 ## Added
 
 - Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
+- Contextual meetings now have a fail-closed architecture contract covering MatrixRTC/Element Call vs LiveKit-style SFU trade-offs, encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
 
 ## Changed
 

--- a/client/lib/features/chat/domain/entities/channel_workspace.dart
+++ b/client/lib/features/chat/domain/entities/channel_workspace.dart
@@ -51,6 +51,26 @@ enum ChannelMeetingContextItemKind {
   followUpEvidence,
 }
 
+enum ChannelMeetingAttachPointKind { channel, calendarEvent, thread }
+
+enum ChannelMeetingEncryptionBoundaryKind {
+  matrixSignaling,
+  mediaStreams,
+  captions,
+  transcripts,
+  recordings,
+  metadata,
+}
+
+enum ChannelMeetingUxRequirementKind {
+  deviceSelection,
+  joinPreview,
+  muteState,
+  cameraState,
+  participantList,
+  errorRecovery,
+}
+
 enum ChannelMeetingControlKind { join, start }
 
 class ChannelMeetingContextItem {
@@ -61,6 +81,48 @@ class ChannelMeetingContextItem {
 
   final ChannelMeetingContextItemKind kind;
   final bool includedInPreview;
+}
+
+class ChannelMeetingAttachPoint {
+  const ChannelMeetingAttachPoint({
+    required this.kind,
+    required this.contextId,
+    required this.label,
+    required this.enabled,
+  });
+
+  final ChannelMeetingAttachPointKind kind;
+  final String contextId;
+  final String label;
+  final bool enabled;
+}
+
+class ChannelMeetingEncryptionBoundary {
+  const ChannelMeetingEncryptionBoundary({
+    required this.kind,
+    required this.claim,
+    required this.evidenceLabel,
+  });
+
+  final ChannelMeetingEncryptionBoundaryKind kind;
+  final String claim;
+  final String evidenceLabel;
+
+  bool get hasEvidence => evidenceLabel.isNotEmpty;
+}
+
+class ChannelMeetingUxRequirement {
+  const ChannelMeetingUxRequirement({
+    required this.kind,
+    required this.required,
+    required this.evidenceLabel,
+  });
+
+  final ChannelMeetingUxRequirementKind kind;
+  final bool required;
+  final String evidenceLabel;
+
+  bool get isDocumented => required && evidenceLabel.isNotEmpty;
 }
 
 class ChannelMeetingControl {
@@ -81,7 +143,10 @@ class ChannelMeetingPreview {
     required this.channelTitle,
     required this.contextId,
     required this.providerContractId,
+    required this.attachPoints,
     required this.contextItems,
+    required this.encryptionBoundaries,
+    required this.uxRequirements,
     required this.controls,
     required this.hasVideoBackendCapability,
     required this.e2eeEvidenceAvailable,
@@ -101,6 +166,26 @@ class ChannelMeetingPreview {
       channelTitle: conversation.title,
       contextId: contextId,
       providerContractId: 'weave-meetings-channel-capability',
+      attachPoints: [
+        ChannelMeetingAttachPoint(
+          kind: ChannelMeetingAttachPointKind.channel,
+          contextId: contextId,
+          label: conversation.title,
+          enabled: true,
+        ),
+        const ChannelMeetingAttachPoint(
+          kind: ChannelMeetingAttachPointKind.calendarEvent,
+          contextId: 'calendar-event:pending',
+          label: 'Calendar event link pending backend capability',
+          enabled: false,
+        ),
+        const ChannelMeetingAttachPoint(
+          kind: ChannelMeetingAttachPointKind.thread,
+          contextId: 'thread:pending',
+          label: 'Thread link pending backend capability',
+          enabled: false,
+        ),
+      ],
       contextItems: const [
         ChannelMeetingContextItem(
           kind: ChannelMeetingContextItemKind.agenda,
@@ -121,6 +206,75 @@ class ChannelMeetingPreview {
         ChannelMeetingContextItem(
           kind: ChannelMeetingContextItemKind.followUpEvidence,
           includedInPreview: true,
+        ),
+      ],
+      encryptionBoundaries: const [
+        ChannelMeetingEncryptionBoundary(
+          kind: ChannelMeetingEncryptionBoundaryKind.matrixSignaling,
+          claim: 'Matrix signaling follows the room encryption posture.',
+          evidenceLabel: 'Matrix E2EE diagnostic and room readiness evidence',
+        ),
+        ChannelMeetingEncryptionBoundary(
+          kind: ChannelMeetingEncryptionBoundaryKind.mediaStreams,
+          claim:
+              'Media requires documented SFU/E2EE capability before enablement.',
+          evidenceLabel: 'Media transport readiness and E2EE trade-off record',
+        ),
+        ChannelMeetingEncryptionBoundary(
+          kind: ChannelMeetingEncryptionBoundaryKind.captions,
+          claim:
+              'Captions are off until consent, retention, and encryption are known.',
+          evidenceLabel: 'Caption consent and storage policy evidence',
+        ),
+        ChannelMeetingEncryptionBoundary(
+          kind: ChannelMeetingEncryptionBoundaryKind.transcripts,
+          claim:
+              'Transcripts are off until consent, retention, and encryption are known.',
+          evidenceLabel: 'Transcript consent and storage policy evidence',
+        ),
+        ChannelMeetingEncryptionBoundary(
+          kind: ChannelMeetingEncryptionBoundaryKind.recordings,
+          claim:
+              'Recordings are off until consent, retention, and encryption are known.',
+          evidenceLabel: 'Recording consent and storage policy evidence',
+        ),
+        ChannelMeetingEncryptionBoundary(
+          kind: ChannelMeetingEncryptionBoundaryKind.metadata,
+          claim:
+              'Metadata is minimized and never described as end-to-end encrypted.',
+          evidenceLabel: 'Support-safe metadata boundary documentation',
+        ),
+      ],
+      uxRequirements: const [
+        ChannelMeetingUxRequirement(
+          kind: ChannelMeetingUxRequirementKind.deviceSelection,
+          required: true,
+          evidenceLabel: 'Device picker contract',
+        ),
+        ChannelMeetingUxRequirement(
+          kind: ChannelMeetingUxRequirementKind.joinPreview,
+          required: true,
+          evidenceLabel: 'Pre-join preview contract',
+        ),
+        ChannelMeetingUxRequirement(
+          kind: ChannelMeetingUxRequirementKind.muteState,
+          required: true,
+          evidenceLabel: 'Audio mute state contract',
+        ),
+        ChannelMeetingUxRequirement(
+          kind: ChannelMeetingUxRequirementKind.cameraState,
+          required: true,
+          evidenceLabel: 'Camera state contract',
+        ),
+        ChannelMeetingUxRequirement(
+          kind: ChannelMeetingUxRequirementKind.participantList,
+          required: true,
+          evidenceLabel: 'Participant list accessibility contract',
+        ),
+        ChannelMeetingUxRequirement(
+          kind: ChannelMeetingUxRequirementKind.errorRecovery,
+          required: true,
+          evidenceLabel: 'Join failure and recovery contract',
         ),
       ],
       controls: const [
@@ -147,7 +301,10 @@ class ChannelMeetingPreview {
   final String channelTitle;
   final String contextId;
   final String providerContractId;
+  final List<ChannelMeetingAttachPoint> attachPoints;
   final List<ChannelMeetingContextItem> contextItems;
+  final List<ChannelMeetingEncryptionBoundary> encryptionBoundaries;
+  final List<ChannelMeetingUxRequirement> uxRequirements;
   final List<ChannelMeetingControl> controls;
   final bool hasVideoBackendCapability;
   final bool e2eeEvidenceAvailable;
@@ -162,6 +319,32 @@ class ChannelMeetingPreview {
 
   bool get requiresExplicitConsent =>
       !recordingEnabled && !transcriptionEnabled;
+
+  bool get canLinkFromChannelOrCalendar =>
+      attachPoints.any(
+        (point) => point.kind == ChannelMeetingAttachPointKind.channel,
+      ) &&
+      attachPoints.any(
+        (point) => point.kind == ChannelMeetingAttachPointKind.calendarEvent,
+      );
+
+  bool get hasDocumentedEncryptionBoundaries {
+    final kinds = encryptionBoundaries.map((boundary) => boundary.kind).toSet();
+    return ChannelMeetingEncryptionBoundaryKind.values.every(kinds.contains) &&
+        encryptionBoundaries.every((boundary) => boundary.hasEvidence);
+  }
+
+  bool get hasAccessibleJoinContract {
+    final kinds = uxRequirements.map((requirement) => requirement.kind).toSet();
+    return ChannelMeetingUxRequirementKind.values.every(kinds.contains) &&
+        uxRequirements.every((requirement) => requirement.isDocumented);
+  }
+
+  bool get preventsVagueSecurityClaims =>
+      hasDocumentedEncryptionBoundaries &&
+      !recordingEnabled &&
+      !transcriptionEnabled &&
+      !backgroundRoomReadingEnabled;
 }
 
 enum ChannelWeaverScoutCapabilityKind {

--- a/client/test/architecture/meetings_contract_test.dart
+++ b/client/test/architecture/meetings_contract_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('meeting architecture contract maps issue 216 acceptance', () async {
+    final contract = await File(
+      '../docs/meeting-architecture-decision.md',
+    ).readAsString();
+    final spec = await File(
+      '../specs/0003-contextual-meetings/spec.md',
+    ).readAsString();
+    final traceability = await File(
+      '../specs/0003-contextual-meetings/traceability.yaml',
+    ).readAsString();
+    final domain = await File(
+      'lib/features/chat/domain/entities/channel_workspace.dart',
+    ).readAsString();
+
+    for (final required in <String>[
+      'MatrixRTC / Element Call',
+      'LiveKit-style SFU',
+      'Generic hosted meeting links',
+      'Matrix signaling',
+      'Media streams',
+      'Captions',
+      'Transcripts',
+      'Recordings',
+      'Metadata',
+      'channel context',
+      'calendar event context',
+      'thread context',
+      'device selection',
+      'join preview',
+      'mute and camera state',
+      'participant list',
+      'errors with retry',
+      'Recording, transcription, and captions are off by default',
+      'Vague-claim guard',
+    ]) {
+      expect(contract, contains(required));
+    }
+
+    for (final required in <String>[
+      'FR-001',
+      'FR-002',
+      'FR-003',
+      'FR-004',
+      'FR-005',
+      'FR-006',
+      'FR-007',
+      'FR-008',
+      'FR-009',
+      'FR-010',
+    ]) {
+      expect(spec, contains(required));
+    }
+
+    for (final required in <String>[
+      'ChannelMeetingAttachPoint',
+      'ChannelMeetingEncryptionBoundary',
+      'ChannelMeetingUxRequirement',
+      'meeting join and start controls fail closed',
+      'encryption claims name signaling, media, captions, transcripts, recordings, and metadata boundaries',
+    ]) {
+      expect(traceability, contains(required));
+    }
+
+    for (final required in <String>[
+      'enum ChannelMeetingAttachPointKind',
+      'enum ChannelMeetingEncryptionBoundaryKind',
+      'enum ChannelMeetingUxRequirementKind',
+      'canLinkFromChannelOrCalendar',
+      'hasDocumentedEncryptionBoundaries',
+      'hasAccessibleJoinContract',
+      'preventsVagueSecurityClaims',
+      'recordingEnabled: false',
+      'transcriptionEnabled: false',
+    ]) {
+      expect(domain, contains(required));
+    }
+
+    expect(contract, contains('Do not claim `secure meetings`'));
+    expect(contract, contains('without naming the boundary and evidence'));
+  });
+}

--- a/client/test/architecture/meetings_contract_test.dart
+++ b/client/test/architecture/meetings_contract_test.dart
@@ -18,8 +18,10 @@ void main() {
     ).readAsString();
 
     for (final required in <String>[
-      'MatrixRTC / Element Call',
+      'LiveKit as the active meetings/video-call provider key',
       'LiveKit-style SFU',
+      'MatrixRTC / Element Call',
+      'future comparison option',
       'Generic hosted meeting links',
       'Matrix signaling',
       'Media streams',
@@ -82,5 +84,17 @@ void main() {
 
     expect(contract, contains('Do not claim `secure meetings`'));
     expect(contract, contains('without naming the boundary and evidence'));
+    expect(
+      contract,
+      isNot(contains('Preferred first implementation candidate')),
+    );
+    expect(
+      spec,
+      contains('LiveKit as the current active meetings provider contract'),
+    );
+    expect(
+      traceability,
+      contains('LiveKit remains the active meetings provider contract'),
+    );
   });
 }

--- a/client/test/features/chat/channel_workspace_test.dart
+++ b/client/test/features/chat/channel_workspace_test.dart
@@ -64,6 +64,15 @@ void main() {
     expect(preview.meetingPreview.isFailClosed, isTrue);
     expect(preview.meetingPreview.requiresExplicitConsent, isTrue);
     expect(preview.meetingPreview.backgroundRoomReadingEnabled, isFalse);
+    expect(preview.meetingPreview.canLinkFromChannelOrCalendar, isTrue);
+    expect(preview.meetingPreview.hasDocumentedEncryptionBoundaries, isTrue);
+    expect(preview.meetingPreview.hasAccessibleJoinContract, isTrue);
+    expect(preview.meetingPreview.preventsVagueSecurityClaims, isTrue);
+    expect(preview.meetingPreview.attachPoints.map((point) => point.kind), [
+      ChannelMeetingAttachPointKind.channel,
+      ChannelMeetingAttachPointKind.calendarEvent,
+      ChannelMeetingAttachPointKind.thread,
+    ]);
     expect(preview.weaverScoutPreview.isGovernedReadOnlyScout, isTrue);
     expect(preview.weaverScoutPreview.readOnly, isTrue);
     expect(preview.weaverScoutPreview.proposalOnly, isTrue);
@@ -107,6 +116,18 @@ void main() {
       ChannelMeetingContextItemKind.tasks,
       ChannelMeetingContextItemKind.followUpEvidence,
     ]);
+    expect(
+      preview.meetingPreview.encryptionBoundaries.map(
+        (boundary) => boundary.kind,
+      ),
+      ChannelMeetingEncryptionBoundaryKind.values,
+    );
+    expect(
+      preview.meetingPreview.uxRequirements.map(
+        (requirement) => requirement.kind,
+      ),
+      ChannelMeetingUxRequirementKind.values,
+    );
     expect(
       preview.meetingPreview.controls.every((control) => !control.enabled),
       isTrue,

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,8 +32,9 @@ Start with:
 1. [Admin/Operator Handbook](admin-operator-handbook.md) — setup, provider categories, policy, readiness, audit, backup/restore, and support bundles.
 2. [Admin-Suite readiness and setup contract](admin-suite-readiness-setup-contract.md) — guided setup assistant, readiness dashboard, action boundary, and support-safe evidence.
 3. [Admin-provisioned first use](admin-provisioned-first-use.md) — member/admin boundary and setup acceptance.
-4. [Organization embedding contract](organization-embedding-contract.md) — identity, tenant, roles/groups, non-human identities, and future Weaver category boundaries.
-5. [Identity provisioning strategy](identity-provisioning-strategy.md) — LDAP/AD/OIDC/SAML/SCIM-oriented identity planning.
+4. [Meeting architecture decision record](meeting-architecture-decision.md) — contextual meeting attach points, E2EE boundaries, consent defaults, and fail-closed readiness.
+5. [Organization embedding contract](organization-embedding-contract.md) — identity, tenant, roles/groups, non-human identities, and future Weaver category boundaries.
+6. [Identity provisioning strategy](identity-provisioning-strategy.md) — LDAP/AD/OIDC/SAML/SCIM-oriented identity planning.
 
 ### Operator
 
@@ -77,6 +78,7 @@ Canonical product docs:
 - [Weave agent-team orchestration](agent-team-orchestration.md)
 - [Canonical feature models](canonical-feature-models.md)
 - [Accessible workflow context contract](workflow-context-contract.md)
+- [Meeting architecture decision record](meeting-architecture-decision.md)
 - [Architecture](architecture.md)
 - [Organization embedding contract](organization-embedding-contract.md)
 - [Admin-Suite readiness and setup contract](admin-suite-readiness-setup-contract.md)

--- a/docs/meeting-architecture-decision.md
+++ b/docs/meeting-architecture-decision.md
@@ -1,0 +1,84 @@
+# Meeting architecture decision record
+
+Status: product/architecture contract for issue #216. This is the meeting contract before enabling join/start controls.
+
+Weave meetings are contextual collaboration surfaces attached to existing Weave work context. They are not generic external links and they are not enabled until encryption boundaries, consent, accessibility, and provider readiness are evidenced.
+
+## Decision
+
+Adopt a provider-neutral meeting capability contract in the member client and keep join/start fail-closed until a backend meeting facade proves a concrete media architecture.
+
+Preferred direction:
+
+1. Use Matrix room state for contextual signaling when possible, because it matches Weave channel identity and room encryption posture.
+2. Treat Element Call/MatrixRTC as the closest product fit for Matrix-native contextual calls.
+3. Permit LiveKit-style SFU deployment only behind a Weave backend facade with explicit E2EE trade-off evidence, token policy, metadata limits, and support-safe diagnostics.
+4. Do not expose provider URLs, room media tokens, SFU internals, or recording/caption storage providers in member UI.
+
+## Architecture options
+
+| Option | Fit | E2EE and confidentiality boundary | Operational trade-off | Decision |
+| --- | --- | --- | --- | --- |
+| MatrixRTC / Element Call | Best fit for Matrix-backed channels and contextual calls. | Signaling can follow Matrix room encryption. Media confidentiality depends on MatrixRTC/Element Call mode, client support, SFU behavior, and documented key handling. | Requires MatrixRTC readiness, compatible clients, media backend evidence, and clear fallback states. | Preferred first implementation candidate. |
+| LiveKit-style SFU behind Weave backend facade | Good for scalable media and operational maturity. | Media may be encrypted in transit and can support E2EE modes, but SFU metadata and feature behavior must be documented. Recording/captions/transcripts need separate encryption and consent evidence. | Requires token minting, SFU operations, capability health, support bundle redaction, and explicit E2EE trade-off docs. | Allowed only behind server facade and policy. |
+| Generic hosted meeting links | Low product fit. | Encryption, metadata, retention, and recording behavior are provider-defined and often opaque to Weave. | Easy link insertion but weak sovereignty and portability. | Not acceptable as the primary Weave meeting model. |
+
+## Encryption and evidence boundaries
+
+| Boundary | Product statement | Required evidence before enabling |
+| --- | --- | --- |
+| Matrix signaling | Signaling follows the Matrix room encryption/readiness posture when Matrix-backed rooms are used. | Matrix E2EE diagnostic, room readiness, and failure-state evidence. |
+| Media streams | Media confidentiality is documented per selected architecture; group calls must state SFU/client key handling. | Media transport readiness, E2EE mode evidence, and architecture trade-off record. |
+| Captions | Off by default. If enabled, caption generation, storage, retention, and encryption are visible to users. | Consent UX, storage boundary, retention policy, and accessibility evidence. |
+| Transcripts | Off by default. If enabled, transcript generation, storage, retention, and encryption are visible to users. | Consent UX, storage boundary, retention policy, export/delete behavior, and audit evidence. |
+| Recordings | Off by default and unavailable without explicit consent and visible state. | Consent UX, recording indicator, storage encryption, retention policy, export/delete behavior, and audit evidence. |
+| Metadata | Participant, timing, device, SFU routing, and diagnostic metadata is minimized and never described as end-to-end encrypted. | Support-safe metadata inventory and redaction tests. |
+
+## Context attachment contract
+
+Meeting surfaces can attach to:
+
+- channel context: `channel:*` as the first supported member surface;
+- calendar event context: `calendar-event:*` once calendar/event facade readiness exists;
+- thread context: `thread:*` once thread identity and retention semantics are explicit.
+
+The member client may show disabled attach points, but join/start stays disabled until backend capability, policy, and encryption evidence are all ready.
+
+## UX and accessibility contract
+
+Before join/start can be enabled, the meeting UI must cover:
+
+- device selection for microphone, camera, and output where supported;
+- join preview with visible camera and microphone state;
+- mute and camera state that are keyboard-operable and screen-reader labelled;
+- participant list with speaking/connection state that is not color-only;
+- clear leave/end state and recovery path;
+- provider/backend unavailable errors with retry and admin/operator setup guidance;
+- captions/transcripts only when explicitly enabled and visibly consented.
+
+## Consent and defaults
+
+Recording, transcription, and captions are off by default. Enabling any of them requires explicit participant-visible consent, persistent in-meeting indicators, retention/export/delete policy, and audit evidence.
+
+## Vague-claim guard
+
+Do not claim `secure meetings`, `encrypted meetings`, or `end-to-end encrypted meetings` without naming the boundary and evidence: signaling, media, captions, transcripts, recordings, and metadata. Product copy must say what is known, what is disabled, and what still needs admin/provider evidence.
+
+## Implementation references
+
+- Domain contract: `client/lib/features/chat/domain/entities/channel_workspace.dart`
+- Domain test: `client/test/features/chat/channel_workspace_test.dart`
+- Architecture guard: `client/test/architecture/meetings_contract_test.dart`
+- Product scope: `docs/product-calendar-e2ee-boards-scope.md`
+- Provider boundary: `docs/provider-replacement-and-anti-silo-contract.md`
+
+## MVP slice
+
+The first shippable slice is a fail-closed contract:
+
+- contextual meeting preview stays attached to a channel and declares future calendar-event/thread attach points;
+- join/start controls remain disabled while backend media capability is absent;
+- encryption boundaries are explicit and evidence-labelled;
+- UX/accessibility requirements are enumerated before enablement;
+- recording/transcription are off by default;
+- tests prevent vague security claims without documented evidence.

--- a/docs/meeting-architecture-decision.md
+++ b/docs/meeting-architecture-decision.md
@@ -6,29 +6,30 @@ Weave meetings are contextual collaboration surfaces attached to existing Weave 
 
 ## Decision
 
-Adopt a provider-neutral meeting capability contract in the member client and keep join/start fail-closed until a backend meeting facade proves a concrete media architecture.
+Adopt a provider-neutral meeting capability contract in the member client and keep join/start fail-closed until the existing backend-owned LiveKit meetings provider contract proves its concrete media architecture.
 
-Preferred direction:
+Current direction:
 
-1. Use Matrix room state for contextual signaling when possible, because it matches Weave channel identity and room encryption posture.
-2. Treat Element Call/MatrixRTC as the closest product fit for Matrix-native contextual calls.
-3. Permit LiveKit-style SFU deployment only behind a Weave backend facade with explicit E2EE trade-off evidence, token policy, metadata limits, and support-safe diagnostics.
-4. Do not expose provider URLs, room media tokens, SFU internals, or recording/caption storage providers in member UI.
+1. Keep LiveKit as the active meetings/video-call provider key in the backend provider registry and runtime configuration.
+2. Route all LiveKit rooms, session tokens, readiness, and diagnostics through a Weave backend facade; Flutter/member UI must only see Weave meeting capability state.
+3. Treat Matrix as the chat/E2EE substrate and possible contextual signaling source, but do not promote MatrixRTC/Element Call as the active Weave meetings provider in this slice.
+4. Keep MatrixRTC/Element Call as a future comparison option only if a later migration updates the backend registry, runtime docs, acceptance tests, and provider readiness contract consistently.
+5. Do not expose provider URLs, room media tokens, SFU internals, or recording/caption storage providers in member UI.
 
 ## Architecture options
 
 | Option | Fit | E2EE and confidentiality boundary | Operational trade-off | Decision |
 | --- | --- | --- | --- | --- |
-| MatrixRTC / Element Call | Best fit for Matrix-backed channels and contextual calls. | Signaling can follow Matrix room encryption. Media confidentiality depends on MatrixRTC/Element Call mode, client support, SFU behavior, and documented key handling. | Requires MatrixRTC readiness, compatible clients, media backend evidence, and clear fallback states. | Preferred first implementation candidate. |
-| LiveKit-style SFU behind Weave backend facade | Good for scalable media and operational maturity. | Media may be encrypted in transit and can support E2EE modes, but SFU metadata and feature behavior must be documented. Recording/captions/transcripts need separate encryption and consent evidence. | Requires token minting, SFU operations, capability health, support bundle redaction, and explicit E2EE trade-off docs. | Allowed only behind server facade and policy. |
+| LiveKit-style SFU behind Weave backend facade | Current active provider contract for meetings/video calls and good fit for scalable media operations. | Media may be encrypted in transit and can support E2EE modes, but SFU metadata and feature behavior must be documented. Recording/captions/transcripts need separate encryption and consent evidence. Matrix chat encryption must not be presented as covering LiveKit media. | Requires backend token minting, SFU operations, capability health, support bundle redaction, and explicit E2EE trade-off docs. | Active provider contract; still fail-closed until backend/media/accessibility evidence is configured and validated. |
+| MatrixRTC / Element Call | Future comparison option for Matrix-native contextual calls, not the active Weave meetings provider contract. | Signaling can follow Matrix room encryption. Media confidentiality depends on MatrixRTC/Element Call mode, client support, SFU behavior, and documented key handling. | Requires registry/runtime/acceptance migration, MatrixRTC readiness, compatible clients, media backend evidence, and clear fallback states. | Future option only; do not silently replace the current LiveKit contract. |
 | Generic hosted meeting links | Low product fit. | Encryption, metadata, retention, and recording behavior are provider-defined and often opaque to Weave. | Easy link insertion but weak sovereignty and portability. | Not acceptable as the primary Weave meeting model. |
 
 ## Encryption and evidence boundaries
 
 | Boundary | Product statement | Required evidence before enabling |
 | --- | --- | --- |
-| Matrix signaling | Signaling follows the Matrix room encryption/readiness posture when Matrix-backed rooms are used. | Matrix E2EE diagnostic, room readiness, and failure-state evidence. |
-| Media streams | Media confidentiality is documented per selected architecture; group calls must state SFU/client key handling. | Media transport readiness, E2EE mode evidence, and architecture trade-off record. |
+| Matrix signaling | Matrix remains the chat/E2EE substrate and may provide contextual room state, but it is not the active generic meetings provider. | Matrix E2EE diagnostic, room readiness, and failure-state evidence. |
+| Media streams | Media confidentiality is documented for the active LiveKit-backed architecture before enablement; group calls must state SFU/client key handling and must not inherit Matrix chat E2EE claims. | LiveKit media transport readiness, E2EE mode evidence, and architecture trade-off record. |
 | Captions | Off by default. If enabled, caption generation, storage, retention, and encryption are visible to users. | Consent UX, storage boundary, retention policy, and accessibility evidence. |
 | Transcripts | Off by default. If enabled, transcript generation, storage, retention, and encryption are visible to users. | Consent UX, storage boundary, retention policy, export/delete behavior, and audit evidence. |
 | Recordings | Off by default and unavailable without explicit consent and visible state. | Consent UX, recording indicator, storage encryption, retention policy, export/delete behavior, and audit evidence. |
@@ -70,6 +71,8 @@ Do not claim `secure meetings`, `encrypted meetings`, or `end-to-end encrypted m
 - Domain test: `client/test/features/chat/channel_workspace_test.dart`
 - Architecture guard: `client/test/architecture/meetings_contract_test.dart`
 - Product scope: `docs/product-calendar-e2ee-boards-scope.md`
+- Guarded surfaces: `docs/roadmap-and-guarded-surfaces.md`
+- Runtime provider contract: `server/docs/runtime-configuration.md`
 - Provider boundary: `docs/provider-replacement-and-anti-silo-contract.md`
 
 ## MVP slice

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -5,7 +5,7 @@ Use this page for release-affecting changes that have merged but are not include
 ## Added
 
 - Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
-- Contextual meetings now have a fail-closed architecture contract covering MatrixRTC/Element Call vs LiveKit-style SFU trade-offs, encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
+- Contextual meetings now have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
 
 ## Changed
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -5,6 +5,7 @@ Use this page for release-affecting changes that have merged but are not include
 ## Added
 
 - Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
+- Contextual meetings now have a fail-closed architecture contract covering MatrixRTC/Element Call vs LiveKit-style SFU trade-offs, encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
 
 ## Changed
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Architecture: architecture.md
       - Canonical feature models: canonical-feature-models.md
       - Accessible workflow context contract: workflow-context-contract.md
+      - Meeting architecture decision record: meeting-architecture-decision.md
       - Acceptance contracts: acceptance-contracts.md
       - Quality and evidence: quality-and-evidence.md
       - Build, evidence, and delivery system: build-evidence-delivery-system.md

--- a/specs/0003-contextual-meetings/plan.md
+++ b/specs/0003-contextual-meetings/plan.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Implement a fail-closed meeting contract for issue #216. The slice documents architecture options and extends the channel workspace meeting domain so future join/start work cannot claim security without boundary evidence.
+Implement a fail-closed meeting contract for issue #216. The slice preserves LiveKit as the active meetings provider contract, documents future architecture comparison options, and extends the channel workspace meeting domain so future join/start work cannot claim security without boundary evidence.
 
 ## Steps
 

--- a/specs/0003-contextual-meetings/plan.md
+++ b/specs/0003-contextual-meetings/plan.md
@@ -1,0 +1,24 @@
+# Implementation plan: Encrypted contextual meetings contract
+
+**Spec**: `specs/0003-contextual-meetings/spec.md`
+**Branch**: `issue-216-meetings-contract`
+**Date**: 2026-05-29
+
+## Summary
+
+Implement a fail-closed meeting contract for issue #216. The slice documents architecture options and extends the channel workspace meeting domain so future join/start work cannot claim security without boundary evidence.
+
+## Steps
+
+1. Add the meeting architecture decision record in `docs/meeting-architecture-decision.md`.
+2. Extend `ChannelMeetingPreview` with attach points, encryption boundaries, and UX requirements.
+3. Cover the domain contract in `client/test/features/chat/channel_workspace_test.dart`.
+4. Add an architecture guard in `client/test/architecture/meetings_contract_test.dart`.
+5. Update documentation navigation and release notes.
+6. Run `specContract`, `acceptanceContract`, `clientCi`, `docs-check`, release label check, and GitHub CI.
+
+## Risks and mitigations
+
+- Risk: product copy overstates E2EE. Mitigation: boundary/evidence tables and architecture tests.
+- Risk: provider internals leak into member UI. Mitigation: provider-neutral domain fields and existing member-client boundary tests.
+- Risk: accessibility is deferred. Mitigation: UX requirements are release-blocking before join/start enablement.

--- a/specs/0003-contextual-meetings/spec.md
+++ b/specs/0003-contextual-meetings/spec.md
@@ -1,0 +1,131 @@
+---
+id: WEAVE-SPEC-0003
+title: Encrypted contextual meetings contract
+version: 0.1.0
+status: proposed
+domain: product-core
+owner: weave-co-leader
+github_issue: 216
+supersedes: []
+depends_on:
+  - WEAVE-SPEC-0001
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew acceptanceContract
+  - flutter test test/features/chat/channel_workspace_test.dart test/architecture/meetings_contract_test.dart
+---
+
+# Feature specification: Encrypted contextual meetings contract
+
+## Intent
+
+Define Weave's meeting architecture and product boundaries before enabling video/audio calls. Meetings must attach to Weave context, fail closed without backend/media evidence, and be honest about encryption boundaries for signaling, media, captions, transcripts, recordings, and metadata.
+
+## Product boundaries
+
+### In scope
+
+- Provider-neutral meeting capability contract for channels, calendar events, and threads.
+- Architecture decision record comparing MatrixRTC/Element Call and LiveKit-style SFU options.
+- Explicit encryption/evidence boundaries for signaling, media, captions, transcripts, recordings, and metadata.
+- UX/accessibility contract for device selection, join preview, mute/camera state, participant list, errors, and recovery.
+- Recording/transcription defaults and consent requirements.
+- Tests that block vague security claims without documented evidence.
+
+### Out of scope
+
+- Enabling live join/start controls before backend media capability exists.
+- Provider-specific meeting links as the primary Weave meeting model.
+- Recording, transcription, or captions without explicit consent and storage/retention evidence.
+- Member UI exposure of provider URLs, room media tokens, SFU internals, credentials, or raw diagnostics.
+
+### Non-negotiable constraints
+
+- Weave remains provider-neutral; member surfaces speak Weave meeting concepts, not provider setup language.
+- Join/start controls must fail closed until capability, policy, and evidence are ready.
+- Encryption claims must name their exact boundary and evidence.
+- Group calls must document SFU/client key handling before they are described as confidential.
+- Accessibility, consent, supportability, auditability, and deployability are release blockers.
+
+## User/admin/operator stories
+
+### US1 - Contextual meeting surface (Priority: P1)
+
+**Actor**: Member
+**Story**: As a member, I can see meetings as part of channel/event/thread work context rather than disconnected links.
+**Why now**: Issue #216 requires video meetings that differentiate Weave from generic meeting links.
+**Independent test**: `flutter test test/features/chat/channel_workspace_test.dart`
+
+**Acceptance scenarios**:
+
+1. Given a channel workspace, when the meetings surface is rendered, then it carries the channel context id and declares channel/calendar-event/thread attach points.
+2. Given backend media capability is absent, when join/start controls are evaluated, then they remain disabled with an explicit capability-unavailable reason.
+
+### US2 - Explicit encryption boundaries (Priority: P1)
+
+**Actor**: Admin/operator/security reviewer
+**Story**: As a reviewer, I can see exactly which meeting boundaries are encrypted, disabled, or metadata-only before the feature is enabled.
+**Why now**: Weave must avoid vague claims about security or E2EE.
+**Independent test**: `flutter test test/architecture/meetings_contract_test.dart`
+
+**Acceptance scenarios**:
+
+1. Given a meeting contract, when encryption is described, then Matrix signaling, media, captions, transcripts, recordings, and metadata each have evidence requirements.
+2. Given product copy uses broad security language, when contract tests run, then it must also name boundary evidence or fail.
+
+### US3 - Consent and accessible join contract (Priority: P1)
+
+**Actor**: Member
+**Story**: As a member, I can understand device, mute/camera, participant, caption/transcript, recording, error, and recovery states before joining.
+**Why now**: Meetings are collaboration-critical and cannot ship as pointer-only or consent-ambiguous UI.
+**Independent test**: Domain and architecture tests assert UX requirements and off-by-default recording/transcription.
+
+**Acceptance scenarios**:
+
+1. Given a meeting preview, when UX requirements are inspected, then device selection, join preview, mute state, camera state, participant list, and error recovery are all documented.
+2. Given recording or transcription is unavailable, when consent posture is evaluated, then both remain off and the preview requires explicit consent before enablement.
+
+## Functional requirements
+
+- **FR-001**: Weave MUST model meeting attach points for channel, calendar event, and thread contexts.
+- **FR-002**: Weave MUST keep meeting join/start controls disabled until backend media capability, policy, and evidence are ready.
+- **FR-003**: Weave MUST document MatrixRTC/Element Call and LiveKit-style SFU trade-offs before selecting an implementation.
+- **FR-004**: Weave MUST define encryption/evidence boundaries for Matrix signaling, media streams, captions, transcripts, recordings, and metadata.
+- **FR-005**: Weave MUST NOT describe metadata as end-to-end encrypted.
+- **FR-006**: Recording and transcription MUST be off by default and require explicit participant-visible consent before enablement.
+- **FR-007**: The meeting UX contract MUST cover device selection, join preview, mute state, camera state, participant list, errors, and recovery.
+- **FR-008**: Member UI MUST NOT expose provider URLs, meeting tokens, SFU internals, credentials, or raw diagnostics.
+- **FR-009**: Tests or contract checks MUST prevent vague security claims unless boundary evidence is documented.
+- **FR-010**: Meeting capability failures MUST be support-safe and actionable for admin/operator setup.
+
+## Domain model and contracts
+
+- Canonical Weave entities affected: ChannelMeetingPreview, ChannelMeetingAttachPoint, ChannelMeetingEncryptionBoundary, ChannelMeetingUxRequirement, ChannelMeetingControl.
+- Provider/category contracts affected: future meeting backend facade, MatrixRTC/Element Call readiness, optional LiveKit-style SFU readiness.
+- API/event contracts affected: future capability endpoint must expose Weave meeting readiness, not provider internals.
+- Policy/RBAC/capability keys affected: meeting join/start, recording, transcription, captions, participant management.
+- Audit/support evidence affected: capability state, encryption boundary evidence, consent state, metadata inventory, support-safe diagnostics.
+
+## Acceptance and evidence mapping
+
+- Gherkin feature path(s): none for proposed fail-closed contract slice.
+- `e2e/scenario_mappings.json` marker(s): none for proposed fail-closed contract slice.
+- Unit/widget/backend/admin/contract test path(s): `client/test/features/chat/channel_workspace_test.dart`, `client/test/architecture/meetings_contract_test.dart`.
+- Live Stack E2E required? no; join/start stays disabled.
+- Support-safe evidence artifact(s): local Flutter/Gradle test output; CI summary under `build/evidence/**` when merged through PR.
+
+## Release and migration impact
+
+- Member impact: clearer meeting readiness and contextual meeting boundaries; no enabled media join yet.
+- Admin/operator impact: explicit evidence requirements before enabling meeting providers.
+- Developer/API impact: extends channel workspace domain model with meeting attach points, encryption boundaries, and UX requirements.
+- Data migration/backfill: none for fail-closed contract.
+- Rollback/reversibility: remove meeting contract fields/UI references without provider data migration.
+- Release-notes label expected: `release-notes-feature`
+
+## Open questions
+
+- [ ] Which backend facade owns MatrixRTC/Element Call readiness and token issuance?
+- [ ] Which policy keys govern recording, transcription, captions, and participant management?
+- [ ] Which acceptance feature should cover first live join/start flow after backend capability exists?

--- a/specs/0003-contextual-meetings/spec.md
+++ b/specs/0003-contextual-meetings/spec.md
@@ -27,7 +27,7 @@ Define Weave's meeting architecture and product boundaries before enabling video
 ### In scope
 
 - Provider-neutral meeting capability contract for channels, calendar events, and threads.
-- Architecture decision record comparing MatrixRTC/Element Call and LiveKit-style SFU options.
+- Architecture decision record preserving LiveKit as the active meetings/video-call provider contract and comparing MatrixRTC/Element Call only as a future option.
 - Explicit encryption/evidence boundaries for signaling, media, captions, transcripts, recordings, and metadata.
 - UX/accessibility contract for device selection, join preview, mute/camera state, participant list, errors, and recovery.
 - Recording/transcription defaults and consent requirements.
@@ -90,7 +90,7 @@ Define Weave's meeting architecture and product boundaries before enabling video
 
 - **FR-001**: Weave MUST model meeting attach points for channel, calendar event, and thread contexts.
 - **FR-002**: Weave MUST keep meeting join/start controls disabled until backend media capability, policy, and evidence are ready.
-- **FR-003**: Weave MUST document MatrixRTC/Element Call and LiveKit-style SFU trade-offs before selecting an implementation.
+- **FR-003**: Weave MUST document LiveKit as the current active meetings provider contract and MatrixRTC/Element Call as a future comparison option unless backend registry, runtime docs, acceptance tests, and readiness contracts are migrated together.
 - **FR-004**: Weave MUST define encryption/evidence boundaries for Matrix signaling, media streams, captions, transcripts, recordings, and metadata.
 - **FR-005**: Weave MUST NOT describe metadata as end-to-end encrypted.
 - **FR-006**: Recording and transcription MUST be off by default and require explicit participant-visible consent before enablement.
@@ -102,7 +102,7 @@ Define Weave's meeting architecture and product boundaries before enabling video
 ## Domain model and contracts
 
 - Canonical Weave entities affected: ChannelMeetingPreview, ChannelMeetingAttachPoint, ChannelMeetingEncryptionBoundary, ChannelMeetingUxRequirement, ChannelMeetingControl.
-- Provider/category contracts affected: future meeting backend facade, MatrixRTC/Element Call readiness, optional LiveKit-style SFU readiness.
+- Provider/category contracts affected: LiveKit-backed meeting backend facade readiness, optional future MatrixRTC/Element Call comparison only after coordinated provider-contract migration.
 - API/event contracts affected: future capability endpoint must expose Weave meeting readiness, not provider internals.
 - Policy/RBAC/capability keys affected: meeting join/start, recording, transcription, captions, participant management.
 - Audit/support evidence affected: capability state, encryption boundary evidence, consent state, metadata inventory, support-safe diagnostics.
@@ -126,6 +126,6 @@ Define Weave's meeting architecture and product boundaries before enabling video
 
 ## Open questions
 
-- [ ] Which backend facade owns MatrixRTC/Element Call readiness and token issuance?
+- [ ] Which backend facade owns LiveKit room/session readiness and token issuance?
 - [ ] Which policy keys govern recording, transcription, captions, and participant management?
 - [ ] Which acceptance feature should cover first live join/start flow after backend capability exists?

--- a/specs/0003-contextual-meetings/tasks.md
+++ b/specs/0003-contextual-meetings/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Encrypted contextual meetings contract
+
+**Spec**: `specs/0003-contextual-meetings/spec.md`
+
+## Implementation
+
+- [x] Document architecture options and E2EE trade-offs.
+- [x] Define signaling/media/caption/transcript/recording/metadata boundaries.
+- [x] Extend channel meeting preview domain model with contextual attach points.
+- [x] Encode device/join/mute/camera/participant/error UX requirements.
+- [x] Keep recording/transcription off by default.
+- [x] Add contract tests that guard vague security claims.
+
+## Evidence
+
+- [ ] `./gradlew specContract acceptanceContract`
+- [ ] `cd client && flutter test test/features/chat/channel_workspace_test.dart test/architecture/meetings_contract_test.dart`
+- [ ] `./gradlew clientCi`
+- [ ] `make docs-check`
+- [ ] GitHub PR checks green

--- a/specs/0003-contextual-meetings/traceability.yaml
+++ b/specs/0003-contextual-meetings/traceability.yaml
@@ -16,8 +16,9 @@ domain_entities:
   - ChannelMeetingUxRequirement
   - ChannelMeetingControl
 provider_neutral_invariants:
-  - meeting join and start controls fail closed until backend media capability is evidenced
+  - meeting join and start controls fail closed until LiveKit-backed backend media capability is evidenced
   - meeting surfaces attach to Weave context instead of generic provider links
+  - LiveKit remains the active meetings provider contract while MatrixRTC/Element Call is future comparison only unless provider contracts migrate together
   - encryption claims name signaling, media, captions, transcripts, recordings, and metadata boundaries
   - recording and transcription are off by default and require explicit participant-visible consent
   - member meeting views do not expose provider URLs, tokens, SFU internals, credentials, or raw diagnostics
@@ -27,6 +28,6 @@ evidence_gates:
   - ./gradlew acceptanceContract
   - flutter test test/features/chat/channel_workspace_test.dart test/architecture/meetings_contract_test.dart
 open_product_core_decisions:
-  - backend facade ownership for MatrixRTC/Element Call readiness and token issuance
+  - backend facade ownership for LiveKit room/session readiness and token issuance
   - policy keys for recording, transcription, captions, and participant management
   - first live meeting join/start acceptance feature

--- a/specs/0003-contextual-meetings/traceability.yaml
+++ b/specs/0003-contextual-meetings/traceability.yaml
@@ -1,0 +1,32 @@
+spec_id: WEAVE-SPEC-0003
+version: 0.1.0
+status: proposed
+github_issue: 216
+release_notes_label: release-notes-feature
+depends_on:
+  - WEAVE-SPEC-0001
+issue_dag:
+  sequential:
+    - issue: 216
+      title: Encrypted contextual meetings
+domain_entities:
+  - ChannelMeetingPreview
+  - ChannelMeetingAttachPoint
+  - ChannelMeetingEncryptionBoundary
+  - ChannelMeetingUxRequirement
+  - ChannelMeetingControl
+provider_neutral_invariants:
+  - meeting join and start controls fail closed until backend media capability is evidenced
+  - meeting surfaces attach to Weave context instead of generic provider links
+  - encryption claims name signaling, media, captions, transcripts, recordings, and metadata boundaries
+  - recording and transcription are off by default and require explicit participant-visible consent
+  - member meeting views do not expose provider URLs, tokens, SFU internals, credentials, or raw diagnostics
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew acceptanceContract
+  - flutter test test/features/chat/channel_workspace_test.dart test/architecture/meetings_contract_test.dart
+open_product_core_decisions:
+  - backend facade ownership for MatrixRTC/Element Call readiness and token issuance
+  - policy keys for recording, transcription, captions, and participant management
+  - first live meeting join/start acceptance feature


### PR DESCRIPTION
Closes #216.

## Summary
- add WEAVE-SPEC-0003 for contextual meetings with traceability against issue #216
- document MatrixRTC/Element Call, LiveKit-style SFU, and generic-link trade-offs plus encryption/evidence boundaries
- add channel meeting domain primitives that fail closed until backend capability, E2EE evidence, and consent/accessibility requirements are satisfied

## Evidence
- `cd client && flutter test test/architecture/meetings_contract_test.dart test/features/chat/channel_workspace_test.dart`
- `PR_LABELS_JSON='["area:chat","area:ux","release-notes-feature"]' ./gradlew releaseNotesLabelCheck --console=plain`
- `./gradlew clientCi --console=plain`
- `git diff --check origin/main..HEAD`

## Veto / risk notes
- Join/start remain disabled; no provider token, direct provider URL, production mutation, release tag, or publish action.
- Recording/transcription/captions stay off until explicit consent, retention, storage, and encryption evidence exist.