### PR TITLE
feat(chat): add overview empty recovery

### DIFF
--- a/client/lib/features/chat/presentation/chat_screen.dart
+++ b/client/lib/features/chat/presentation/chat_screen.dart
@@ -104,6 +104,8 @@ class ChatScreen extends ConsumerWidget {
               message: l10n.chatEmptyMessage,
               guidance: l10n.chatEmptyGuidance,
               icon: Icons.chat_bubble_outline,
+              actionLabel: l10n.chatStaleRoomsRetryButton,
+              onAction: () => ref.read(chatProvider.notifier).retry(),
             ),
           ),
           ChatViewPhase.error ||

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -345,8 +345,27 @@ void main() {
     testWidgets('shows the empty state when there are no conversations', (
       tester,
     ) async {
+      final semantics = tester.ensureSemantics();
+      var loadCount = 0;
       final repository = FakeChatRepository(
-        loadConversationsHandler: () async => const <ChatConversation>[],
+        loadConversationsHandler: () async {
+          loadCount++;
+          if (loadCount == 1) {
+            return const <ChatConversation>[];
+          }
+
+          return const <ChatConversation>[
+            ChatConversation(
+              id: '!project:home.internal',
+              title: 'Project',
+              previewType: ChatConversationPreviewType.text,
+              previewText: 'Recovered room',
+              unreadCount: 0,
+              isInvite: false,
+              isDirectMessage: false,
+            ),
+          ];
+        },
       );
       final securityRepository = buildSecurityRepository();
 
@@ -371,6 +390,17 @@ void main() {
         ),
         findsOneWidget,
       );
+      expect(find.text('Refresh rooms'), findsOneWidget);
+      expect(find.bySemanticsLabel('Refresh rooms'), findsOneWidget);
+
+      await tester.tap(find.text('Refresh rooms'));
+      await tester.pumpAndSettle();
+
+      expect(repository.loadConversationsCalls, 2);
+      expect(find.text('Project'), findsOneWidget);
+      expect(find.text('Recovered room'), findsOneWidget);
+      expect(find.text('No conversations yet'), findsNothing);
+      semantics.dispose();
     });
 
     testWidgets(


### PR DESCRIPTION
## Summary
- adds an explicit `Refresh rooms` action to the chat overview empty state
- reuses the existing chat retry path so recovered rooms render after refresh
- covers message, guidance, accessible action, and reload behavior in the chat overview widget test

Closes #410.

## Evidence
- `build/issue-410-client-gates.log`
- `build/issue-410-release-label-check.log`
- `cd client && flutter gen-l10n`
- `cd client && dart format --output=none --set-exit-if-changed lib/features/chat/presentation/chat_screen.dart test/features/chat/chat_screen_test.dart lib/l10n/generated`
- `cd client && flutter test test/features/chat/chat_screen_test.dart` → `14/14`
- `PR_LABELS_JSON='["release-notes-feature"]' ./gradlew releaseNotesLabelCheck --console=plain`

## Release notes
- `release-notes-feature`
