### PR TITLE
feat(onboarding): add signed-out recovery action

### DIFF
--- a/client/lib/core/router/app_router.dart
+++ b/client/lib/core/router/app_router.dart
@@ -56,9 +56,11 @@ GoRouter appRouter(Ref ref) {
         case BootstrapPhase.ready:
           try {
             final status = await ref.read(firstRunStatusProvider.future);
-            final needsFirstRunStatus =
-                status == null || !status.firstRunComplete;
-            if (needsFirstRunStatus) {
+            if (status == null) {
+              return (onFirstRun || onSignIn) ? null : AppRoutes.firstRun;
+            }
+
+            if (!status.firstRunComplete) {
               return onFirstRun ? null : AppRoutes.firstRun;
             }
 

--- a/client/lib/core/router/app_router.g.dart
+++ b/client/lib/core/router/app_router.g.dart
@@ -55,4 +55,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'f056e0837304c1278f65112196afc7023c878f2f';
+String _$appRouterHash() => r'4333ef38cd75f4a03b36ce9566d7f1b036d815c5';

--- a/client/lib/features/onboarding/presentation/first_run_screen.dart
+++ b/client/lib/features/onboarding/presentation/first_run_screen.dart
@@ -32,7 +32,12 @@ class FirstRunScreen extends ConsumerWidget {
             onRetry: () => ref.invalidate(firstRunStatusProvider),
           ),
           data: (status) => status == null
-              ? ErrorState(message: l10n.firstRunSignedOutMessage)
+              ? ErrorState(
+                  message: l10n.firstRunSignedOutMessage,
+                  guidance: l10n.firstRunSignedOutGuidance,
+                  retryLabel: l10n.firstRunSignInAction,
+                  onRetry: () => context.go(AppRoutes.signIn),
+                )
               : _FirstRunStatusView(status: status),
         ),
       ),

--- a/client/lib/features/onboarding/presentation/first_run_screen.dart
+++ b/client/lib/features/onboarding/presentation/first_run_screen.dart
@@ -37,6 +37,7 @@ class FirstRunScreen extends ConsumerWidget {
                   guidance: l10n.firstRunSignedOutGuidance,
                   retryLabel: l10n.firstRunSignInAction,
                   onRetry: () => context.go(AppRoutes.signIn),
+                  semanticLabel: l10n.firstRunSignedOutSemanticLabel,
                 )
               : _FirstRunStatusView(status: status),
         ),

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -152,6 +152,8 @@
   "firstRunLoadingHint": "Profil, Rolle und Modulbereitschaft werden vom Weave-Backend geladen.",
   "firstRunLoadFailure": "Der Erststart-Status konnte nicht vom Weave-Backend geladen werden.",
   "firstRunSignedOutMessage": "Melde dich an, um deinen Weave-Erststart-Status zu sehen.",
+  "firstRunSignedOutGuidance": "Wir brauchen eine aktive Weave-SSO-Sitzung, bevor Profil, Rolle und Modulbereitschaft geprüft werden können.",
+  "firstRunSignInAction": "Zur Anmeldung",
   "firstRunReadyTitle": "Dein Weave-Arbeitsbereich ist bereit",
   "firstRunNeedsAttentionTitle": "Dein Weave-Arbeitsbereich wird vorbereitet",
   "firstRunDescription": "Du hast dich einmal per Weave-SSO angemeldet. Weave prüft Profil und Zusammenarbeitsmodule; separate Matrix- oder Nextcloud-Zugangsdaten sind nicht nötig.",

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -154,6 +154,7 @@
   "firstRunSignedOutMessage": "Melde dich an, um deinen Weave-Erststart-Status zu sehen.",
   "firstRunSignedOutGuidance": "Wir brauchen eine aktive Weave-SSO-Sitzung, bevor Profil, Rolle und Modulbereitschaft geprüft werden können.",
   "firstRunSignInAction": "Zur Anmeldung",
+  "firstRunSignedOutSemanticLabel": "Melde dich an, um deinen Weave-Erststart-Status zu sehen. Wir brauchen eine aktive Weave-SSO-Sitzung, bevor Profil, Rolle und Modulbereitschaft geprüft werden können. Aktion: Zur Anmeldung",
   "firstRunReadyTitle": "Dein Weave-Arbeitsbereich ist bereit",
   "firstRunNeedsAttentionTitle": "Dein Weave-Arbeitsbereich wird vorbereitet",
   "firstRunDescription": "Du hast dich einmal per Weave-SSO angemeldet. Weave prüft Profil und Zusammenarbeitsmodule; separate Matrix- oder Nextcloud-Zugangsdaten sind nicht nötig.",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -367,6 +367,8 @@
   "firstRunLoadingHint": "Loading your profile, role, and module readiness from the Weave backend.",
   "firstRunLoadFailure": "We could not load your first-run status from the Weave backend.",
   "firstRunSignedOutMessage": "Sign in to view your Weave first-run status.",
+  "firstRunSignedOutGuidance": "We need an active Weave SSO session before we can check your profile, role, and module readiness.",
+  "firstRunSignInAction": "Go to sign in",
   "firstRunReadyTitle": "Your Weave workspace is ready",
   "firstRunNeedsAttentionTitle": "Your Weave workspace is being prepared",
   "firstRunDescription": "You signed in once with Weave SSO. Weave is checking your profile and collaboration modules; no separate Matrix or Nextcloud credentials are needed.",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -369,6 +369,7 @@
   "firstRunSignedOutMessage": "Sign in to view your Weave first-run status.",
   "firstRunSignedOutGuidance": "We need an active Weave SSO session before we can check your profile, role, and module readiness.",
   "firstRunSignInAction": "Go to sign in",
+  "firstRunSignedOutSemanticLabel": "Sign in to view your Weave first-run status. We need an active Weave SSO session before we can check your profile, role, and module readiness. Action: Go to sign in",
   "firstRunReadyTitle": "Your Weave workspace is ready",
   "firstRunNeedsAttentionTitle": "Your Weave workspace is being prepared",
   "firstRunDescription": "You signed in once with Weave SSO. Weave is checking your profile and collaboration modules; no separate Matrix or Nextcloud credentials are needed.",

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -635,6 +635,12 @@ abstract class AppLocalizations {
   /// **'Go to sign in'**
   String get firstRunSignInAction;
 
+  /// No description provided for @firstRunSignedOutSemanticLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign in to view your Weave first-run status. We need an active Weave SSO session before we can check your profile, role, and module readiness. Action: Go to sign in'**
+  String get firstRunSignedOutSemanticLabel;
+
   /// No description provided for @firstRunReadyTitle.
   ///
   /// In en, this message translates to:

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -623,6 +623,18 @@ abstract class AppLocalizations {
   /// **'Sign in to view your Weave first-run status.'**
   String get firstRunSignedOutMessage;
 
+  /// No description provided for @firstRunSignedOutGuidance.
+  ///
+  /// In en, this message translates to:
+  /// **'We need an active Weave SSO session before we can check your profile, role, and module readiness.'**
+  String get firstRunSignedOutGuidance;
+
+  /// No description provided for @firstRunSignInAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Go to sign in'**
+  String get firstRunSignInAction;
+
   /// No description provided for @firstRunReadyTitle.
   ///
   /// In en, this message translates to:

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -312,6 +312,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Melde dich an, um deinen Weave-Erststart-Status zu sehen.';
 
   @override
+  String get firstRunSignedOutGuidance =>
+      'Wir brauchen eine aktive Weave-SSO-Sitzung, bevor Profil, Rolle und Modulbereitschaft geprüft werden können.';
+
+  @override
+  String get firstRunSignInAction => 'Zur Anmeldung';
+
+  @override
   String get firstRunReadyTitle => 'Dein Weave-Arbeitsbereich ist bereit';
 
   @override

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -319,6 +319,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get firstRunSignInAction => 'Zur Anmeldung';
 
   @override
+  String get firstRunSignedOutSemanticLabel =>
+      'Melde dich an, um deinen Weave-Erststart-Status zu sehen. Wir brauchen eine aktive Weave-SSO-Sitzung, bevor Profil, Rolle und Modulbereitschaft geprüft werden können. Aktion: Zur Anmeldung';
+
+  @override
   String get firstRunReadyTitle => 'Dein Weave-Arbeitsbereich ist bereit';
 
   @override

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -307,6 +307,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Sign in to view your Weave first-run status.';
 
   @override
+  String get firstRunSignedOutGuidance =>
+      'We need an active Weave SSO session before we can check your profile, role, and module readiness.';
+
+  @override
+  String get firstRunSignInAction => 'Go to sign in';
+
+  @override
   String get firstRunReadyTitle => 'Your Weave workspace is ready';
 
   @override

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -314,6 +314,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get firstRunSignInAction => 'Go to sign in';
 
   @override
+  String get firstRunSignedOutSemanticLabel =>
+      'Sign in to view your Weave first-run status. We need an active Weave SSO session before we can check your profile, role, and module readiness. Action: Go to sign in';
+
+  @override
   String get firstRunReadyTitle => 'Your Weave workspace is ready';
 
   @override

--- a/client/test/core/router/app_router_test.dart
+++ b/client/test/core/router/app_router_test.dart
@@ -128,6 +128,7 @@ void main() {
       required ServerConfiguration? configuration,
       InMemorySecureStore? secureStore,
       FirstRunStatus? firstRunStatus,
+      Future<FirstRunStatus?> Function()? firstRunStatusLoader,
     }) {
       final container = ProviderContainer.test(
         overrides: [
@@ -147,7 +148,9 @@ void main() {
             ),
           ),
           firstRunStatusProvider.overrideWith(
-            (ref) async => firstRunStatus ?? buildTestFirstRunStatus(),
+            (ref) =>
+                firstRunStatusLoader?.call() ??
+                Future.value(firstRunStatus ?? buildTestFirstRunStatus()),
           ),
           userProfileProvider.overrideWith((ref) async => null),
           workspaceConnectionStateProvider.overrideWithValue(
@@ -376,6 +379,47 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(SignInScreen), findsOneWidget);
+    });
+
+    testWidgets('lets signed-out first-run recovery reach sign-in', (
+      tester,
+    ) async {
+      final secureStore = InMemorySecureStore();
+      await secureStore.write(
+        authSessionStorageKey,
+        AuthSessionDto.fromSession(buildTestAuthSession()).encode(),
+      );
+      final container = createContainer(
+        configuration: buildTestConfiguration(),
+        secureStore: secureStore,
+        firstRunStatusLoader: () async => null,
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const WeaveApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FirstRunScreen), findsOneWidget);
+      expect(find.text('Go to sign in'), findsOneWidget);
+
+      await tester.tap(find.text('Go to sign in'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SignInScreen), findsOneWidget);
+      expect(
+        container
+            .read(appRouterProvider)
+            .routeInformationProvider
+            .value
+            .uri
+            .path,
+        AppRoutes.signIn,
+      );
     });
   });
 }

--- a/client/test/features/onboarding/first_run_screen_test.dart
+++ b/client/test/features/onboarding/first_run_screen_test.dart
@@ -157,6 +157,12 @@ void main() {
         findsOneWidget,
       );
       expect(find.textContaining('active Weave SSO session'), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(
+          'Sign in to view your Weave first-run status. We need an active Weave SSO session before we can check your profile, role, and module readiness. Action: Go to sign in',
+        ),
+        findsOneWidget,
+      );
 
       await tester.tap(find.text('Go to sign in'));
       await tester.pumpAndSettle();

--- a/client/test/features/onboarding/first_run_screen_test.dart
+++ b/client/test/features/onboarding/first_run_screen_test.dart
@@ -1,4 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:weave/core/router/app_routes.dart';
 import 'package:weave/features/onboarding/domain/entities/first_run_status.dart';
 import 'package:weave/features/onboarding/presentation/first_run_screen.dart';
 import 'package:weave/features/onboarding/presentation/providers/first_run_status_provider.dart';
@@ -118,6 +121,47 @@ void main() {
         findsWidgets,
       );
       expect(find.text('Continue to chat'), findsNothing);
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    });
+
+    testWidgets('routes signed-out users back to sign-in recovery', (
+      tester,
+    ) async {
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: AppRoutes.firstRun,
+            builder: (context, state) => const FirstRunScreen(),
+          ),
+          GoRoute(
+            path: AppRoutes.signIn,
+            builder: (context, state) => const Scaffold(
+              body: Center(child: Text('Sign-in route ready')),
+            ),
+          ),
+        ],
+        initialLocation: AppRoutes.firstRun,
+      );
+
+      await tester.pumpWidget(
+        createTestRouterApp(
+          router,
+          overrides: [firstRunStatusProvider.overrideWith((ref) async => null)],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Sign in to view your Weave first-run status.'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('active Weave SSO session'), findsOneWidget);
+
+      await tester.tap(find.text('Go to sign in'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Sign-in route ready'), findsOneWidget);
       await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
     });


### PR DESCRIPTION
Closes #409.

## Summary
- Adds signed-out first-run recovery guidance that explains the missing Weave SSO session.
- Routes the recovery action to `AppRoutes.signIn` and keeps production router redirects from bouncing signed-out users back to first-run.
- Covers widget-level recovery copy/semantics plus production `appRouterProvider` sign-in navigation.
- Refreshes generated Riverpod router output for the redirect change.

## Local gates
- `cd client && dart run build_runner build --delete-conflicting-outputs`
- `cd client && dart format --output=none --set-exit-if-changed lib/core/router/app_router.dart lib/features/onboarding/presentation/first_run_screen.dart test/core/router/app_router_test.dart test/features/onboarding/first_run_screen_test.dart`
- `cd client && flutter test test/core/router/app_router_test.dart test/features/onboarding/first_run_screen_test.dart`
- `./gradlew clientCi`
- `git diff --exit-code -- client/lib client/test docs/assets/marketing docs/assets/roadmap`

## Evidence
- Branch: `issue-409-first-run-signin-recovery`
- PR labels: `area:ux`, `release-notes-feature`
- Client/A11y review: PASS
- QA integration Veto: PASS; router redirect fixed and generated drift fixed in `client/lib/core/router/app_router.g.dart`
