### PR TITLE
ux: guide first-run load failure recovery

### DIFF
--- a/client/lib/features/onboarding/presentation/first_run_screen.dart
+++ b/client/lib/features/onboarding/presentation/first_run_screen.dart
@@ -28,6 +28,7 @@ class FirstRunScreen extends ConsumerWidget {
           ),
           error: (error, _) => ErrorState(
             message: l10n.firstRunLoadFailure,
+            guidance: l10n.firstRunLoadFailureGuidance,
             retryLabel: l10n.retryButton,
             onRetry: () => ref.invalidate(firstRunStatusProvider),
           ),

--- a/client/lib/features/onboarding/presentation/providers/first_run_status_provider.dart
+++ b/client/lib/features/onboarding/presentation/providers/first_run_status_provider.dart
@@ -22,10 +22,12 @@ final firstRunStatusRepositoryProvider = Provider<FirstRunStatusRepository>((
   );
 });
 
+Duration? _doNotRetryFirstRunStatus(int retryCount, Object error) => null;
+
 final firstRunStatusProvider = FutureProvider<FirstRunStatus?>((ref) async {
   ref.watch(weaveAuthenticatedSessionProvider);
   return ref.watch(firstRunStatusRepositoryProvider).loadStatus();
-});
+}, retry: _doNotRetryFirstRunStatus);
 
 final chatProvisioningStatusProvider =
     Provider<AsyncValue<FirstRunModuleStatus?>>((ref) {

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -151,6 +151,7 @@
   "firstRunLoadingLabel": "Weave-Arbeitsbereich wird geprüft…",
   "firstRunLoadingHint": "Profil, Rolle und Modulbereitschaft werden vom Weave-Backend geladen.",
   "firstRunLoadFailure": "Der Erststart-Status konnte nicht vom Weave-Backend geladen werden.",
+  "firstRunLoadFailureGuidance": "Prüfe deine Verbindung und versuche es erneut. Wenn das Problem bestehen bleibt, bitte einen Admin zu bestätigen, dass das Backend erreichbar ist.",
   "firstRunSignedOutMessage": "Melde dich an, um deinen Weave-Erststart-Status zu sehen.",
   "firstRunSignedOutGuidance": "Wir brauchen eine aktive Weave-SSO-Sitzung, bevor Profil, Rolle und Modulbereitschaft geprüft werden können.",
   "firstRunSignInAction": "Zur Anmeldung",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -366,6 +366,7 @@
   "firstRunLoadingLabel": "Checking your Weave workspace…",
   "firstRunLoadingHint": "Loading your profile, role, and module readiness from the Weave backend.",
   "firstRunLoadFailure": "We could not load your first-run status from the Weave backend.",
+  "firstRunLoadFailureGuidance": "Check your connection and try again. If this keeps happening, ask an admin to confirm the backend is reachable.",
   "firstRunSignedOutMessage": "Sign in to view your Weave first-run status.",
   "firstRunSignedOutGuidance": "We need an active Weave SSO session before we can check your profile, role, and module readiness.",
   "firstRunSignInAction": "Go to sign in",

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -617,6 +617,12 @@ abstract class AppLocalizations {
   /// **'We could not load your first-run status from the Weave backend.'**
   String get firstRunLoadFailure;
 
+  /// No description provided for @firstRunLoadFailureGuidance.
+  ///
+  /// In en, this message translates to:
+  /// **'Check your connection and try again. If this keeps happening, ask an admin to confirm the backend is reachable.'**
+  String get firstRunLoadFailureGuidance;
+
   /// No description provided for @firstRunSignedOutMessage.
   ///
   /// In en, this message translates to:

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -308,6 +308,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Der Erststart-Status konnte nicht vom Weave-Backend geladen werden.';
 
   @override
+  String get firstRunLoadFailureGuidance =>
+      'Prüfe deine Verbindung und versuche es erneut. Wenn das Problem bestehen bleibt, bitte einen Admin zu bestätigen, dass das Backend erreichbar ist.';
+
+  @override
   String get firstRunSignedOutMessage =>
       'Melde dich an, um deinen Weave-Erststart-Status zu sehen.';
 

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -303,6 +303,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'We could not load your first-run status from the Weave backend.';
 
   @override
+  String get firstRunLoadFailureGuidance =>
+      'Check your connection and try again. If this keeps happening, ask an admin to confirm the backend is reachable.';
+
+  @override
   String get firstRunSignedOutMessage =>
       'Sign in to view your Weave first-run status.';
 

--- a/client/test/features/onboarding/first_run_screen_test.dart
+++ b/client/test/features/onboarding/first_run_screen_test.dart
@@ -125,6 +125,47 @@ void main() {
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
     });
 
+    testWidgets('recovers from load failures with guidance and retry', (
+      tester,
+    ) async {
+      var loadAttempts = 0;
+      await tester.pumpWidget(
+        createTestApp(
+          const FirstRunScreen(),
+          overrides: [
+            firstRunStatusProvider.overrideWith((ref) {
+              loadAttempts += 1;
+              if (loadAttempts == 1) {
+                return Future<FirstRunStatus?>.error(
+                  Exception('backend unavailable'),
+                  StackTrace.current,
+                );
+              }
+              return Future.value(buildTestFirstRunStatus());
+            }),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 1));
+
+      expect(
+        find.text(
+          'We could not load your first-run status from the Weave backend.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Check your connection'), findsOneWidget);
+
+      await tester.tap(find.text('Retry'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Your Weave workspace is ready'), findsOneWidget);
+      expect(loadAttempts, 2);
+      await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    });
+
     testWidgets('routes signed-out users back to sign-in recovery', (
       tester,
     ) async {

--- a/client/test/features/onboarding/first_run_screen_test.dart
+++ b/client/test/features/onboarding/first_run_screen_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:weave/core/router/app_routes.dart';
 import 'package:weave/features/onboarding/domain/entities/first_run_status.dart';
+import 'package:weave/features/onboarding/domain/repositories/first_run_status_repository.dart';
 import 'package:weave/features/onboarding/presentation/first_run_screen.dart';
 import 'package:weave/features/onboarding/presentation/providers/first_run_status_provider.dart';
+import 'package:weave/integrations/weave_api/presentation/providers/weave_authenticated_session_provider.dart';
 
 import '../../helpers/first_run_status_fixture.dart';
 import '../../helpers/test_app.dart';
@@ -133,21 +136,27 @@ void main() {
         createTestApp(
           const FirstRunScreen(),
           overrides: [
-            firstRunStatusProvider.overrideWith((ref) {
-              loadAttempts += 1;
-              if (loadAttempts == 1) {
-                return Future<FirstRunStatus?>.error(
-                  Exception('backend unavailable'),
-                  StackTrace.current,
-                );
-              }
-              return Future.value(buildTestFirstRunStatus());
-            }),
+            weaveAuthenticatedSessionProvider.overrideWithValue(
+              AsyncData(
+                WeaveAuthenticatedSession(
+                  apiBaseUrl: Uri.parse('https://weave.test/api'),
+                  accessToken: 'token',
+                ),
+              ),
+            ),
+            firstRunStatusRepositoryProvider.overrideWithValue(
+              _RetryingFirstRunStatusRepository(() {
+                loadAttempts += 1;
+                if (loadAttempts == 1) {
+                  throw Exception('backend unavailable');
+                }
+                return buildTestFirstRunStatus();
+              }),
+            ),
           ],
         ),
       );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pumpAndSettle();
 
       expect(
         find.text(
@@ -213,4 +222,13 @@ void main() {
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
     });
   });
+}
+
+class _RetryingFirstRunStatusRepository implements FirstRunStatusRepository {
+  const _RetryingFirstRunStatusRepository(this._load);
+
+  final FirstRunStatus? Function() _load;
+
+  @override
+  Future<FirstRunStatus?> loadStatus() async => _load();
 }


### PR DESCRIPTION
## Summary
- Adds localized guidance below first-run load failures so users know to retry, check connectivity, and ask an admin to verify backend reachability.
- Keeps first-run status provider failures visible by disabling automatic Riverpod retry for this startup check.
- Covers retry recovery and accessibility guidelines in the first-run widget test.

## Gates
- `cd client && flutter gen-l10n && dart format --output=none --set-exit-if-changed lib/features/onboarding/presentation/first_run_screen.dart lib/features/onboarding/presentation/providers/first_run_status_provider.dart test/features/onboarding/first_run_screen_test.dart lib/l10n/generated && flutter test test/features/onboarding/first_run_screen_test.dart`
- `PR_LABELS_JSON='["area:ux","release-notes-feature"]' ./gradlew releaseNotesLabelCheck --console=plain`
- `./gradlew ci --console=plain`

Closes #413.
