### PR TITLE
feat(chat): prioritize active overview conversations

### DIFF
--- a/client/lib/features/chat/domain/entities/chat_conversation.dart
+++ b/client/lib/features/chat/domain/entities/chat_conversation.dart
@@ -128,11 +128,13 @@ int _compareConversationActivity(
 }
 
 int _compareUnread(int left, int right) {
-  if (left > 0 && right == 0) {
+  final leftHasUnread = left > 0;
+  final rightHasUnread = right > 0;
+  if (leftHasUnread && !rightHasUnread) {
     return -1;
   }
-  if (left == 0 && right > 0) {
+  if (!leftHasUnread && rightHasUnread) {
     return 1;
   }
-  return right.compareTo(left);
+  return 0;
 }

--- a/client/lib/features/chat/domain/entities/chat_conversation.dart
+++ b/client/lib/features/chat/domain/entities/chat_conversation.dart
@@ -38,22 +38,22 @@ class ChatOverview {
     return ChatOverview(
       favorites: conversations
           .where((conversation) => conversation.isFavorite)
-          .toList(growable: false),
+          .sortedByActivity(),
       personalMessages: conversations
           .where(
             (conversation) =>
                 conversation.isDirectMessage && !conversation.isAiChat,
           )
-          .toList(growable: false),
+          .sortedByActivity(),
       channels: conversations
           .where(
             (conversation) =>
                 !conversation.isDirectMessage && !conversation.isAiChat,
           )
-          .toList(growable: false),
+          .sortedByActivity(),
       aiChats: conversations
           .where((conversation) => conversation.isAiChat)
-          .toList(growable: false),
+          .sortedByActivity(),
     );
   }
 
@@ -81,23 +81,58 @@ class ChatOverview {
   }
 
   ChatConversation? get nextConversation {
-    final unique = <String>{};
-    final candidates = <ChatConversation>[
-      ...favorites.where((conversation) => conversation.unreadCount > 0),
-      ...personalMessages.where((conversation) => conversation.unreadCount > 0),
-      ...channels.where((conversation) => conversation.unreadCount > 0),
+    final unique = <String, ChatConversation>{};
+    for (final conversation in [
       ...favorites,
       ...personalMessages,
       ...channels,
       ...aiChats,
-    ];
-
-    for (final conversation in candidates) {
-      if (unique.add(conversation.id)) {
-        return conversation;
-      }
+    ]) {
+      unique.putIfAbsent(conversation.id, () => conversation);
     }
 
-    return null;
+    final candidates = unique.values.sortedByActivity();
+    return candidates.isEmpty ? null : candidates.first;
   }
+}
+
+extension on Iterable<ChatConversation> {
+  List<ChatConversation> sortedByActivity() {
+    return toList(growable: false)..sort(_compareConversationActivity);
+  }
+}
+
+int _compareConversationActivity(
+  ChatConversation left,
+  ChatConversation right,
+) {
+  final unreadComparison = _compareUnread(left.unreadCount, right.unreadCount);
+  if (unreadComparison != 0) {
+    return unreadComparison;
+  }
+
+  final leftActivity = left.lastActivityAt;
+  final rightActivity = right.lastActivityAt;
+  if (leftActivity != null && rightActivity != null) {
+    final activityComparison = rightActivity.compareTo(leftActivity);
+    if (activityComparison != 0) {
+      return activityComparison;
+    }
+  } else if (leftActivity != null) {
+    return -1;
+  } else if (rightActivity != null) {
+    return 1;
+  }
+
+  return left.title.toLowerCase().compareTo(right.title.toLowerCase());
+}
+
+int _compareUnread(int left, int right) {
+  if (left > 0 && right == 0) {
+    return -1;
+  }
+  if (left == 0 && right > 0) {
+    return 1;
+  }
+  return right.compareTo(left);
 }

--- a/client/test/features/chat/chat_overview_test.dart
+++ b/client/test/features/chat/chat_overview_test.dart
@@ -73,6 +73,15 @@ void main() {
       isDirectMessage: true,
       lastActivityAt: DateTime(2026, 5, 1, 11),
     );
+    final unreadOlderDm = ChatConversation(
+      id: '@drew:home.internal',
+      title: 'Drew',
+      previewType: ChatConversationPreviewType.text,
+      unreadCount: 5,
+      isInvite: false,
+      isDirectMessage: true,
+      lastActivityAt: DateTime(2026, 4, 30, 10),
+    );
     const quietNoActivityDm = ChatConversation(
       id: '@bea:home.internal',
       title: 'Bea',
@@ -96,11 +105,13 @@ void main() {
       quietNoActivityDm,
       unreadOlderChannel,
       quietOlderDm,
+      unreadOlderDm,
       unreadRecentDm,
     ]);
 
     expect(overview.personalMessages, [
       unreadRecentDm,
+      unreadOlderDm,
       quietOlderDm,
       quietNoActivityDm,
     ]);

--- a/client/test/features/chat/chat_overview_test.dart
+++ b/client/test/features/chat/chat_overview_test.dart
@@ -43,4 +43,68 @@ void main() {
     expect(overview.unreadCount, 2);
     expect(overview.nextConversation, favoriteChannel);
   });
+
+  test('prioritizes unread and recent activity within overview groups', () {
+    final quietRecentChannel = ChatConversation(
+      id: '!recent:home.internal',
+      title: 'Recent channel',
+      previewType: ChatConversationPreviewType.text,
+      unreadCount: 0,
+      isInvite: false,
+      isDirectMessage: false,
+      lastActivityAt: DateTime(2026, 5, 1, 12),
+      isFavorite: true,
+    );
+    final unreadOlderChannel = ChatConversation(
+      id: '!unread-older:home.internal',
+      title: 'Unread older channel',
+      previewType: ChatConversationPreviewType.text,
+      unreadCount: 1,
+      isInvite: false,
+      isDirectMessage: false,
+      lastActivityAt: DateTime(2026, 4, 30, 12),
+    );
+    final unreadRecentDm = ChatConversation(
+      id: '@alex:home.internal',
+      title: 'Alex',
+      previewType: ChatConversationPreviewType.text,
+      unreadCount: 2,
+      isInvite: false,
+      isDirectMessage: true,
+      lastActivityAt: DateTime(2026, 5, 1, 11),
+    );
+    const quietNoActivityDm = ChatConversation(
+      id: '@bea:home.internal',
+      title: 'Bea',
+      previewType: ChatConversationPreviewType.text,
+      unreadCount: 0,
+      isInvite: false,
+      isDirectMessage: true,
+    );
+    final quietOlderDm = ChatConversation(
+      id: '@casey:home.internal',
+      title: 'Casey',
+      previewType: ChatConversationPreviewType.text,
+      unreadCount: 0,
+      isInvite: false,
+      isDirectMessage: true,
+      lastActivityAt: DateTime(2026, 4, 29, 9),
+    );
+
+    final overview = ChatOverview.fromConversations([
+      quietRecentChannel,
+      quietNoActivityDm,
+      unreadOlderChannel,
+      quietOlderDm,
+      unreadRecentDm,
+    ]);
+
+    expect(overview.personalMessages, [
+      unreadRecentDm,
+      quietOlderDm,
+      quietNoActivityDm,
+    ]);
+    expect(overview.channels, [unreadOlderChannel, quietRecentChannel]);
+    expect(overview.nextConversation, unreadRecentDm);
+  });
 }

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -606,7 +606,7 @@ void main() {
       expect(find.text('Open security settings'), findsOneWidget);
     });
 
-    testWidgets('shows recency badges and keeps the newest room first', (
+    testWidgets('shows recency badges and keeps unread rooms first', (
       tester,
     ) async {
       final now = DateTime.now();
@@ -627,12 +627,21 @@ void main() {
             isInvite: false,
             isDirectMessage: false,
           ),
+          const ChatConversation(
+            id: '!older-unread:home.internal',
+            title: 'Older unread room',
+            previewType: ChatConversationPreviewType.text,
+            previewText: 'Unread update',
+            unreadCount: 1,
+            isInvite: false,
+            isDirectMessage: false,
+          ),
           ChatConversation(
             id: '!older:home.internal',
             title: 'Older room',
             previewType: ChatConversationPreviewType.text,
             previewText: 'Yesterday update',
-            lastActivityAt: yesterdayAtNoon,
+            lastActivityAt: yesterdayAtNoon.subtract(const Duration(hours: 1)),
             unreadCount: 0,
             isInvite: false,
             isDirectMessage: false,
@@ -657,6 +666,10 @@ void main() {
 
       expect(find.text('Active now'), findsOneWidget);
       expect(find.text('Yesterday'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text('Older unread room')).dy,
+        lessThan(tester.getTopLeft(find.text('Newest room')).dy),
+      );
       expect(
         tester.getTopLeft(find.text('Newest room')).dy,
         lessThan(tester.getTopLeft(find.text('Older room')).dy),


### PR DESCRIPTION
## Summary
- Sort Chat overview groups by unread activity, latest activity, then title fallback.
- Make the Home "Open next work item" target use the same de-duplicated activity priority.
- Add domain coverage for unread/recent ordering across groups.

## Tests
- `cd client && dart format --output=none --set-exit-if-changed lib/features/chat/domain/entities/chat_conversation.dart test/features/chat/chat_overview_test.dart && flutter test test/features/chat/chat_overview_test.dart test/features/chat/chat_screen_test.dart`
- `PR_LABELS_JSON='["area:chat","release-notes-feature"]' ./gradlew releaseNotesLabelCheck --console=plain`

Closes #415.
