### PR TITLE
feat(shell): prioritize active chat chips

### DIFF
--- a/client/lib/features/chat/domain/entities/chat_conversation.dart
+++ b/client/lib/features/chat/domain/entities/chat_conversation.dart
@@ -80,7 +80,7 @@ class ChatOverview {
     return total;
   }
 
-  ChatConversation? get nextConversation {
+  List<ChatConversation> get activeConversations {
     final unique = <String, ChatConversation>{};
     for (final conversation in [
       ...favorites,
@@ -91,7 +91,11 @@ class ChatOverview {
       unique.putIfAbsent(conversation.id, () => conversation);
     }
 
-    final candidates = unique.values.sortedByActivity();
+    return unique.values.sortedByActivity();
+  }
+
+  ChatConversation? get nextConversation {
+    final candidates = activeConversations;
     return candidates.isEmpty ? null : candidates.first;
   }
 }

--- a/client/lib/features/shell/presentation/shell_recent_activity.dart
+++ b/client/lib/features/shell/presentation/shell_recent_activity.dart
@@ -158,23 +158,7 @@ class _ChatActivityContent extends StatelessWidget {
   List<ChatConversation> _recentConversations(
     List<ChatConversation> conversations,
   ) {
-    final sorted = conversations.toList()
-      ..sort((left, right) {
-        final leftActivity = left.lastActivityAt;
-        final rightActivity = right.lastActivityAt;
-        if (leftActivity == null && rightActivity == null) {
-          return left.title.compareTo(right.title);
-        }
-        if (leftActivity == null) {
-          return 1;
-        }
-        if (rightActivity == null) {
-          return -1;
-        }
-        return rightActivity.compareTo(leftActivity);
-      });
-
-    return sorted
+    return ChatOverview.fromConversations(conversations).activeConversations
         .take(ShellRecentActivity._maxItemsPerSection)
         .toList(growable: false);
   }

--- a/client/test/features/chat/chat_overview_test.dart
+++ b/client/test/features/chat/chat_overview_test.dart
@@ -116,6 +116,14 @@ void main() {
       quietNoActivityDm,
     ]);
     expect(overview.channels, [unreadOlderChannel, quietRecentChannel]);
+    expect(overview.activeConversations, [
+      unreadRecentDm,
+      unreadOlderChannel,
+      unreadOlderDm,
+      quietRecentChannel,
+      quietOlderDm,
+      quietNoActivityDm,
+    ]);
     expect(overview.nextConversation, unreadRecentDm);
   });
 }

--- a/client/test/features/shell/app_shell_test.dart
+++ b/client/test/features/shell/app_shell_test.dart
@@ -269,6 +269,46 @@ void main() {
       );
     });
 
+    testWidgets('prioritizes unread rooms in recent activity quick links', (
+      tester,
+    ) async {
+      final now = DateTime(2026, 5, 29, 12);
+      final chatRepository = FakeChatRepository(
+        loadConversationsHandler: () async => [
+          ChatConversation(
+            id: '!quiet-latest:weave.local',
+            title: 'Quiet latest',
+            previewType: ChatConversationPreviewType.text,
+            previewText: 'Latest quiet update',
+            lastActivityAt: now.subtract(const Duration(minutes: 1)),
+            unreadCount: 0,
+            isInvite: false,
+            isDirectMessage: false,
+          ),
+          const ChatConversation(
+            id: '!unread-older:weave.local',
+            title: 'Unread older',
+            previewType: ChatConversationPreviewType.text,
+            previewText: 'Still unread',
+            unreadCount: 1,
+            isInvite: false,
+            isDirectMessage: false,
+          ),
+        ],
+      );
+
+      await pumpReadyShell(tester, chatRepository: chatRepository);
+
+      expect(find.widgetWithText(ActionChip, 'Unread older'), findsOneWidget);
+      expect(find.widgetWithText(ActionChip, 'Quiet latest'), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.widgetWithText(ActionChip, 'Unread older')).dx,
+        lessThan(
+          tester.getTopLeft(find.widgetWithText(ActionChip, 'Quiet latest')).dx,
+        ),
+      );
+    });
+
     testWidgets('opens a recent room quick link with the app route', (
       tester,
     ) async {


### PR DESCRIPTION
Closes #417.\n\n## Summary\n- expose ChatOverview.activeConversations as the shared de-duplicated unread-first ordering\n- reuse that ordering for shell Recent activity room chips\n- cover ordering at domain and shell widget level\n\n## Evidence\n- cd client && dart format --output=none --set-exit-if-changed lib/features/chat/domain/entities/chat_conversation.dart lib/features/shell/presentation/shell_recent_activity.dart test/features/chat/chat_overview_test.dart test/features/shell/app_shell_test.dart && flutter test test/features/chat/chat_overview_test.dart test/features/shell/app_shell_test.dart\n- PR_LABELS_JSON='["area:chat","area:ux","release-notes-feature"]' ./gradlew releaseNotesLabelCheck --console=plain\n- ./gradlew ci --console=plain (log: build/issue-417-gradle-ci-local-after-commit.log)