### PR TITLE
fix(chat): keep unread room badges compact

### DIFF
--- a/client/lib/features/chat/presentation/chat_screen.dart
+++ b/client/lib/features/chat/presentation/chat_screen.dart
@@ -855,13 +855,28 @@ class _ConversationTrailing extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    final metadataPills = <Widget>[
+      if (recencyLabel != null)
+        _ConversationMetadataPill(
+          label: recencyLabel!,
+          backgroundColor: theme.colorScheme.secondaryContainer,
+          foregroundColor: theme.colorScheme.onSecondaryContainer,
+          horizontalPadding: 8,
+        ),
+      if (unreadCount > 0)
+        _ConversationMetadataPill(
+          label: unreadCount.toString(),
+          backgroundColor: theme.colorScheme.primary,
+          foregroundColor: theme.colorScheme.onPrimary,
+          horizontalPadding: 10,
+        ),
+    ];
+
     return SizedBox(
       width: 156,
-      child: Wrap(
-        alignment: WrapAlignment.end,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        spacing: 6,
-        runSpacing: 4,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
           if (timestamp != null)
             Text(
@@ -872,19 +887,18 @@ class _ConversationTrailing extends StatelessWidget {
                 color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
-          if (recencyLabel != null)
-            _ConversationMetadataPill(
-              label: recencyLabel!,
-              backgroundColor: theme.colorScheme.secondaryContainer,
-              foregroundColor: theme.colorScheme.onSecondaryContainer,
-              horizontalPadding: 8,
-            ),
-          if (unreadCount > 0)
-            _ConversationMetadataPill(
-              label: unreadCount.toString(),
-              backgroundColor: theme.colorScheme.primary,
-              foregroundColor: theme.colorScheme.onPrimary,
-              horizontalPadding: 10,
+          if (timestamp != null && metadataPills.isNotEmpty)
+            const SizedBox(height: 4),
+          if (metadataPills.isNotEmpty)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final pill in metadataPills) ...[
+                  if (pill != metadataPills.first) const SizedBox(width: 6),
+                  Flexible(child: pill),
+                ],
+              ],
             ),
         ],
       ),
@@ -921,6 +935,8 @@ class _ConversationMetadataPill extends StatelessWidget {
         ),
         child: Text(
           label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
           style: theme.textTheme.labelSmall?.copyWith(
             color: foregroundColor,
             fontWeight: FontWeight.w600,

--- a/client/lib/features/chat/presentation/chat_screen.dart
+++ b/client/lib/features/chat/presentation/chat_screen.dart
@@ -872,8 +872,8 @@ class _ConversationTrailing extends StatelessWidget {
         ),
     ];
 
-    return SizedBox(
-      width: 156,
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 156),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.end,

--- a/client/lib/features/chat/presentation/chat_screen.dart
+++ b/client/lib/features/chat/presentation/chat_screen.dart
@@ -852,55 +852,78 @@ class _ConversationTrailing extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.end,
-      children: [
-        if (timestamp != null)
-          Text(
-            timestamp!,
-            style: theme.textTheme.labelMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
-          ),
-        if (recencyLabel != null) ...[
-          const SizedBox(height: 6),
-          DecoratedBox(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.secondaryContainer,
-              borderRadius: BorderRadius.circular(999),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: Text(
-                recencyLabel!,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onSecondaryContainer,
-                  fontWeight: FontWeight.w600,
-                ),
+    return SizedBox(
+      width: 156,
+      child: Wrap(
+        alignment: WrapAlignment.end,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        spacing: 6,
+        runSpacing: 4,
+        children: [
+          if (timestamp != null)
+            Text(
+              timestamp!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
-          ),
-        ],
-        if (unreadCount > 0) ...[
-          const SizedBox(height: 8),
-          DecoratedBox(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.primary,
-              borderRadius: BorderRadius.circular(999),
+          if (recencyLabel != null)
+            _ConversationMetadataPill(
+              label: recencyLabel!,
+              backgroundColor: theme.colorScheme.secondaryContainer,
+              foregroundColor: theme.colorScheme.onSecondaryContainer,
+              horizontalPadding: 8,
             ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-              child: Text(
-                unreadCount.toString(),
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onPrimary,
-                ),
-              ),
+          if (unreadCount > 0)
+            _ConversationMetadataPill(
+              label: unreadCount.toString(),
+              backgroundColor: theme.colorScheme.primary,
+              foregroundColor: theme.colorScheme.onPrimary,
+              horizontalPadding: 10,
             ),
-          ),
         ],
-      ],
+      ),
+    );
+  }
+}
+
+class _ConversationMetadataPill extends StatelessWidget {
+  const _ConversationMetadataPill({
+    required this.label,
+    required this.backgroundColor,
+    required this.foregroundColor,
+    required this.horizontalPadding,
+  });
+
+  final String label;
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final double horizontalPadding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: horizontalPadding,
+          vertical: 4,
+        ),
+        child: Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: foregroundColor,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/client/lib/features/chat/presentation/chat_screen.dart
+++ b/client/lib/features/chat/presentation/chat_screen.dart
@@ -791,6 +791,9 @@ class _ConversationTile extends StatelessWidget {
 
     return Semantics(
       container: true,
+      button: true,
+      enabled: true,
+      onTap: onTap,
       label: semanticsLabel,
       child: ExcludeSemantics(
         child: Card(

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -607,7 +607,7 @@ void main() {
       expect(find.text('Open security settings'), findsOneWidget);
     });
 
-    testWidgets('shows recency badges and keeps unread rooms first', (
+    testWidgets('keeps unread recent room metadata within the tile', (
       tester,
     ) async {
       final semantics = tester.ensureSemantics();
@@ -690,6 +690,7 @@ void main() {
           .getSemanticsData();
       expect(unreadRoomSemanticsData.label, contains('Older unread room'));
       expect(unreadRoomSemanticsData.label, contains('Unread update'));
+      expect(unreadRoomSemanticsData.label, contains('Active now'));
       expect(unreadRoomSemanticsData.label, contains('3 unread messages'));
       expect(unreadRoomSemanticsData.hasAction(SemanticsAction.tap), isTrue);
       semantics.dispose();

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -622,17 +622,18 @@ void main() {
             title: 'Newest room',
             previewType: ChatConversationPreviewType.text,
             previewText: 'Fresh update',
-            lastActivityAt: now.subtract(const Duration(minutes: 10)),
+            lastActivityAt: now.subtract(const Duration(hours: 2)),
             unreadCount: 0,
             isInvite: false,
             isDirectMessage: false,
           ),
-          const ChatConversation(
+          ChatConversation(
             id: '!older-unread:home.internal',
             title: 'Older unread room',
             previewType: ChatConversationPreviewType.text,
             previewText: 'Unread update',
-            unreadCount: 1,
+            lastActivityAt: now.subtract(const Duration(minutes: 20)),
+            unreadCount: 3,
             isInvite: false,
             isDirectMessage: false,
           ),
@@ -665,6 +666,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Active now'), findsOneWidget);
+      expect(find.text('3'), findsOneWidget);
+      expect(find.text('Today'), findsOneWidget);
       expect(find.text('Yesterday'), findsOneWidget);
       expect(
         tester.getTopLeft(find.text('Older unread room')).dy,

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/core/theme/app_theme.dart';
@@ -609,6 +610,7 @@ void main() {
     testWidgets('shows recency badges and keeps unread rooms first', (
       tester,
     ) async {
+      final semantics = tester.ensureSemantics();
       final now = DateTime.now();
       final yesterdayAtNoon = DateTime(
         now.year,
@@ -676,6 +678,21 @@ void main() {
         tester.getTopLeft(find.text('Newest room')).dy,
         lessThan(tester.getTopLeft(find.text('Older room')).dy),
       );
+
+      final unreadRoomSemantics = find.byWidgetPredicate(
+        (widget) =>
+            widget is Semantics &&
+            widget.properties.button == true &&
+            (widget.properties.label ?? '').contains('Older unread room'),
+      );
+      final unreadRoomSemanticsData = tester
+          .getSemantics(unreadRoomSemantics)
+          .getSemanticsData();
+      expect(unreadRoomSemanticsData.label, contains('Older unread room'));
+      expect(unreadRoomSemanticsData.label, contains('Unread update'));
+      expect(unreadRoomSemanticsData.label, contains('3 unread messages'));
+      expect(unreadRoomSemanticsData.hasAction(SemanticsAction.tap), isTrue);
+      semantics.dispose();
     });
 
     testWidgets('keeps the last room list visible when a manual refresh fails', (

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -622,7 +622,7 @@ void main() {
             title: 'Newest room',
             previewType: ChatConversationPreviewType.text,
             previewText: 'Fresh update',
-            lastActivityAt: now.subtract(const Duration(hours: 2)),
+            lastActivityAt: now.subtract(const Duration(minutes: 10)),
             unreadCount: 0,
             isInvite: false,
             isDirectMessage: false,
@@ -665,9 +665,8 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Active now'), findsOneWidget);
+      expect(find.text('Active now'), findsWidgets);
       expect(find.text('3'), findsOneWidget);
-      expect(find.text('Today'), findsOneWidget);
       expect(find.text('Yesterday'), findsOneWidget);
       expect(
         tester.getTopLeft(find.text('Older unread room')).dy,


### PR DESCRIPTION
## Summary
- keep chat conversation trailing metadata constrained with wrapping pills
- preserve timestamp, recency, and unread count visibility for unread recent rooms
- extend chat widget coverage for the timestamp + recency + unread case

## Linked issue
Closes #419

## Impact
- User/admin/operator impact: fixes member chat list overflow for unread rooms with recent activity.
- Accessibility/localization impact: existing localized recency strings remain visible; metadata text remains present in the widget tree.
- Contract/spec changes: none.

## Checks
- `cd client && dart format --output=none --set-exit-if-changed lib/features/chat/presentation/chat_screen.dart test/features/chat/chat_screen_test.dart`
- `cd client && flutter analyze --fatal-infos lib/features/chat/presentation/chat_screen.dart test/features/chat/chat_screen_test.dart`
- `cd client && flutter test test/features/chat/chat_screen_test.dart`
- `./gradlew clientCi`
