### PR TITLE
fix(chat): announce restored room drafts

### DIFF
--- a/client/lib/features/chat/presentation/chat_room_screen.dart
+++ b/client/lib/features/chat/presentation/chat_room_screen.dart
@@ -398,7 +398,11 @@ class _ChatRoomScreenState extends ConsumerState<ChatRoomScreen> {
               if (_draftRestored && !_loading)
                 MaterialBanner(
                   leading: const Icon(Icons.edit_note_outlined),
-                  content: Text(l10n.chatRoomDraftRestoredMessage),
+                  content: Semantics(
+                    container: true,
+                    liveRegion: true,
+                    child: Text(l10n.chatRoomDraftRestoredMessage),
+                  ),
                   actions: [
                     TextButton(
                       onPressed: () => setState(() {

--- a/client/test/features/chat/chat_room_screen_test.dart
+++ b/client/test/features/chat/chat_room_screen_test.dart
@@ -445,6 +445,7 @@ void main() {
   });
 
   testWidgets('restores a local unsent draft for the room', (tester) async {
+    final semantics = tester.ensureSemantics();
     final repository = FakeChatRepository(
       loadRoomTimelineHandler: (_) async => buildTimeline(),
     );
@@ -463,6 +464,18 @@ void main() {
 
     expect(find.text('Draft restored from this device.'), findsOneWidget);
     expect(find.text('Remember the release notes'), findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is Semantics &&
+            widget.properties.liveRegion == true &&
+            widget.child is Text &&
+            ((widget.child! as Text).data?.contains('Draft restored') ?? false),
+      ),
+      findsOneWidget,
+    );
+    expect(find.bySemanticsLabel('Close'), findsOneWidget);
+    semantics.dispose();
   });
 
   testWidgets('shows retryable failures in the room', (tester) async {


### PR DESCRIPTION
## Summary
- Announce restored chat room drafts as a live semantic region.
- Keep restored draft text in the composer and the banner close action available.

## Evidence
- `cd client && flutter test test/features/chat/chat_room_screen_test.dart`
- `PR_LABELS_JSON='["release-notes-bugfix"]' ./gradlew releaseNotesLabelCheck clientCi`

## Veto
- QA/Evidence: PASS
- Client UX/accessibility: no blocker from local semantics evidence; L2 retry runs were inconclusive due runner/context failure, not a product defect.

Closes #421
