### PR TITLE
feat(ux): add shared success state

### DIFF
--- a/client/lib/core/widgets/success_state.dart
+++ b/client/lib/core/widgets/success_state.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:weave/core/widgets/state_panel.dart';
+
+/// A shared success-state placeholder with friendly guidance and recovery.
+///
+/// Use [message] for a short user-facing confirmation and [guidance] for
+/// details or next steps. The optional action keeps follow-up flows consistent
+/// with other shared state panels.
+class SuccessState extends StatelessWidget {
+  const SuccessState({
+    super.key,
+    required this.message,
+    this.guidance,
+    this.icon = Icons.check_circle_outline,
+    this.actionLabel,
+    this.onAction,
+    this.semanticLabel,
+  });
+
+  /// Localised user-facing success title.
+  final String message;
+
+  /// Optional localised details or next-step guidance.
+  final String? guidance;
+
+  /// Decorative icon shown above the message.
+  final IconData icon;
+
+  /// Optional follow-up action label.
+  final String? actionLabel;
+
+  /// Callback for the optional follow-up action.
+  final VoidCallback? onAction;
+
+  /// Optional full screen-reader label for the live success-state region.
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return StatePanel(
+      variant: StatePanelVariant.success,
+      message: message,
+      guidance: guidance,
+      icon: icon,
+      actionLabel: actionLabel,
+      onAction: onAction,
+      semanticLabel: semanticLabel,
+    );
+  }
+}

--- a/client/test/core/widgets/core_widgets_test.dart
+++ b/client/test/core/widgets/core_widgets_test.dart
@@ -4,6 +4,7 @@ import 'package:weave/core/widgets/empty_state.dart';
 import 'package:weave/core/widgets/error_state.dart';
 import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/core/widgets/state_panel.dart';
+import 'package:weave/core/widgets/success_state.dart';
 
 void main() {
   group('StatePanel', () {
@@ -35,6 +36,91 @@ void main() {
 
       await tester.tap(find.text('Done'));
       expect(acknowledged, isTrue);
+    });
+  });
+
+  group('SuccessState', () {
+    testWidgets('displays shared success chrome with guidance', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SuccessState(
+              message: 'Saved',
+              guidance: 'Your changes are available to the workspace.',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Saved'), findsOneWidget);
+      expect(
+        find.text('Your changes are available to the workspace.'),
+        findsOneWidget,
+      );
+      expect(find.byType(Card), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
+      expect(
+        find.bySemanticsLabel(
+          'Saved. Your changes are available to the workspace.',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders follow-up action when provided', (tester) async {
+      var opened = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuccessState(
+              message: 'Saved',
+              actionLabel: 'Open',
+              onAction: () => opened = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Open'), findsOneWidget);
+      expect(find.bySemanticsLabel('Saved. Action: Open'), findsOneWidget);
+      expect(find.bySemanticsLabel('Open'), findsOneWidget);
+      await tester.tap(find.text('Open'));
+      expect(opened, isTrue);
+    });
+
+    testWidgets('accepts an explicit screen-reader label', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SuccessState(
+              message: 'Saved',
+              guidance: 'Your changes are available to the workspace.',
+              semanticLabel: 'Settings saved successfully.',
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        find.bySemanticsLabel('Settings saved successfully.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('meets labeledTapTargetGuideline', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SuccessState(
+              message: 'Saved',
+              actionLabel: 'Open',
+              onAction: () {},
+            ),
+          ),
+        ),
+      );
+
+      await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
     });
   });
 


### PR DESCRIPTION
## Summary
- add a shared `SuccessState` wrapper for success/recovery UI
- cover composed semantics, explicit screen-reader labels, action semantics, and tap-target accessibility

## Evidence
- `cd client && flutter analyze --fatal-infos lib/core/widgets/success_state.dart test/core/widgets/core_widgets_test.dart`
- `cd client && flutter test test/core/widgets/core_widgets_test.dart`
- `PR_LABELS_JSON='["area:ux","post-mvp","release-notes-skip"]' ./gradlew releaseNotesLabelCheck --console=plain`
- `./gradlew ci --console=plain`

Closes #423
Advances #51
