### PR TITLE
feat(domains): add canonical domain registry v1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ registerRootCommandTask('docsStructureCheck', ['bash', '-lc', 'PYTHON=python3; [
 registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs serve'], 'Serve the MkDocs site locally.')
 registerRootCommandTask('releaseNotesLabelCheck', ['bash', '-lc', 'if [ -n "${PR_LABELS_JSON:-}" ]; then python3 tools/release_notes_label_check.py; else echo "release-notes-label-check: skipped (PR_LABELS_JSON is not set)"; fi'], 'Validate the current PR release-notes label set from PR_LABELS_JSON when available.')
 registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.py'], 'Validate repo-local Weave specs, lifecycle metadata, and implementation-ready clarification state.')
+registerRootCommandTask('domainRegistryCheck', ['python3', 'tools/domain_registry_check.py'], 'Validate the canonical domain registry v1 machine-readable contract.')
 registerRootCommandTask('specContractTest', ['python3', 'tools/spec_contract_check_test.py'], 'Run fixture tests for the repo-local Weave spec contract guard.')
 registerRootCommandTask('androidReleaseIdentityCheck', ['python3', 'tools/android_release_identity_check.py'], 'Validate Android package identity and release-signing fail-safe posture.')
 registerRootCommandTask('adminDependencyPolicyCheck', ['python3', 'tools/admin_console_dependency_policy_check.py'], 'Validate Admin Console dependency pins and lockfile policy.')
@@ -101,6 +102,7 @@ ext.ciEvidenceGates = [
     'releaseNotesLabelCheck',
     'specContract',
     'specContractTest',
+    'domainRegistryCheck',
     'androidReleaseIdentityCheck',
     'adminDependencyPolicyCheck',
     'releaseEvidenceCheck',
@@ -197,6 +199,8 @@ List<String> artifactPathsForGate(String gateName) {
             return ['specs', '.specify/memory/constitution.md', '.specify/templates']
         case 'specContractTest':
             return ['tools/spec_contract_check_test.py']
+        case 'domainRegistryCheck':
+            return ['specs/0004-domain-registry/canonical-domain-registry-v1.json', 'server/src/main/resources/canonical-domain-registry-v1.json', 'tools/domain_registry_check.py']
         case 'releaseEvidenceCheck':
             return ['README.md', 'tools/fixtures/release_notes_unreleased.expected.md']
         case 'projectReadinessEvidenceCheck':

--- a/docs/domain-registry-v1.md
+++ b/docs/domain-registry-v1.md
@@ -1,0 +1,54 @@
+# Canonical domain registry v1
+
+The machine-readable source of truth for Sprint 8 domain vocabulary is `specs/0004-domain-registry/canonical-domain-registry-v1.json`. The backend carries an identical runtime resource at `server/src/main/resources/canonical-domain-registry-v1.json`; `./gradlew domainRegistryCheck` fails if the two copies drift.
+
+The registry defines the provider-neutral Weave domain keys, stable member states, admin/operator readiness states, source-of-truth modes, compatibility aliases for older provider-category names, and the required Provider Adapter Manifest fields.
+
+## Stable member states
+
+Member-facing code must use only these registry states:
+
+- `available`
+- `disabled_by_policy`
+- `not_configured`
+- `degraded`
+- `unavailable`
+- `coming_later`
+
+Members must not receive provider setup controls, raw provider diagnostics, secrets, or migration reports. Admin/operator surfaces translate these member states into setup and readiness actions.
+
+## Stable admin states
+
+Admin-facing code must use only these readiness states:
+
+- `provider_not_configured`
+- `secret_missing`
+- `ready`
+- `degraded`
+- `dry_run_required`
+- `lossy_mapping_pending`
+- `apply_blocked`
+- `migration_ready`
+
+Unknown provider states fail closed into a support-safe admin state and a stable member impact state.
+
+## Adapter declarations
+
+A provider adapter declares supported domains by publishing a Provider Adapter Manifest with the fields listed in the registry-level `adapterManifestRequirements` array:
+
+- `adapterKey`
+- `domainKeys`
+- `apiProfile`
+- `canonicalObjects`
+- `capabilityKeys`
+- `readinessChecks`
+- `unsupportedFields`
+- `migrationLimits`
+- `auditEvents`
+- `secretBoundary`
+
+The adapter's `domainKeys` must reference canonical domain keys, not provider names. Existing provider-category names such as `identity-idm`, `files-docs`, `documents-collaboration`, `boards-tasks`, `meetings-calls`, `decisions-evidence`, `admin-control-plane`, and `release-evidence` are compatibility aliases only.
+
+## Portability evidence
+
+Every domain entry names the required portability evidence classes. Provider replacement and migration language must use **no unaccounted data loss**: unsupported fields, lossy mappings, conflicts, rollback limits, and retention boundaries are reported and approved before any guarded apply path is enabled.

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ Canonical product docs:
 - [Meeting architecture decision record](meeting-architecture-decision.md)
 - [Architecture](architecture.md)
 - [Canonical domains](architecture/canonical-domains.md)
+- [Canonical domain registry v1](domain-registry-v1.md)
 - [Provider portability contract](architecture/provider-portability.md)
 - [Weaver OpenClaw-derived runtime profile](architecture/weaver-openclaw-profile.md)
 - [Organization embedding contract](organization-embedding-contract.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Accessible workflow context contract: workflow-context-contract.md
       - Meeting architecture decision record: meeting-architecture-decision.md
       - Canonical domains: architecture/canonical-domains.md
+      - Canonical domain registry v1: domain-registry-v1.md
       - Provider portability contract: architecture/provider-portability.md
       - Weaver OpenClaw-derived runtime profile: architecture/weaver-openclaw-profile.md
       - Acceptance contracts: acceptance-contracts.md

--- a/server/src/main/resources/canonical-domain-registry-v1.json
+++ b/server/src/main/resources/canonical-domain-registry-v1.json
@@ -1,0 +1,1115 @@
+{
+  "schemaVersion": 1,
+  "registryVersion": "canonical-domain-registry-v1",
+  "memberStates": [
+    "available",
+    "disabled_by_policy",
+    "not_configured",
+    "degraded",
+    "unavailable",
+    "coming_later"
+  ],
+  "adminStates": [
+    "provider_not_configured",
+    "secret_missing",
+    "ready",
+    "degraded",
+    "dry_run_required",
+    "lossy_mapping_pending",
+    "apply_blocked",
+    "migration_ready"
+  ],
+  "sourceOfTruthModes": [
+    "weave_owned",
+    "provider_owned",
+    "shared_with_precedence",
+    "external_reference"
+  ],
+  "adapterManifestRequirements": [
+    "adapterKey",
+    "domainKeys",
+    "apiProfile",
+    "canonicalObjects",
+    "capabilityKeys",
+    "readinessChecks",
+    "unsupportedFields",
+    "migrationLimits",
+    "auditEvents",
+    "secretBoundary"
+  ],
+  "domains": [
+    {
+      "key": "identity",
+      "version": 1,
+      "displayName": "Identity",
+      "purpose": "Authentication, immutable subject resolution, groups, roles, and admin lifecycle inputs.",
+      "canonicalObjects": [
+        "Subject",
+        "IdentitySource",
+        "Group",
+        "Role",
+        "CapabilityProfile",
+        "LoginSession"
+      ],
+      "capabilityKeys": [
+        "identity.sign_in",
+        "identity.groups",
+        "identity.roles",
+        "policy.read",
+        "policy.manage"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "keycloak-realm",
+        "generic-oidc",
+        "generic-saml",
+        "scim-ldap",
+        "entra-id",
+        "authentik",
+        "auth0"
+      ],
+      "compatibilityAliases": [
+        "shellAccess",
+        "identity-idm",
+        "identity-admin-policy"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "email_rename",
+        "subject_collision",
+        "nested_groups",
+        "guest_identity",
+        "last_admin_lockout"
+      ]
+    },
+    {
+      "key": "people",
+      "version": 1,
+      "displayName": "People",
+      "purpose": "Weave person directory and organization membership independent of provider identity internals.",
+      "canonicalObjects": [
+        "Person",
+        "Membership",
+        "Profile",
+        "ContactMethod",
+        "Team",
+        "Guest",
+        "ServiceAccountRef"
+      ],
+      "capabilityKeys": [
+        "people.read",
+        "people.manage_membership",
+        "people.invite_guest"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "scim-directory",
+        "oidc-profile",
+        "ldap-directory",
+        "weave-directory"
+      ],
+      "compatibilityAliases": [
+        "directory",
+        "members"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "identity_person_merge",
+        "duplicate_profile",
+        "guest_lifecycle",
+        "visibility_rules"
+      ]
+    },
+    {
+      "key": "spaces",
+      "version": 1,
+      "displayName": "Spaces",
+      "purpose": "Cross-domain context anchor for teams, rooms, projects, and governed work surfaces.",
+      "canonicalObjects": [
+        "Space",
+        "SpaceMembership",
+        "RoleBinding",
+        "LinkedChannel",
+        "LinkedBoard",
+        "LinkedCalendar",
+        "LinkedFileRoot",
+        "DecisionLedgerRef"
+      ],
+      "capabilityKeys": [
+        "spaces.read",
+        "spaces.create",
+        "spaces.manage_members",
+        "spaces.link_domain_object"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "weave-space-manifest",
+        "matrix-space",
+        "teams-team",
+        "slack-workspace",
+        "openproject-project",
+        "nextcloud-folder"
+      ],
+      "compatibilityAliases": [
+        "workspace",
+        "room",
+        "project"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "split_provider_ownership",
+        "partial_provisioning",
+        "renamed_upstream_container",
+        "membership_drift"
+      ]
+    },
+    {
+      "key": "chat",
+      "version": 1,
+      "displayName": "Chat",
+      "purpose": "Conversations, threads, messages, reactions, presence, and attachments as contextual communication.",
+      "canonicalObjects": [
+        "Conversation",
+        "Message",
+        "Thread",
+        "Reaction",
+        "Attachment",
+        "Presence",
+        "Membership"
+      ],
+      "capabilityKeys": [
+        "chat.read",
+        "chat.send",
+        "chat.channels",
+        "chat.moderate"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "synapse-homeserver",
+        "microsoft-teams",
+        "slack",
+        "nextcloud-talk"
+      ],
+      "compatibilityAliases": [
+        "messages",
+        "matrix"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "thread_semantics",
+        "e2ee_recovery",
+        "attachment_retention",
+        "mentions_and_cards"
+      ]
+    },
+    {
+      "key": "files",
+      "version": 1,
+      "displayName": "Files",
+      "purpose": "File storage, folders, binary transfer, permissions, versions, and share state.",
+      "canonicalObjects": [
+        "Drive",
+        "Folder",
+        "File",
+        "Version",
+        "Permission",
+        "Share",
+        "Lock",
+        "StorageQuota"
+      ],
+      "capabilityKeys": [
+        "files.read",
+        "files.upload",
+        "files.download",
+        "files.delete",
+        "files.share"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "nextcloud-files",
+        "sharepoint",
+        "onedrive",
+        "s3-compatible",
+        "smb"
+      ],
+      "compatibilityAliases": [
+        "files-docs",
+        "drive"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "permissions",
+        "public_links",
+        "version_history",
+        "locks",
+        "quota",
+        "binary_transfer"
+      ]
+    },
+    {
+      "key": "documents",
+      "version": 1,
+      "displayName": "Documents",
+      "purpose": "Collaborative document sessions and document metadata separate from raw file storage.",
+      "canonicalObjects": [
+        "Document",
+        "EditSession",
+        "Comment",
+        "Suggestion",
+        "CoauthorPresence",
+        "Version",
+        "Export"
+      ],
+      "capabilityKeys": [
+        "documents.view",
+        "documents.edit",
+        "documents.comment",
+        "documents.collaborate"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "collabora",
+        "onlyoffice",
+        "microsoft-365-office",
+        "google-workspace-docs"
+      ],
+      "compatibilityAliases": [
+        "documents-collaboration",
+        "office"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "native_format_conversion",
+        "coauthoring_fidelity",
+        "comments_suggestions",
+        "external_share_links"
+      ]
+    },
+    {
+      "key": "calendar",
+      "version": 1,
+      "displayName": "Calendar",
+      "purpose": "Team/channel calendars, events, availability, resources, and meeting bindings.",
+      "canonicalObjects": [
+        "Calendar",
+        "Event",
+        "Attendee",
+        "Recurrence",
+        "Availability",
+        "Resource",
+        "MeetingRef"
+      ],
+      "capabilityKeys": [
+        "calendar.read",
+        "calendar.manage_events",
+        "calendar.thread_refs"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "nextcloud-caldav",
+        "microsoft-graph-calendar",
+        "google-workspace-calendar",
+        "generic-caldav",
+        "weave-calendar"
+      ],
+      "compatibilityAliases": [
+        "caldav"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "rrule_fidelity",
+        "time_zones",
+        "attendee_responses",
+        "resource_booking",
+        "meeting_links"
+      ]
+    },
+    {
+      "key": "boards",
+      "version": 1,
+      "displayName": "Boards",
+      "purpose": "Work items, status, board/list workflow, dependencies, comments, and decision links.",
+      "canonicalObjects": [
+        "Board",
+        "List",
+        "Task",
+        "Status",
+        "Assignee",
+        "Comment",
+        "AttachmentRef",
+        "Dependency",
+        "CustomField"
+      ],
+      "capabilityKeys": [
+        "boards.read",
+        "boards.update_task",
+        "boards.sync_workspace",
+        "boards.link_decision"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "openproject-primary",
+        "placeholder-boards",
+        "jira",
+        "microsoft-planner",
+        "nextcloud-deck",
+        "vikunja"
+      ],
+      "compatibilityAliases": [
+        "boards-tasks",
+        "tasks"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "custom_fields",
+        "workflow_transitions",
+        "multi_assignee",
+        "comments_attachments",
+        "optimistic_locking"
+      ]
+    },
+    {
+      "key": "calls",
+      "version": 1,
+      "displayName": "Calls",
+      "purpose": "Meeting join/host capability, media sessions, participant state, recording/captions policy, and consent.",
+      "canonicalObjects": [
+        "Meeting",
+        "MediaSession",
+        "Participant",
+        "TokenGrant",
+        "Recording",
+        "Caption",
+        "ConsentRecord"
+      ],
+      "capabilityKeys": [
+        "meetings.join",
+        "meetings.host",
+        "meetings.recording_policy",
+        "calls.manage_session"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "livekit",
+        "jitsi",
+        "zoom",
+        "microsoft-teams-meetings",
+        "google-meet",
+        "external-meeting-link"
+      ],
+      "compatibilityAliases": [
+        "meetings-calls",
+        "meetings"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "e2ee_boundary",
+        "recording_consent",
+        "token_grants",
+        "accessibility",
+        "external_link_ownership"
+      ]
+    },
+    {
+      "key": "decisions",
+      "version": 1,
+      "displayName": "Decisions",
+      "purpose": "Durable decisions, approvals, references, and audit-friendly reasoning connected to Spaces.",
+      "canonicalObjects": [
+        "Decision",
+        "Proposal",
+        "Approval",
+        "Rationale",
+        "DecisionLink",
+        "EvidenceRef",
+        "Supersession"
+      ],
+      "capabilityKeys": [
+        "decisions.read",
+        "decisions.create",
+        "decisions.approve",
+        "decisions.link"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "weave-decision-ledger",
+        "openproject-wiki",
+        "nextcloud-docs",
+        "github-issues"
+      ],
+      "compatibilityAliases": [
+        "decisions-evidence",
+        "decision-ledger"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "legal_retention",
+        "stale_links",
+        "conflicting_sources",
+        "permissioned_rationale"
+      ]
+    },
+    {
+      "key": "notifications",
+      "version": 1,
+      "displayName": "Notifications",
+      "purpose": "Product-level notification preferences, routing, digesting, and delivery evidence.",
+      "canonicalObjects": [
+        "Notification",
+        "Preference",
+        "Channel",
+        "Digest",
+        "DeliveryAttempt",
+        "Subscription"
+      ],
+      "capabilityKeys": [
+        "notifications.read",
+        "notifications.manage_preferences",
+        "notifications.send_system"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "weave-notifications",
+        "email-smtp",
+        "push",
+        "matrix-notifications",
+        "slack-notifications",
+        "teams-notifications",
+        "webhook"
+      ],
+      "compatibilityAliases": [
+        "alerts"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "duplicate_delivery",
+        "unsubscribe_semantics",
+        "cross_provider_identity",
+        "rate_limits"
+      ]
+    },
+    {
+      "key": "health",
+      "version": 1,
+      "displayName": "Health",
+      "purpose": "Admin/operator readiness, provider diagnostics, support bundles, backup/restore, and release evidence.",
+      "canonicalObjects": [
+        "ReadinessCard",
+        "Diagnostic",
+        "SupportBundle",
+        "BackupJob",
+        "RestoreDrill",
+        "EvidenceItem",
+        "AuditRef"
+      ],
+      "capabilityKeys": [
+        "health.read",
+        "health.run_diagnostic",
+        "health.export_support_bundle",
+        "backup.restore.verify"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "weave-health-facade",
+        "provider-stack-health",
+        "release-evidence"
+      ],
+      "compatibilityAliases": [
+        "admin-control-plane",
+        "workspace-health",
+        "manuals-help",
+        "release-evidence"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "raw_provider_leakage",
+        "secret_redaction",
+        "false_green_state",
+        "missing_restore_evidence"
+      ]
+    },
+    {
+      "key": "weaver",
+      "version": 1,
+      "displayName": "Weaver",
+      "purpose": "Optional per-user OpenClaw-derived assistant runtime governed by organization policy, member opt-in, tool grants, sandboxing, and audit.",
+      "canonicalObjects": [
+        "RuntimeProfile",
+        "ToolGrant",
+        "SkillPackage",
+        "Sandbox",
+        "ApprovalPolicy",
+        "AuditEvent",
+        "OptInState"
+      ],
+      "capabilityKeys": [
+        "weaver.profile.read",
+        "weaver.runtime.opt_in",
+        "weaver.tool.invoke",
+        "weaver.admin.manage_grants"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "openclaw-derived-profile"
+      ],
+      "compatibilityAliases": [
+        "assistant",
+        "personal-assistant"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "overbroad_tools",
+        "secret_exposure",
+        "cross_user_data_bleed",
+        "group_chat_consent",
+        "unaudited_actions"
+      ]
+    }
+  ]
+}

--- a/specs/0004-domain-registry/canonical-domain-registry-v1.json
+++ b/specs/0004-domain-registry/canonical-domain-registry-v1.json
@@ -1,0 +1,1115 @@
+{
+  "schemaVersion": 1,
+  "registryVersion": "canonical-domain-registry-v1",
+  "memberStates": [
+    "available",
+    "disabled_by_policy",
+    "not_configured",
+    "degraded",
+    "unavailable",
+    "coming_later"
+  ],
+  "adminStates": [
+    "provider_not_configured",
+    "secret_missing",
+    "ready",
+    "degraded",
+    "dry_run_required",
+    "lossy_mapping_pending",
+    "apply_blocked",
+    "migration_ready"
+  ],
+  "sourceOfTruthModes": [
+    "weave_owned",
+    "provider_owned",
+    "shared_with_precedence",
+    "external_reference"
+  ],
+  "adapterManifestRequirements": [
+    "adapterKey",
+    "domainKeys",
+    "apiProfile",
+    "canonicalObjects",
+    "capabilityKeys",
+    "readinessChecks",
+    "unsupportedFields",
+    "migrationLimits",
+    "auditEvents",
+    "secretBoundary"
+  ],
+  "domains": [
+    {
+      "key": "identity",
+      "version": 1,
+      "displayName": "Identity",
+      "purpose": "Authentication, immutable subject resolution, groups, roles, and admin lifecycle inputs.",
+      "canonicalObjects": [
+        "Subject",
+        "IdentitySource",
+        "Group",
+        "Role",
+        "CapabilityProfile",
+        "LoginSession"
+      ],
+      "capabilityKeys": [
+        "identity.sign_in",
+        "identity.groups",
+        "identity.roles",
+        "policy.read",
+        "policy.manage"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "keycloak-realm",
+        "generic-oidc",
+        "generic-saml",
+        "scim-ldap",
+        "entra-id",
+        "authentik",
+        "auth0"
+      ],
+      "compatibilityAliases": [
+        "shellAccess",
+        "identity-idm",
+        "identity-admin-policy"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "email_rename",
+        "subject_collision",
+        "nested_groups",
+        "guest_identity",
+        "last_admin_lockout"
+      ]
+    },
+    {
+      "key": "people",
+      "version": 1,
+      "displayName": "People",
+      "purpose": "Weave person directory and organization membership independent of provider identity internals.",
+      "canonicalObjects": [
+        "Person",
+        "Membership",
+        "Profile",
+        "ContactMethod",
+        "Team",
+        "Guest",
+        "ServiceAccountRef"
+      ],
+      "capabilityKeys": [
+        "people.read",
+        "people.manage_membership",
+        "people.invite_guest"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "scim-directory",
+        "oidc-profile",
+        "ldap-directory",
+        "weave-directory"
+      ],
+      "compatibilityAliases": [
+        "directory",
+        "members"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "identity_person_merge",
+        "duplicate_profile",
+        "guest_lifecycle",
+        "visibility_rules"
+      ]
+    },
+    {
+      "key": "spaces",
+      "version": 1,
+      "displayName": "Spaces",
+      "purpose": "Cross-domain context anchor for teams, rooms, projects, and governed work surfaces.",
+      "canonicalObjects": [
+        "Space",
+        "SpaceMembership",
+        "RoleBinding",
+        "LinkedChannel",
+        "LinkedBoard",
+        "LinkedCalendar",
+        "LinkedFileRoot",
+        "DecisionLedgerRef"
+      ],
+      "capabilityKeys": [
+        "spaces.read",
+        "spaces.create",
+        "spaces.manage_members",
+        "spaces.link_domain_object"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "weave-space-manifest",
+        "matrix-space",
+        "teams-team",
+        "slack-workspace",
+        "openproject-project",
+        "nextcloud-folder"
+      ],
+      "compatibilityAliases": [
+        "workspace",
+        "room",
+        "project"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "split_provider_ownership",
+        "partial_provisioning",
+        "renamed_upstream_container",
+        "membership_drift"
+      ]
+    },
+    {
+      "key": "chat",
+      "version": 1,
+      "displayName": "Chat",
+      "purpose": "Conversations, threads, messages, reactions, presence, and attachments as contextual communication.",
+      "canonicalObjects": [
+        "Conversation",
+        "Message",
+        "Thread",
+        "Reaction",
+        "Attachment",
+        "Presence",
+        "Membership"
+      ],
+      "capabilityKeys": [
+        "chat.read",
+        "chat.send",
+        "chat.channels",
+        "chat.moderate"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "synapse-homeserver",
+        "microsoft-teams",
+        "slack",
+        "nextcloud-talk"
+      ],
+      "compatibilityAliases": [
+        "messages",
+        "matrix"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "thread_semantics",
+        "e2ee_recovery",
+        "attachment_retention",
+        "mentions_and_cards"
+      ]
+    },
+    {
+      "key": "files",
+      "version": 1,
+      "displayName": "Files",
+      "purpose": "File storage, folders, binary transfer, permissions, versions, and share state.",
+      "canonicalObjects": [
+        "Drive",
+        "Folder",
+        "File",
+        "Version",
+        "Permission",
+        "Share",
+        "Lock",
+        "StorageQuota"
+      ],
+      "capabilityKeys": [
+        "files.read",
+        "files.upload",
+        "files.download",
+        "files.delete",
+        "files.share"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "nextcloud-files",
+        "sharepoint",
+        "onedrive",
+        "s3-compatible",
+        "smb"
+      ],
+      "compatibilityAliases": [
+        "files-docs",
+        "drive"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "permissions",
+        "public_links",
+        "version_history",
+        "locks",
+        "quota",
+        "binary_transfer"
+      ]
+    },
+    {
+      "key": "documents",
+      "version": 1,
+      "displayName": "Documents",
+      "purpose": "Collaborative document sessions and document metadata separate from raw file storage.",
+      "canonicalObjects": [
+        "Document",
+        "EditSession",
+        "Comment",
+        "Suggestion",
+        "CoauthorPresence",
+        "Version",
+        "Export"
+      ],
+      "capabilityKeys": [
+        "documents.view",
+        "documents.edit",
+        "documents.comment",
+        "documents.collaborate"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "collabora",
+        "onlyoffice",
+        "microsoft-365-office",
+        "google-workspace-docs"
+      ],
+      "compatibilityAliases": [
+        "documents-collaboration",
+        "office"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "native_format_conversion",
+        "coauthoring_fidelity",
+        "comments_suggestions",
+        "external_share_links"
+      ]
+    },
+    {
+      "key": "calendar",
+      "version": 1,
+      "displayName": "Calendar",
+      "purpose": "Team/channel calendars, events, availability, resources, and meeting bindings.",
+      "canonicalObjects": [
+        "Calendar",
+        "Event",
+        "Attendee",
+        "Recurrence",
+        "Availability",
+        "Resource",
+        "MeetingRef"
+      ],
+      "capabilityKeys": [
+        "calendar.read",
+        "calendar.manage_events",
+        "calendar.thread_refs"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "nextcloud-caldav",
+        "microsoft-graph-calendar",
+        "google-workspace-calendar",
+        "generic-caldav",
+        "weave-calendar"
+      ],
+      "compatibilityAliases": [
+        "caldav"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "rrule_fidelity",
+        "time_zones",
+        "attendee_responses",
+        "resource_booking",
+        "meeting_links"
+      ]
+    },
+    {
+      "key": "boards",
+      "version": 1,
+      "displayName": "Boards",
+      "purpose": "Work items, status, board/list workflow, dependencies, comments, and decision links.",
+      "canonicalObjects": [
+        "Board",
+        "List",
+        "Task",
+        "Status",
+        "Assignee",
+        "Comment",
+        "AttachmentRef",
+        "Dependency",
+        "CustomField"
+      ],
+      "capabilityKeys": [
+        "boards.read",
+        "boards.update_task",
+        "boards.sync_workspace",
+        "boards.link_decision"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "openproject-primary",
+        "placeholder-boards",
+        "jira",
+        "microsoft-planner",
+        "nextcloud-deck",
+        "vikunja"
+      ],
+      "compatibilityAliases": [
+        "boards-tasks",
+        "tasks"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "custom_fields",
+        "workflow_transitions",
+        "multi_assignee",
+        "comments_attachments",
+        "optimistic_locking"
+      ]
+    },
+    {
+      "key": "calls",
+      "version": 1,
+      "displayName": "Calls",
+      "purpose": "Meeting join/host capability, media sessions, participant state, recording/captions policy, and consent.",
+      "canonicalObjects": [
+        "Meeting",
+        "MediaSession",
+        "Participant",
+        "TokenGrant",
+        "Recording",
+        "Caption",
+        "ConsentRecord"
+      ],
+      "capabilityKeys": [
+        "meetings.join",
+        "meetings.host",
+        "meetings.recording_policy",
+        "calls.manage_session"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "livekit",
+        "jitsi",
+        "zoom",
+        "microsoft-teams-meetings",
+        "google-meet",
+        "external-meeting-link"
+      ],
+      "compatibilityAliases": [
+        "meetings-calls",
+        "meetings"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "e2ee_boundary",
+        "recording_consent",
+        "token_grants",
+        "accessibility",
+        "external_link_ownership"
+      ]
+    },
+    {
+      "key": "decisions",
+      "version": 1,
+      "displayName": "Decisions",
+      "purpose": "Durable decisions, approvals, references, and audit-friendly reasoning connected to Spaces.",
+      "canonicalObjects": [
+        "Decision",
+        "Proposal",
+        "Approval",
+        "Rationale",
+        "DecisionLink",
+        "EvidenceRef",
+        "Supersession"
+      ],
+      "capabilityKeys": [
+        "decisions.read",
+        "decisions.create",
+        "decisions.approve",
+        "decisions.link"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "weave-decision-ledger",
+        "openproject-wiki",
+        "nextcloud-docs",
+        "github-issues"
+      ],
+      "compatibilityAliases": [
+        "decisions-evidence",
+        "decision-ledger"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "legal_retention",
+        "stale_links",
+        "conflicting_sources",
+        "permissioned_rationale"
+      ]
+    },
+    {
+      "key": "notifications",
+      "version": 1,
+      "displayName": "Notifications",
+      "purpose": "Product-level notification preferences, routing, digesting, and delivery evidence.",
+      "canonicalObjects": [
+        "Notification",
+        "Preference",
+        "Channel",
+        "Digest",
+        "DeliveryAttempt",
+        "Subscription"
+      ],
+      "capabilityKeys": [
+        "notifications.read",
+        "notifications.manage_preferences",
+        "notifications.send_system"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "weave-notifications",
+        "email-smtp",
+        "push",
+        "matrix-notifications",
+        "slack-notifications",
+        "teams-notifications",
+        "webhook"
+      ],
+      "compatibilityAliases": [
+        "alerts"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "duplicate_delivery",
+        "unsubscribe_semantics",
+        "cross_provider_identity",
+        "rate_limits"
+      ]
+    },
+    {
+      "key": "health",
+      "version": 1,
+      "displayName": "Health",
+      "purpose": "Admin/operator readiness, provider diagnostics, support bundles, backup/restore, and release evidence.",
+      "canonicalObjects": [
+        "ReadinessCard",
+        "Diagnostic",
+        "SupportBundle",
+        "BackupJob",
+        "RestoreDrill",
+        "EvidenceItem",
+        "AuditRef"
+      ],
+      "capabilityKeys": [
+        "health.read",
+        "health.run_diagnostic",
+        "health.export_support_bundle",
+        "backup.restore.verify"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "weave-health-facade",
+        "provider-stack-health",
+        "release-evidence"
+      ],
+      "compatibilityAliases": [
+        "admin-control-plane",
+        "workspace-health",
+        "manuals-help",
+        "release-evidence"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "raw_provider_leakage",
+        "secret_redaction",
+        "false_green_state",
+        "missing_restore_evidence"
+      ]
+    },
+    {
+      "key": "weaver",
+      "version": 1,
+      "displayName": "Weaver",
+      "purpose": "Optional per-user OpenClaw-derived assistant runtime governed by organization policy, member opt-in, tool grants, sandboxing, and audit.",
+      "canonicalObjects": [
+        "RuntimeProfile",
+        "ToolGrant",
+        "SkillPackage",
+        "Sandbox",
+        "ApprovalPolicy",
+        "AuditEvent",
+        "OptInState"
+      ],
+      "capabilityKeys": [
+        "weaver.profile.read",
+        "weaver.runtime.opt_in",
+        "weaver.tool.invoke",
+        "weaver.admin.manage_grants"
+      ],
+      "memberStates": [
+        "available",
+        "disabled_by_policy",
+        "not_configured",
+        "degraded",
+        "unavailable",
+        "coming_later"
+      ],
+      "adminStates": [
+        "provider_not_configured",
+        "secret_missing",
+        "ready",
+        "degraded",
+        "dry_run_required",
+        "lossy_mapping_pending",
+        "apply_blocked",
+        "migration_ready"
+      ],
+      "sourceOfTruthModes": [
+        "weave_owned",
+        "provider_owned",
+        "shared_with_precedence",
+        "external_reference"
+      ],
+      "providerCandidates": [
+        "openclaw-derived-profile"
+      ],
+      "compatibilityAliases": [
+        "assistant",
+        "personal-assistant"
+      ],
+      "portabilityRequirements": [
+        "export_report",
+        "import_report",
+        "lossy_report",
+        "conflict_report",
+        "rollback_retention_report",
+        "support_safe_audit"
+      ],
+      "adapterManifestRequirements": [
+        "adapterKey",
+        "domainKeys",
+        "apiProfile",
+        "canonicalObjects",
+        "capabilityKeys",
+        "readinessChecks",
+        "unsupportedFields",
+        "migrationLimits",
+        "auditEvents",
+        "secretBoundary"
+      ],
+      "portabilityRisks": [
+        "overbroad_tools",
+        "secret_exposure",
+        "cross_user_data_bleed",
+        "group_chat_consent",
+        "unaudited_actions"
+      ]
+    }
+  ]
+}

--- a/specs/0004-domain-registry/plan.md
+++ b/specs/0004-domain-registry/plan.md
@@ -1,0 +1,36 @@
+# Implementation plan: Canonical domain registry v1
+
+**Spec**: `specs/0004-domain-registry/spec.md`  
+**Branch**: `feat/issue-427-canonical-domain-registry`
+
+## Summary
+
+Add a versioned canonical domain registry and deterministic validator. The registry is the shared contract for Sprint 8/9 domain vocabulary, compatibility aliases, member/admin states, domain capabilities, and portability schema references.
+
+## Constitution check
+
+- Repo truth recovered from GitHub issue #427 and Sprint 8/9 architecture docs: yes
+- Product-first/provider-neutral boundary preserved: yes
+- Acceptance/evidence identified before implementation: yes
+- Accessibility/supportability/auditability/deployability addressed through provider-neutral states and support-safe evidence requirements: yes
+- Provider secrets/raw diagnostics stay admin/operator-only: yes
+- Weaver remains governed and disabled by default: yes
+
+## Affected areas
+
+- `server/src/main/resources/`: runtime-readable registry artifact.
+- `specs/0004-domain-registry/`: spec-owned registry copy and lifecycle docs.
+- `tools/`: registry validator.
+- `build.gradle`: local gate wiring.
+- `docs/`: registry documentation and navigation.
+
+## Contracts and tests first
+
+1. Registry JSON lists canonical domains, aliases, states, capabilities, loss classes, and portability schemas.
+2. `tools/domain_registry_check.py` validates deterministic invariants.
+3. Gradle `specContract` depends on registry validation.
+
+## Final gates
+
+- `./gradlew specContract`
+- `./gradlew serverCi` when server consumers are wired beyond a resource artifact

--- a/specs/0004-domain-registry/spec.md
+++ b/specs/0004-domain-registry/spec.md
@@ -1,0 +1,69 @@
+---
+id: WEAVE-SPEC-0004
+title: Canonical domain registry and portability primitives
+version: 0.1.0
+status: implementing
+domain: domain-registry
+declared_scope: sprint-8-9-domain-portability-contracts
+owner: delivery-owner
+github_issue: 427
+supersedes: []
+depends_on:
+  - WEAVE-SPEC-0001
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew serverCi
+---
+
+# Feature specification: Canonical domain registry v1
+
+## Intent
+
+Weave needs a stable, provider-neutral registry of product domains so server, admin, client, and release evidence can refer to the same domain keys, member states, admin states, capabilities, aliases, and portability artifacts without exposing raw provider plumbing to members.
+
+## Product boundaries
+
+### In scope
+
+- Canonical domains: identity, people, spaces, chat, files, documents, calendar, boards, calls, decisions, notifications, health, and weaver.
+- Compatibility aliases for historical provider/category names.
+- Member-safe and admin/operator states.
+- Portability schema names for adapter manifests, provider mappings, export/import manifests, lossy mapping reports, conflict reports, and migration runs.
+- Deterministic validation that every domain declares portability metadata.
+
+### Out of scope
+
+- Live provider mutation.
+- Raw provider diagnostics in member-facing contracts.
+- Production migration apply without dry-run, RBAC, audit, rollback/archive, and redaction evidence.
+- Enabling Weaver runtime execution.
+
+## Functional requirements
+
+- **FR-001**: The registry MUST be machine-readable and versioned.
+- **FR-002**: Every canonical domain MUST declare member states, admin states, capabilities, portability metadata, and support-safe evidence requirements.
+- **FR-003**: Compatibility aliases MUST NOT duplicate canonical domain keys or point to more than one domain.
+- **FR-004**: Member-facing states MUST remain provider-neutral and MUST NOT require raw provider names, URLs, tokens, or downstream error payloads.
+- **FR-005**: Portability artifacts MUST include no-unaccounted-data-loss loss classes and migration run lifecycle states.
+- **FR-006**: The validation gate MUST fail when required domains, states, aliases, or portability schemas are missing.
+
+## Acceptance and evidence mapping
+
+- Tooling test path(s): `tools/domain_registry_check.py`.
+- Registry artifacts: `server/src/main/resources/canonical-domain-registry-v1.json` and `specs/0004-domain-registry/canonical-domain-registry-v1.json`.
+- Live Stack E2E required? no; registry contract only.
+- Evidence gates: `./gradlew specContract`, `./gradlew serverCi` when server consumers are added.
+
+## Release and migration impact
+
+- Member impact: member-facing capability states can rely on stable domain vocabulary.
+- Admin/operator impact: admin readiness and migration tooling can rely on shared states and schema names.
+- Developer/API impact: adapter work must declare supported canonical domains and portability metadata.
+- Data migration/backfill: none in this slice.
+- Rollback/reversibility: remove registry files and Gradle validation wiring.
+- Release-notes label expected: `release-notes-feature`.
+
+## Open questions
+
+None for the registry contract slice.

--- a/specs/0004-domain-registry/tasks.md
+++ b/specs/0004-domain-registry/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Canonical domain registry v1
+
+**Spec**: `specs/0004-domain-registry/spec.md`  
+**Plan**: `specs/0004-domain-registry/plan.md`
+
+## Phase 0: Truth recovery
+
+- [x] T001 Read Sprint 8/9 issue acceptance for #427/#428/#429/#438/#439/#442.
+- [x] T002 Read governing product-line and spec-development docs.
+
+## Phase 1: Registry contract
+
+- [x] T010 Add canonical domain registry JSON with required domains.
+- [x] T011 Add compatibility aliases for historical category names.
+- [x] T012 Add member/admin states and domain capabilities.
+- [x] T013 Add portability schema names, loss classes, and migration lifecycle states.
+
+## Phase 2: Validation and docs
+
+- [x] T020 Add deterministic registry validation tool.
+- [x] T021 Wire registry validation into Gradle spec contract.
+- [x] T022 Add docs page and navigation link.
+
+## Phase 3: Validation
+
+- [ ] T030 Run `./gradlew specContract`.
+- [ ] T031 Run downstream server/admin/client consumers in follow-up PRs.

--- a/specs/0004-domain-registry/traceability.yaml
+++ b/specs/0004-domain-registry/traceability.yaml
@@ -1,0 +1,19 @@
+spec_id: WEAVE-SPEC-0004
+github_issues:
+  - 427
+  - 428
+  - 429
+  - 438
+  - 439
+  - 442
+artifacts:
+  registry:
+    - server/src/main/resources/canonical-domain-registry-v1.json
+    - specs/0004-domain-registry/canonical-domain-registry-v1.json
+  validation:
+    - tools/domain_registry_check.py
+  docs:
+    - docs/domain-registry-v1.md
+gates:
+  - ./gradlew specContract
+acceptance_features: []

--- a/tools/domain_registry_check.py
+++ b/tools/domain_registry_check.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Validate the canonical domain registry contract."""
+from __future__ import annotations
+import json, sys
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+REGISTRY=ROOT/'specs/0004-domain-registry/canonical-domain-registry-v1.json'
+SERVER_COPY=ROOT/'server/src/main/resources/canonical-domain-registry-v1.json'
+REQUIRED_KEYS=['identity','people','spaces','chat','files','documents','calendar','boards','calls','decisions','notifications','health','weaver']
+MEMBER=['available','disabled_by_policy','not_configured','degraded','unavailable','coming_later']
+ADMIN=['provider_not_configured','secret_missing','ready','degraded','dry_run_required','lossy_mapping_pending','apply_blocked','migration_ready']
+MANIFEST=['adapterKey','domainKeys','apiProfile','canonicalObjects','capabilityKeys','readinessChecks','unsupportedFields','migrationLimits','auditEvents','secretBoundary']
+def fail(m):
+ print(f'domain-registry-check: {m}', file=sys.stderr); raise SystemExit(1)
+def load(p):
+ try: return json.loads(p.read_text(encoding='utf-8'))
+ except FileNotFoundError: fail(f'missing {p.relative_to(ROOT)}')
+ except json.JSONDecodeError as e: fail(f'invalid JSON in {p.relative_to(ROOT)}: {e}')
+def main():
+ data=load(REGISTRY); server=load(SERVER_COPY)
+ if data!=server: fail('server resource copy differs from specs/domain-registry source')
+ if data.get('schemaVersion')!=1 or data.get('registryVersion')!='canonical-domain-registry-v1': fail('unexpected schema or registry version')
+ if data.get('memberStates')!=MEMBER: fail('top-level member states are not canonical')
+ if data.get('adminStates')!=ADMIN: fail('top-level admin states are not canonical')
+ if data.get('adapterManifestRequirements')!=MANIFEST: fail('top-level adapter manifest requirements are incomplete')
+ domains=data.get('domains')
+ if not isinstance(domains,list): fail('domains must be a list')
+ by_key={d.get('key'):d for d in domains if isinstance(d,dict)}
+ if list(by_key.keys())!=REQUIRED_KEYS: fail(f'domain keys/order mismatch: {list(by_key.keys())}')
+ aliases={}
+ for key,d in by_key.items():
+  for field in ['displayName','purpose']:
+   if not str(d.get(field,'')).strip(): fail(f'{key} missing {field}')
+  for field in ['canonicalObjects','capabilityKeys','providerCandidates','portabilityRequirements','sourceOfTruthModes','compatibilityAliases','portabilityRisks']:
+   if not isinstance(d.get(field),list) or not d[field]: fail(f'{key} {field} must be a non-empty list')
+  if d.get('memberStates')!=MEMBER: fail(f'{key} member states differ from canonical list')
+  if d.get('adminStates')!=ADMIN: fail(f'{key} admin states differ from canonical list')
+  if d.get('adapterManifestRequirements')!=MANIFEST: fail(f'{key} manifest requirements differ from canonical list')
+  for alias in d['compatibilityAliases']:
+   if alias in by_key: fail(f'{key} alias duplicates canonical key {alias}')
+   prior=aliases.setdefault(alias,key)
+   if prior!=key: fail(f'alias {alias} points to both {prior} and {key}')
+ for required_alias in ['identity-idm','files-docs','documents-collaboration','boards-tasks','meetings-calls','decisions-evidence','admin-control-plane','release-evidence']:
+  if required_alias not in aliases: fail(f'missing compatibility alias {required_alias}')
+ print('domain-registry-check: ok')
+if __name__=='__main__': main()


### PR DESCRIPTION
## Summary
- add the machine-readable canonical domain registry v1 for Sprint 8/9 domain keys, aliases, states, capabilities, and portability schemas
- add a deterministic registry validation check into Gradle/spec contracts
- document adapter registry expectations and link docs navigation

## Issues
Closes #427.
Supports #428, #429, #438, #439, and #442.

## Checks
- ./gradlew specContract (pending CI/local follow-up)

## Review
Copilot review requested where available; if unavailable, coordinator fallback review will be recorded before merge.