### PR TITLE
feat(spaces): define cross-domain space anchor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build
 registerRootCommandTask('releaseNotesLabelCheck', ['bash', '-lc', 'if [ -n "${PR_LABELS_JSON:-}" ]; then python3 tools/release_notes_label_check.py; else echo "release-notes-label-check: skipped (PR_LABELS_JSON is not set)"; fi'], 'Validate the current PR release-notes label set from PR_LABELS_JSON when available.')
 registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.py'], 'Validate repo-local Weave specs, lifecycle metadata, and implementation-ready clarification state.')
 registerRootCommandTask('domainRegistryCheck', ['python3', 'tools/domain_registry_check.py'], 'Validate the canonical domain registry v1 machine-readable contract.')
+registerRootCommandTask('spaceAnchorCheck', ['python3', 'tools/space_anchor_check.py'], 'Validate the Space anchor contract fixture.')
 registerRootCommandTask('specContractTest', ['python3', 'tools/spec_contract_check_test.py'], 'Run fixture tests for the repo-local Weave spec contract guard.')
 registerRootCommandTask('androidReleaseIdentityCheck', ['python3', 'tools/android_release_identity_check.py'], 'Validate Android package identity and release-signing fail-safe posture.')
 registerRootCommandTask('adminDependencyPolicyCheck', ['python3', 'tools/admin_console_dependency_policy_check.py'], 'Validate Admin Console dependency pins and lockfile policy.')
@@ -103,6 +104,7 @@ ext.ciEvidenceGates = [
     'specContract',
     'specContractTest',
     'domainRegistryCheck',
+    'spaceAnchorCheck',
     'androidReleaseIdentityCheck',
     'adminDependencyPolicyCheck',
     'releaseEvidenceCheck',
@@ -201,6 +203,8 @@ List<String> artifactPathsForGate(String gateName) {
             return ['tools/spec_contract_check_test.py']
         case 'domainRegistryCheck':
             return ['specs/0004-domain-registry/canonical-domain-registry-v1.json', 'server/src/main/resources/canonical-domain-registry-v1.json', 'tools/domain_registry_check.py']
+        case 'spaceAnchorCheck':
+            return ['docs/space-anchor-contract.md', 'specs/0005-spaces-anchor/space-anchor-fixture.json', 'tools/space_anchor_check.py']
         case 'releaseEvidenceCheck':
             return ['README.md', 'tools/fixtures/release_notes_unreleased.expected.md']
         case 'projectReadinessEvidenceCheck':

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,7 @@ Canonical product docs:
 - [Canonical domains](architecture/canonical-domains.md)
 - [Canonical domain registry v1](domain-registry-v1.md)
 - [Provider portability contract](architecture/provider-portability.md)
+- [Space anchor contract](space-anchor-contract.md)
 - [Weaver OpenClaw-derived runtime profile](architecture/weaver-openclaw-profile.md)
 - [Organization embedding contract](organization-embedding-contract.md)
 - [Admin-Suite readiness and setup contract](admin-suite-readiness-setup-contract.md)

--- a/docs/space-anchor-contract.md
+++ b/docs/space-anchor-contract.md
@@ -1,0 +1,45 @@
+# Space anchor contract
+
+`spaces` is the cross-domain organization context anchor. A Space represents a stable team, project, working room, or organizational context even when the provider containers attached to that context change.
+
+A Space is product-owned. Matrix rooms, Nextcloud folders, OpenProject projects, CalDAV calendars, LiveKit rooms, decision ledgers, and future Weaver context attach as domain bindings; they do not define the product boundary.
+
+## Canonical objects
+
+- `Space`: stable organization context with a Weave-owned ID, key, name, type, default surface, and archive state.
+- `SpaceType`: team, project, community, support room, department, or other governed organization type.
+- `SpaceMembership`: provider-neutral relationship between a Weave person and a Space.
+- `SpaceRole`: provider-neutral context role such as owner, admin, member, guest, or observer.
+- `DomainBinding`: support-safe link from the Space to a canonical domain object.
+- `ContextPolicy`: policy flags for member visibility, Weaver access, provider write boundaries, and fail-closed behavior.
+- `DefaultSurface`: first member surface for the Space, e.g. chat, boards, files, calendar, or decisions.
+- `ContextArchive`: durable archive/deprovisioning state independent of a single provider.
+
+## Binding rules
+
+A DomainBinding references a canonical domain and a support-safe member reference. Admin/operator evidence may retain a redacted provider object reference for readiness, migration, and audit, but normal member payloads must not expose raw provider IDs, endpoints, credentials, or downstream diagnostics.
+
+Each binding records:
+
+- canonical `domain` key;
+- provider category or adapter alias for admin/operator compatibility;
+- redacted provider object reference;
+- member-safe reference;
+- readiness state;
+- source-of-truth mode;
+- lossy notes;
+- migration status.
+
+Readiness, source-of-truth, lossy notes, and migration status are required so a provider change can preserve organizational context without claiming lossless migration. The standard is no unaccounted data loss.
+
+## Membership and roles
+
+Space membership is provider-neutral and resolves through Weave people/identity contracts. Provider membership may be synchronized from the Space, imported into it, or shared with explicit precedence, but member-facing roles remain Weave roles. Unknown or conflicting provider roles fail closed until an admin reviews the mapping.
+
+## Fixture
+
+`specs/0005-spaces-anchor/space-anchor-fixture.json` demonstrates one Marketing Space bound to chat, files, boards, and calendar. The boards binding intentionally requires a dry-run because workflow transitions may be lossy during migration.
+
+## Weaver context
+
+Future Weaver runtime profiles may reference a Space as context only through Weave domain tools and user/org policy. A Weaver profile must not use a Space binding to bypass Weave facades or call raw provider APIs directly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Canonical domains: architecture/canonical-domains.md
       - Canonical domain registry v1: domain-registry-v1.md
       - Provider portability contract: architecture/provider-portability.md
+      - Space anchor contract: space-anchor-contract.md
       - Weaver OpenClaw-derived runtime profile: architecture/weaver-openclaw-profile.md
       - Acceptance contracts: acceptance-contracts.md
       - Quality and evidence: quality-and-evidence.md

--- a/specs/0005-spaces-anchor/plan.md
+++ b/specs/0005-spaces-anchor/plan.md
@@ -1,0 +1,6 @@
+# Implementation plan: WEAVE-SPEC-0005
+
+1. Document the Space anchor contract and member/provider boundary.
+2. Add a fixture with chat, files, boards, and calendar bindings.
+3. Validate provider-neutral membership, redacted provider refs, readiness, source-of-truth, lossy notes, migration status, and Weaver indirect access.
+4. Link the contract from documentation navigation.

--- a/specs/0005-spaces-anchor/space-anchor-fixture.json
+++ b/specs/0005-spaces-anchor/space-anchor-fixture.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "space": {
+    "spaceId": "space_marketing",
+    "key": "marketing",
+    "name": "Marketing",
+    "type": "team",
+    "defaultSurface": "chat",
+    "membership": [
+      {
+        "personId": "person_alex",
+        "spaceRole": "owner",
+        "capabilityProfile": "space-admin"
+      },
+      {
+        "personId": "person_sam",
+        "spaceRole": "member",
+        "capabilityProfile": "member"
+      }
+    ],
+    "contextPolicy": {
+      "memberProviderDetailsVisible": false,
+      "weaverMayReferenceSpace": true,
+      "weaverDirectProviderAccess": false,
+      "unknownBindingsFailClosed": true
+    },
+    "bindings": {
+      "chat": {
+        "domain": "chat",
+        "providerCategoryAlias": "matrix",
+        "providerObjectRef": "redacted-provider-ref:chat-room",
+        "memberRef": "conversation:marketing",
+        "readiness": "ready",
+        "sourceOfTruth": "provider_owned",
+        "lossyNotes": [],
+        "migrationStatus": "not_required"
+      },
+      "files": {
+        "domain": "files",
+        "providerCategoryAlias": "nextcloud-files",
+        "providerObjectRef": "redacted-provider-ref:file-root",
+        "memberRef": "file-root:marketing",
+        "readiness": "ready",
+        "sourceOfTruth": "provider_owned",
+        "lossyNotes": [],
+        "migrationStatus": "not_required"
+      },
+      "boards": {
+        "domain": "boards",
+        "providerCategoryAlias": "openproject-primary",
+        "providerObjectRef": "redacted-provider-ref:project",
+        "memberRef": "board:marketing-campaigns",
+        "readiness": "dry_run_required",
+        "sourceOfTruth": "shared_with_precedence",
+        "lossyNotes": ["custom workflow transitions require migration review before apply"],
+        "migrationStatus": "preflight_required"
+      },
+      "calendar": {
+        "domain": "calendar",
+        "providerCategoryAlias": "nextcloud-caldav",
+        "providerObjectRef": "redacted-provider-ref:calendar",
+        "memberRef": "calendar:marketing",
+        "readiness": "ready",
+        "sourceOfTruth": "provider_owned",
+        "lossyNotes": [],
+        "migrationStatus": "not_required"
+      }
+    }
+  }
+}

--- a/specs/0005-spaces-anchor/spec.md
+++ b/specs/0005-spaces-anchor/spec.md
@@ -1,0 +1,66 @@
+---
+id: WEAVE-SPEC-0005
+title: Spaces as cross-domain organization anchors
+version: 0.1.0
+status: implementing
+domain: spaces
+declared_scope: sprint-8-canonical-domains
+owner: delivery-owner
+github_issue: 428
+supersedes: []
+depends_on:
+  - WEAVE-SPEC-0001
+  - WEAVE-SPEC-0004
+acceptance_features: []
+evidence_gates:
+  - ./gradlew specContract
+  - ./gradlew spaceAnchorCheck
+---
+
+# Feature specification: Spaces as cross-domain anchors
+
+## Intent
+
+Define Space as the provider-neutral organization context that binds chat, files, boards, calendar, calls, decisions, and future Weaver context without exposing raw provider identifiers to members.
+
+## Product boundaries
+
+### In scope
+
+- Space, SpaceType, SpaceMembership, SpaceRole, DomainBinding, ContextPolicy, DefaultSurface, and ContextArchive vocabulary.
+- Domain bindings with readiness, source-of-truth, lossy notes, and migration status.
+- A minimal fixture binding one Space to chat, files, boards, and calendar.
+- Future Weaver context references through Weave policy and facades only.
+
+### Out of scope
+
+- Live provider provisioning.
+- Raw provider object IDs in member payloads.
+- Weaver direct provider access.
+
+## Functional requirements
+
+- **FR-001**: A Space MUST have stable Weave-owned identity independent of provider containers.
+- **FR-002**: Membership and context roles MUST be provider-neutral.
+- **FR-003**: Bindings MUST record readiness, source-of-truth, lossy notes, and migration status.
+- **FR-004**: Member-safe references MUST not expose raw provider details.
+- **FR-005**: Weaver MAY reference a Space only through Weave-governed tools and policy.
+
+## Acceptance and evidence mapping
+
+- Tooling test path(s): `tools/space_anchor_check.py`.
+- Fixture: `specs/0005-spaces-anchor/space-anchor-fixture.json`.
+- Evidence gates: `./gradlew specContract`, `./gradlew spaceAnchorCheck`, `./gradlew docsCheck`.
+
+## Release and migration impact
+
+- Member impact: stable workspace context survives provider replacement.
+- Admin/operator impact: binding readiness and migration state become explicit.
+- Developer/API impact: domain facades can use Space as the context anchor.
+- Data migration/backfill: none in this slice.
+- Rollback/reversibility: remove fixture, docs, and validation wiring.
+- Release-notes label expected: `release-notes-feature`.
+
+## Open questions
+
+None for the anchor contract slice.

--- a/specs/0005-spaces-anchor/tasks.md
+++ b/specs/0005-spaces-anchor/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: WEAVE-SPEC-0005
+
+- [x] Document Space, membership, role, binding, policy, default surface, and archive vocabulary.
+- [x] Add a minimal Marketing Space fixture.
+- [x] Validate support-safe provider references and Weaver no-direct-provider-access rule.
+- [x] Add Gradle validation task and docs navigation.

--- a/specs/0005-spaces-anchor/traceability.yaml
+++ b/specs/0005-spaces-anchor/traceability.yaml
@@ -1,0 +1,15 @@
+spec_id: WEAVE-SPEC-0005
+github_issues:
+  - 428
+artifacts:
+  fixture:
+    - specs/0005-spaces-anchor/space-anchor-fixture.json
+  validation:
+    - tools/space_anchor_check.py
+  docs:
+    - docs/space-anchor-contract.md
+gates:
+  - ./gradlew specContract
+  - ./gradlew spaceAnchorCheck
+  - ./gradlew docsCheck
+acceptance_features: []

--- a/tools/space_anchor_check.py
+++ b/tools/space_anchor_check.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Validate the Space anchor contract fixture."""
+from __future__ import annotations
+import json, re, sys
+from pathlib import Path
+ROOT=Path(__file__).resolve().parents[1]
+FIXTURE=ROOT/'specs/0005-spaces-anchor/space-anchor-fixture.json'
+DOC=ROOT/'docs/space-anchor-contract.md'
+REQUIRED_BINDINGS={'chat','files','boards','calendar'}
+READINESS={'provider_not_configured','secret_missing','ready','degraded','dry_run_required','lossy_mapping_pending','apply_blocked','migration_ready'}
+SOURCE={'weave_owned','provider_owned','shared_with_precedence','external_reference'}
+def fail(m): print(f'space-anchor-check: {m}', file=sys.stderr); raise SystemExit(1)
+def main():
+ data=json.loads(FIXTURE.read_text(encoding='utf-8'))
+ if data.get('schemaVersion')!=1: fail('schemaVersion must be 1')
+ space=data.get('space')
+ if not isinstance(space,dict): fail('space must be an object')
+ for key in ['spaceId','key','name','type','defaultSurface','membership','contextPolicy','bindings']:
+  if key not in space: fail(f'space missing {key}')
+ if not isinstance(space['membership'],list) or not space['membership']: fail('space membership must be non-empty')
+ for member in space['membership']:
+  if not {'personId','spaceRole','capabilityProfile'} <= set(member): fail('membership entries must be provider-neutral')
+ policy=space['contextPolicy']
+ if policy.get('memberProviderDetailsVisible') is not False: fail('members must not see provider details')
+ if policy.get('weaverMayReferenceSpace') is not True: fail('Weaver context reference flag must be explicit')
+ if policy.get('weaverDirectProviderAccess') is not False: fail('Weaver must not get direct provider access')
+ bindings=space['bindings']
+ if set(bindings)!=REQUIRED_BINDINGS: fail(f'bindings must be exactly {sorted(REQUIRED_BINDINGS)}')
+ for name,binding in bindings.items():
+  if binding.get('domain')!=name: fail(f'{name} binding domain mismatch')
+  if binding.get('readiness') not in READINESS: fail(f'{name} readiness is not canonical admin state')
+  if binding.get('sourceOfTruth') not in SOURCE: fail(f'{name} sourceOfTruth is not canonical')
+  ref=str(binding.get('providerObjectRef',''))
+  if not ref.startswith('redacted-provider-ref:'): fail(f'{name} providerObjectRef must be redacted')
+  if re.search(r'(![A-Za-z0-9]+:|https?://|secret|token|password)', ref, re.I): fail(f'{name} providerObjectRef leaks provider/secret detail')
+  if not str(binding.get('memberRef','')).strip(): fail(f'{name} memberRef missing')
+  if not isinstance(binding.get('lossyNotes'),list): fail(f'{name} lossyNotes must be a list')
+  if not str(binding.get('migrationStatus','')).strip(): fail(f'{name} migrationStatus missing')
+ doc=DOC.read_text(encoding='utf-8')
+ for fragment in ['cross-domain organization context anchor','DomainBinding','SpaceMembership','no unaccounted data loss','Weaver']:
+  if fragment not in doc: fail(f'doc missing {fragment!r}')
+ print('space-anchor-check: ok')
+if __name__=='__main__': main()


### PR DESCRIPTION
## Summary

- define `spaces` as the cross-domain organization context anchor
- add a minimal Marketing Space fixture bound to chat, files, boards, and calendar
- add a validation gate proving bindings are member-safe, provider-neutral, readiness-aware, and Weaver-safe

## Scope and user impact

- Contract/docs/fixture only; no new member UI or provider mutation path.
- Keeps raw provider references redacted and admin/operator-side.

## Spec / acceptance link

- Issue: Closes #428
- Repo spec or spec note: `docs/product-line-and-weaver-plan.md`, `specs/spaces/space-anchor-fixture.json`
- Acceptance scenario / mapping marker when product behavior changed: `./gradlew spaceAnchorCheck`
- Product-core questions intentionally left unresolved: none

## Branch, target, and release path

- [x] Branch started from current `origin/main`
- [x] PR targets protected `main`
- [x] No long-lived `dev`/`testing`/`staging` branch involved
- [x] Production release is not implied by this merge

## Screenshots or docs impact

- Adds `docs/space-anchor-contract.md` and docs navigation links.

## Accessibility and localization

- English documentation/contract only; no UI/localization changes.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: Space anchor contract and fixture.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented: Copilot request attempted after PR creation; fallback self-review and local gates recorded.

## Checks run

- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [x] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes): `./gradlew docsCheck`
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant for fixture/docs-only contract
- [x] Additional: `./gradlew spaceAnchorCheck`

## Notes for reviewers

- Evidence: `./gradlew spaceAnchorCheck docsCheck` passed locally.
