### PR TITLE
test(e2e): map product readiness waterfall evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 - Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
 - Contextual meetings now have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
+- Sprint 8/Sprint 9 acceptance now includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
 
 ## Changed
 
@@ -62,11 +63,11 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Security
 
-- Nothing yet.
+- Product-readiness evidence now records provider-switching, OpenClaw runtime isolation, Weaver tool approval, RBAC, redaction, scan, and support-bundle expectations as explicit release blockers.
 
 ## Accessibility
 
-- Nothing yet.
+- Sprint 9 release readiness now treats admin setup, provider switching/report review, Calls/LiveKit states, Weaver approvals, and member capability states as release-blocking accessibility flows.
 
 ## Migration/Operator Notes
 

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -56,6 +56,8 @@ void main() {
         'Member sees stable capabilities only after joining',
         'Admin configures domains through setup and reviews readiness evidence',
         'Provider switch evidence distinguishes spec acceptance from live migration',
+        'Admin validates domains, dry-runs identity, checks portability, and members see provider-neutral states',
+        'Admin bootstraps organization, validates domains, configures providers, enables Weaver, and member works provider-neutrally',
         'Weaver AI runtime stays excluded from Spec 0001 acceptance',
       ]),
     );

--- a/client/test/release_1/v0_1_release_spine_contract_test.dart
+++ b/client/test/release_1/v0_1_release_spine_contract_test.dart
@@ -10,8 +10,18 @@ void main() {
     final firstUse = File('../docs/admin-provisioned-first-use.md');
     final canonicalModels = File('../docs/canonical-feature-models.md');
     final architecture = File('../docs/architecture.md');
+    final sprint8Board = File('../docs/project/sprint-8-delivery-board.md');
+    final sprint9Waterfall = File(
+      '../docs/sprint-9-product-readiness-waterfall.md',
+    );
     final mapping = File('../e2e/scenario_mappings.json');
     final feature = File('../e2e/features/v0_1_dogfood_release.feature');
+    final sprint8DomainControlPlaneFeature = File(
+      '../e2e/features/sprint_8_domain_control_plane.feature',
+    );
+    final productReadinessFeature = File(
+      '../e2e/features/product_readiness_waterfall.feature',
+    );
 
     test('documents dogfood-production scope without preview claims', () {
       // V01_HOME_DAILY_LOOP
@@ -224,6 +234,83 @@ void main() {
         // ignore: avoid_print
         print(marker);
       }
+    });
+
+    test('documents the Sprint 8 domain control-plane evidence scenario', () {
+      // SPRINT8_DOMAIN_CONTROL_PLANE_EVIDENCE
+      expect(sprint8Board.existsSync(), isTrue);
+      expect(sprint8DomainControlPlaneFeature.existsSync(), isTrue);
+      final boardText = sprint8Board.readAsStringSync();
+      final featureText = sprint8DomainControlPlaneFeature.readAsStringSync();
+
+      for (final required in <String>[
+        'Sprint 8 dependency DAG',
+        '#434',
+        'Sprint 8 acceptance scenario',
+        './gradlew acceptanceContract',
+        'scenario mapping evidence',
+      ]) {
+        expect(boardText, contains(required));
+      }
+
+      for (final required in <String>[
+        '@weave-sprint8-domain-control-plane-evidence',
+        'reviews canonical domain setup',
+        'runs a Keycloak desired-state dry-run',
+        'reviews domain-first readiness states',
+        'provider switch is blocked',
+        'Boards portability dry-run report',
+        'provider-neutral domain states only',
+        'Weaver remains disabled by default',
+        'live-stack evidence is green, waived, or explicitly not required',
+      ]) {
+        expect(featureText, contains(required));
+      }
+
+      // ignore: avoid_print
+      print('SPRINT8_DOMAIN_CONTROL_PLANE_EVIDENCE');
+    });
+
+    test('documents the Sprint 9 product-readiness waterfall evidence', () {
+      // PRODUCT_READINESS_WATERFALL
+      expect(sprint9Waterfall.existsSync(), isTrue);
+      expect(productReadinessFeature.existsSync(), isTrue);
+      final markdown = sprint9Waterfall.readAsStringSync();
+      final featureText = productReadinessFeature.readAsStringSync();
+
+      for (final required in <String>[
+        'Sprint 9 product-readiness waterfall evidence',
+        'Product-ready definition',
+        'Domain registry version',
+        'Migration contract version',
+        'Keycloak dry-run sample',
+        'Calls/LiveKit readiness artifact',
+        'Weaver tool approval proof',
+        'OpenClaw fork image digest/SBOM/scan refs',
+        'Security report',
+        'Privacy report',
+        'Accessibility report',
+        'Support-safe release evidence bundle',
+        'Live-stack execution is required for release-candidate promotion',
+      ]) {
+        expect(markdown, contains(required));
+      }
+
+      for (final required in <String>[
+        '@weave-product-readiness-waterfall',
+        'reviews the domain registry',
+        'runs Keycloak desired-state dry-run',
+        'provider apply is blocked',
+        'reviews migration dry-run, lossy report, conflict report, rollback boundary, and member impact preview',
+        'approves selected tools for that group',
+        'member sees only approved Weave domain tools',
+        'no raw provider tokens or secrets are exposed',
+      ]) {
+        expect(featureText, contains(required));
+      }
+
+      // ignore: avoid_print
+      print('PRODUCT_READINESS_WATERFALL');
     });
 
     test('keeps the Gherkin release spine mapped to executable evidence', () {

--- a/docs/accessibility-release-gate.md
+++ b/docs/accessibility-release-gate.md
@@ -45,6 +45,18 @@ Sprint 4 adds work-room surfaces that must be usable with a screen reader, Brail
 | Meeting Capsule | fail-closed join/start controls, consent/evidence copy, and clear Matrix-chat vs media-protection boundaries | `test/features/chat/channel_workspace_test.dart`, `test/release_1/v0_1_release_spine_contract_test.dart` |
 | Weaver Scout | read-only/proposal-only status, citable source list, support-safe failure copy, and explicit approval-receipt requirement | `test/features/chat/channel_workspace_test.dart`, `test/release_1/ux_release_copy_contract_test.dart` |
 
+## Sprint 9 product-readiness accessibility scope
+
+Sprint 9 treats setup, provider switching/report review, Calls/LiveKit readiness, Weaver approvals, and member capability states as release-blocking accessibility flows. Automated evidence must prove keyboard-reachable controls, visible labels, support-safe status text, and no color-only readiness states; manual evidence must cover screen-reader traversal before an RC can be promoted.
+
+| Sprint 9 flow | Required evidence shape | Current automated anchor |
+| --- | --- | --- |
+| Admin setup and domain registry review | keyboard-accessible setup progression, stable domain labels, and no raw provider setup in member paths | `test/features/onboarding/setup_flow_test.dart`, `test/release_1/v0_1_release_spine_contract_test.dart` |
+| Provider switching and report review | dry-run, lossy, conflict, rollback, member-impact, and blocked-apply states are reachable and text-first | `admin-console/src/App.test.tsx`, `server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java` |
+| Calls/LiveKit readiness | join/start states fail closed with labeled controls and honest media/E2EE readiness copy | `test/features/chat/channel_workspace_test.dart`, `docs/meeting-architecture-decision.md` |
+| Weaver approvals | group enablement, tool approval, member opt-in, and unauthorized-tool blocks are announced and audit refs are not color-only | `server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java` |
+| Member capability states | provider-neutral states are exposed as semantic text and never require provider diagnostics | `test/features/settings/settings_screen_test.dart`, `test/features/app/weave_app_backend_capability_flow_test.dart` |
+
 ## Manual assistive-technology evidence required before release sign-off
 
 Record the tester, date, platform, assistive technology, result, and evidence link in the release issue or runbook. Manual-only checks are a gate; they may not be inferred from green widget tests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,7 @@ Release and evidence docs:
 - [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md)
 - [Sprint 6 closure report](sprint-6-closure-report.md)
 - [Sprint 8 delivery board policy](project/sprint-8-delivery-board.md)
+- [Sprint 9 product-readiness waterfall evidence](sprint-9-product-readiness-waterfall.md)
 
 Historical/context docs:
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -6,6 +6,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 - Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
 - Contextual meetings now have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
+- Sprint 8/Sprint 9 acceptance now includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
 
 ## Changed
 
@@ -17,11 +18,11 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Security
 
-- Nothing yet.
+- Product-readiness evidence now records provider-switching, OpenClaw runtime isolation, Weaver tool approval, RBAC, redaction, scan, and support-bundle expectations as explicit release blockers.
 
 ## Accessibility
 
-- Nothing yet.
+- Sprint 9 release readiness now treats admin setup, provider switching/report review, Calls/LiveKit states, Weaver approvals, and member capability states as release-blocking accessibility flows.
 
 ## Migration/Operator Notes
 

--- a/docs/sprint-9-product-readiness-waterfall.md
+++ b/docs/sprint-9-product-readiness-waterfall.md
@@ -1,0 +1,92 @@
+# Sprint 9 product-readiness waterfall evidence
+
+Status: support-safe acceptance and release-readiness contract for `#436`, `#449`, and `#450`.
+
+Sprint 9 is not a marketing sprint. It is a product-readiness waterfall: governance, architecture, control plane, domain implementation, Weaver policy, and release readiness must each leave reviewable evidence before any product-ready claim is made.
+
+## Governance and board evidence
+
+- Milestone: [`Sprint 9 — Product Readiness Waterfall`](https://github.com/masssi164/weave/milestone/9).
+- Board: [Weave Delivery Board](https://github.com/users/masssi164/projects/2/views/1).
+- Required phases: Governance, Architecture, Control Plane, Domain Implementation, Weaver, Release Readiness.
+- Required issue labels: `track:sprint-9`, one `phase:*` label, priority, type, and `release-blocker` for any product-readiness blocker.
+- Done rule: no issue moves to Done without acceptance criteria, evidence, and a claim decision.
+- README and marketing updates stay blocked until the linked evidence exists.
+- Provider apply stays blocked until dry-run, reports, RBAC, audit, rollback, and redaction evidence exist.
+- Weaver runtime execution stays blocked until OpenClaw fork image digest/SBOM/scan refs, isolation, tool grants, member opt-in, approval policy, and audit evidence exist.
+
+## Product-ready definition
+
+A Weave capability is product-ready only when all of these are true:
+
+1. The member-facing surface uses Weave-owned domain language and stable states only.
+2. Backend policy evaluates capability and role/group grants before provider access.
+3. Provider readiness, migration, conflict, rollback, and lossy mapping reports are admin/operator-only and support-safe.
+4. Accessibility evidence covers keyboard and screen-reader paths for setup, provider switching, calls, Weaver approvals, and member capability states.
+5. Security and privacy evidence proves no raw provider tokens, SecretRef contents, raw provider errors, provider URLs with credentials, private member memory, or personal identifiers are emitted in client, admin console, runtime profile, logs, support bundles, screenshots, docs, or release artifacts.
+6. Release evidence points to executable tests, scenario mappings, or explicit release-owner waivers rather than screenshots alone.
+
+## Vertical scenario evidence bundle
+
+The `@weave-product-readiness-waterfall` scenario maps to this support-safe bundle:
+
+| Required evidence | Source-backed pointer | Claim decision |
+| --- | --- | --- |
+| Domain registry version | `canonical-domain-facade-v1` from `CanonicalDomainDefinition` and `CanonicalDomainFacadeServicesTest` | Registry read is proven through backend domain-facade contracts for files/documents, calendar/meetings, boards/tasks, and identity/admin policy. |
+| Migration contract version | `provider-switch-portability-v1` release evidence name covering preflight, portable export/import, cutover, rollback, and recovery | Apply remains a guarded decision; full automated cross-provider migration is not claimed. |
+| Keycloak dry-run sample | `AdminControlPlaneControllerTest.adminRealmDryRunIsBackendOwnedDeterministicAndSupportSafe` and `KeycloakRealmDryRunProviderTest.plansRealmImportWithoutEnablingDestructiveApply` | Desired-state dry-run is deterministic, support-safe, and does not enable destructive apply. |
+| Provider apply blocked state | `AdminControlPlaneControllerTest.operatorAndMemberCannotApplyIdentityRealmWhenPolicyForbidsProviderConfiguration` | Provider apply requires an authorized owner/admin role and is decision-only in this slice. |
+| Boards/OpenProject portability report | `DomainAdapterRegistryMapperTest.coreProductDomainsCarryExecutableAdapterFitContracts` and the Boards portability fragments in `ProviderCapabilityContracts` | Boards portability is dry-run/report evidence, not live data movement. |
+| Calls/LiveKit readiness artifact | `docs/meeting-architecture-decision.md` and `docs/roadmap-and-guarded-surfaces.md` | LiveKit remains the active meetings provider contract; join/start stay fail-closed until backend token, media, E2EE, support, and accessibility evidence passes. |
+| Weaver tool approval proof | `WeaverRuntimeServiceTest.generatesAuditedPerUserDockerProfileFromCapabilityPolicy` | Generated profiles include only approved tools and are audited; `exec` and elevated surfaces stay disabled by default. |
+| Member opt-in and unauthorized tool block | `WeaverRuntimeServiceTest.blocksRuntimeWhenUserPolicyDoesNotGrantWeaverEnabled` and `docs/admin-provisioned-first-use.md` | Members receive a governed profile only after policy grant and opt-in; unauthorized tools are disabled_by_policy and audited/blocked. |
+| OpenClaw fork image digest/SBOM/scan refs | `openclaw-fork-image-digest-placeholder`, `openclaw-fork-sbom-placeholder`, `openclaw-fork-scan-placeholder` | Required before runtime execution or RC promotion; placeholder references are explicit blockers, not shipped evidence. |
+
+## Security report
+
+Provider switching threat model:
+
+- Threat: apply before dry-run or before migration/lossy/conflict/rollback evidence exists. Mitigation: Admin Console and backend require dry-run evidence, cutover gates, rollback boundary, recovery actions, and RBAC before guarded apply.
+- Threat: raw provider tokens, provider URLs, downstream errors, SecretRef contents, or provider-internal IDs leak into client/admin/runtime/log/evidence paths. Mitigation: SecretRefs are handles only; support-safe checks scan evidence; admin/member tests assert no raw credentials or provider diagnostics are rendered.
+- Threat: unauthorized role approves provider apply. Mitigation: backend control-plane tests deny operator/member apply and require `admin.provider.configure` through owner/admin policy.
+
+OpenClaw runtime isolation and Weaver tools threat model:
+
+- Threat: generated runtime exposes broad OpenClaw tools, exec, elevated access, or raw provider adapters by default. Mitigation: Weaver profile generation is disabled by default, per-user, Dockerized, workspace-policy-derived, audited, and tool-allowlisted.
+- Threat: a member invokes an unapproved domain tool. Mitigation: runtime profile contains only approved Weave domain tools and disabled_by_policy state for everything else; unauthorized capability paths fail closed before provider access.
+- Threat: OpenClaw fork/container vulnerability is ignored. Mitigation: OpenClaw fork image digest, SBOM, and scan refs are mandatory release evidence before runtime execution; until then, runtime execution remains blocked.
+
+Dependency scans, container scans, and OpenClaw fork image scans are release-blocker gates. If scan artifacts are absent, the release evidence must record a blocker or release-owner waiver with expiry.
+
+## Privacy report
+
+- Weaver memory policy: member private memory is user-scoped by default; admins see policy state, approval metadata, and audit refs only unless an explicit authorized export/support workflow exists.
+- Export/delete expectations: domain data follows the provider replacement contract with dry-run inventory, export expectation, delete/deprovision expectation, rollback boundary, and support-safe audit evidence.
+- Support bundles: only redacted summaries, evidence refs, versions, stable states, and blocker codes are shareable. Raw provider payloads, raw logs, provider URLs with credentials, private member memory, personal display names, and SecretRef contents are excluded.
+
+## Accessibility report
+
+Release readiness requires evidence for:
+
+- Admin setup path keyboard access.
+- Provider switching/report review keyboard access.
+- Calls join/leave/mute/camera/error states with screen-reader labels and honest fail-closed states.
+- Weaver approval flow screen-reader access.
+- Member capability states exposed through semantic status text, not color alone.
+
+The canonical checklist is `docs/accessibility-release-gate.md`; Sprint 9 adds the explicit requirement that setup, provider switching/report review, Calls/LiveKit readiness, Weaver approvals, and member capability states are all release-blocking flows.
+
+## Support-safe release evidence bundle
+
+Every Sprint 9 release bundle must include:
+
+- `domainRegistryVersion`: `canonical-domain-facade-v1`.
+- `migrationContractVersion`: `provider-switch-portability-v1`.
+- `keycloakDryRunSample`: support-safe desired-state dry-run reference only.
+- `callsLiveKitReadinessArtifact`: meeting architecture and guarded-surface evidence refs.
+- `openclawForkImageDigestRef`, `openclawForkSbomRef`, `openclawForkScanRef`: required before runtime execution, explicit blocker if absent.
+- `weaverToolApprovalProof`: audited generated profile with approved Weave domain tools only.
+- `scenarioMapping`: `@weave-product-readiness-waterfall` in `e2e/scenario_mappings.json`.
+- `redactionCheck`: no raw provider tokens, cookies, private keys, raw provider errors, provider URLs with credentials, personal data, SecretRef contents, or private live logs.
+
+Live-stack execution is required for release-candidate promotion unless a release-owner waiver names the exact blocker, commit, compensating evidence, expiry, and owner. PR-safe CI can merge the mapping and offline evidence, but cannot promote an RC by itself.

--- a/e2e/features/product_readiness_waterfall.feature
+++ b/e2e/features/product_readiness_waterfall.feature
@@ -1,0 +1,23 @@
+Feature: Product-ready sovereign collaboration setup
+
+  Product readiness is a waterfall contract: governance and architecture evidence
+  come first, then control-plane dry-runs and provider readiness, then guarded
+  Weaver enablement, and only then member-visible provider-neutral work.
+
+  @weave-product-readiness-waterfall
+  Scenario: Admin bootstraps organization, validates domains, configures providers, enables Weaver, and member works provider-neutrally
+    Given an organization owner signs in through Keycloak
+    When the owner reviews the domain registry
+    And the owner runs Keycloak desired-state dry-run
+    And the owner configures Spaces and domain bindings
+    And the owner reviews provider readiness for chat, files, documents, calendar, boards, and calls
+    And the owner attempts provider apply before migration reports exist
+    Then provider apply is blocked
+    When the owner reviews migration dry-run, lossy report, conflict report, rollback boundary, and member impact preview
+    Then provider apply can be approved only by an authorized role
+    When the owner enables Weaver for a group
+    And approves selected tools for that group
+    And a member opts in to Weaver
+    Then the member sees only approved Weave domain tools
+    And the member sees provider-neutral domain states
+    And no raw provider tokens or secrets are exposed

--- a/e2e/features/sprint_8_domain_control_plane.feature
+++ b/e2e/features/sprint_8_domain_control_plane.feature
@@ -1,0 +1,17 @@
+Feature: Sprint 8 domain control-plane evidence
+
+  Sprint 8 acceptance proves that domain setup and provider-control-plane
+  boundaries are executable product contracts, not provider-specific intent.
+
+  @weave-sprint8-domain-control-plane-evidence
+  Scenario: Admin validates domains, dry-runs identity, checks portability, and members see provider-neutral states
+    Given an organization admin opens the Admin Console
+    When the admin reviews canonical domain setup
+    And runs a Keycloak desired-state dry-run
+    And reviews domain-first readiness states
+    And attempts provider switch without dry-run evidence
+    Then the provider switch is blocked
+    When the admin reviews a Boards portability dry-run report
+    Then the member client still sees provider-neutral domain states only
+    And Weaver remains disabled by default unless organization policy enables it
+    And live-stack evidence is green, waived, or explicitly not required for this slice

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -1003,6 +1003,122 @@
           ]
         }
       ]
+    },
+    {
+      "tag": "@weave-sprint8-domain-control-plane-evidence",
+      "scenario": "Admin validates domains, dry-runs identity, checks portability, and members see provider-neutral states",
+      "feature": "e2e/features/sprint_8_domain_control_plane.feature",
+      "executableTest": "client/test/release_1/v0_1_release_spine_contract_test.dart",
+      "evidenceMarkers": [
+        "SPRINT8_DOMAIN_CONTROL_PLANE_EVIDENCE"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "docs/project/sprint-8-delivery-board.md",
+          "fragments": [
+            "#434",
+            "Sprint 8 acceptance scenario",
+            "./gradlew acceptanceContract",
+            "scenario mapping evidence"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeServicesTest.java",
+          "fragments": [
+            "contractsCoverRemainingNonChatDomainsWithoutThinProviderProxyVocabulary",
+            "memberReadinessFailsClosedWithoutAdminSelectedMappingsAndHidesProviderDiagnostics",
+            "canonical-domain-facade-v1"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java",
+          "fragments": [
+            "adminRealmDryRunIsBackendOwnedDeterministicAndSupportSafe",
+            "providerReplacementDryRunReturnsBackendOwnedPortableSwitchContract",
+            "operatorAndMemberCannotApplyIdentityRealmWhenPolicyForbidsProviderConfiguration"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java",
+          "fragments": [
+            "coreProductDomainsCarryExecutableAdapterFitContracts",
+            "providerRegistryAdapterFitSupportsMixedProviderPostureWithoutMemberProviderIds",
+            "openproject-primary"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java",
+          "fragments": [
+            "keepsWeaverDisabledByDefaultEvenForRuntimeGroup",
+            "blocksRuntimeWhenUserPolicyDoesNotGrantWeaverEnabled"
+          ]
+        },
+        {
+          "path": "docs/sprint-9-product-readiness-waterfall.md",
+          "fragments": [
+            "Live-stack execution is required for release-candidate promotion unless a release-owner waiver"
+          ]
+        }
+      ]
+    },
+    {
+      "tag": "@weave-product-readiness-waterfall",
+      "scenario": "Admin bootstraps organization, validates domains, configures providers, enables Weaver, and member works provider-neutrally",
+      "feature": "e2e/features/product_readiness_waterfall.feature",
+      "executableTest": "client/test/release_1/v0_1_release_spine_contract_test.dart",
+      "evidenceMarkers": [
+        "PRODUCT_READINESS_WATERFALL"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "docs/sprint-9-product-readiness-waterfall.md",
+          "fragments": [
+            "Product-ready definition",
+            "Domain registry version",
+            "Migration contract version",
+            "Keycloak dry-run sample",
+            "Calls/LiveKit readiness artifact",
+            "Weaver tool approval proof",
+            "OpenClaw fork image digest/SBOM/scan refs",
+            "Security report",
+            "Privacy report",
+            "Accessibility report",
+            "Support-safe release evidence bundle",
+            "Live-stack execution is required for release-candidate promotion"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeServicesTest.java",
+          "fragments": [
+            "contractsCoverRemainingNonChatDomainsWithoutThinProviderProxyVocabulary",
+            "canonical-domain-facade-v1",
+            "memberReadinessFailsClosedWithoutAdminSelectedMappingsAndHidesProviderDiagnostics"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java",
+          "fragments": [
+            "adminRealmDryRunIsBackendOwnedDeterministicAndSupportSafe",
+            "providerReplacementDryRunReturnsBackendOwnedPortableSwitchContract",
+            "operatorAndMemberCannotApplyIdentityRealmWhenPolicyForbidsProviderConfiguration"
+          ]
+        },
+        {
+          "path": "server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java",
+          "fragments": [
+            "generatesAuditedPerUserDockerProfileFromCapabilityPolicy",
+            "blocksRuntimeWhenUserPolicyDoesNotGrantWeaverEnabled",
+            "files.read"
+          ]
+        },
+        {
+          "path": "docs/accessibility-release-gate.md",
+          "fragments": [
+            "release evidence index",
+            "Sprint 9 product-readiness accessibility scope"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Sprint 6 epic closure report: sprint-6-epic-closure-report.md
       - Sprint 6 closure report: sprint-6-closure-report.md
       - Sprint 8 delivery board policy: project/sprint-8-delivery-board.md
+      - Sprint 9 product-readiness waterfall evidence: sprint-9-product-readiness-waterfall.md
       - v0.1.0-rc.2 release evidence: release-v0.1-rc2-evidence.md
       - Accessibility release gate: accessibility-release-gate.md
       - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md


### PR DESCRIPTION
## Summary

- Add Sprint 8 domain control-plane Gherkin acceptance for canonical domains, Keycloak dry-run, provider-switch blocking, Boards portability, member provider-neutral states, and Weaver default-disabled policy.
- Add Sprint 9 product-readiness waterfall Gherkin acceptance and mapped evidence for domain registry version, migration contract version, Keycloak dry-run, Calls/LiveKit readiness, Weaver approvals, member opt-in, redaction, security/privacy/accessibility, and support-safe release evidence.
- Document the Sprint 9 product-ready definition, security/privacy/accessibility reports, scan/SBOM blockers, live-stack evidence rule, release-note impact, and MkDocs navigation.

## Scope and user impact

- User impact is evidence/readiness only: normal member behavior is unchanged.
- Release impact: product-ready claims now point at mapped evidence and explicit blockers/waivers instead of screenshots or implicit claims.

## Spec / acceptance link

- Issue: Refs #434, #436, #449, #450
- Repo spec or spec note: `docs/project/sprint-8-delivery-board.md`, `docs/sprint-9-product-readiness-waterfall.md`, `docs/accessibility-release-gate.md`
- Acceptance scenario / mapping marker when product behavior changed: `@weave-sprint8-domain-control-plane-evidence` → `SPRINT8_DOMAIN_CONTROL_PLANE_EVIDENCE`; `@weave-product-readiness-waterfall` → `PRODUCT_READINESS_WATERFALL`
- Product-core questions intentionally left unresolved: none; OpenClaw fork image digest/SBOM/scan refs remain explicit release blockers before runtime execution/RC promotion.

## Branch, target, and release path

- [x] Branch started from current `origin/main`
- [x] PR targets protected `main`
- [x] No long-lived `dev`/`testing`/`staging` branch involved
- [x] Production release is not implied by this merge

## Screenshots or docs impact

- Docs only; no screenshot assets changed.
- README release-notes block regenerated with `python3 tools/readme_release_notes.py --update`.

## Accessibility and localization

- Adds Sprint 9 release-blocking accessibility scope for admin setup, provider switching/report review, Calls/LiveKit states, Weaver approvals, and member capability states.
- English-only repo docs; no localization files changed.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: acceptance scenarios and evidence docs only; no API shape changed.
- [x] `./gradlew specContract` run for spec/product-contract changes

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented

## Checks run

- [x] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (not run; scoped evidence/docs change)
- [x] `./gradlew docsCheck` after installing pinned docs deps into `build/docs-venv`
- [x] `./gradlew releaseEvidenceCheck`
- [ ] `flutter pub get` (covered by Flutter test dependency resolution)
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [x] `dart format client/test/release_1/v0_1_release_spine_contract_test.dart`
- [ ] `flutter analyze --fatal-infos`
- [x] `cd client && flutter test test/release_1/v0_1_release_spine_contract_test.dart`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (not relevant; no screenshot assets changed)
- [ ] Live-stack validation: not collected in PR-safe local gate; release-candidate promotion requires green live evidence or explicit release-owner waiver per `docs/sprint-9-product-readiness-waterfall.md`.
- [x] Targeted server evidence tests: `cd server && ./gradlew test --tests 'com.massimotter.weave.backend.domainfacade.CanonicalDomainFacadeServicesTest' --tests 'com.massimotter.weave.backend.controller.AdminControlPlaneControllerTest' --tests 'com.massimotter.weave.backend.provider.DomainAdapterRegistryMapperTest' --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest'`
- [x] Redaction smoke scan over changed evidence/docs artifacts

## Notes for reviewers

- This PR intentionally records OpenClaw fork image digest/SBOM/scan refs as release blockers, not as completed runtime evidence.
- The product-readiness waterfall can merge as PR-safe evidence; it does not promote an RC or enable Weaver runtime execution.

### Parent orchestration rerun
- Rebased on current `origin/main` and pushed mapping fix commit `d2a3340c24fa3d333b31a64afaeaf8c82fe4518a`.
- CI failure investigated: prior Gradle CI failed because `client/test/live_stack_feature_mapping_test.dart` expected 32 scenarios while Sprint 8/9 added two mapped Gherkin scenarios; the new commit updates the executable mapping guard to 34 scenarios.
- Local gates passed after rerun:
  - `./gradlew specContract`
  - `./gradlew acceptanceContract`
  - `./gradlew releaseEvidenceCheck`
  - `./gradlew docsCheck`
  - `./gradlew clientCi` (398 passed, 6 skipped; initial run failed only because the mapping-fix commit was created during the cleanliness check, rerun passed from a clean tree)
- Live-stack evidence was not collected in this PR-safe local run; release-candidate promotion still requires green live-stack evidence or an explicit release-owner waiver per `docs/sprint-9-product-readiness-waterfall.md`.
- Fallback review note: Copilot/premium review is non-blocking; merge readiness depends on green required checks, exactly one release-notes label, clean branch, and no blocking findings.

### Parent orchestration rerun after merge train
- Rebased on latest main after PRs #461, #457, #456, and #459 merged; preserved Weaver tool-registry scenario mapping.
- New head: `8c50b95`.
- Local gates passed: `cd client && flutter test test/live_stack_feature_mapping_test.dart test/release_1/v0_1_release_spine_contract_test.dart`; `./gradlew acceptanceContract releaseEvidenceCheck docsCheck --console=plain`.
