### PR TITLE
docs: add Sprint 8 and 9 closure audits

### DIFF
--- a/docs/sprint-8-closure-report.md
+++ b/docs/sprint-8-closure-report.md
@@ -1,0 +1,64 @@
+# Sprint 8 closure report: Canonical Domains & Portable Provider Contracts
+
+Status: closure-ready audit, 2026-05-31.
+
+## Closure verdict
+
+Sprint 8 is functionally closed: the GitHub milestone has zero open issues at the time of this report update. The latest implementation `main` CI for head `68e8d65d5cf2a3a648e9aa9963a3be05c3b86dcc` is green; final closure now depends on this closure-report PR and milestone-close verification.
+
+## GitHub truth
+
+- Milestone: `Sprint 8 — Canonical Domains & Portable Provider Contracts`.
+- Open issues at update time: 0.
+- Final implementation head before this report: `68e8d65` (`docs(marketing): ship README v2 claim matrix (#458)`).
+- Latest implementation main CI runs: #464 run `26697124472` success, #465 run `26697126259` success, #458 run `26697128118` success.
+
+## Issue DAG and final state
+
+| Issue | Dependency role | Closing evidence | Final state |
+| --- | --- | --- | --- |
+| #425 | Sprint governance root. | PR #452. | Closed. |
+| #426 | Foundation docs. | PR #453. | Closed. |
+| #427 | Canonical domain registry v1. | PR #454. | Closed. |
+| #428 | Space anchor. | PR #455. | Closed. |
+| #429 | No-unaccounted-data-loss contract. | PR #461, reinforced by #457/#464. | Closed. |
+| #430 | Keycloak desired realm dry-run. | PR #462. | Closed. |
+| #431 | Admin Console domain-first setup/provider switching gates. | PR #456 plus #464 apply-gate evidence. | Closed. |
+| #432 | Boards portability parity. | PR #465. | Closed. |
+| #433 | Governed OpenClaw-derived runtime profile. | PR #459. | Closed. |
+| #434 | Sprint 8 domain-control-plane acceptance evidence. | PR #460. | Closed. |
+| #435 | README sovereign collaboration rewrite. | PR #458. | Closed. |
+| #283 | Legacy identity/Boards vertical mapping prototype. | Superseded and closed by #462, #465, #456, #464 evidence. | Closed. |
+
+## Merged PR order and evidence
+
+| Order | PR | Main commit | Label | Evidence |
+| --- | --- | --- | --- | --- |
+| 1 | #452 Sprint 8 delivery board policy | `cdc2e05` | `release-notes-skip` | PR checks green. |
+| 2 | #453 canonical domain foundation docs | `bcec006` | `release-notes-feature` | PR checks green. |
+| 3 | #454 canonical domain registry v1 | `5590098` | `release-notes-feature` | PR checks green; main CI `26695569929` green. |
+| 4 | #455 Space anchor | `06bfb0d` | `release-notes-feature` | PR checks green; main CI `26695769160` green. |
+| 5 | #461 no-unaccounted-data-loss contract | `7f0b467` | `release-notes-feature` | PR checks green; main CI `26696213184` green. |
+| 6 | #457 server domain portability contracts | `7e1adb5` | `release-notes-feature` | PR checks green; main CI `26696214854` green. |
+| 7 | #456 Admin Console apply gates | `943c802` | `release-notes-feature` | PR checks green; main CI `26696216153` green. |
+| 8 | #459 governed Weaver runtime profile | `c832d05` | `release-notes-feature` | PR checks green; main CI `26696217413` green. |
+| 9 | #460 Sprint 8/9 acceptance evidence | `b7e4431` | `release-notes-feature` | PR checks green; main CI `26696488056` green. |
+| 10 | #462 Keycloak dry-run hardening | `72e97ac` | `release-notes-feature` | PR checks green; main CI `26696489550` green. |
+| 11 | #464 migration apply gates | `08d62b1` | `release-notes-feature` | PR checks green; main CI `26697124472` success. |
+| 12 | #465 Boards/Calls/domain readiness contracts | `19d0cc1` | `release-notes-feature` | PR checks green; main CI `26697126259` success. |
+| 13 | #458 README v2 claim matrix | `68e8d65` | `release-notes-feature` | PR checks green; review threads resolved/outdated; main CI `26697128118` success. |
+
+## Local gates for this report
+
+Run before merging this closure report:
+
+- `WEAVE_DOCS_VENV=build/docs-venv ./gradlew docsCheck releaseEvidenceCheck --console=plain`
+
+## Release and RC impact
+
+Sprint 8 locks the canonical domain, Spaces, portability, Admin Console gate, identity dry-run, Boards parity, acceptance evidence, and README foundation needed for dogfood-production readiness. It does not claim a production release tag; release promotion remains governed by release evidence and final `main` CI.
+
+## Remaining gate
+
+- Merge this closure report after its docs/release checks pass.
+- Verify both milestones remain at zero open issues, then close the milestones.

--- a/docs/sprint-9-closure-report.md
+++ b/docs/sprint-9-closure-report.md
@@ -1,0 +1,68 @@
+# Sprint 9 closure report: Product Readiness Waterfall
+
+Status: closure-ready audit, 2026-05-31.
+
+## Closure verdict
+
+Sprint 9 is functionally closed: the GitHub milestone has zero open issues at the time of this report update. The latest implementation `main` CI for head `68e8d65d5cf2a3a648e9aa9963a3be05c3b86dcc` is green; final closure now depends on this closure-report PR and milestone-close verification.
+
+## GitHub truth
+
+- Milestone: `Sprint 9 — Product Readiness Waterfall`.
+- Open issues at update time: 0.
+- Final implementation head before this report: `68e8d65` (`docs(marketing): ship README v2 claim matrix (#458)`).
+- Latest implementation main CI runs: #464 run `26697124472` success, #465 run `26697126259` success, #458 run `26697128118` success.
+
+## Issue DAG and final state
+
+| Issue | Phase | Closing evidence | Final state |
+| --- | --- | --- | --- |
+| #436 | 0 — governance | PR #460 readiness evidence plus this closure report. | Closed. |
+| #437 | 1 — docs foundation | PR #453 and PR #458. | Closed. |
+| #438 | 1 — registry/portability primitives | PR #454, #457, #461, #464. | Closed. |
+| #439 | 1 — core domains | PR #455, #456, #465. | Closed. |
+| #440 | 2 — identity | PR #462 plus #464 identity/audit apply-gate blockers. | Closed. |
+| #441 | 2 — admin console | PR #456 plus #460/#464 evidence. | Closed. |
+| #442 | 2 — provider migration contracts | PR #461, #457, #464. | Closed. |
+| #443 | 3 — work surfaces | PR #456, #460, #465. | Closed. |
+| #444 | 3 — Boards | PR #465 plus #456/#464 gate foundations. | Closed. |
+| #445 | 3 — Calls | PR #465. | Closed. |
+| #446 | 4 — Weaver baseline | PR #459. | Closed. |
+| #447 | 4 — Weaver policy | PR #459. | Closed. |
+| #448 | 4 — Weaver tools | PR #459. | Closed. |
+| #449 | 5 — quality hardening | PR #459 and PR #460. | Closed. |
+| #450 | 5 — full product-readiness vertical | PR #460. | Closed. |
+| #451 | 5 — README v2/claim matrix | PR #458. | Closed. |
+
+## Merged PR order and evidence
+
+| Order | PR | Main commit | Label | Evidence |
+| --- | --- | --- | --- | --- |
+| 1 | #453 canonical domain foundation docs | `bcec006` | `release-notes-feature` | PR checks green. |
+| 2 | #454 canonical domain registry v1 | `5590098` | `release-notes-feature` | PR checks green; main CI green. |
+| 3 | #455 Space anchor | `06bfb0d` | `release-notes-feature` | PR checks green; main CI green. |
+| 4 | #461 no-unaccounted-data-loss contract | `7f0b467` | `release-notes-feature` | PR checks green; main CI green. |
+| 5 | #457 server portability contracts | `7e1adb5` | `release-notes-feature` | PR checks green; main CI green. |
+| 6 | #456 admin control-plane apply gates | `943c802` | `release-notes-feature` | PR checks green; main CI green. |
+| 7 | #459 governed Weaver runtime/tool contract | `c832d05` | `release-notes-feature` | PR checks green; main CI green. |
+| 8 | #460 product-readiness/e2e evidence | `b7e4431` | `release-notes-feature` | PR checks green; main CI `26696488056` green. |
+| 9 | #462 Keycloak dry-run hardening | `72e97ac` | `release-notes-feature` | PR checks green; main CI `26696489550` green. |
+| 10 | #464 migration apply gates | `08d62b1` | `release-notes-feature` | PR checks green; main CI `26697124472` success. |
+| 11 | #465 Boards/Calls/domain readiness contracts | `19d0cc1` | `release-notes-feature` | PR checks green; main CI `26697126259` success. |
+| 12 | #458 README v2 claim matrix | `68e8d65` | `release-notes-feature` | PR checks green; main CI `26697128118` success. |
+
+## Gates and evidence
+
+Local gates run across the implementation PRs included server, acceptance, spec, docs, release evidence, targeted Flutter release-spine tests, and PR-level GitHub Gradle CI/Release Notes Label Check. This closure report must additionally pass:
+
+- `WEAVE_DOCS_VENV=build/docs-venv ./gradlew docsCheck releaseEvidenceCheck --console=plain`
+
+## Release and RC impact
+
+Sprint 9 establishes the product-readiness waterfall evidence for v0.1 dogfood-production posture: provider-neutral member surfaces, admin/operator control plane, identity and portability gates, Boards/Calls readiness contracts, governed Weaver policy boundaries, quality evidence, and README claim matrix. No production release or RC tag is published by this report.
+
+## Remaining gate
+
+- Wait for the latest post-merge `main` CI for #464/#465/#458 to complete green.
+- Merge this closure report after docs/release checks pass.
+- Verify the milestone remains at zero open issues, then close the milestone.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,8 @@ nav:
       - Sprint 6 closure report: sprint-6-closure-report.md
       - Sprint 8 delivery board policy: project/sprint-8-delivery-board.md
       - Sprint 9 product-readiness waterfall evidence: sprint-9-product-readiness-waterfall.md
+      - Sprint 8 closure audit: sprint-8-closure-report.md
+      - Sprint 9 closure audit: sprint-9-closure-report.md
       - v0.1.0-rc.2 release evidence: release-v0.1-rc2-evidence.md
       - Accessibility release gate: accessibility-release-gate.md
       - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md


### PR DESCRIPTION
## Summary

- add Sprint 8 closure audit documenting the open milestone, issue DAG, merged PR order, CI evidence, release impact, blockers, and next safe action
- add Sprint 9 closure audit documenting the product-readiness waterfall backlog, phase-by-phase issue ledger, prerequisite PR evidence, release/RC limits, and blockers
- add both audits to the MkDocs navigation

## Scope and user impact

- Documentation/release evidence only; no runtime behavior changes.
- Explicitly does not claim Sprint 8 or Sprint 9 closure because GitHub truth still shows open issues.
- Records final audited `main` CI run `26696217413` as green for `c832d05`, while milestone closure remains blocked by open issues.

## Spec / acceptance link

- Issues: Refs Sprint 8 milestone issues #283, #425-#435; Refs Sprint 9 milestone issues #436-#451
- Repo spec or spec note: `docs/weave-operating-model.md`, `docs/spec-driven-development.md`, `.specify/memory/constitution.md`
- Acceptance scenario / mapping marker when product behavior changed: not applicable; closure audit documentation only
- Product-core questions intentionally left unresolved: none

## Checks run

- `WEAVE_DOCS_VENV=build/docs-venv ./gradlew docsCheck releaseEvidenceCheck`

## Release notes

- `release-notes-skip` — audit/report-only documentation, no product/runtime behavior change.

### Parent orchestration update
- Rebased after PRs #460, #462, #464, #465, and #458 merged.
- Updated both closure reports to reflect zero open Sprint 8/Sprint 9 issues and the latest implementation merge train.
- Local gate passed: `WEAVE_DOCS_VENV=build/docs-venv ./gradlew docsCheck releaseEvidenceCheck --console=plain`.
- Final milestone closure remains gated on latest `main` CI for the implementation head and this PR's own checks.
