### PR TITLE
feat(portability): gate migration apply contracts

### DIFF
--- a/docs/architecture/no-unaccounted-data-loss.md
+++ b/docs/architecture/no-unaccounted-data-loss.md
@@ -30,7 +30,7 @@ Machine-readable schemas live under `server/src/main/resources/contracts/portabi
 
 ## Dry-run gate
 
-Provider migration apply is impossible until a successful dry-run report exists. A `MigrationRun` with `applyAllowed: true` must be in `dry_run_success` or `apply_ready` state and must include a non-empty dry-run report reference, provider mapping reference, object counts, content hashes, and audit references. Missing reports, conflicts, unclassified losses, or unsafe redaction force `applyAllowed: false`.
+Provider migration apply is impossible until a successful dry-run report exists. A `MigrationRun` follows the canonical lifecycle `discovered`, `preflight_failed`, `preflight_passed`, `exported`, `dry_run_completed`, `blocked`, `approved`, `applying`, `applied`, `verified`, `rolled_back`, and `archived`. A run with `applyAllowed: true` must be in `approved`, `applying`, `applied`, or `verified` state and must include a non-empty dry-run report reference, provider mapping reference, object counts, content hashes, audit references, admin approval, rollback/archive boundary, and post-apply verification reference. Missing reports, conflicts, unclassified losses, incomplete identity mapping, unavailable audit sink, or unsafe redaction force `applyAllowed: false`.
 
 ## Support-safe redaction
 

--- a/server/src/main/java/com/massimotter/weave/backend/controller/MigrationController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/MigrationController.java
@@ -1,7 +1,10 @@
 package com.massimotter.weave.backend.controller;
 
+import com.massimotter.weave.backend.model.migration.MigrationApplyGateRequest;
+import com.massimotter.weave.backend.model.migration.MigrationApplyGateResponse;
 import com.massimotter.weave.backend.model.migration.MigrationDryRunRequest;
 import com.massimotter.weave.backend.model.migration.MigrationDryRunResponse;
+import com.massimotter.weave.backend.service.migration.MigrationApplyGateService;
 import com.massimotter.weave.backend.service.migration.MigrationDryRunService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -17,14 +20,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class MigrationController {
 
     private final MigrationDryRunService migrationDryRunService;
+    private final MigrationApplyGateService migrationApplyGateService;
 
-    public MigrationController(MigrationDryRunService migrationDryRunService) {
+    public MigrationController(
+            MigrationDryRunService migrationDryRunService,
+            MigrationApplyGateService migrationApplyGateService) {
         this.migrationDryRunService = migrationDryRunService;
+        this.migrationApplyGateService = migrationApplyGateService;
     }
 
     @PostMapping("/api/migration/dry-runs")
     @Operation(summary = "Create a replay-safe migration inventory dry-run")
     public MigrationDryRunResponse dryRun(@Valid @RequestBody MigrationDryRunRequest request) {
         return migrationDryRunService.dryRun(request);
+    }
+
+    @PostMapping("/api/migration/apply-gates")
+    @Operation(summary = "Validate generic provider migration apply gates without mutating providers")
+    public MigrationApplyGateResponse applyGate(@Valid @RequestBody MigrationApplyGateRequest request) {
+        return migrationApplyGateService.evaluate(request);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/migration/MigrationApplyGateRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/migration/MigrationApplyGateRequest.java
@@ -1,0 +1,37 @@
+package com.massimotter.weave.backend.model.migration;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Map;
+
+public record MigrationApplyGateRequest(
+        @NotBlank @Size(max = 128) String runId,
+        @NotBlank @Size(max = 64) String domainKey,
+        @NotBlank @Size(max = 64) String requestedLifecycle,
+        @Size(max = 256) String dryRunReportRef,
+        @Size(max = 256) String exportSnapshotRef,
+        @Size(max = 256) String importPlanRef,
+        @Size(max = 256) String providerMappingRef,
+        @Size(max = 256) String lossyMappingReportRef,
+        @Size(max = 256) String conflictReportRef,
+        @Size(max = 256) String memberImpactPreviewRef,
+        @Size(max = 256) String adminApprovalRef,
+        @Size(max = 256) String rollbackArchiveRef,
+        @Size(max = 256) String postApplyVerificationRef,
+        @NotNull Map<@Size(max = 64) String, Integer> objectCounts,
+        List<@Size(max = 96) String> contentHashes,
+        List<@Size(max = 256) String> auditRefs,
+        boolean identityMappingComplete,
+        boolean auditSinkAvailable,
+        boolean adminApproved,
+        List<@Size(max = 512) String> providerDiagnostics) {
+
+    public MigrationApplyGateRequest {
+        objectCounts = objectCounts == null ? Map.of() : Map.copyOf(objectCounts);
+        contentHashes = contentHashes == null ? List.of() : List.copyOf(contentHashes);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+        providerDiagnostics = providerDiagnostics == null ? List.of() : List.copyOf(providerDiagnostics);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/migration/MigrationApplyGateResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/migration/MigrationApplyGateResponse.java
@@ -1,0 +1,45 @@
+package com.massimotter.weave.backend.model.migration;
+
+import java.util.List;
+import java.util.Map;
+
+public record MigrationApplyGateResponse(
+        String runId,
+        String domainKey,
+        String lifecycle,
+        boolean applyAllowed,
+        boolean supportSafe,
+        boolean providerDiagnosticsRedacted,
+        List<String> requiredArtifacts,
+        List<String> missingArtifacts,
+        List<String> blockers,
+        List<String> nextActions,
+        SupportSafeEvidenceBundle evidenceBundle) {
+
+    public MigrationApplyGateResponse {
+        requiredArtifacts = requiredArtifacts == null ? List.of() : List.copyOf(requiredArtifacts);
+        missingArtifacts = missingArtifacts == null ? List.of() : List.copyOf(missingArtifacts);
+        blockers = blockers == null ? List.of() : List.copyOf(blockers);
+        nextActions = nextActions == null ? List.of() : List.copyOf(nextActions);
+    }
+
+    public record SupportSafeEvidenceBundle(
+            String runId,
+            String domainKey,
+            String lifecycle,
+            Map<String, Integer> objectCounts,
+            List<String> contentHashes,
+            List<String> auditRefs,
+            List<String> artifactRefs,
+            List<String> redactedDiagnostics,
+            String redaction) {
+
+        public SupportSafeEvidenceBundle {
+            objectCounts = objectCounts == null ? Map.of() : Map.copyOf(objectCounts);
+            contentHashes = contentHashes == null ? List.of() : List.copyOf(contentHashes);
+            auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+            artifactRefs = artifactRefs == null ? List.of() : List.copyOf(artifactRefs);
+            redactedDiagnostics = redactedDiagnostics == null ? List.of() : List.copyOf(redactedDiagnostics);
+        }
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/migration/MigrationApplyGateService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/migration/MigrationApplyGateService.java
@@ -1,0 +1,167 @@
+package com.massimotter.weave.backend.service.migration;
+
+import com.massimotter.weave.backend.model.migration.MigrationApplyGateRequest;
+import com.massimotter.weave.backend.model.migration.MigrationApplyGateResponse;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MigrationApplyGateService {
+
+    private static final Set<String> LIFECYCLE = Set.of(
+            "discovered",
+            "preflight_failed",
+            "preflight_passed",
+            "exported",
+            "dry_run_completed",
+            "blocked",
+            "approved",
+            "applying",
+            "applied",
+            "verified",
+            "rolled_back",
+            "archived");
+    private static final List<String> REQUIRED_ARTIFACTS = List.of(
+            "dryRunReportRef",
+            "exportSnapshotRef",
+            "importPlanRef",
+            "providerMappingRef",
+            "lossyMappingReportRef",
+            "conflictReportRef",
+            "memberImpactPreviewRef",
+            "adminApprovalRef",
+            "rollbackArchiveRef",
+            "postApplyVerificationRef");
+    private static final Pattern UNSAFE = Pattern.compile(
+            "(?i)(https?://|token|password|passwd|client[_-]?secret|authorization|bearer|cookie|private[_-]?key|secretref://|credential)");
+    private static final Pattern SHA_256 = Pattern.compile("^sha256:[a-f0-9]{64}$");
+
+    public MigrationApplyGateResponse evaluate(MigrationApplyGateRequest request) {
+        String lifecycle = normalizeLifecycle(request.requestedLifecycle());
+        List<String> blockers = new ArrayList<>();
+        List<String> missing = missingArtifacts(request);
+        if (!LIFECYCLE.contains(lifecycle)) {
+            blockers.add("unknown migration lifecycle state: " + safeLifecycle(request.requestedLifecycle()));
+        }
+        if (!missing.isEmpty()) {
+            blockers.add("apply blocked until required portability artifacts exist: " + String.join(", ", missing));
+        }
+        if (request.objectCounts().isEmpty()) {
+            blockers.add("apply blocked until object counts are recorded");
+        }
+        if (request.contentHashes().isEmpty() || request.contentHashes().stream().anyMatch(hash -> !SHA_256.matcher(hash).matches())) {
+            blockers.add("apply blocked until content hashes use sha256 evidence references");
+        }
+        if (request.auditRefs().isEmpty()) {
+            blockers.add("apply blocked until migration audit references exist");
+        }
+        if (!request.identityMappingComplete()) {
+            blockers.add("apply blocked until identity mapping is complete");
+        }
+        if (!request.auditSinkAvailable()) {
+            blockers.add("apply blocked until the audit sink is available");
+        }
+        if (!request.adminApproved()) {
+            blockers.add("apply blocked until an admin approval record is present");
+        }
+        boolean applyAllowed = blockers.isEmpty() && Set.of("approved", "applying", "applied", "verified").contains(lifecycle);
+        if (blockers.isEmpty() && !applyAllowed) {
+            blockers.add("apply blocked until lifecycle reaches approved after dry-run and preflight evidence");
+        }
+        boolean finalApplyAllowed = blockers.isEmpty() && applyAllowed;
+        String effectiveLifecycle = finalApplyAllowed ? lifecycle : "blocked";
+        return new MigrationApplyGateResponse(
+                request.runId(),
+                request.domainKey(),
+                effectiveLifecycle,
+                finalApplyAllowed,
+                true,
+                true,
+                REQUIRED_ARTIFACTS,
+                missing,
+                List.copyOf(blockers),
+                nextActions(finalApplyAllowed, missing),
+                evidenceBundle(request, effectiveLifecycle));
+    }
+
+    private List<String> missingArtifacts(MigrationApplyGateRequest request) {
+        Map<String, String> refs = artifactRefs(request);
+        return REQUIRED_ARTIFACTS.stream()
+                .filter(name -> blank(refs.get(name)))
+                .toList();
+    }
+
+    private MigrationApplyGateResponse.SupportSafeEvidenceBundle evidenceBundle(
+            MigrationApplyGateRequest request,
+            String lifecycle) {
+        return new MigrationApplyGateResponse.SupportSafeEvidenceBundle(
+                request.runId(),
+                request.domainKey(),
+                lifecycle,
+                request.objectCounts(),
+                request.contentHashes(),
+                request.auditRefs(),
+                artifactRefs(request).values().stream().filter(value -> !blank(value)).map(this::redact).toList(),
+                request.providerDiagnostics().stream().map(this::redact).toList(),
+                "support_safe");
+    }
+
+    private Map<String, String> artifactRefs(MigrationApplyGateRequest request) {
+        Map<String, String> refs = new LinkedHashMap<>();
+        refs.put("dryRunReportRef", request.dryRunReportRef());
+        refs.put("exportSnapshotRef", request.exportSnapshotRef());
+        refs.put("importPlanRef", request.importPlanRef());
+        refs.put("providerMappingRef", request.providerMappingRef());
+        refs.put("lossyMappingReportRef", request.lossyMappingReportRef());
+        refs.put("conflictReportRef", request.conflictReportRef());
+        refs.put("memberImpactPreviewRef", request.memberImpactPreviewRef());
+        refs.put("adminApprovalRef", request.adminApprovalRef());
+        refs.put("rollbackArchiveRef", request.rollbackArchiveRef());
+        refs.put("postApplyVerificationRef", request.postApplyVerificationRef());
+        return refs;
+    }
+
+    private List<String> nextActions(boolean applyAllowed, List<String> missing) {
+        if (applyAllowed) {
+            return List.of(
+                    "Proceed only through the feature-gated migration apply path.",
+                    "Keep audit publication and rollback/archive evidence attached to the run.");
+        }
+        List<String> actions = new ArrayList<>();
+        if (!missing.isEmpty()) {
+            actions.add("Attach missing export/import, dry-run, lossy/conflict, impact, approval, rollback, and verification artifacts.");
+        }
+        actions.add("Resolve identity mapping and audit-sink blockers before any apply mutation.");
+        actions.add("Expose only the support-safe evidence bundle to admins and reviewers.");
+        return actions;
+    }
+
+    private String normalizeLifecycle(String lifecycle) {
+        return lifecycle == null ? "discovered" : lifecycle.toLowerCase(Locale.ROOT).trim().replace('-', '_');
+    }
+
+    private String safeLifecycle(String lifecycle) {
+        String value = normalizeLifecycle(lifecycle);
+        return UNSAFE.matcher(value).replaceAll("redacted");
+    }
+
+    private String redact(String value) {
+        if (blank(value)) {
+            return "";
+        }
+        if (UNSAFE.matcher(value).find()) {
+            return "redacted-provider-value";
+        }
+        return value;
+    }
+
+    private boolean blank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/server/src/main/resources/contracts/portability/migration-run.schema.json
+++ b/server/src/main/resources/contracts/portability/migration-run.schema.json
@@ -1,1 +1,47 @@
-{"$schema":"https://json-schema.org/draft/2020-12/schema","$id":"https://weave.local/contracts/portability/migration-run.schema.json","title":"MigrationRun","type":"object","additionalProperties":false,"required":["runId","domainKey","state","dryRunReportRef","providerMappingRef","objectCounts","contentHashes","auditRefs","applyAllowed","redaction"],"properties":{"runId":{"type":"string"},"domainKey":{"type":"string"},"state":{"type":"string","enum":["draft","dry_run_required","dry_run_success","dry_run_failed","apply_blocked","apply_ready","applied","rolled_back"]},"dryRunReportRef":{"type":"string"},"providerMappingRef":{"type":"string"},"objectCounts":{"type":"object","minProperties":1,"additionalProperties":{"type":"integer","minimum":0}},"contentHashes":{"type":"array","minItems":1,"items":{"type":"string","pattern":"^sha256:[a-f0-9]{64}$"}},"auditRefs":{"type":"array","minItems":1,"items":{"type":"string"}},"applyAllowed":{"type":"boolean"},"redaction":{"type":"string","enum":["support_safe"]}}}
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weave.local/contracts/portability/migration-run.schema.json",
+  "title": "MigrationRun",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "runId",
+    "domainKey",
+    "state",
+    "dryRunReportRef",
+    "providerMappingRef",
+    "objectCounts",
+    "contentHashes",
+    "auditRefs",
+    "applyAllowed",
+    "redaction"
+  ],
+  "properties": {
+    "runId": {"type": "string"},
+    "domainKey": {"type": "string"},
+    "state": {
+      "type": "string",
+      "enum": [
+        "discovered",
+        "preflight_failed",
+        "preflight_passed",
+        "exported",
+        "dry_run_completed",
+        "blocked",
+        "approved",
+        "applying",
+        "applied",
+        "verified",
+        "rolled_back",
+        "archived"
+      ]
+    },
+    "dryRunReportRef": {"type": "string"},
+    "providerMappingRef": {"type": "string"},
+    "objectCounts": {"type": "object", "minProperties": 1, "additionalProperties": {"type": "integer", "minimum": 0}},
+    "contentHashes": {"type": "array", "minItems": 1, "items": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$"}},
+    "auditRefs": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+    "applyAllowed": {"type": "boolean"},
+    "redaction": {"type": "string", "enum": ["support_safe"]}
+  }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/controller/PlatformProductContractControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/PlatformProductContractControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -156,6 +157,48 @@ class PlatformProductContractControllerTest {
         String firstJob = com.jayway.jsonpath.JsonPath.read(first.getResponse().getContentAsString(), "$.jobId");
         String secondJob = com.jayway.jsonpath.JsonPath.read(second.getResponse().getContentAsString(), "$.jobId");
         org.assertj.core.api.Assertions.assertThat(secondJob).isEqualTo(firstJob);
+    }
+
+    @Test
+    void migrationApplyGateBlocksMissingArtifactsAndRedactsEvidence() throws Exception {
+        mockMvc.perform(post("/api/migration/apply-gates")
+                        .with(workspaceJwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "runId": "migration-chat-apply-001",
+                                  "domainKey": "chat",
+                                  "requestedLifecycle": "approved",
+                                  "dryRunReportRef": "dry-run:chat:001",
+                                  "exportSnapshotRef": "export:chat:001",
+                                  "importPlanRef": "import:chat:001",
+                                  "providerMappingRef": "mapping:chat:001",
+                                  "memberImpactPreviewRef": "impact:chat:001",
+                                  "rollbackArchiveRef": "rollback:chat:001",
+                                  "postApplyVerificationRef": "verify:chat:001",
+                                  "objectCounts": {"Conversation": 2, "Message": 10},
+                                  "contentHashes": ["sha256:3333333333333333333333333333333333333333333333333333333333333333"],
+                                  "auditRefs": ["audit:migration.dry_run:001"],
+                                  "identityMappingComplete": false,
+                                  "auditSinkAvailable": false,
+                                  "adminApproved": false,
+                                  "providerDiagnostics": ["Authorization: Bearer raw-token", "https://provider.example.invalid/private"]
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.applyAllowed").value(false))
+                .andExpect(jsonPath("$.lifecycle").value("blocked"))
+                .andExpect(jsonPath("$.missingArtifacts[*]", hasItems("lossyMappingReportRef", "conflictReportRef", "adminApprovalRef")))
+                .andExpect(jsonPath("$.blockers[*]", hasItems(
+                        "apply blocked until identity mapping is complete",
+                        "apply blocked until the audit sink is available",
+                        "apply blocked until an admin approval record is present")))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.providerDiagnosticsRedacted").value(true))
+                .andExpect(jsonPath("$.evidenceBundle.redaction").value("support_safe"))
+                .andExpect(content().string(not(containsString("raw-token"))))
+                .andExpect(content().string(not(containsString("provider.example.invalid"))))
+                .andExpect(content().string(not(containsString("Authorization: Bearer"))));
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/service/migration/MigrationApplyGateServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/migration/MigrationApplyGateServiceTest.java
@@ -1,0 +1,120 @@
+package com.massimotter.weave.backend.service.migration;
+
+import com.massimotter.weave.backend.model.migration.MigrationApplyGateRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MigrationApplyGateServiceTest {
+
+    private final MigrationApplyGateService service = new MigrationApplyGateService();
+
+    @Test
+    void blocksApplyWhenRequiredArtifactsIdentityMappingOrAuditSinkAreMissing() {
+        var response = service.evaluate(new MigrationApplyGateRequest(
+                "migration-chat-001",
+                "chat",
+                "approved",
+                "dry-run:chat:001",
+                "export:chat:001",
+                "import:chat:001",
+                "mapping:chat:001",
+                null,
+                null,
+                "impact:chat:001",
+                null,
+                "rollback:chat:001",
+                "verify:chat:001",
+                Map.of("Conversation", 2),
+                List.of("sha256:1111111111111111111111111111111111111111111111111111111111111111"),
+                List.of("audit:migration.dry_run:001"),
+                false,
+                false,
+                false,
+                List.of("Authorization: Bearer raw-token", "https://provider.example.invalid/private")));
+
+        assertThat(response.applyAllowed()).isFalse();
+        assertThat(response.lifecycle()).isEqualTo("blocked");
+        assertThat(response.missingArtifacts()).contains("lossyMappingReportRef", "conflictReportRef", "adminApprovalRef");
+        assertThat(response.blockers()).contains(
+                "apply blocked until identity mapping is complete",
+                "apply blocked until the audit sink is available",
+                "apply blocked until an admin approval record is present");
+        assertThat(response.supportSafe()).isTrue();
+        assertThat(response.providerDiagnosticsRedacted()).isTrue();
+        assertThat(response.evidenceBundle().redaction()).isEqualTo("support_safe");
+        assertThat(response.toString())
+                .doesNotContain("raw-token")
+                .doesNotContain("provider.example.invalid")
+                .doesNotContain("Authorization: Bearer");
+    }
+
+    @Test
+    void allowsApprovedApplyOnlyWhenLifecycleAndEvidenceAreComplete() {
+        var response = service.evaluate(completeRequest("approved"));
+
+        assertThat(response.applyAllowed()).isTrue();
+        assertThat(response.lifecycle()).isEqualTo("approved");
+        assertThat(response.blockers()).isEmpty();
+        assertThat(response.evidenceBundle().artifactRefs()).contains(
+                "dry-run:boards:001",
+                "export:boards:001",
+                "import:boards:001",
+                "approval:boards:001",
+                "verify:boards:001");
+    }
+
+    @Test
+    void recordsExactMigrationLifecycleStatesAndBlocksPrematureApply() {
+        assertThat(List.of(
+                "discovered",
+                "preflight_failed",
+                "preflight_passed",
+                "exported",
+                "dry_run_completed",
+                "blocked",
+                "approved",
+                "applying",
+                "applied",
+                "verified",
+                "rolled_back",
+                "archived"))
+                .allSatisfy(state -> assertThat(service.evaluate(completeRequest(state)).lifecycle())
+                        .isEqualTo(SetLike.applyCapable(state) ? state : "blocked"));
+
+        assertThat(service.evaluate(completeRequest("preflight_passed")).blockers())
+                .contains("apply blocked until lifecycle reaches approved after dry-run and preflight evidence");
+    }
+
+    private MigrationApplyGateRequest completeRequest(String lifecycle) {
+        return new MigrationApplyGateRequest(
+                "migration-boards-001",
+                "boards",
+                lifecycle,
+                "dry-run:boards:001",
+                "export:boards:001",
+                "import:boards:001",
+                "mapping:boards:001",
+                "lossy:boards:001",
+                "conflict:boards:001",
+                "impact:boards:001",
+                "approval:boards:001",
+                "rollback:boards:001",
+                "verify:boards:001",
+                Map.of("Board", 1, "Task", 12),
+                List.of("sha256:2222222222222222222222222222222222222222222222222222222222222222"),
+                List.of("audit:migration.dry_run:001", "audit:migration.apply_requested:001"),
+                true,
+                true,
+                true,
+                List.of("support-safe diagnostic"));
+    }
+
+    private static final class SetLike {
+        private static boolean applyCapable(String state) {
+            return List.of("approved", "applying", "applied", "verified").contains(state);
+        }
+    }
+}

--- a/specs/0006-portability-contract/migration-run-apply-blocked.json
+++ b/specs/0006-portability-contract/migration-run-apply-blocked.json
@@ -1,7 +1,7 @@
 {
   "runId": "migration_boards_openproject_to_placeholder_002",
   "domainKey": "boards",
-  "state": "dry_run_required",
+  "state": "blocked",
   "dryRunReportRef": "",
   "providerMappingRef": "mapping:boards:openproject-placeholder:002",
   "objectCounts": {"Board": 1},

--- a/specs/0006-portability-contract/migration-run-dry-run-success.json
+++ b/specs/0006-portability-contract/migration-run-dry-run-success.json
@@ -1,12 +1,12 @@
 {
   "runId": "migration_boards_openproject_to_placeholder_001",
   "domainKey": "boards",
-  "state": "dry_run_success",
+  "state": "approved",
   "dryRunReportRef": "dry-run:boards:001",
   "providerMappingRef": "mapping:boards:openproject-placeholder:001",
   "objectCounts": {"Board": 1, "Task": 12, "Comment": 5},
   "contentHashes": ["sha256:1111111111111111111111111111111111111111111111111111111111111111"],
-  "auditRefs": ["audit:migration.dry_run:001"],
+  "auditRefs": ["audit:migration.dry_run:001", "audit:migration.apply_requested:001"],
   "applyAllowed": true,
   "redaction": "support_safe"
 }

--- a/tools/portability_contract_check.py
+++ b/tools/portability_contract_check.py
@@ -52,9 +52,12 @@ def main():
   for field in ['objectCounts','contentHashes','providerMappingRef','auditRefs','redaction']:
    if not fixture.get(field): fail(f'{fixture.get("runId")} missing {field}')
   if fixture.get('redaction')!='support_safe': fail(f'{fixture.get("runId")} must be support_safe')
- if success.get('applyAllowed') is not True or success.get('state') not in {'dry_run_success','apply_ready'} or not success.get('dryRunReportRef'):
-  fail('successful fixture must require successful dry-run before apply')
- if blocked.get('applyAllowed') is not False or blocked.get('dryRunReportRef'):
+ lifecycle=schemas['migration-run.schema.json'].get('properties',{}).get('state',{}).get('enum',[])
+ expected_lifecycle=['discovered','preflight_failed','preflight_passed','exported','dry_run_completed','blocked','approved','applying','applied','verified','rolled_back','archived']
+ if lifecycle!=expected_lifecycle: fail('MigrationRun lifecycle states must match the canonical migration engine order')
+ if success.get('applyAllowed') is not True or success.get('state') not in {'approved','applying','applied','verified'} or not success.get('dryRunReportRef'):
+  fail('successful fixture must require approved post-dry-run evidence before apply')
+ if blocked.get('applyAllowed') is not False or blocked.get('state')!='blocked' or blocked.get('dryRunReportRef'):
   fail('blocked fixture must prove apply impossible without dry-run report')
  print('portability-contract-check: ok')
 if __name__=='__main__': main()


### PR DESCRIPTION
## Summary

- add a generic migration apply-gate contract endpoint that evaluates lifecycle state, required portability artifacts, identity mapping, admin approval, rollback/archive evidence, post-apply verification, and audit-sink readiness before any provider mutation can be allowed
- align the MigrationRun schema/fixtures with the Sprint 9 lifecycle (`discovered` through `archived`) and enforce it in `portabilityContractCheck`
- add controller and service tests proving missing artifacts, incomplete identity mapping, unavailable audit sinks, and unsafe provider diagnostics block apply and stay support-safe

## Scope and user impact

- Server/admin control-plane contract only; no live provider mutation and no member-facing migration UI.
- Supports #442 server-side acceptance for lifecycle, preflight/apply blockers, support-safe evidence bundles, redaction, identity-mapping, audit-sink, rollback/archive, and post-apply verification gates.
- Also reinforces #440-style identity control-plane safety by requiring complete identity mapping and audit availability before apply.

## Spec / acceptance link

- Issue: Refs #442, refs #440
- Repo spec or spec note: `specs/0006-portability-contract/spec.md`, `docs/architecture/no-unaccounted-data-loss.md`
- Acceptance scenario / mapping marker when product behavior changed: existing provider switch portability mapping; contract evidence in `MigrationApplyGateServiceTest`, `PlatformProductContractControllerTest`, and `tools/portability_contract_check.py`
- Product-core questions intentionally left unresolved: live production migration apply remains out of scope; this PR validates gates only.

## Branch, target, and release path

- [x] Branch started from current `origin/main`
- [x] PR targets protected `main`
- [x] No long-lived `dev`/`testing`/`staging` branch involved
- [x] Production release is not implied by this merge

## Screenshots or docs impact

- No screenshots. Updates the no-unaccounted-data-loss architecture contract and portability fixtures.

## Accessibility and localization

- No UI/localization changes.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: `/api/migration/apply-gates` contract and MigrationRun lifecycle/schema are updated.
- [x] `./gradlew specContract` run for spec/product-contract changes

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented: fallback self-review; Copilot request can be retried by the integrator if available.

## Checks run

- [x] `./gradlew serverCi acceptanceContract specContract portabilityContractCheck releaseEvidenceCheck`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] Flutter/client gates: not applicable
- [ ] Live-stack validation: not applicable for non-mutating server contract

## Notes for reviewers

- The apply gate intentionally returns `applyAllowed=false` unless all required artifacts exist, identity mapping is complete, the audit sink is available, admin approval is present, and lifecycle is apply-capable.
- Provider diagnostics are reduced to support-safe placeholders before entering the evidence bundle.
