### PR TITLE
chore(spec): enforce pinned corpus conformance

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -4,21 +4,21 @@ Version: 0.1.0
 Ratified: 2026-05-28  
 Last amended: 2026-05-28
 
-This constitution governs repo-local specifications under `specs/`, Spec Kit-style templates under `.specify/templates/`, and repo-safe AI-assisted delivery guidance. It turns Weave planning into versioned, reviewable, executable product contracts.
+This constitution governs implementation-repo conformance to the pinned Weave Specification Corpus referenced by `specs/weave-specs.lock.json`, plus transitional repo-local specifications under `specs/`, Spec Kit-style templates under `.specify/templates/`, and repo-safe AI-assisted delivery guidance. It keeps fachliche specification truth separate from implementation/evidence truth.
 
 ## Core principles
 
 ### I. Repo truth over chat memory
 
-The current source of truth is this monorepo, GitHub issues/PRs, protected-branch status, and sanitized CI/evidence artifacts. Agent memory, old chat, older checkouts, and external notebooks are orientation only. A generated wiki or documentation site may explain specs, but it must not become the canonical source.
+Repo truth over chat memory means this monorepo, GitHub issues/PRs, protected-branch status, and sanitized CI/evidence artifacts are the current implementation/evidence truth. Fachliche product/domain specification truth lives in the pinned Weave Specification Corpus. Agent memory, old chat, older checkouts, and external notebooks are orientation only. Generated wiki/docs/projections may explain specs, but must not become canonical truth.
 
 ### II. Product-core before implementation
 
-Specs must describe Weave product outcomes before implementation tactics. Product vocabulary is category-first and provider-neutral: identity/IDM, chat, files, calendar, boards/tasks, meetings, documents/collaboration, decisions, health, and the optional Weaver runtime. Raw provider setup, secrets, endpoint rotation, support diagnostics, and policy authoring stay admin/operator side.
+The pinned specification corpus must describe Weave product outcomes before implementation tactics. Product vocabulary is category-first and provider-neutral: identity/IDM, spaces, chat, files, calendar, boards/tasks, meetings, documents/collaboration, decisions/evidence, admin health/ops, and the optional Weaver runtime. Raw provider setup, secrets, endpoint rotation, support diagnostics, and policy authoring stay admin/operator side.
 
 ### III. Acceptance and evidence first
 
-For new product behavior, write or update product-language acceptance before implementation. A reviewable scenario needs a stable mapping to executable evidence in `e2e/scenario_mappings.json` or a named draft/proposed blocker. `./gradlew acceptanceContract` and `./gradlew specContract` are the minimum spec gates.
+For new product behavior, write or update product-language acceptance in the spec corpus before implementation. A reviewable scenario needs a stable mapping to executable evidence in `e2e/scenario_mappings.json` or a named draft/proposed blocker. `./gradlew specCorpusConformance`, `./gradlew acceptanceContract`, and the transitional `./gradlew specContract` are the minimum spec/evidence gates.
 
 ### IV. Accessibility, supportability, auditability, deployability
 
@@ -65,4 +65,4 @@ Assistant invocation must respect runtime policy:
 
 ## Governance
 
-This constitution supersedes ad-hoc sprint habits for spec-driven work. Amendments require a PR that updates this file, `docs/spec-driven-development.md`, and any affected templates or guards. The guard task is `./gradlew specContract`.
+This constitution supersedes ad-hoc sprint habits for spec-driven work. Amendments require a PR that updates this file, `docs/spec-driven-development.md`, `specs/weave-specs.lock.json` when the canonical corpus changes, and any affected templates or guards. The primary conformance guard is `./gradlew specCorpusConformance`; the transitional repo-local guard remains `./gradlew specContract`.

--- a/.specify/templates/weave-agent-briefs.md
+++ b/.specify/templates/weave-agent-briefs.md
@@ -4,7 +4,7 @@ Use these compact templates for repo-safe AI-assisted delivery. Do not paste tra
 
 ## Invocation matrix
 
-- Delivery lead: recovers repo/GitHub/CI truth, plans the issue DAG, integrates evidence, and enforces gates.
+- Delivery lead: recovers spec-corpus truth first, then repo/GitHub/CI truth, plans the issue DAG, integrates evidence, and enforces gates.
 - Repo roles: scoped prompts with logical responsibilities such as Product/Spec, Architecture/Contract, Client/A11y, Server/Domain, Admin/Policy, Provider/Infra, QA/Evidence, Docs/Release, Security/Privacy, and Integration Review.
 - Coding harnesses: use only when explicitly selected by the operator environment. The product repo must not name deployable live harness profiles or allowlists.
 - Copilot review: fallback-only; do not block PR readiness on Copilot premium review exhaustion.
@@ -14,7 +14,7 @@ Use these compact templates for repo-safe AI-assisted delivery. Do not paste tra
 
 Use the smallest pattern that solves the slice:
 
-1. Recover truth from repo/GitHub/CI and identify the contract/spec.
+1. Recover truth from the pinned spec corpus, then repo/GitHub/CI, and identify the contract/spec.
 2. Build a task DAG; parallelize only independent file/contract areas.
 3. Give each worker exact inputs, allowed files, required gates, and stop conditions.
 4. Integrate from evidence, not transcript claims.
@@ -27,9 +27,9 @@ Material optimization means a change that improves correctness, traceability, se
 ## Truth-Recovery
 
 ```text
-Recover current truth from the Weave repo, GitHub issues/PRs, and CI/evidence.
+Recover current truth from the pinned Weave Specification Corpus, then the Weave repo, GitHub issues/PRs, and CI/evidence.
 Do not rely on chat memory except as orientation.
-Return: branch, relevant docs/specs, open PRs/issues, latest CI/evidence, blockers, smallest safe next slice.
+Return: spec corpus commit/IDs, branch, relevant conformance docs/specs, open PRs/issues, latest CI/evidence, blockers, smallest safe next slice.
 Do not modify files.
 ```
 
@@ -99,7 +99,7 @@ Return:
 ```text
 Plan a real Weave sprint from the governing spec.
 Inputs: <spec.md/plan.md/tasks.md/docs/issues>.
-Do first: recover truth from main, specs, GitHub issues/PRs, CI/evidence.
+Do first: recover truth from the pinned spec corpus, then main, repo conformance specs, GitHub issues/PRs, CI/evidence.
 Output: sprint goal, issue DAG, PR train order, required roles, required gates, merge authorization status, product-core blockers.
 If issues are missing and GitHub access is available, create/update them with dependency notes and parallel/sequential labels.
 Do not implement yet.

--- a/.specify/templates/weave-plan-template.md
+++ b/.specify/templates/weave-plan-template.md
@@ -1,7 +1,8 @@
 # Implementation plan: Replace with title
 
-**Spec**: `specs/0000-slug/spec.md`  
-**Branch**: `type/short-slug`  
+**Spec corpus commit/ID**: `<commit> / <WEAVE-...>`
+**Repo conformance spec**: `specs/0000-slug/spec.md` when applicable
+**Branch**: `type/short-slug`
 **Date**: YYYY-MM-DD
 
 ## Summary
@@ -10,6 +11,7 @@ One paragraph: technical approach that satisfies the spec without expanding prod
 
 ## Constitution check
 
+- Spec corpus truth recovered from `specs/weave-specs.lock.json` and relevant corpus files: yes/no
 - Repo truth recovered from `main`, docs, GitHub issue/PR state, and CI evidence: yes/no
 - Product-first/provider-neutral boundary preserved: yes/no
 - Acceptance/evidence path identified before implementation: yes/no
@@ -67,6 +69,7 @@ Use specialists only when they reduce risk or parallelize independent files. Eac
 
 ## Final gates
 
+- `./gradlew specCorpusConformance`
 - `./gradlew specContract`
 - `./gradlew acceptanceContract`
 - Smallest area gate(s):

--- a/.specify/templates/weave-tasks-template.md
+++ b/.specify/templates/weave-tasks-template.md
@@ -1,13 +1,14 @@
 # Tasks: Replace with title
 
-**Spec**: `specs/0000-slug/spec.md`  
-**Plan**: `specs/0000-slug/plan.md`
+**Spec corpus commit/ID**: `<commit> / <WEAVE-...>`
+**Repo conformance spec**: `specs/0000-slug/spec.md` when applicable
+**Plan**: `specs/0000-slug/plan.md` when applicable
 
 Task format: `- [ ] T001 [P?] [US?/Area] Description with exact path and gate`
 
 ## Phase 0: Truth recovery
 
-- [ ] T001 [Spec] Re-read `AGENTS.md`, `.specify/memory/constitution.md`, the spec, and referenced docs.
+- [ ] T001 [Spec] Re-read `specs/weave-specs.lock.json`, the relevant spec corpus files, `AGENTS.md`, `.specify/memory/constitution.md`, and referenced docs.
 - [ ] T002 [Spec] Verify branch starts from current `origin/main` and no unrelated local changes are present.
 - [ ] T003 [Spec] Verify linked issue/PR status and release-notes label expectations.
 
@@ -16,7 +17,7 @@ Task format: `- [ ] T001 [P?] [US?/Area] Description with exact path and gate`
 - [ ] T010 [Acceptance] Update or create product-language Gherkin under `e2e/features/` when product behavior changes.
 - [ ] T011 [Acceptance] Update `e2e/scenario_mappings.json` with stable marker and executable evidence.
 - [ ] T012 [Contracts] Add or update API/event/provider contract files before implementation.
-- [ ] T013 [Evidence] Run `./gradlew specContract` and `./gradlew acceptanceContract`; expected red/green state documented.
+- [ ] T013 [Evidence] Run `./gradlew specCorpusConformance`, `./gradlew specContract`, and `./gradlew acceptanceContract`; expected red/green state documented.
 
 ## Phase 2: Implementation slices
 
@@ -38,6 +39,6 @@ Group implementation by independently testable user story. Mark `[P]` only when 
 - [ ] T040 Run required area gates.
 - [ ] T041 Run `./gradlew ci` for cross-stack/release-relevant changes.
 - [ ] T042 Run Integration-Gate or Optimization-Review; loop on material findings.
-- [ ] T043 Fill PR body with spec ID, acceptance/evidence, risks, and fallback review evidence.
+- [ ] T043 Fill PR body with spec corpus commit/ID, acceptance/evidence, risks, and fallback review evidence.
 - [ ] T044 Update spec status/version or document why it remains draft/proposed.
 - [ ] T045 Assistant handoff: preserve durable decisions, evidence, blockers, and next safe action only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Weave is one monorepo. `client/`, `server/`, `infra/`, `e2e/`, `docs/`, and `rel
 
 Old `weave-backend` and `weave-infra` checkouts are stale. Ignore them.
 
-Current truth: this repo, README/docs, GitHub issues/PRs/milestones, repo-local `specs/`, and executable evidence. `~/code/specs` is orientation/cross-session contract context; repo-local specs/docs remain the implementation authority when they are more current.
+Truth split: the canonical fachliche specification truth is the pinned Weave Specification Corpus in `specs/weave-specs.lock.json` (local default `../weave-specs`). This repo is implementation/evidence truth: code, tests, CI, release evidence, GitHub issues/PRs/milestones, and generated or transitional spec projections. If corpus and repo reality disagree, create an explicit spec-change or conformance-fix task; never let implementation state silently redefine product/domain meaning.
 
 Language policy: every `AGENTS.md`, agent prompt, checked-in project instruction, PR body, issue body, code comment, and documentation change must be written in English unless a user-facing localization file explicitly requires another language.
 
@@ -19,10 +19,10 @@ Before coding, opening PRs, merging, or declaring work complete, read and follow
 - `docs/developer-handbook.md` for coding conventions, Gradle gates, generated code, accessibility/i18n, and evidence expectations.
 - `docs/gitflow-pr-workflow.md` for protected `main`, short-lived branches, PR readiness, merge rules, and release-notes labels.
 - `docs/weave-operating-model.md` for delivery lifecycle and governance.
-- `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and relevant repo-local `specs/` for spec-driven delivery.
+- `specs/weave-specs.lock.json`, the pinned spec corpus files, `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and transitional repo-local `specs/` for conformance context.
 - Domain docs near the changed area (`client/`, `server/`, `infra/`, `e2e/`, `docs/`).
 
-Default gates: `./gradlew acceptanceContract`, `./gradlew clientCi`, `./gradlew serverCi`, `./gradlew adminCi`, `./gradlew infraStatic`, `./gradlew docsCheck`, and `./gradlew releaseEvidenceCheck`; use the smallest meaningful subset and `./gradlew ci` for cross-stack changes.
+Default gates: `./gradlew specCorpusConformance`, `./gradlew acceptanceContract`, `./gradlew clientCi`, `./gradlew serverCi`, `./gradlew adminCi`, `./gradlew infraStatic`, `./gradlew docsCheck`, and `./gradlew releaseEvidenceCheck`; use the smallest meaningful subset and `./gradlew ci` for cross-stack changes.
 
 ## Autonomous sprint ownership
 
@@ -36,7 +36,7 @@ A sprint-finish request authorizes normal repository delivery actions needed to 
 
 When assigned a sprint or milestone, the delivery lead must run this loop without handing decomposition back to the requester:
 
-1. **Truth recovery**: fetch current `origin/main`, inspect GitHub milestone/issues/PRs/checks, read linked specs/tasks/docs, and identify the governing sprint lifecycle.
+1. **Truth recovery**: identify governing spec corpus files first, then fetch current `origin/main`, inspect GitHub milestone/issues/PRs/checks, read linked repo specs/tasks/docs as conformance artifacts, and identify the governing sprint lifecycle.
 2. **Acceptance derivation**: turn each issue/spec/task into testable acceptance criteria and evidence gates. If an issue lacks acceptance, infer it from linked specs/docs and update the issue or sprint plan instead of asking the user for restatement.
 3. **Issue DAG**: build or repair the dependency graph; mark independent work parallel and ordered work sequential.
 4. **Delegation**: brief scoped reviewers or implementers with strict repo-safe inputs: task id, allowed files/globs, relevant docs, derived acceptance, required gates, output contract, and stop conditions.
@@ -70,6 +70,6 @@ Accessibility, supportability, auditability, and deployability are release block
 
 - Write agent instructions, PRs, issues, code comments, and documentation in English unless an explicit localization file requires another language.
 - Follow `docs/developer-handbook.md`, `docs/gitflow-pr-workflow.md`, `docs/weave-operating-model.md`, and relevant domain docs before coding, opening PRs, merging, or declaring work complete.
-- If the user asks to finish a sprint/milestone, derive acceptance from GitHub issues/milestones, repo specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
+- If the user asks to finish a sprint/milestone, derive acceptance first from the pinned spec corpus, then from GitHub issues/milestones, repo conformance specs/tasks, docs, CI policy, and evidence; do not require the user to restate issue acceptance criteria.
 - Keep live assistant runtime configuration, allowlists, hierarchy, model routing, and personal operator paths outside this product repo.
 - Use protected `main`, short-lived branches, exactly one `release-notes-*` label per PR, smallest meaningful local gates, green CI, fallback review evidence, and GitHub closure verification before reporting completion.

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ registerRootCommandTask('docsBuild', ['bash', '-lc', 'PYTHON=python3; [ -x build
 registerRootCommandTask('docsStructureCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py'], 'Run lightweight documentation structure checks.')
 registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs serve'], 'Serve the MkDocs site locally.')
 registerRootCommandTask('releaseNotesLabelCheck', ['bash', '-lc', 'if [ -n "${PR_LABELS_JSON:-}" ]; then python3 tools/release_notes_label_check.py; else echo "release-notes-label-check: skipped (PR_LABELS_JSON is not set)"; fi'], 'Validate the current PR release-notes label set from PR_LABELS_JSON when available.')
-registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.py'], 'Validate repo-local Weave specs, lifecycle metadata, and implementation-ready clarification state.')
+registerRootCommandTask('specCorpusConformance', ['python3', 'tools/spec_corpus_conformance_check.py'], 'Validate the pinned Weave Specification Corpus and the spec-truth vs implementation-evidence boundary.')
+registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.py'], 'Validate transitional repo-local Weave specs, lifecycle metadata, and implementation-ready clarification state.')
 registerRootCommandTask('domainRegistryCheck', ['python3', 'tools/domain_registry_check.py'], 'Validate the canonical domain registry v1 machine-readable contract.')
 registerRootCommandTask('spaceAnchorCheck', ['python3', 'tools/space_anchor_check.py'], 'Validate the Space anchor contract fixture.')
 registerRootCommandTask('portabilityContractCheck', ['python3', 'tools/portability_contract_check.py'], 'Validate provider portability and no-unaccounted-data-loss migration schemas.')
@@ -102,6 +103,7 @@ ext.ciEvidenceGates = [
     'infraStatic',
     'docsCheck',
     'releaseNotesLabelCheck',
+    'specCorpusConformance',
     'specContract',
     'specContractTest',
     'domainRegistryCheck',
@@ -199,6 +201,8 @@ List<String> artifactPathsForGate(String gateName) {
     switch (gateName) {
         case 'docsCheck':
             return ['build/docs/user', 'build/docs/admin']
+        case 'specCorpusConformance':
+            return ['specs/weave-specs.lock.json', 'tools/spec_corpus_conformance_check.py']
         case 'specContract':
             return ['specs', '.specify/memory/constitution.md', '.specify/templates']
         case 'specContractTest':

--- a/docs/agent-team-orchestration.md
+++ b/docs/agent-team-orchestration.md
@@ -10,8 +10,8 @@ A delivery lead owns issue/PR orchestration, merge sequencing, integration, and 
 
 Use this loop until the issue DAG is integrated or a real blocker stops safe progress:
 
-1. Recover truth from `main`, repo specs/docs/tasks, GitHub issues/PRs, and CI/evidence.
-2. Identify the governing spec and decide whether it is ready for implementation. Keep unresolved product-core questions in `draft`/`proposed`.
+1. Recover truth from the pinned spec corpus, then `main`, repo conformance specs/docs/tasks, GitHub issues/PRs, and CI/evidence.
+2. Identify the governing corpus spec and decide whether it is ready for implementation. Keep unresolved product-core questions in `draft`/`proposed`.
 3. Convert the spec plan/tasks into a GitHub issue DAG. Label independent work `parallel`; label ordered work `sequential`; link issues/PRs back to the spec.
 4. Cut short-lived branches from updated `main` and open reviewable PRs in dependency order.
 5. Assign scoped implementation or review work only for narrow issue slices, each with exact files, inputs, stop conditions, and a required gate.
@@ -27,7 +27,7 @@ Material optimization means improved correctness, traceability, security/privacy
 
 Durable sprint state belongs in GitHub and repo files, not chat transcripts:
 
-- Specification stewarding lives in `specs/<id>/spec.md`, `plan.md`, `tasks.md`, and traceability files.
+- Specification stewarding lives in the pinned spec corpus; repo-local `specs/<id>/spec.md`, `plan.md`, `tasks.md`, and traceability files are transitional conformance artifacts.
 - Work tracking lives in GitHub issues with dependency notes and `parallel`/`sequential` labels.
 - Implementation state lives in PRs and CI artifacts.
 - Release impact lives in exactly one release-notes label per PR.

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -117,8 +117,8 @@ A Weave sprint is not one green PR. A sprint starts from an accepted or explicit
 
 Required sprint shape:
 
-1. Recover truth from `main`, `specs/`, GitHub issues/PRs, and CI artifacts.
-2. Select or create the governing spec, then keep product-core ambiguity in `draft`/`proposed` with explicit `[NEEDS CLARIFICATION: ...]` markers.
+1. Recover fachliche truth from the pinned spec corpus first, then implementation truth from `main`, transitional `specs/`, GitHub issues/PRs, and CI artifacts.
+2. Select or create the governing spec-corpus contract; keep product-core ambiguity in `draft`/`proposed` with explicit `[NEEDS CLARIFICATION: ...]` markers.
 3. Break the spec plan/tasks into a GitHub issue DAG with `parallel`/`sequential` labels where ordering matters.
 4. For each implementation slice, open a short-lived branch and one reviewable PR with exactly one release-notes label.
 5. Merge PRs in dependency order after green CI, required local gates, and fallback human/agent review evidence. Copilot review is optional while premium review requests are exhausted.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ Start with:
 
 1. [Developer Handbook](developer-handbook.md) — local prerequisites, Java 21+ requirement, Gradle gates, client/server/admin/infra workflows, and evidence expectations.
 2. [Trunk-based PR and release workflow](gitflow-pr-workflow.md) — branch, review, label, release-note, and merge rules.
-3. [Spec-driven development for Weave](spec-driven-development.md) — repo-local specs, lifecycle, evidence gates, and agent orchestration.
+3. [Spec-driven development for Weave](spec-driven-development.md) — pinned spec corpus, conformance lifecycle, evidence gates, and agent orchestration.
 4. [AI-assisted delivery orchestration](agent-team-orchestration.md) — repo-safe roles, handoff briefs, runtime-boundary guardrails, and optimization loop.
 5. [Canonical domains](architecture/canonical-domains.md) — product-owned domain registry for identity, people, spaces, chat, files, documents, calendar, boards, calls, decisions, notifications, health, and Weaver.
 6. [Provider portability contract](architecture/provider-portability.md) — adapter manifests, mapping tables, reports, and no-unaccounted-data-loss rules.
@@ -74,7 +74,7 @@ Start with:
 
 ## Documentation maturity map
 
-Canonical product docs:
+Implementation conformance docs and product-facing projections:
 
 - [Root README](https://github.com/masssi164/weave/blob/main/README.md)
 - [v0.1 Golden Path readiness](v0.1-golden-path.md)
@@ -119,13 +119,13 @@ Release and evidence docs:
 
 Historical/context docs:
 
-- Sprint reports and strategy notes are useful provenance, but they are secondary to the canonical product docs above.
+- Sprint reports and strategy notes are useful provenance, but they are secondary to the pinned spec corpus and current implementation conformance docs above.
 - Research notes under `docs/research/` are evidence inputs, not current product promises.
 - [Roadmap and guarded surfaces](roadmap-and-guarded-surfaces.md) records future or guarded areas without promoting them as shipped.
 
-## Current product truth
+## Current product direction projection
 
-The active product direction is [Weave product line and Weaver integration plan](product-line-and-weaver-plan.md): Weave is product-first and provider-neutral. Admin/provider setup, IDM/RBAC, readiness, whitelisting, and support-safe diagnostics come before optional Weaver personal-assistant runtime work.
+The canonical product/domain truth is the pinned Weave Specification Corpus referenced by `specs/weave-specs.lock.json`. This repo projects the active direction through [Weave product line and Weaver integration plan](product-line-and-weaver-plan.md): Weave is product-first and provider-neutral. Admin/provider setup, IDM/RBAC, readiness, whitelisting, and support-safe diagnostics come before optional Weaver personal-assistant runtime work.
 
 Weaver remains optional, governed, auditable, support-safe, and disabled by default. Any future per-user PA runtime must be generated from Weave organization policy as an isolated OpenClaw-derived profile and follow the rule: user-rights, organization-whitelisted capabilities. See [Governed Weaver runtime security contract](governed-weaver-runtime-security-contract.md) for the runtime/model/tool-provider split, approval receipts, and support-safe evidence boundary.
 

--- a/docs/product-flow-activity-diagrams.md
+++ b/docs/product-flow-activity-diagrams.md
@@ -10,9 +10,9 @@ Executable scenario anchors:
 
 Source/quality-check anchors:
 
-- Identity/profile source of truth: `specs/03-identity-and-unified-user-profile.md:73` and `/api/me`.
-- CI/smoke/E2E source of truth: `specs/10-ci-smoke-and-e2e-contract.md:59`.
-- Spec-map guard source: `/tool/spec_map.dart` in the repository that owns the checked mapping.
+- Identity/profile specification anchor: pinned spec corpus `domains/identity-idm/spec.md` plus implementation endpoint `/api/me`.
+- CI/smoke/E2E specification anchor: pinned spec corpus `steering/devops-conformance.md` plus implementation gates in `build.gradle` and `e2e/scenario_mappings.json`.
+- Spec-map guard source: `client/tool/acceptance_contract.dart` and `e2e/scenario_mappings.json` in this implementation repository.
 - `/admin/protocol` is not a current Weave product route here; treat it only as shorthand for raw admin/protocol fallback surfaces unless a future spec defines the endpoint.
 - `/storage/power` is not a current Weave product route here; treat it only as shorthand for the manual storage/power budget gate unless a future spec defines the endpoint.
 

--- a/docs/spec-driven-development.md
+++ b/docs/spec-driven-development.md
@@ -1,143 +1,117 @@
 # Spec-driven development for Weave
 
-Status: active delivery framework, 2026-05-28.
+Status: active delivery framework, updated 2026-05-31.
 
-Weave uses a lightweight Spec Kit-inspired workflow adapted to the existing monorepo, Gradle gates, Gherkin acceptance contracts, and repo-safe AI-assisted delivery model.
+Weave now separates two truths:
 
-The rule is simple: **Git-versioned specs are truth; generated docs/wiki views are projections.**
+- **Specification truth**: the fachliche Weave Specification Corpus, pinned by `specs/weave-specs.lock.json` and normally located at `../weave-specs`.
+- **Implementation/evidence truth**: this monorepo, GitHub issues/PRs/checks, CI artifacts, release evidence, and runtime evidence.
 
-## Why not a standalone wiki?
+The implementation repository must conform to the pinned specification corpus. It must not silently redefine product/domain meaning.
 
-A separate manual wiki would drift from code, CI, and PR evidence. Weave may publish generated documentation from `specs/` and `docs/`, but the canonical source remains:
+## Framework
 
-- `specs/` for versioned product/system contracts;
-- `.specify/memory/constitution.md` for non-negotiable spec rules;
-- `e2e/features/` and `e2e/scenario_mappings.json` for executable acceptance mapping;
-- `build/evidence/` and CI artifacts for proof;
-- GitHub issues/PRs for work tracking.
+Weave SDD uses a combined framework:
 
-## Folder model
+- GitHub Spec Kit lifecycle: constitution -> specify -> plan -> tasks -> implement.
+- Kiro-style split: steering files plus domain/provider specs.
+- Domain-Driven Design: bounded contexts, ubiquitous language, context map, provider anti-corruption layers.
+- Specification by Example / BDD / Gherkin: product-language examples mapped to executable acceptance.
+- C4 and ADRs: architecture views and decision records.
+- OpenAPI, AsyncAPI, and JSON Schema: contract-first APIs, events, reports, and evidence structures.
+- OpenClaw Orchestrator Pattern: `weave-co-leader` routes scoped work to L2/L3 agents with file-reference-only briefs and Veto gates.
 
-```text
-.specify/
-├── memory/constitution.md
-└── templates/
-    ├── weave-spec-template.md
-    ├── weave-plan-template.md
-    ├── weave-tasks-template.md
-    └── weave-agent-briefs.md
+## Canonical corpus
 
-specs/
-├── README.md
-└── 0000-weave-spec-framework/
-    ├── spec.md
-    ├── plan.md
-    ├── tasks.md
-    ├── traceability.yaml
-    ├── contracts/
-    ├── acceptance/
-    └── evidence/
-```
+The canonical corpus owns:
 
-## Lifecycle
+- product constitution;
+- ubiquitous language;
+- domain context map;
+- domain specs;
+- provider specs;
+- acceptance examples;
+- OpenAPI/AsyncAPI/JSON Schema contracts;
+- C4/ADR architecture decisions;
+- release/RC gate definitions.
 
-- `draft`: safe place for product questions and `[NEEDS CLARIFICATION: ...]` markers.
-- `proposed`: reviewable direction, still allowed to carry explicit unresolved questions.
-- `accepted`: contract approved; no clarification markers.
-- `implementing`: active work; no clarification markers.
-- `implemented`: implemented or merge-ready with evidence; no clarification markers.
-- `superseded`, `deprecated`, `rejected`: historical states.
+This repo owns:
 
-`./gradlew specContract` enforces required metadata and blocks clarification markers in implementation-ready specs. `./gradlew specContractTest` protects the guard itself with small fixtures.
+- code and generated code;
+- tests and acceptance mappings;
+- CI and Gradle gates;
+- release notes and support-safe evidence;
+- GitHub issue/PR/milestone state;
+- generated projections or historical transitional specs that prove conformance.
 
-## When full specs are required
+## Required first step for agents
 
-Use full `spec.md` + `plan.md` + `tasks.md` for:
+Before coding, opening PRs, merging, or declaring work complete:
 
-- new product capabilities;
-- provider-neutral domain contracts;
-- auth, IDM, RBAC, policy, whitelisting, or admin readiness;
-- Weaver runtime integration;
-- Gherkin/acceptance changes;
-- API/event/provider contract changes;
-- release-blocking evidence or architecture migrations.
-
-For tiny bug fixes, a linked issue/spec note plus tests/evidence is enough unless the change touches product contracts.
+1. Read `specs/weave-specs.lock.json`.
+2. Read the relevant files in the pinned spec corpus.
+3. Identify the bounded context, provider boundary, examples, contracts, and Veto dimensions.
+4. Only then inspect implementation repo files and GitHub state.
+5. Run `./gradlew specCorpusConformance` for spec-driven work.
 
 ## Product-core safety rule
 
-Do not let assistants invent unresolved product decisions. If the answer changes the product core, keep the spec `draft` or `proposed` and write the uncertainty explicitly.
-
-Product-core questions that require product owner/team confirmation include:
-
-- first `WEAVE-SPEC-0001` product slice: organization embedding, Chat facade, identity policy, or another foundation;
-- exact minimal domain vocabulary for the first user-visible release;
-- which provider categories must be mandatory vs optional in v0.1/v0.2;
-- when Weaver moves from placeholder category to governed runtime implementation;
-- which agentic developer-assistance capability, if any, is allowed inside Weave policy.
+Do not let assistants invent unresolved product decisions. If an answer changes Weave product meaning, provider promises, domain vocabulary, accessibility/supportability/auditability/deployability, or Weaver policy, update the spec corpus first or mark the work blocked.
 
 ## Sprint orchestration
 
-A sprint is the execution of a spec-backed issue DAG, not a single implementation PR. The expected autonomous flow is:
+A sprint is the execution of a spec-backed issue DAG, not a single implementation PR.
 
-1. The delivery lead recovers current truth from repo/GitHub/CI.
-2. Product/spec and architecture/contract reviewers confirm whether the governing spec is implementable or needs clarification.
-3. The co-leader creates or updates GitHub issues for the spec tasks, labels them `parallel` or `sequential`, and records dependencies in issue bodies.
-4. Scoped implementers or reviewers work on narrow issues on short-lived branches.
-5. The delivery lead opens PRs, assigns exactly one release-notes label, waits for green CI/gates, runs Integration-Gate, and merges in dependency order when authorized.
-6. After each merge, the delivery lead updates `main`, revises remaining tasks if necessary, and continues.
-7. Sprint closure records the spec, issue DAG, merged PR train, gates, evidence artifacts, unresolved product decisions, and next release/RC action.
+Expected autonomous flow:
 
-Durable sprint state belongs in specs, issues, PRs, and checked-in reports. Agent chat/session state is disposable.
+1. `weave-co-leader` identifies governing spec corpus files.
+2. Product/spec and architecture/contract reviewers validate fachliche readiness.
+3. Quality/evidence reviewers require examples and executable mapping.
+4. Security/privacy/accessibility/provider/ops reviewers apply Veto where relevant.
+5. Only accepted/implementing specs become implementation issues.
+6. Scoped implementers receive file-reference-only briefs: spec IDs, paths, allowed files, gates, stop conditions.
+7. PRs prove conformance with tests, CI, evidence artifacts, and exactly one release-notes label.
+8. Sprint closure cites spec version, issue DAG, merged PRs, gates, evidence, unresolved decisions, and next safe action.
+
+Durable sprint state belongs in the spec corpus, GitHub, repo evidence, and checked-in closure reports. Agent chat/session state is disposable.
 
 ## DevOps traceability
 
 Every implementation PR should connect:
 
 ```text
-GitHub issue or spec note
-  -> WEAVE-SPEC-ID and version
-  -> acceptance scenario / mapping marker when product behavior changes
-  -> test/contract/evidence gate
-  -> sanitized CI evidence
+spec corpus commit/version
+  -> domain/provider spec ID
+  -> acceptance example / scenario mapping marker
+  -> contract schema when applicable
+  -> GitHub issue/PR
+  -> local/GitHub gate commands
+  -> sanitized evidence artifacts
   -> exactly one release-notes label
 ```
 
-Minimum review evidence:
+Minimum gates:
 
-- `./gradlew specContract` and `./gradlew specContractTest` for spec/framework changes;
-- `./gradlew acceptanceContract` when product behavior or Gherkin may be affected;
-- the smallest area gate (`clientCi`, `serverCi`, `adminCi`, `infraStatic`, `docsStructureCheck`, etc.);
-- `./gradlew ci` for cross-stack or release-relevant changes.
+- `./gradlew specCorpusConformance` for spec-driven work.
+- `./gradlew specContract` while transitional repo-local specs still exist.
+- `./gradlew acceptanceContract` when product behavior or Gherkin may be affected.
+- Smallest area gate (`clientCi`, `serverCi`, `adminCi`, `infraStatic`, `docsStructureCheck`, etc.).
+- `./gradlew ci` for cross-stack or release-relevant changes when local toolchain supports it.
 
 ## AI-assisted delivery model
 
 The delivery lead coordinates; scoped reviewers/implementers execute narrow tasks. Runtime configuration and allowlists are operator-owned outside this product repository. The repo-local workflow contract is [AI-assisted delivery orchestration](agent-team-orchestration.md).
 
-Recommended review roles:
+Do not add live agent allowlists, personal operator paths, model routing, private hierarchy definitions, or operator-runtime JSON examples to this product repo.
 
-- **Product/spec steward**: product-core wording, lifecycle status, frontmatter, scope boundaries, open questions.
-- **Client/accessibility specialist**: Flutter UX, screen-reader/Braille-friendly behavior, l10n, widget/semantics tests.
-- **Server/domain-facade specialist**: canonical domain models, authorization, audit, provider boundaries, backend contracts.
-- **Admin/policy specialist**: Admin Console, Workspace Health, IDM/RBAC, policy previews, readiness, whitelisting.
-- **Provider/infra specialist**: OpenTofu, adapters, runner/env posture, backup/restore, support bundles.
-- **QA/evidence specialist**: Gherkin, `scenario_mappings.json`, Live Stack evidence, sanitized artifacts.
-- **Docs/release specialist**: docs navigation, handbooks, release notes, PR templates, closure reports.
-- **Security/privacy specialist**: secrets, raw provider payloads, audit, support-safe diagnostics, external-provider risk.
-- **Integration reviewer**: final PR readiness, diff scope, labels, gates, fallback review evidence.
+## Hard stops
 
-## Assistant invocation rules
+Stop before:
 
-- Treat reviewer/implementer names as logical roles, not live runtime configuration.
-- Do not add live agent allowlists, personal operator paths, model routing, private hierarchy definitions, or operator-runtime JSON examples to this product repo.
-- Do not use Copilot review as a blocker while premium review requests are exhausted. Record fallback human/assistant review plus green CI.
-- Do not paste old transcripts into assistants. Give them exact specs/docs, allowed files, required gates, and stop conditions.
-- Run Integration-Gate/Optimization-Review loops until there is no material improvement opportunity or a product-core clarification blocks safe progress.
-- Stop before secrets, live infra mutation, data loss, history rewrite, hidden scope expansion, or unresolved product-core ambiguity.
-
-## First rollout
-
-1. Land the framework and `WEAVE-SPEC-0000`.
-2. Choose `WEAVE-SPEC-0001` only after product-core confirmation.
-3. Run the first real feature through: spec -> plan -> tasks -> acceptance mapping -> implementation -> evidence -> PR.
-4. Generate any wiki/docs view from repo files after the pattern proves useful.
+- secrets or raw provider payload exposure;
+- live infra mutation without approval;
+- data loss or destructive cleanup;
+- history rewrite;
+- hidden scope expansion;
+- product-core ambiguity;
+- implementation that lacks a governing spec corpus path.

--- a/docs/weave-operating-model.md
+++ b/docs/weave-operating-model.md
@@ -4,11 +4,12 @@ This page is the compact working contract for Weave delivery. It keeps sprint, r
 
 ## Source of truth
 
-- Current implementation truth lives in this monorepo, GitHub issues/PRs, protected-branch status, and executable CI/evidence artifacts.
+- Fachliche product/domain specification truth lives in the pinned Weave Specification Corpus referenced by `specs/weave-specs.lock.json` (default local path: `../weave-specs`).
+- Current implementation/evidence truth lives in this monorepo, GitHub issues/PRs, protected-branch status, and executable CI/evidence artifacts.
 - Historical chat, agent transcripts, local memories, and old checkouts are orientation only; verify them before acting.
 - Sprint state belongs in GitHub issues, PRs, and closure reports, not in bootstrap prompts.
-- Product and architecture decisions belong in repo docs and repo-local `specs/`; PR bodies carry current acceptance/evidence for one slice.
-- `~/code/specs` and external notebooks are orientation only. New durable product/system contracts live under `specs/` and are checked by `./gradlew specContract`.
+- Product and architecture decisions must be made in the spec corpus first; this repo carries generated projections, transitional conformance specs, implementation docs, and PR evidence for one slice.
+- Legacy `~/code/specs`, external notebooks, and repo-local transitional `specs/` are orientation/conformance artifacts only. They must not silently redefine the pinned corpus.
 
 ## Branch and release model
 
@@ -49,8 +50,8 @@ A PR is merge-ready only when protected checks are green, required conversations
 
 Use this loop:
 
-1. Recover current truth from repo, GitHub, and CI.
-2. Select the smallest next slice.
+1. Recover specification truth from the pinned spec corpus, then implementation truth from repo, GitHub, and CI.
+2. Select the smallest next conformance slice.
 3. Spawn scoped specialists only when useful.
 4. Require evidence-only returns.
 5. Run the integration gate before PR handoff or merge.

--- a/specs/0000-weave-spec-framework/plan.md
+++ b/specs/0000-weave-spec-framework/plan.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Add a lightweight Weave-specific Spec Kit layer without importing a heavy workflow wholesale. The framework stores versioned specs in the repo, validates lifecycle metadata with a local guard, and documents repo-safe AI-assisted delivery orchestration.
+Add a lightweight Weave-specific Spec Kit layer without importing a heavy workflow wholesale. The implementation repo stores transitional conformance specs, validates lifecycle metadata with local guards, and documents repo-safe AI-assisted delivery orchestration while the pinned spec corpus remains canonical product/domain truth.
 
 ## Constitution check
 
@@ -25,7 +25,7 @@ Add a lightweight Weave-specific Spec Kit layer without importing a heavy workfl
 - `tools/`: deterministic spec contract guard.
 - `build.gradle`/`Makefile`: local gate wiring.
 - `.github/pull_request_template.md`: spec/evidence traceability prompt.
-- `AGENTS.md`: point contributors at repo-local specs and fallback review reality.
+- `AGENTS.md`: point contributors at the pinned spec corpus, repo conformance specs, and fallback review reality.
 
 ## Contracts and tests first
 
@@ -51,7 +51,7 @@ Add a lightweight Weave-specific Spec Kit layer without importing a heavy workfl
 
 - Start with framework-only spec `WEAVE-SPEC-0000`.
 - Use the next product-core slice as the first real `WEAVE-SPEC-0001` only after the product owner/team resolves required product-core questions.
-- Keep generated wiki/docs as projections, not canonical source.
+- Keep repo-local specs, generated wiki/docs, and documentation pages as conformance artifacts or projections, not canonical product/domain source.
 
 ## Risks and mitigations
 
@@ -67,6 +67,7 @@ Add a lightweight Weave-specific Spec Kit layer without importing a heavy workfl
 
 ## Final gates
 
+- `./gradlew specCorpusConformance`
 - `./gradlew specContract`
 - `./gradlew specContractTest`
 - `./gradlew docsStructureCheck`

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,29 +1,33 @@
-# Weave specs
+# Weave specs in the implementation repository
 
-Repo-local specs are the versioned product/system contracts for Weave. They are the source for implementation, review, evidence, and generated documentation. A wiki or NotebookLM notebook may summarize these files, but must not replace them as truth.
+This directory is **not** the canonical fachliche specification truth anymore.
 
-## Workflow
+Canonical specification truth lives in the pinned Weave Specification Corpus referenced by:
 
-1. Copy `.specify/templates/weave-spec-template.md` into `specs/NNNN-slug/spec.md`.
-2. Keep status `draft` or `proposed` while product-core questions remain.
-3. Add `plan.md`, `tasks.md`, `traceability.yaml`, and contract/evidence folders only when the slice is ready for implementation planning.
-4. Add or update Gherkin and `e2e/scenario_mappings.json` before product implementation.
-5. Run `./gradlew specContract` and `./gradlew acceptanceContract` before review.
-6. Use `weave-co-leader` to brief specialists with small scopes and required gates.
+- `specs/weave-specs.lock.json`
+- default local corpus path: `../weave-specs`
 
-## Status rule
+This implementation repository is the **conformance and evidence truth**. It contains code, tests, CI gates, release evidence, generated projections, and historical repo-local specs that must conform to the pinned spec corpus.
 
-`draft` and `proposed` specs may contain `[NEEDS CLARIFICATION: ...]`. `accepted`, `implementing`, and `implemented` specs may not.
+## Truth boundary
 
-## Directory convention
+- Specification truth: the corpus at the lockfile `specCorpus.localPath` (default `../weave-specs`), pinned by `specs/weave-specs.lock.json`.
+- Implementation/evidence truth: this repo, GitHub issues/PRs/checks, CI artifacts, and checked-in release evidence.
+- Generated docs/indexes/projections are not canonical.
+- Legacy `specs/0000-*` through `specs/0007-*` remain transitional implementation-conformance artifacts until migrated into the spec corpus. They must not override the corpus.
 
-```text
-specs/0001-short-slug/
-├── spec.md
-├── plan.md
-├── tasks.md
-├── traceability.yaml
-├── contracts/
-├── acceptance/
-└── evidence/
+## Required workflow
+
+1. Identify governing spec corpus files first.
+2. Inspect this repo only after the fachliche spec boundary is known.
+3. If spec corpus and repo reality disagree, create an explicit spec-change or conformance-fix task.
+4. Run `./gradlew specCorpusConformance` before any spec-driven implementation claim.
+5. Run the smallest relevant implementation gates after conformance is established.
+
+## Current local conformance gate
+
+```bash
+./gradlew specCorpusConformance
 ```
+
+This validates that the pinned spec corpus exists, is on the expected commit, has the required domain/steering files, and lint-passes.

--- a/specs/weave-specs.lock.json
+++ b/specs/weave-specs.lock.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "purpose": "Pin the canonical Weave specification corpus consumed by this implementation repository.",
+  "truthBoundary": {
+    "specificationTruth": "../weave-specs",
+    "implementationEvidenceTruth": "."
+  },
+  "specCorpus": {
+    "localPath": "../weave-specs",
+    "gitCommit": "88c4c416b74422a9c62137a0b5dd89370b1ce743",
+    "manifest": "generated/manifest.json",
+    "lintCommand": "python3 tools/spec_lint.py"
+  },
+  "generatedProjectionPolicy": "Implementation-repo specs/docs may project or prove conformance to this corpus, but must not redefine fachliche product/domain truth."
+}

--- a/tools/spec_contract_check.py
+++ b/tools/spec_contract_check.py
@@ -64,7 +64,8 @@ FRAMEWORK_REQUIRED_FILES = {
         "Live runtime configuration",
     ],
     "docs/spec-driven-development.md": [
-        "Git-versioned specs are truth",
+        "Specification truth",
+        "Implementation/evidence truth",
         "agent-team-orchestration.md",
         "Do not add live agent allowlists",
     ],

--- a/tools/spec_contract_check_test.py
+++ b/tools/spec_contract_check_test.py
@@ -124,7 +124,7 @@ class SpecContractCheckTest(unittest.TestCase):
             ".specify/templates/weave-plan-template.md": "Constitution check\n",
             ".specify/templates/weave-tasks-template.md": "Assistant handoff\n",
             ".specify/templates/weave-agent-briefs.md": "Optimization-Review\nCoding-Harness-Brief\nLive runtime configuration\nallowAgents\n",
-            "docs/spec-driven-development.md": "Git-versioned specs are truth\nagent-team-orchestration.md\nDo not add live agent allowlists\n",
+            "docs/spec-driven-development.md": "Specification truth\nImplementation/evidence truth\nagent-team-orchestration.md\nDo not add live agent allowlists\n",
             "docs/agent-team-orchestration.md": "Material optimization\nRuntime boundary\nForbidden repo-local content\noperator-runtime JSON examples\n",
         }
         for relative, content in files.items():
@@ -142,7 +142,7 @@ class SpecContractCheckTest(unittest.TestCase):
             ".specify/templates/weave-plan-template.md": "Constitution check\n",
             ".specify/templates/weave-tasks-template.md": "Assistant handoff\n",
             ".specify/templates/weave-agent-briefs.md": "Optimization-Review\nCoding-Harness-Brief\nLive runtime configuration\n",
-            "docs/spec-driven-development.md": "Git-versioned specs are truth\nagent-team-orchestration.md\nDo not add live agent allowlists\n",
+            "docs/spec-driven-development.md": "Specification truth\nImplementation/evidence truth\nagent-team-orchestration.md\nDo not add live agent allowlists\n",
             "docs/agent-team-orchestration.md": "Material optimization\nRuntime boundary\nForbidden repo-local content\noperator-runtime JSON examples\n",
         }
         for relative, content in files.items():

--- a/tools/spec_corpus_conformance_check.py
+++ b/tools/spec_corpus_conformance_check.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Validate that the Weave implementation repo consumes the canonical spec corpus.
+
+This check enforces the truth split:
+- /code/weave-specs = fachliche specification truth
+- /code/weave = implementation/evidence conformance truth
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK_PATH = ROOT / "specs" / "weave-specs.lock.json"
+REQUIRED_CORPUS_FILES = [
+    "AGENTS.md",
+    "README.md",
+    "steering/product-constitution.md",
+    "steering/sdd-framework.md",
+    "steering/ubiquitous-language.md",
+    "steering/domain-context-map.md",
+    "steering/provider-portability-principles.md",
+    "steering/devops-conformance.md",
+    "steering/openclaw-orchestrator-pattern.md",
+    "generated/manifest.json",
+]
+REQUIRED_DOMAIN_DIRS = [
+    "identity-idm",
+    "spaces",
+    "chat",
+    "files",
+    "calendar",
+    "boards-tasks",
+    "documents-office",
+    "meetings-calls",
+    "decisions-evidence",
+    "admin-health-ops",
+    "weaver-governed-pa",
+]
+IMPLEMENTATION_TRUTH_BOUNDARY_FILES = [
+    "AGENTS.md",
+    "docs/spec-driven-development.md",
+    "docs/weave-operating-model.md",
+    "docs/agent-team-orchestration.md",
+    "docs/developer-handbook.md",
+    "docs/index.md",
+    ".specify/memory/constitution.md",
+    ".specify/templates/weave-agent-briefs.md",
+    ".specify/templates/weave-plan-template.md",
+    ".specify/templates/weave-tasks-template.md",
+    "specs/README.md",
+]
+FORBIDDEN_IMPLEMENTATION_TRUTH_MARKERS = [
+    "Git-versioned specs are truth; generated docs/wiki views are projections.",
+    "Repo-local specs are the versioned product/system contracts for Weave. They are the source",
+    "Product and architecture decisions belong in repo docs and repo-local `specs/`",
+    "New durable product/system contracts live under `specs/`",
+    "Spec-driven development for Weave](spec-driven-development.md) — repo-local specs",
+    "Recover truth from `main`, repo specs/docs/tasks",
+    "Recover truth from repo/GitHub/CI and identify the contract/spec.",
+    "Recover current truth from the Weave repo, GitHub issues/PRs, and CI/evidence.",
+    "Do first: recover truth from main, specs, GitHub issues/PRs, CI/evidence.",
+]
+REQUIRED_IMPLEMENTATION_TRUTH_MARKERS = {
+    "AGENTS.md": ["pinned Weave Specification Corpus", "implementation/evidence truth"],
+    "docs/spec-driven-development.md": ["Specification truth", "Implementation/evidence truth"],
+    "docs/weave-operating-model.md": ["pinned Weave Specification Corpus", "implementation/evidence truth"],
+    "specs/README.md": ["canonical fachliche specification truth", "conformance and evidence truth"],
+}
+
+
+def fail(message: str) -> None:
+    print(f"spec-corpus-conformance: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def run(args: list[str], cwd: Path) -> str:
+    proc = subprocess.run(args, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if proc.returncode != 0:
+        fail(f"command failed in {cwd}: {' '.join(args)}\n{proc.stdout}")
+    return proc.stdout.strip()
+
+
+def run_from_lock(command: str, cwd: Path) -> None:
+    proc = subprocess.run(
+        command,
+        cwd=cwd,
+        shell=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        executable="/bin/bash",
+    )
+    if proc.returncode != 0:
+        fail(f"command failed in {cwd}: {command}\n{proc.stdout}")
+
+
+def load_lock() -> dict[str, Any]:
+    if not LOCK_PATH.exists():
+        fail("missing specs/weave-specs.lock.json")
+    try:
+        data = json.loads(LOCK_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid lock JSON: {exc}")
+    if data.get("schemaVersion") != 1:
+        fail("lock schemaVersion must be 1")
+    return data
+
+
+def main() -> None:
+    lock = load_lock()
+    corpus_cfg = lock.get("specCorpus") or {}
+    truth_boundary = lock.get("truthBoundary") or {}
+    local_path = corpus_cfg.get("localPath")
+    expected_commit = corpus_cfg.get("gitCommit")
+    if not local_path or not expected_commit:
+        fail("lock specCorpus.localPath and specCorpus.gitCommit are required")
+    if truth_boundary.get("specificationTruth") != local_path:
+        fail("lock truthBoundary.specificationTruth must match specCorpus.localPath")
+    if truth_boundary.get("implementationEvidenceTruth") != ".":
+        fail("lock truthBoundary.implementationEvidenceTruth must be '.'")
+    if "must not redefine" not in str(lock.get("generatedProjectionPolicy", "")):
+        fail("lock generatedProjectionPolicy must state that repo projections do not redefine corpus truth")
+
+    corpus_root = (ROOT / local_path).resolve()
+    if not corpus_root.exists():
+        fail(f"spec corpus path not found: {corpus_root}")
+    if not (corpus_root / ".git").exists():
+        fail(f"spec corpus is not a git repository: {corpus_root}")
+
+    actual_commit = run(["git", "rev-parse", "HEAD"], corpus_root)
+    if actual_commit != expected_commit:
+        fail(f"spec corpus commit mismatch: lock={expected_commit}, actual={actual_commit}")
+    dirty = run(["git", "status", "--porcelain"], corpus_root)
+    if dirty:
+        fail(f"spec corpus has uncommitted changes; pinned conformance requires a clean corpus tree\n{dirty}")
+
+    for rel in REQUIRED_CORPUS_FILES:
+        if not (corpus_root / rel).exists():
+            fail(f"spec corpus missing required file: {rel}")
+    for slug in REQUIRED_DOMAIN_DIRS:
+        if not (corpus_root / "domains" / slug / "spec.md").exists():
+            fail(f"spec corpus missing domain spec: domains/{slug}/spec.md")
+
+    lint_command = str(corpus_cfg.get("lintCommand") or "python3 tools/spec_lint.py")
+    run_from_lock(lint_command, corpus_root)
+
+    manifest_rel = str(corpus_cfg.get("manifest", "generated/manifest.json"))
+    manifest_path = corpus_root / manifest_rel
+    if not manifest_path.exists():
+        fail(f"spec corpus manifest missing at locked path: {manifest_rel}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not manifest.get("do_not_hand_edit"):
+        fail("spec corpus manifest must be generated and marked do_not_hand_edit")
+    seen_manifest_ids: set[str] = set()
+    for entry in manifest.get("entries", []):
+        entry_id = entry.get("id")
+        entry_path = entry.get("path")
+        if not entry_id or not entry_path:
+            fail(f"spec corpus manifest entry missing id/path: {entry}")
+        if entry_id in seen_manifest_ids:
+            fail(f"spec corpus manifest duplicate id: {entry_id}")
+        seen_manifest_ids.add(entry_id)
+        if entry.get("truth") != "specification":
+            fail(f"spec corpus manifest entry {entry_id} must declare truth=specification")
+        if not (corpus_root / str(entry_path)).exists():
+            fail(f"spec corpus manifest entry path missing: {entry_path}")
+    ids = {entry.get("id") for entry in manifest.get("entries", [])}
+    required_ids = {
+        "WEAVE-STEERING-PRODUCT-CONSTITUTION",
+        "WEAVE-STEERING-SDD-FRAMEWORK",
+        "WEAVE-STEERING-DEVOPS-CONFORMANCE",
+        "WEAVE-DOMAIN-IDENTITY-IDM",
+        "WEAVE-DOMAIN-DOCUMENTS-OFFICE",
+        "WEAVE-DOMAIN-WEAVER-GOVERNED-PA",
+    }
+    missing = sorted(required_ids - ids)
+    if missing:
+        fail(f"spec corpus manifest missing required IDs: {missing}")
+
+    for rel in IMPLEMENTATION_TRUTH_BOUNDARY_FILES:
+        path = ROOT / rel
+        if path.exists():
+            text = path.read_text(encoding="utf-8")
+            for marker in FORBIDDEN_IMPLEMENTATION_TRUTH_MARKERS:
+                if marker in text:
+                    fail(f"{rel} still presents implementation repo specs as canonical spec truth")
+            for marker in REQUIRED_IMPLEMENTATION_TRUTH_MARKERS.get(rel, []):
+                if marker not in text:
+                    fail(f"{rel} missing required truth-boundary marker: {marker!r}")
+
+    print(
+        "spec-corpus-conformance: ok "
+        f"(spec corpus {corpus_root}, commit {actual_commit[:12]}, {len(manifest.get('entries', []))} entries)"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Pins the canonical Weave Specification Corpus via `specs/weave-specs.lock.json` at `88c4c416b74422a9c62137a0b5dd89370b1ce743`.
- Adds `./gradlew specCorpusConformance` and hardens it for corpus cleanliness, manifest integrity, required spec IDs/files, lint execution, and repo truth-boundary wording.
- Updates repo docs/templates so this repository is implementation/evidence truth and repo-local specs are transitional conformance artifacts only.

## Spec / traceability

- Closes #510
- Spec corpus commit: `88c4c416b74422a9c62137a0b5dd89370b1ce743`
- Governing spec IDs: `WEAVE-STEERING-SDD-FRAMEWORK`, `WEAVE-STEERING-DEVOPS-CONFORMANCE`, `WEAVE-STEERING-PRODUCT-CONSTITUTION`
- Lockfile: `specs/weave-specs.lock.json`
- Evidence paths: `tools/spec_corpus_conformance_check.py`, `build/evidence/ci-summary.json` when CI runs

## Impact

- User/admin/operator impact: no runtime product behavior change.
- Developer/DevOps impact: implementation PRs now have a deterministic spec-corpus conformance gate and clearer SSOT boundary.
- Accessibility/localization: not applicable; docs/process only.
- Security/privacy: no secrets, raw provider payloads, live infra mutation, tag, or artifact publication.

## Checks run

- `git diff --check`
- `./gradlew specCorpusConformance specContract specContractTest docsStructureCheck docsCheck --console=plain`

## Release notes

- Label: `release-notes-feature`
