### PR TITLE
docs(spec): remove repo-local SSOT wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Do not stop after one PR. Do not report success from local git state, a green br
 - `admin-console/`: admin UX, readiness, policy preview, setup flows.
 - `infra/`: OpenTofu, deploy, backup/restore, support bundles.
 - `e2e/`: Gherkin contracts and evidence mapping.
-- `docs/`: current product truth, release notes, handbooks, closure reports.
+- `docs/`: implementation-facing product projections, release notes, handbooks, closure reports.
 
 Use compact templates from `.specify/templates/weave-agent-briefs.md`: Truth-Recovery, Specialist-Brief, Coding-Harness-Brief, Evidence-Return, Integration-Gate, Optimization-Review, and Session-Handoff. Use `docs/agent-team-orchestration.md` for repo-safe AI-assisted delivery guidance.
 

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -140,7 +140,7 @@ python3 -m pip install -r docs/requirements.txt
 make docs-check
 ```
 
-`make docs-check` runs the lightweight repository docs validator and a strict MkDocs build. `make docs-build` is available when you only need the strict MkDocs build after dependencies are installed. Keep existing docs linked from navigation or from handbook pages so product truth does not drift into orphaned Markdown.
+`make docs-check` runs the lightweight repository docs validator and a strict MkDocs build. `make docs-build` is available when you only need the strict MkDocs build after dependencies are installed. Keep existing docs linked from navigation or from handbook pages so implementation-facing product guidance does not drift into orphaned Markdown.
 
 ## Release notes workflow
 

--- a/docs/domain-registry-v1.md
+++ b/docs/domain-registry-v1.md
@@ -1,6 +1,6 @@
 # Canonical domain registry v1
 
-The machine-readable source of truth for Sprint 8 domain vocabulary is `specs/0004-domain-registry/canonical-domain-registry-v1.json`. The backend carries an identical runtime resource at `server/src/main/resources/canonical-domain-registry-v1.json`; `./gradlew domainRegistryCheck` fails if the two copies drift.
+The machine-readable implementation conformance fixture for Sprint 8 domain vocabulary is `specs/0004-domain-registry/canonical-domain-registry-v1.json`. The pinned Weave Specification Corpus remains canonical product/domain truth. The backend carries an identical runtime resource at `server/src/main/resources/canonical-domain-registry-v1.json`; `./gradlew domainRegistryCheck` fails if the implementation copies drift.
 
 The registry defines the provider-neutral Weave domain keys, stable member states, admin/operator readiness states, source-of-truth modes, compatibility aliases for older provider-category names, and the required Provider Adapter Manifest fields.
 

--- a/docs/project/sprint-8-delivery-board.md
+++ b/docs/project/sprint-8-delivery-board.md
@@ -2,7 +2,7 @@
 
 Status: active delivery policy for `Sprint 8 — Canonical Domains & Portable Provider Contracts`.
 
-Sprint 8 turns the provider-neutral product direction into reviewable delivery lanes for canonical domains, portable provider contracts, Keycloak desired-state dry-run, Admin Console control-plane gates, and the OpenClaw-derived Weaver foundation. The sprint board is the execution surface; repo docs, specs, issues, PRs, and CI evidence remain the source of truth.
+Sprint 8 turns the provider-neutral product direction into reviewable delivery lanes for canonical domains, portable provider contracts, Keycloak desired-state dry-run, Admin Console control-plane gates, and the OpenClaw-derived Weaver foundation. The sprint board is the historical execution surface; repo docs, transitional specs, issues, PRs, and CI evidence are implementation evidence, while the pinned Weave Specification Corpus remains canonical product/domain truth.
 
 ## Milestone and board
 

--- a/docs/sprint-10-closure-report.md
+++ b/docs/sprint-10-closure-report.md
@@ -2,7 +2,7 @@
 
 ## Governing scope
 
-Sprint 10 closes the readiness debt discovered after the Sprint 8/9 audit. The sprint is governed by GitHub milestone 10 and issues #466–#477, repo-local specs, the acceptance contract mapping, and executable Gradle gates.
+Sprint 10 closes the readiness debt discovered after the Sprint 8/9 audit. The sprint is governed by GitHub milestone 10 and issues #466–#477, transitional repo-local conformance specs, the acceptance contract mapping, and executable Gradle gates.
 
 ## Issue DAG final state
 

--- a/docs/workflow-context-contract.md
+++ b/docs/workflow-context-contract.md
@@ -1,8 +1,8 @@
 # Accessible workflow context contract
 
-Status: companion contract projection for `specs/0002-context-driven-workflows/spec.md` and issue #218. The repo-local spec remains the canonical source; this page explains the workflow model before any visual builder.
+Status: companion contract projection for `specs/0002-context-driven-workflows/spec.md` and issue #218. The pinned Weave Specification Corpus remains canonical product/domain truth; this repo-local spec and page are implementation conformance evidence for the workflow model before any visual builder.
 
-Weave workflows are linear, context-driven work records. They help people and governed agents coordinate work without turning the primary experience into a visual-only diagram canvas. A diagram can be added later, but the accessible linear view is the source of truth.
+Weave workflows are linear, context-driven work records. They help people and governed agents coordinate work without turning the primary experience into a visual-only diagram canvas. A diagram can be added later, but the accessible linear view is the primary member-facing representation.
 
 ## Primitives
 

--- a/tools/domain_registry_check.py
+++ b/tools/domain_registry_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the canonical domain registry contract."""
+"""Validate the domain registry implementation conformance fixture."""
 from __future__ import annotations
 import json, sys
 from pathlib import Path
@@ -18,7 +18,7 @@ def load(p):
  except json.JSONDecodeError as e: fail(f'invalid JSON in {p.relative_to(ROOT)}: {e}')
 def main():
  data=load(REGISTRY); server=load(SERVER_COPY)
- if data!=server: fail('server resource copy differs from specs/domain-registry source')
+ if data!=server: fail('server resource copy differs from repo domain-registry conformance fixture')
  if data.get('schemaVersion')!=1 or data.get('registryVersion')!='canonical-domain-registry-v1': fail('unexpected schema or registry version')
  if data.get('memberStates')!=MEMBER: fail('top-level member states are not canonical')
  if data.get('adminStates')!=ADMIN: fail('top-level admin states are not canonical')

--- a/tools/spec_corpus_conformance_check.py
+++ b/tools/spec_corpus_conformance_check.py
@@ -64,6 +64,10 @@ FORBIDDEN_IMPLEMENTATION_TRUTH_MARKERS = [
     "Recover truth from repo/GitHub/CI and identify the contract/spec.",
     "Recover current truth from the Weave repo, GitHub issues/PRs, and CI/evidence.",
     "Do first: recover truth from main, specs, GitHub issues/PRs, CI/evidence.",
+    "repo-local spec remains the canonical source",
+    "repo docs, specs, issues, PRs, and CI evidence remain the source of truth",
+    "The machine-readable source of truth for Sprint",
+    "product truth does not drift into orphaned Markdown",
 ]
 REQUIRED_IMPLEMENTATION_TRUTH_MARKERS = {
     "AGENTS.md": ["pinned Weave Specification Corpus", "implementation/evidence truth"],


### PR DESCRIPTION
## Summary

- Removes remaining repo-local source-of-truth wording that survived the initial spec-corpus SSOT cleanup.
- Reframes repo docs/spec projections as implementation evidence or conformance fixtures while keeping runtime provider source-of-truth language intact.
- Extends `tools/spec_corpus_conformance_check.py` with the stale patterns found in this follow-up audit.

## Spec / traceability

- Closes #512
- Follows merged PR #511 / issue #510.
- Spec corpus commit: `88c4c416b74422a9c62137a0b5dd89370b1ce743`
- Governing spec IDs: `WEAVE-STEERING-SDD-FRAMEWORK`, `WEAVE-STEERING-DEVOPS-CONFORMANCE`, `WEAVE-STEERING-PRODUCT-CONSTITUTION`
- Lockfile: `specs/weave-specs.lock.json`
- Evidence paths: `AGENTS.md`, `docs/workflow-context-contract.md`, `docs/domain-registry-v1.md`, `docs/project/sprint-8-delivery-board.md`, `tools/spec_corpus_conformance_check.py`

## Impact

- User/admin/operator impact: none; docs/governance wording only.
- Developer/DevOps impact: stronger guard against reintroducing repo-local spec canonicality.
- Security/privacy: no secrets, raw provider payloads, live infra mutation, release publication, or destructive state changes.

## Checks run

- `git diff --check`
- `./gradlew specCorpusConformance specContract specContractTest docsStructureCheck --console=plain`
- `python3 -m venv build/docs-venv && build/docs-venv/bin/python -m pip install --quiet -r docs/requirements.txt && ./gradlew docsCheck --console=plain`
- `./gradlew domainRegistryCheck --console=plain`

## Release notes

- Label: `release-notes-feature`
