### PR TITLE
chore(devops): codify sprint bootstrap flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Do not stop after one PR. Do not report success from local git state, a green br
 - `docs/`: implementation-facing product projections, release notes, handbooks, closure reports.
 
 Use compact templates from `.specify/templates/weave-agent-briefs.md`: Truth-Recovery, Specialist-Brief, Coding-Harness-Brief, Evidence-Return, Integration-Gate, Optimization-Review, and Session-Handoff. Use `docs/agent-team-orchestration.md` for repo-safe AI-assisted delivery guidance.
+For new sprint setup or audit, use `docs/sprint-bootstrap-and-board-flow.md` and `tools/sprint_bootstrap.py` so milestones, issue DAGs, and the Weave Delivery Board stay reproducible from file-backed state.
 
 ## Hard stops
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ registerRootCommandTask('docsStructureCheck', ['bash', '-lc', 'PYTHON=python3; [
 registerRootCommandTask('docsServe', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" -m mkdocs serve'], 'Serve the MkDocs site locally.')
 registerRootCommandTask('releaseNotesLabelCheck', ['bash', '-lc', 'if [ -n "${PR_LABELS_JSON:-}" ]; then python3 tools/release_notes_label_check.py; else echo "release-notes-label-check: skipped (PR_LABELS_JSON is not set)"; fi'], 'Validate the current PR release-notes label set from PR_LABELS_JSON when available.')
 registerRootCommandTask('specCorpusConformance', ['python3', 'tools/spec_corpus_conformance_check.py'], 'Validate the pinned Weave Specification Corpus and the spec-truth vs implementation-evidence boundary.')
+registerRootCommandTask('sprintBootstrapAudit', ['python3', 'tools/sprint_bootstrap.py', '--plan', 'tools/fixtures/sprint_bootstrap_sprint12.json', '--audit-only'], 'Audit sprint milestone, issue DAG, and Weave Delivery Board wiring from a file-backed sprint plan.')
 registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.py'], 'Validate transitional repo-local Weave specs, lifecycle metadata, and implementation-ready clarification state.')
 registerRootCommandTask('domainRegistryCheck', ['python3', 'tools/domain_registry_check.py'], 'Validate the canonical domain registry v1 machine-readable contract.')
 registerRootCommandTask('spaceAnchorCheck', ['python3', 'tools/space_anchor_check.py'], 'Validate the Space anchor contract fixture.')
@@ -104,6 +105,7 @@ ext.ciEvidenceGates = [
     'docsCheck',
     'releaseNotesLabelCheck',
     'specCorpusConformance',
+    'sprintBootstrapAudit',
     'specContract',
     'specContractTest',
     'domainRegistryCheck',
@@ -203,6 +205,8 @@ List<String> artifactPathsForGate(String gateName) {
             return ['build/docs/user', 'build/docs/admin']
         case 'specCorpusConformance':
             return ['specs/weave-specs.lock.json', 'tools/spec_corpus_conformance_check.py']
+        case 'sprintBootstrapAudit':
+            return ['tools/sprint_bootstrap.py', 'tools/fixtures/sprint_bootstrap_sprint12.json', 'docs/sprint-bootstrap-and-board-flow.md']
         case 'specContract':
             return ['specs', '.specify/memory/constitution.md', '.specify/templates']
         case 'specContractTest':

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -117,6 +117,8 @@ A Weave sprint is not one green PR. A sprint starts from an accepted or explicit
 
 Required sprint shape:
 
+Sprint bootstrap and audit are file-backed by `tools/sprint_bootstrap.py`; see `docs/sprint-bootstrap-and-board-flow.md`. This is the bridge from the pinned spec corpus to GitHub milestones, issues, the Weave Delivery Board, and CI/evidence gates.
+
 1. Recover fachliche truth from the pinned spec corpus first, then implementation truth from `main`, transitional `specs/`, GitHub issues/PRs, and CI artifacts.
 2. Select or create the governing spec-corpus contract; keep product-core ambiguity in `draft`/`proposed` with explicit `[NEEDS CLARIFICATION: ...]` markers.
 3. Break the spec plan/tasks into a GitHub issue DAG with `parallel`/`sequential` labels where ordering matters.

--- a/docs/sprint-bootstrap-and-board-flow.md
+++ b/docs/sprint-bootstrap-and-board-flow.md
@@ -1,0 +1,125 @@
+# Sprint bootstrap and Delivery Board flow
+
+Status: implementation/evidence workflow, 2026-05-31.
+
+This page defines how Weave creates or audits a sprint delivery surface after the specification truth has been established in the pinned Weave Specification Corpus.
+
+## Truth split
+
+- Specification truth: the pinned Weave Specification Corpus referenced by `specs/weave-specs.lock.json`.
+- DevOps/evidence truth: GitHub milestone, GitHub issues, Weave Delivery Board, PRs, CI, local gates, and checked-in closure reports.
+
+A sprint does not create product truth. A sprint executes or validates conformance to product/domain truth.
+
+## Required sprint control-plane surfaces
+
+Every new sprint must have:
+
+- a GitHub milestone with clear title and concise description;
+- an epic/program issue;
+- issue DAG with concrete implementation, evidence, docs, accessibility, security/privacy, and release-ops issues as needed;
+- issue labels for priority, type, track, domain/area, and evidence expectations;
+- membership in the Weave Delivery Board;
+- default board status `Todo` until work starts;
+- exactly one release-notes label on every implementation PR;
+- a closure report or explicit blocker report before the sprint is called done.
+
+## Bootstrap/audit script
+
+Use the Gradle gate:
+
+```sh
+./gradlew sprintBootstrapAudit
+```
+
+or run the script directly:
+
+```sh
+python3 tools/sprint_bootstrap.py --plan tools/fixtures/sprint_bootstrap_sprint12.json --audit-only
+```
+
+The script audits:
+
+- milestone existence/state;
+- expected issues by number;
+- required labels;
+- expected milestone assignment;
+- Weave Delivery Board membership;
+- Delivery Board Status field value.
+
+For future sprints, create a new JSON plan based on `tools/fixtures/sprint_bootstrap_sprint12.json` and run:
+
+```sh
+python3 tools/sprint_bootstrap.py --plan tools/fixtures/sprint_bootstrap_sprint13.json --apply
+```
+
+`--apply` may create missing milestone/issues, add issues to the Weave Delivery Board, and set their status. Use it only after the governing spec corpus files are identified.
+
+## Plan schema
+
+Minimum shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "sprint": {
+    "number": 13,
+    "goal": "Short sprint goal rooted in the spec corpus."
+  },
+  "specCorpus": {
+    "lockFile": "specs/weave-specs.lock.json",
+    "requiredGate": "./gradlew specCorpusConformance"
+  },
+  "milestone": {
+    "title": "Sprint 13 — Example",
+    "description": "Concise milestone description."
+  },
+  "project": {
+    "owner": "masssi164",
+    "number": 2,
+    "title": "Weave Delivery Board",
+    "defaultStatus": "Todo"
+  },
+  "issues": [
+    {
+      "title": "area(domain): issue title",
+      "labels": ["priority:p0", "type:story", "track:sprint-13", "evidence:required"],
+      "projectStatus": "Todo",
+      "body": "Issue body with spec id, scope, dependencies, acceptance, gates, and release-note expectation."
+    }
+  ]
+}
+```
+
+After `--apply`, commit the generated plan with issue numbers filled in or update the plan manually. Sprint setup must remain reproducible from file, not from chat memory.
+
+## Issue body requirements
+
+Every issue should include:
+
+- governing spec corpus IDs and paths;
+- user/admin/operator value;
+- allowed scope and forbidden scope;
+- dependencies and blocked-by notes;
+- acceptance criteria and required gates;
+- release-notes expectation;
+- whether it is parallel or sequential;
+- support-safe evidence requirements.
+
+## Board status rules
+
+- `Todo`: planned and not started.
+- `In Progress`: active branch/worktree or delegated worker exists.
+- `Done`: issue closed and linked PR/evidence is merged or explicitly not required.
+
+If a PR is green but not merged, the issue is not done.
+
+## Co-leader handoff
+
+`weave-co-leader` may close a sprint only after:
+
+1. `tools/sprint_bootstrap.py --audit-only` passes for the target sprint plan or the sprint-specific equivalent evidence is recorded.
+2. All sprint issues are closed or explicitly moved out with rationale.
+3. All linked PRs are merged or blocked with exact evidence.
+4. `origin/main` contains the closure report.
+5. Final CI/evidence gates are green or a product-owner blocker is recorded.

--- a/specs/weave-specs.lock.json
+++ b/specs/weave-specs.lock.json
@@ -7,7 +7,7 @@
   },
   "specCorpus": {
     "localPath": "../weave-specs",
-    "gitCommit": "88c4c416b74422a9c62137a0b5dd89370b1ce743",
+    "gitCommit": "24c746c674da7d98e5c6abc1f1abac033a8774f2",
     "manifest": "generated/manifest.json",
     "lintCommand": "python3 tools/spec_lint.py"
   },

--- a/tools/fixtures/sprint_bootstrap_sprint12.json
+++ b/tools/fixtures/sprint_bootstrap_sprint12.json
@@ -1,0 +1,197 @@
+{
+  "schemaVersion": 1,
+  "sprint": {
+    "number": 12,
+    "goal": "Provider portability and lifecycle readiness under the pinned Weave Specification Corpus."
+  },
+  "specCorpus": {
+    "lockFile": "specs/weave-specs.lock.json",
+    "requiredGate": "./gradlew specCorpusConformance"
+  },
+  "milestone": {
+    "title": "Sprint 12 — Provider Portability & Lifecycle Readiness",
+    "description": "Provider portability, lifecycle, accessibility, Office/WOPI, identity, support, and release-ops readiness driven by the pinned Weave Specification Corpus."
+  },
+  "project": {
+    "owner": "masssi164",
+    "number": 2,
+    "title": "Weave Delivery Board",
+    "defaultStatus": "Todo"
+  },
+  "issueDefaults": {
+    "releaseNotes": "exactly-one-release-notes-label-per-PR",
+    "dependencyNotation": "Dependencies/Blocks section in issue body",
+    "truthOrder": [
+      "spec-corpus",
+      "implementation-repo",
+      "GitHub",
+      "CI/evidence"
+    ]
+  },
+  "issues": [
+    {
+      "number": 499,
+      "title": "chore(program): run Sprint 12 as provider-portability and lifecycle readiness",
+      "labels": [
+        "release-blocker",
+        "priority:p0",
+        "type:epic",
+        "phase:0-governance",
+        "evidence:required",
+        "track:sprint-12"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 500,
+      "title": "architecture(portability): define provider portability schema v2 and adapter mapping reports",
+      "labels": [
+        "release-blocker",
+        "priority:p0",
+        "type:story",
+        "domain:portability",
+        "phase:1-architecture",
+        "area:server",
+        "area:docs",
+        "evidence:required",
+        "track:sprint-12"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 501,
+      "title": "platform(portability): implement dry-run evidence contract for Files, Calendar, Boards, and Chat",
+      "labels": [
+        "release-blocker",
+        "priority:p0",
+        "type:story",
+        "domain:boards",
+        "domain:portability",
+        "phase:2-control-plane",
+        "area:server",
+        "area:admin-console",
+        "domain:chat",
+        "domain:files",
+        "domain:calendar",
+        "evidence:required",
+        "track:sprint-12"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 502,
+      "title": "adr(documents): choose first Office/WOPI provider path and security model",
+      "labels": [
+        "priority:p0",
+        "type:docs",
+        "phase:1-architecture",
+        "area:server",
+        "area:docs",
+        "domain:documents",
+        "evidence:required",
+        "guarded",
+        "track:sprint-12"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 503,
+      "title": "identity(lifecycle): add SCIM, reconcile, offboarding, and recertification contract after Keycloak baseline",
+      "labels": [
+        "release-blocker",
+        "priority:p0",
+        "type:story",
+        "domain:identity",
+        "phase:2-control-plane",
+        "area:server",
+        "area:admin-console",
+        "domain:control-plane",
+        "evidence:required",
+        "track:sprint-12"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 504,
+      "title": "chat(matrix): lock E2EE, export, retention, and support diagnostics product boundaries",
+      "labels": [
+        "priority:p1",
+        "type:story",
+        "area:server",
+        "area:client",
+        "area:docs",
+        "domain:chat",
+        "evidence:required",
+        "track:sprint-12",
+        "phase:3-domain-readiness"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 505,
+      "title": "weaver(preflight): write sandbox and per-user runtime isolation ADR",
+      "labels": [
+        "priority:p1",
+        "type:docs",
+        "domain:weaver",
+        "area:infra",
+        "area:docs",
+        "evidence:required",
+        "guarded",
+        "track:sprint-12",
+        "phase:4-weaver-preflight"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 506,
+      "title": "weaver(preflight): define signed skills/tools registry and SecretRef/OAuth contract",
+      "labels": [
+        "priority:p1",
+        "type:story",
+        "domain:weaver",
+        "area:server",
+        "area:docs",
+        "evidence:required",
+        "guarded",
+        "track:sprint-12",
+        "phase:4-weaver-preflight"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 507,
+      "title": "quality(accessibility): replace waivers with permanent release-promotion gate",
+      "labels": [
+        "release-blocker",
+        "priority:p0",
+        "type:task",
+        "domain:health",
+        "area:client",
+        "area:admin-console",
+        "area:e2e",
+        "area:docs",
+        "evidence:required",
+        "track:sprint-12",
+        "phase:5-release-ops"
+      ],
+      "projectStatus": "Todo"
+    },
+    {
+      "number": 508,
+      "title": "ops(self-hosted): define provider-aware backup, restore, upgrade, and schema migration contract",
+      "labels": [
+        "priority:p1",
+        "type:story",
+        "domain:health",
+        "domain:portability",
+        "area:infra",
+        "area:docs",
+        "evidence:required",
+        "track:sprint-12",
+        "phase:5-release-ops"
+      ],
+      "projectStatus": "Todo"
+    }
+  ]
+}

--- a/tools/sprint_bootstrap.py
+++ b/tools/sprint_bootstrap.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Create or audit Weave sprint control-plane state.
+
+The script intentionally treats GitHub as delivery/evidence truth and the pinned
+Weave Specification Corpus as fachliche specification truth. It can audit an
+existing sprint or, with --apply, create missing milestone/issues/project-board
+links from a JSON plan.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REPO = "masssi164/weave"
+DEFAULT_PROJECT_OWNER = "masssi164"
+DEFAULT_PROJECT_NUMBER = 2
+
+
+def fail(message: str) -> None:
+    print(f"sprint-bootstrap: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def run(args: list[str], *, check: bool = True) -> str:
+    proc = subprocess.run(args, cwd=ROOT, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if check and proc.returncode != 0:
+        fail(f"command failed: {' '.join(args)}\n{proc.stdout}")
+    return proc.stdout.strip()
+
+
+def gh_json(args: list[str]) -> Any:
+    out = run(["gh", *args])
+    try:
+        return json.loads(out) if out else None
+    except json.JSONDecodeError as exc:
+        fail(f"gh returned invalid JSON for {' '.join(args)}: {exc}\n{out[:500]}")
+
+
+def load_plan(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid plan JSON: {path}: {exc}")
+    for key in ["sprint", "milestone", "issues"]:
+        if key not in data:
+            fail(f"plan missing required key: {key}")
+    if not isinstance(data["issues"], list) or not data["issues"]:
+        fail("plan.issues must be a non-empty list")
+    return data
+
+
+def issue_view(repo: str, number: int) -> dict[str, Any] | None:
+    out = run([
+        "gh", "issue", "view", str(number), "--repo", repo,
+        "--json", "number,title,state,url,labels,milestone,body",
+    ], check=False)
+    if not out:
+        return None
+    if out.startswith("GraphQL") or "not found" in out.lower():
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def milestone_by_title(repo: str, title: str) -> dict[str, Any] | None:
+    milestones = gh_json(["api", f"repos/{repo}/milestones?state=all&per_page=100"])
+    for milestone in milestones:
+        if milestone.get("title") == title:
+            return milestone
+    return None
+
+
+def project_context(owner: str, project_number: int) -> tuple[str, dict[str, Any], dict[str, str]]:
+    projects = gh_json(["project", "list", "--owner", owner, "--format", "json", "--limit", "50"])["projects"]
+    project = next((p for p in projects if p.get("number") == project_number), None)
+    if not project:
+        fail(f"GitHub project not found: owner={owner} number={project_number}")
+    fields = gh_json(["project", "field-list", str(project_number), "--owner", owner, "--format", "json", "--limit", "50"])["fields"]
+    status_field = next((f for f in fields if f.get("name") == "Status"), None)
+    status_options = {o["name"]: o["id"] for o in (status_field or {}).get("options", [])}
+    return project["id"], status_field or {}, status_options
+
+
+def project_items(owner: str, project_number: int) -> dict[int, dict[str, Any]]:
+    data = gh_json(["project", "item-list", str(project_number), "--owner", owner, "--format", "json", "--limit", "200"])
+    result: dict[int, dict[str, Any]] = {}
+    for item in data.get("items", []):
+        content = item.get("content") or {}
+        number = content.get("number")
+        if isinstance(number, int):
+            result[number] = item
+    return result
+
+
+def ensure_project_status(owner: str, project_number: int, issue_url: str, issue_number: int, status: str, apply: bool) -> tuple[str, str]:
+    items = project_items(owner, project_number)
+    item = items.get(issue_number)
+    if not item:
+        if not apply:
+            return "missing", "not in project"
+        run(["gh", "project", "item-add", str(project_number), "--owner", owner, "--url", issue_url, "--format", "json"])
+        items = project_items(owner, project_number)
+        item = items.get(issue_number)
+        if not item:
+            return "missing", "project item add did not materialize"
+    current = item.get("status") or ""
+    if status and current != status:
+        if not apply:
+            return "wrong-status", f"{current!r} != {status!r}"
+        project_id, status_field, status_options = project_context(owner, project_number)
+        option_id = status_options.get(status)
+        if not status_field or not option_id:
+            return "wrong-status", f"status option not available: {status}"
+        run([
+            "gh", "project", "item-edit",
+            "--id", item["id"],
+            "--project-id", project_id,
+            "--field-id", status_field["id"],
+            "--single-select-option-id", option_id,
+        ])
+        return "ok", f"status set {status}"
+    return "ok", current or "present"
+
+
+def create_issue(repo: str, issue: dict[str, Any], milestone_title: str, apply: bool) -> dict[str, Any] | None:
+    if not apply:
+        return None
+    labels = []
+    for label in issue.get("labels", []):
+        labels.extend(["--label", label])
+    args = [
+        "gh", "issue", "create", "--repo", repo,
+        "--title", issue["title"],
+        "--body", issue.get("body", "Created by tools/sprint_bootstrap.py"),
+        "--milestone", milestone_title,
+        *labels,
+    ]
+    url = run(args)
+    number = int(url.rstrip("/").split("/")[-1])
+    return issue_view(repo, number)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan", required=True, type=Path)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--project-owner", default=DEFAULT_PROJECT_OWNER)
+    parser.add_argument("--project-number", type=int, default=DEFAULT_PROJECT_NUMBER)
+    parser.add_argument("--apply", action="store_true", help="Create missing milestone/issues/project links")
+    parser.add_argument("--audit-only", action="store_true", help="Fail if expected state is missing; default when --apply is absent")
+    args = parser.parse_args()
+
+    plan = load_plan(args.plan)
+    apply = args.apply
+    milestone_title = plan["milestone"]["title"]
+    expected_project_status = plan.get("project", {}).get("defaultStatus", "Todo")
+
+    report: dict[str, Any] = {
+        "schemaVersion": 1,
+        "repo": args.repo,
+        "project": {"owner": args.project_owner, "number": args.project_number},
+        "plan": str(args.plan),
+        "apply": apply,
+        "milestone": {},
+        "issues": [],
+        "ok": True,
+    }
+
+    milestone = milestone_by_title(args.repo, milestone_title)
+    if not milestone:
+        if apply:
+            run([
+                "gh", "api", f"repos/{args.repo}/milestones", "--method", "POST",
+                "-f", f"title={milestone_title}",
+                "-f", f"description={plan['milestone'].get('description', '')}",
+            ])
+            milestone = milestone_by_title(args.repo, milestone_title)
+        else:
+            report["ok"] = False
+            report["milestone"] = {"title": milestone_title, "status": "missing"}
+    if milestone:
+        report["milestone"] = {
+            "title": milestone.get("title"),
+            "number": milestone.get("number"),
+            "state": milestone.get("state"),
+            "open_issues": milestone.get("open_issues"),
+            "closed_issues": milestone.get("closed_issues"),
+            "html_url": milestone.get("html_url"),
+        }
+
+    for expected in plan["issues"]:
+        actual = issue_view(args.repo, expected["number"]) if expected.get("number") else None
+        if not actual and expected.get("title"):
+            # Avoid fuzzy matching; sprint plans should pin created issue numbers after first apply.
+            actual = create_issue(args.repo, expected, milestone_title, apply)
+        entry: dict[str, Any] = {"expected": {k: expected.get(k) for k in ["number", "title"]}}
+        if not actual:
+            entry["status"] = "missing"
+            report["ok"] = False
+            report["issues"].append(entry)
+            continue
+        labels = {label["name"] for label in actual.get("labels", [])}
+        missing_labels = sorted(set(expected.get("labels", [])) - labels)
+        milestone_ok = (actual.get("milestone") or {}).get("title") == milestone_title
+        project_status, project_note = ensure_project_status(
+            args.project_owner, args.project_number, actual["url"], actual["number"], expected.get("projectStatus", expected_project_status), apply
+        )
+        ok = not missing_labels and milestone_ok and project_status == "ok"
+        if not ok:
+            report["ok"] = False
+        entry.update({
+            "number": actual["number"],
+            "title": actual["title"],
+            "state": actual["state"],
+            "url": actual["url"],
+            "milestoneOk": milestone_ok,
+            "missingLabels": missing_labels,
+            "projectStatus": project_status,
+            "projectNote": project_note,
+            "ok": ok,
+        })
+        report["issues"].append(entry)
+
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    if not report["ok"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #514.

Codifies the sprint bootstrap/control-plane flow so Weave sprints can be created or audited from file-backed state instead of chat history.

## What changed

- Adds `tools/sprint_bootstrap.py` to audit/apply sprint milestone, issue DAG, and Weave Delivery Board state.
- Adds `tools/fixtures/sprint_bootstrap_sprint12.json` as the current Sprint 12 plan/audit fixture.
- Adds `./gradlew sprintBootstrapAudit`.
- Documents the flow in `docs/sprint-bootstrap-and-board-flow.md`.
- Updates repo guidance to point `weave-co-leader` at the flow.
- Advances `specs/weave-specs.lock.json` to the spec-corpus commit that documents canonical update authority.

## Evidence

- `python3 -m py_compile tools/sprint_bootstrap.py` ✅
- `./gradlew specCorpusConformance sprintBootstrapAudit specContract docsStructureCheck --console=plain` ✅
- `git diff --check` ✅

## Local note

- `./gradlew docsCheck --console=plain` was attempted but local `docsBuild` cannot run because this Xcode Python environment does not have `mkdocs` installed. CI should run with the documented dependency setup.
