### PR TITLE
docs: incorporate Weaver RuntimeProfile projection decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Sprint 8/Sprint 9 acceptance now includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
 - Sprint 11 Live Stack acceptance now maps a provider-reality vertical for Files, Calendar, Boards, Calls, and Documents with live-runtime evidence separated from manual accessibility accounting.
 - Sprint 12 adds provider portability schema v2 fixtures and reports for Files, Calendar, Boards, and Chat, plus Office/WOPI, Weaver isolation, Weaver registry, identity lifecycle, accessibility, and operator lifecycle contracts.
-- Weaver/OpenClaw release documentation now clarifies the signed RuntimeProfile boundary: Weave projects admin-governed Chat domain providers, model aliases, MCP/tool/skill grants, credentials, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
+- Weaver/OpenClaw release documentation now clarifies the signed RuntimeProfile boundary: Weave projects admin-governed Chat domain providers, model aliases, MCP/tool/skill grants, CredentialRefs and short-lived runtime token references, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
 
 ## Changed
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Sprint 8/Sprint 9 acceptance now includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
 - Sprint 11 Live Stack acceptance now maps a provider-reality vertical for Files, Calendar, Boards, Calls, and Documents with live-runtime evidence separated from manual accessibility accounting.
 - Sprint 12 adds provider portability schema v2 fixtures and reports for Files, Calendar, Boards, and Chat, plus Office/WOPI, Weaver isolation, Weaver registry, identity lifecycle, accessibility, and operator lifecycle contracts.
+- Weaver/OpenClaw release documentation now clarifies the signed RuntimeProfile boundary: Weave projects admin-governed Chat domain providers, model aliases, MCP/tool/skill grants, credentials, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
 
 ## Changed
 
@@ -123,6 +124,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 - Product-readiness evidence now records provider-switching, OpenClaw runtime isolation, Weaver tool approval, RBAC, redaction, scan, and support-bundle expectations as explicit release blockers.
 - Weaver runtime remains disabled-by-default behind isolation, SecretRef/OAuth broker, signed manifest, egress, audit, and support-bundle redaction contracts.
+- Chat-channel projection and Credential Broker implementation for governed Weaver RuntimeProfiles is tracked as Sprint 13 follow-up #519; v0.1.0-rc.3 must not claim that broad runtime execution or raw OpenClaw dashboard/config access is available to members.
 
 ## Accessibility
 

--- a/docs/architecture/adr-003-weaver-runtime-isolation.md
+++ b/docs/architecture/adr-003-weaver-runtime-isolation.md
@@ -18,10 +18,14 @@ The first self-hosted Weaver preflight path is per-user, short-lived containers 
 ## Required controls before enablement
 
 - per-user runtime profile and workspace identity;
+- one active user/trust boundary per runtime context/container, with inactive users represented only by stored state/profile until activated;
+- separate state, workspace, and agent directory per runtime;
 - deny-by-default egress with declared capability grants;
+- internal network access only to Weave API, Weave MCP Gateway, and allowed channel/MCP proxies;
 - filesystem isolation and no implicit host mounts;
 - lifecycle cleanup, CPU/memory/disk quotas, and stale-session reap;
-- SecretRef/OAuth broker only, never raw secrets in runtime profiles or tool results;
+- profile reload/restart on admin changes and rollback to the previous signed RuntimeProfile;
+- SecretRef/OAuth broker and short-lived runtime token only, never raw secrets in runtime profiles or tool results;
 - audit events for install, grant, invoke, deny, cleanup, and support bundle export;
 - support bundle redaction for prompts, payloads, tokens, cookies, private keys, and provider bodies.
 

--- a/docs/architecture/weaver-openclaw-profile.md
+++ b/docs/architecture/weaver-openclaw-profile.md
@@ -11,6 +11,8 @@ Weaver is the optional personal-assistant product line inside Weave. Sprint 8 de
 
 ## Runtime profile contract
 
+The signed `WeaverRuntimeProfile` is the single source consumed by the OpenClaw-derived Weaver runtime. The runtime may render an internal `openclaw.json`, channel/plugin entries, MCP server entries, tool filters, model defaults, and sandbox settings, but those files are generated implementation artifacts. Normal members must not edit them or use the raw OpenClaw dashboard/config wizard to bypass Weave policy.
+
 A Weaver runtime profile must be generated per user and per organization. The profile contains only support-safe, auditable grants.
 
 | Profile section | Requirement |
@@ -25,6 +27,19 @@ A Weaver runtime profile must be generated per user and per organization. The pr
 | Audit | Every tool call, approval decision, denied action, and capability-bound data access emits support-safe audit evidence. |
 | Member opt-in | Runtime is disabled until the member opts in where required and the organization enables the capability. |
 | Group-chat consent | Assistant participation in shared spaces requires explicit organization policy and conversation-level consent signals. |
+
+Minimum profile fields for the next implementation slice:
+
+- profile version, signature, `runtimeProfileHash`, expiry, revocation status, and rollback pointer;
+- model provider aliases, default, fallback order, and user-selectable alias list from admin policy;
+- domain capability catalog including `chat.read`, `chat.send`, `files.read`, `calendar.read`, and `weaver.enabled`;
+- Chat domain provider binding and OpenClaw channel/plugin projection for Matrix, Teams, iMessage, Slack, Telegram, or another supported provider;
+- MCP server/tool/skill grants from Weave policy only, with personal MCPs routed through Weave approval where allowed;
+- tool and sandbox deny policy where `tools.deny` wins globally and `bundle-mcp`, gateway, cron, exec, write, and patch-style tools are disabled unless explicitly granted;
+- CredentialRefs and short-lived runtime token references only;
+- audit policy requiring `runtimeProfileHash`, user, tool, domain, providerRef, credentialRef when applicable, and policy decision for model/channel/tool/MCP calls.
+
+Admin Chat provider changes are provider migrations, not member adapter switches: Weave checks readiness/migration, binds credentials through the Credential Broker, generates RuntimeProfile vNext, projects the selected provider into OpenClaw channel/plugin config, reloads or restarts the user runtime, and keeps member UX inside Weave.
 
 ## Capability rule
 

--- a/docs/governed-weaver-runtime-security-contract.md
+++ b/docs/governed-weaver-runtime-security-contract.md
@@ -12,6 +12,22 @@ Weaver is an optional per-user personal-assistant runtime. It is generated from 
 - **Policy source**: Admin Console policy plus IDM/RBAC group/user grants plus member opt-in where allowed.
 - **Secret posture**: SecretRefs only. Raw provider tokens, downstream payloads, service endpoints, and secret values never appear in the runtime profile, member client, logs, support bundles, screenshots, or release evidence.
 
+## RuntimeProfile and OpenClaw projection boundary
+
+The Weaver/OpenClaw fork consumes one signed `WeaverRuntimeProfile` from Weave. Weave remains the source of truth for domains, provider selection, policy, credentials, and audit; OpenClaw configuration is generated runtime output, not a member-managed product model.
+
+Required projection controls:
+
+- RuntimeProfile Loader renders internal `openclaw.json` from the signed Weave profile.
+- Normal members cannot edit `openclaw.json`, run the OpenClaw config wizard, manage gateway/channels/plugins/MCP/secrets/sandbox/exec/tool allowlists, or use raw dashboard controls for those areas.
+- Member-facing Weaver settings are limited to policy-allowed model aliases, style, memory/workspace preferences, allowed skills, and allowed personal MCP connection flows exposed by Weave.
+- Admin policy projects model defaults, fallbacks, and allowed aliases; users choose only among Weave aliases, not raw provider/model identifiers.
+- Admin Chat domain provider changes project into OpenClaw channel/plugin configuration. Matrix, Teams, iMessage, Slack, Telegram, and other OpenClaw channels/plugins are technical providers behind the Weave Chat domain, not member-swappable chat adapters.
+- MCP servers, skills, and tools are distributed through Weave policy. `tools.deny` is hard-deny; `bundle-mcp`, gateway, cron, exec, write, and patch-style capabilities remain default-deny unless the signed profile explicitly allows a constrained use.
+- OpenClaw Policy/Doctor output is conformance lint over generated settings. It is not a second source of truth.
+
+Correct Chat provider-change flow: Admin changes the Chat domain provider in Weave -> readiness/migration checks run -> Credential Broker binds new provider credentials -> signed RuntimeProfile vNext is generated -> OpenClaw channel/plugin projection changes -> the per-user runtime reloads or restarts -> the user continues through Weave UX.
+
 ## Disabled-by-default gates
 
 Runtime provisioning is fail-closed unless all gates pass:
@@ -26,14 +42,17 @@ If any gate fails, member surfaces show only `disabled_by_policy`, `not_configur
 
 ## Isolation boundary
 
-Each enabled user receives one isolated runtime boundary, or an implementation-equivalent hard isolation model, with:
+Each enabled active user/trust boundary receives one isolated runtime boundary, or an implementation-equivalent hard isolation model, with:
 
 - per-user workspace volume;
 - per-user memory store;
 - per-user session store;
+- separate runtime state and agent directory;
 - no access to another user's workspace, memory, or sessions;
 - no raw provider tokens;
-- only Weave-issued tool endpoints/grants;
+- only Weave API, Weave MCP Gateway, and allowed channel/MCP proxy access;
+- short-lived runtime tokens plus CredentialRefs, not stored provider secrets;
+- profile reload/restart and rollback to the previous signed profile on admin changes;
 - audit-required profile generation and tool invocation.
 
 ## Approval policy

--- a/docs/product-line-and-weaver-plan.md
+++ b/docs/product-line-and-weaver-plan.md
@@ -204,6 +204,11 @@ Goal: plug the PA into an already-governed product.
   - tool/capability allowlist from admin policy;
   - sandbox defaults;
   - exec disabled or heavily restricted by default.
+- Generate that runtime config only from a signed Weave `WeaverRuntimeProfile`; `openclaw.json`, channel/plugin setup, MCP servers, model defaults/fallbacks, and tool filters are implementation output, not member UX or a second policy source.
+- Treat Chat provider changes as Weave Chat domain migrations. Admin Console selects Matrix, Teams, iMessage, Slack, Telegram, or another supported Chat provider; Weave runs readiness/migration checks, binds credentials through the Credential Broker, regenerates RuntimeProfile vNext, projects OpenClaw channel/plugin configuration, and reloads/restarts the user's runtime.
+- Keep raw OpenClaw dashboard/config/wizard surfaces locked down or RBAC-stripped for members. Member `Mein Weaver` settings may cover style, memory/workspace, admin-approved model aliases, allowed skills, and allowed personal MCP connection flows only.
+- Keep MCP servers, skills, `bundle-mcp`, gateway, cron, exec, write, and patch-style tools default-deny unless admin policy explicitly grants a constrained capability. `tools.deny` is the hard global deny layer.
+- Use CredentialRefs and short-lived runtime tokens only; provider secrets, OAuth refresh tokens, channel tokens, and MCP OAuth credentials live behind the Weave Credential Broker.
 - Add audit for Weaver capability usage.
 - Only fork OpenClaw where existing configuration/plugin hooks cannot enforce the required boundary.
 
@@ -212,6 +217,7 @@ Evidence gate:
 - Weaver cannot see or call capabilities not enabled by admin policy.
 - User workspace customization cannot escape org baseline.
 - Exec/elevated surfaces are disabled by default and require explicit admin policy.
+- Audit records include `runtimeProfileHash`, user, tool, domain, providerRef, credentialRef where applicable, and decision for model/channel/tool/MCP calls.
 
 ## Cross-session tracking rule
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -9,6 +9,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Sprint 8/Sprint 9 acceptance now includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
 - Sprint 11 Live Stack acceptance now maps a provider-reality vertical for Files, Calendar, Boards, Calls, and Documents with live-runtime evidence separated from manual accessibility accounting.
 - Sprint 12 adds provider portability schema v2 fixtures and reports for Files, Calendar, Boards, and Chat, plus Office/WOPI, Weaver isolation, Weaver registry, identity lifecycle, accessibility, and operator lifecycle contracts.
+- Weaver/OpenClaw release documentation now clarifies the signed RuntimeProfile boundary: Weave projects admin-governed Chat domain providers, model aliases, MCP/tool/skill grants, credentials, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
 
 ## Changed
 
@@ -25,6 +26,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 - Product-readiness evidence now records provider-switching, OpenClaw runtime isolation, Weaver tool approval, RBAC, redaction, scan, and support-bundle expectations as explicit release blockers.
 - Weaver runtime remains disabled-by-default behind isolation, SecretRef/OAuth broker, signed manifest, egress, audit, and support-bundle redaction contracts.
+- Chat-channel projection and Credential Broker implementation for governed Weaver RuntimeProfiles is tracked as Sprint 13 follow-up #519; v0.1.0-rc.3 must not claim that broad runtime execution or raw OpenClaw dashboard/config access is available to members.
 
 ## Accessibility
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -9,7 +9,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Sprint 8/Sprint 9 acceptance now includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
 - Sprint 11 Live Stack acceptance now maps a provider-reality vertical for Files, Calendar, Boards, Calls, and Documents with live-runtime evidence separated from manual accessibility accounting.
 - Sprint 12 adds provider portability schema v2 fixtures and reports for Files, Calendar, Boards, and Chat, plus Office/WOPI, Weaver isolation, Weaver registry, identity lifecycle, accessibility, and operator lifecycle contracts.
-- Weaver/OpenClaw release documentation now clarifies the signed RuntimeProfile boundary: Weave projects admin-governed Chat domain providers, model aliases, MCP/tool/skill grants, credentials, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
+- Weaver/OpenClaw release documentation now clarifies the signed RuntimeProfile boundary: Weave projects admin-governed Chat domain providers, model aliases, MCP/tool/skill grants, CredentialRefs and short-lived runtime token references, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
 
 ## Changed
 

--- a/docs/sprint-12-closure-report.md
+++ b/docs/sprint-12-closure-report.md
@@ -10,6 +10,8 @@ Sprint 12 is incorporated through PR #517, merged to protected `main` as commit 
 
 The sprint added the provider-portability and lifecycle-readiness contracts needed before Weave can honestly promise provider replacement or later Weaver execution. It deliberately does not claim lossless migration, live production migration apply, broad Weaver runtime execution, or provider-specific UI ownership.
 
+Post-merge release-gate reconciliation incorporated the Weaver/OpenClaw RuntimeProfile decision: Weave remains source of truth for domains, admin policy, provider selection, credentials, and audit; the OpenClaw-derived Weaver runtime consumes a signed `WeaverRuntimeProfile` and renders internal config as implementation output only. Chat provider changes are admin-governed Weave Chat domain migrations that project into OpenClaw channel/plugin configuration, not member-swappable raw chat adapters. The executable implementation slice is tracked as Sprint 13 issue #519.
+
 ## Issue DAG final state
 
 | Issue | Scope | Final state |
@@ -57,9 +59,12 @@ Release-facing changes are documented in `docs/release-notes/unreleased.md` and 
 
 Next release action: publish the next prerelease candidate from protected `main` after closure report merge and green `main` CI. Production release still requires explicit production approval and release-owner signoff.
 
+The release candidate may keep Weaver runtime execution disabled by default while carrying the clarified RuntimeProfile/channel-projection boundary as release documentation. The missing loader/generator/broker/admin/client/infra implementation work is explicitly deferred to #519 and is not represented as shipped v0.1.0-rc.3 functionality.
+
 ## Non-goals and follow-ups
 
 - No production provider migration apply path was enabled.
 - No claim of lossless migration was introduced; the release promise is no unaccounted data loss.
 - No broad Weaver runtime execution was enabled; stronger sandbox evidence such as gVisor/runsc or Firecracker remains required before widening runtime claims.
 - Office/WOPI remains a documented provider path, not a shipped live Office editor surface.
+- #519 tracks the next governed Weaver RuntimeProfile slice: RuntimeProfile Loader, raw OpenClaw config lockdown, Chat channel/plugin projection, Credential Broker, admin model/chat/MCP/tool distribution, `Mein Weaver` member boundary, per-user container lifecycle, rollback, and audit fields.

--- a/specs/0007-governed-weaver-runtime/spec.md
+++ b/specs/0007-governed-weaver-runtime/spec.md
@@ -55,6 +55,11 @@ Define the first implementation-ready Weaver runtime contract without making Wea
 - **FR-010**: Admin/operator evidence MUST include policy posture and audit metadata, not private member memory content.
 - **FR-011**: Release evidence MUST capture OpenClaw fork/image digest/SBOM/scan references before any release claim.
 - **FR-012**: Weaver approval UX MUST be screen-reader accessible and must not rely on color-only state.
+- **FR-013**: A `WeaverRuntimeProfile` MUST be the only source consumed by the OpenClaw-derived Weaver runtime. The signed profile MUST include version, hash, revocation metadata, model aliases/defaults/fallbacks, domain provider projections, MCP/tool/skill grants, sandbox/tool-deny policy, CredentialRefs, and audit policy.
+- **FR-014**: Chat provider changes MUST be modeled as admin-governed Weave Chat domain provider migrations. The profile generator MUST project the selected Chat provider into OpenClaw channel/plugin configuration; members MUST NOT switch raw chat adapters or edit channel tokens.
+- **FR-015**: Raw OpenClaw configuration surfaces (`openclaw.json`, `openclaw config`, setup wizard, dashboard controls for gateway/channels/MCP/secrets/sandbox/exec/tool allowlists) MUST be disabled, read-only, or RBAC-stripped for normal members.
+- **FR-016**: Credential handling MUST use Weave Credential Broker references and short-lived runtime tokens. Weaver profiles, logs, prompts, support bundles, and release evidence MUST NOT contain provider secrets, OAuth refresh tokens, cookies, or credential-bearing provider URLs.
+- **FR-017**: Every model, channel, tool, MCP, and provider call MUST emit support-safe audit metadata containing at least `runtimeProfileHash`, user, tool, domain, providerRef, credentialRef where applicable, and policy decision.
 
 ## Initial tool set
 
@@ -64,6 +69,32 @@ Define the first implementation-ready Weaver runtime contract without making Wea
 - `chat.search_messages` read-only or guarded by chat policy.
 - `notifications.create_action_request` guarded external-send.
 - `boards.comment` write-with-approval.
+
+## RuntimeProfile projection model
+
+The implementation projection for the Weaver/OpenClaw fork is intentionally one-way:
+
+1. Weave remains source of truth for domains, admin policy, provider selection, credentials, and audit.
+2. The server profile generator signs and versions a `WeaverRuntimeProfile` from that source of truth.
+3. The Weaver RuntimeProfile Loader renders internal `openclaw.json` and related channel/plugin/MCP/tool settings as runtime implementation detail.
+4. OpenClaw Policy/Doctor is used as a conformance lint gate over rendered settings, not as a second policy source.
+
+The minimum profile sections are:
+
+| Section | Requirement |
+| --- | --- |
+| Identity and profile metadata | Organization, user, profile version, `runtimeProfileHash`, expiry, revocation status, and previous-profile rollback pointer. |
+| Models | Admin-selected provider/model aliases, default, fallback order, and user-selectable aliases only. |
+| Domains and providers | Stable domain grants such as `chat.read`, `chat.send`, `files.read`, `calendar.read`, and `weaver.enabled`, plus providerRef bindings hidden from member UX. |
+| Chat channel projection | Selected Chat domain provider (`matrix`, `teams`, `imessage`, `slack`, etc.) rendered into OpenClaw channel/plugin configuration. Multiple channels may exist for one user runtime, but the admin-governed Weave Chat domain binding drives the projection. |
+| MCP, skills, and tools | Admin-distributed MCP servers/tools/skills only; personal MCPs only through a Weave-approved flow. `tools.deny` remains hard-deny and `bundle-mcp` is disabled unless the profile explicitly permits it. |
+| Credentials | CredentialRefs and short-lived runtime token references only; OAuth refresh/runtime credentials stay behind the Weave Credential Broker. |
+| Sandbox and runtime lifecycle | One active user/trust boundary per runtime context/container, separate workspace/state/agentDir, internal-only network targets, reload/restart on profile changes, and rollback to the previous signed profile. |
+| Audit | Required fields for model/channel/tool/MCP/provider calls and denied decisions. |
+
+Provider-change flow: Admin changes the Weave Chat domain provider -> server readiness and migration checks run -> Credential Broker binds new provider credentials -> `WeaverRuntimeProfile` vNext is generated and signed -> OpenClaw channel/plugin projection changes -> user runtime reloads or restarts -> member continues through Weave UX.
+
+This flow is tracked for the next implementation slice in issue #519 and is not a new Sprint 12 runtime-execution claim.
 
 ## Acceptance mapping
 


### PR DESCRIPTION
## Summary

- incorporates Massimo's Weaver/OpenClaw RuntimeProfile architecture decision into the Sprint 12 release documentation and governed Weaver spec projection
- clarifies Chat provider changes as admin-governed Weave domain migrations projected into OpenClaw channel/plugin config, not member-swappable raw adapters
- files Sprint 13 follow-up #519 for the executable loader/generator/broker/admin/client/infra slice and updates release notes/README projection

## Impact

- User/admin/operator impact: v0.1.0-rc.3 documentation now blocks overclaiming broad Weaver runtime execution or raw OpenClaw member configuration.
- Spec/contracts: updates WEAVE-SPEC-0007 projection and Weaver runtime security/isolation docs.
- Accessibility/localization: documentation-only; no user-facing strings or UI changed.

## Checks

- `./gradlew specContract docsCheck releaseEvidenceCheck --console=plain` — passed
- `./gradlew acceptanceContract --console=plain` — passed

## Follow-up

- #519 tracks RuntimeProfile Loader, raw config lockdown, Chat channel/plugin projection, Credential Broker, Admin Console distribution, `Mein Weaver`, per-user lifecycle/rollback, and audit implementation.
