### PR TITLE
spec: map Sprint 13 Weaver RuntimeProfile projection

### DIFF
--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -956,6 +956,22 @@
             "portable-export-import-contract",
             "rollback-recovery-plan"
           ]
+        },
+        {
+          "path": "specs/0007-governed-weaver-runtime/spec.md",
+          "fragments": [
+            "The Weaver RuntimeProfile Loader renders internal `openclaw.json` and related channel/plugin/MCP/tool settings as runtime implementation detail.",
+            "Stable `channels.weave-chat` configuration with Weave API/runtime token/profile hash metadata.",
+            "Provider-change flow: Admin changes the Weave Chat domain provider"
+          ]
+        },
+        {
+          "path": "docs/architecture/weaver-openclaw-profile.md",
+          "fragments": [
+            "The signed `WeaverRuntimeProfile` is the single source consumed by the OpenClaw-derived Weaver runtime.",
+            "Matrix, Teams, iMessage, Slack, Telegram, or another supported provider are backend providerRefs",
+            "Admin Chat provider changes are provider migrations, not member adapter switches"
+          ]
         }
       ],
       "evidenceMode": "offline-spec"

--- a/specs/0007-governed-weaver-runtime/tasks.md
+++ b/specs/0007-governed-weaver-runtime/tasks.md
@@ -12,3 +12,10 @@
 - [x] T008 [#448] Audit and redact tool invocation results.
 - [x] T009 [#449] Add security/privacy/accessibility/support-safe evidence report.
 - [ ] T010 [Evidence] Run `./gradlew specContract acceptanceContract serverCi docsCheck --console=plain`.
+
+## Sprint 13 RuntimeProfile projection refresh
+
+- [x] T011 [#519/#522] Define the signed `WeaverRuntimeProfile` as the only source consumed by the OpenClaw-derived runtime.
+- [x] T012 [#519/#522] Preserve stable `channels.weave-chat` for Chat-domain provider changes while Matrix, Teams, iMessage, Slack, and future providers remain backend `providerRef` bindings.
+- [x] T013 [#519/#522] Require CredentialRefs and short-lived runtime token references only; exclude provider secrets and OAuth refresh tokens from profiles, logs, support bundles, and release evidence.
+- [x] T014 [#519/#522] Map the provider-change acceptance evidence to the Sprint 13 RuntimeProfile projection and Weaver/OpenClaw architecture boundary.

--- a/specs/0007-governed-weaver-runtime/traceability.yaml
+++ b/specs/0007-governed-weaver-runtime/traceability.yaml
@@ -7,6 +7,8 @@ github_issues:
   - 447
   - 448
   - 449
+  - 519
+  - 522
 release_notes_label: release-notes-feature
 acceptance_features:
   - e2e/features/v0_1_dogfood_release.feature
@@ -20,6 +22,8 @@ acceptance_scenarios:
   - tag: '@weave-v01-provider-switch-portability'
     evidence:
       - admin-console/src/App.test.tsx
+      - specs/0007-governed-weaver-runtime/spec.md
+      - docs/architecture/weaver-openclaw-profile.md
 evidence_gates:
   - ./gradlew specContract
   - ./gradlew acceptanceContract


### PR DESCRIPTION
## Summary

- maps Sprint 13 issues #519/#522 into the governed Weaver RuntimeProfile traceability
- records the stable `channels.weave-chat` / CredentialRef projection refresh as completed spec tasks
- extends provider-switch acceptance evidence to the RuntimeProfile projection and Weaver/OpenClaw architecture boundary

## Verification

- `./gradlew specContract acceptanceContract docsCheck releaseEvidenceCheck --console=plain`

Fixes #522
Part of #519
