### PR TITLE
feat(client): add governed Mein Weaver member UX

### DIFF
--- a/client/lib/features/agents/domain/entities/agent_capability_policy.dart
+++ b/client/lib/features/agents/domain/entities/agent_capability_policy.dart
@@ -14,6 +14,7 @@ class AgentCapabilityPolicy {
   const AgentCapabilityPolicy({
     required this.canManageCapabilities,
     required this.capabilities,
+    this.weaverMemberUx = WeaverMemberUxState.disabled,
     this.isFailClosed = false,
   });
 
@@ -22,6 +23,7 @@ class AgentCapabilityPolicy {
   }) {
     return AgentCapabilityPolicy(
       canManageCapabilities: canManageCapabilities,
+      weaverMemberUx: WeaverMemberUxState.disabled,
       capabilities: const <AgentCapabilityState>[
         AgentCapabilityState(
           capability: AgentCapability.personalAssistant,
@@ -43,6 +45,7 @@ class AgentCapabilityPolicy {
     return AgentCapabilityPolicy(
       canManageCapabilities: canManageCapabilities,
       isFailClosed: true,
+      weaverMemberUx: WeaverMemberUxState.blockedState,
       capabilities: const <AgentCapabilityState>[
         AgentCapabilityState(
           capability: AgentCapability.personalAssistant,
@@ -63,6 +66,10 @@ class AgentCapabilityPolicy {
     required WorkspaceCapabilitySnapshot workspaceCapabilities,
   }) {
     final weaver = workspaceCapabilities.weaver;
+    final enabled =
+        weaver.policyState == WorkspaceCapabilityPolicyState.allowed &&
+        weaver.readiness == WorkspaceCapabilityReadiness.ready &&
+        weaver.grants('weaver.enabled');
     final availability = switch (weaver.policyState) {
       WorkspaceCapabilityPolicyState.disabled =>
         AgentCapabilityAvailability.disabledByPolicy,
@@ -71,18 +78,20 @@ class AgentCapabilityPolicy {
       WorkspaceCapabilityPolicyState.unavailable =>
         AgentCapabilityAvailability.adminSetupRequired,
       WorkspaceCapabilityPolicyState.allowed =>
-        weaver.readiness == WorkspaceCapabilityReadiness.ready &&
-                weaver.grants('weaver.enabled')
+        enabled
             ? AgentCapabilityAvailability.adminSetupRequired
             : AgentCapabilityAvailability.disabledByPolicy,
     };
 
     return AgentCapabilityPolicy(
       canManageCapabilities: canManageCapabilities,
+      weaverMemberUx: WeaverMemberUxState.fromCapability(weaver),
       capabilities: <AgentCapabilityState>[
         AgentCapabilityState(
           capability: AgentCapability.personalAssistant,
-          enablement: AgentCapabilityEnablement.disabled,
+          enablement: enabled
+              ? AgentCapabilityEnablement.enabled
+              : AgentCapabilityEnablement.disabled,
           availability: availability,
         ),
         const AgentCapabilityState(
@@ -96,6 +105,7 @@ class AgentCapabilityPolicy {
 
   final bool canManageCapabilities;
   final List<AgentCapabilityState> capabilities;
+  final WeaverMemberUxState weaverMemberUx;
   final bool isFailClosed;
 
   bool get canStartAnyCapability {
@@ -128,5 +138,120 @@ class AgentCapabilityState {
   bool get canStart {
     return enablement == AgentCapabilityEnablement.enabled &&
         availability != AgentCapabilityAvailability.blocked;
+  }
+}
+
+class WeaverMemberUxState {
+  const WeaverMemberUxState({
+    required this.available,
+    required this.isBlocked,
+    required this.modelAliases,
+    required this.allowedSkills,
+    required this.allowedPersonalConnections,
+    required this.canConfigureStyle,
+    required this.canConfigureMemory,
+    required this.canConfigureWorkspace,
+    this.memberImpact,
+  });
+
+  static const disabled = WeaverMemberUxState(
+    available: false,
+    isBlocked: false,
+    modelAliases: <String>[],
+    allowedSkills: <String>[],
+    allowedPersonalConnections: <String>[],
+    canConfigureStyle: false,
+    canConfigureMemory: false,
+    canConfigureWorkspace: false,
+  );
+
+  static const blockedState = WeaverMemberUxState(
+    available: false,
+    isBlocked: true,
+    modelAliases: <String>[],
+    allowedSkills: <String>[],
+    allowedPersonalConnections: <String>[],
+    canConfigureStyle: false,
+    canConfigureMemory: false,
+    canConfigureWorkspace: false,
+  );
+
+  factory WeaverMemberUxState.fromCapability(WorkspaceCapabilityState weaver) {
+    final available =
+        weaver.policyState == WorkspaceCapabilityPolicyState.allowed &&
+        weaver.readiness == WorkspaceCapabilityReadiness.ready &&
+        weaver.grants('weaver.enabled');
+    if (!available) {
+      return WeaverMemberUxState(
+        available: false,
+        isBlocked: weaver.readiness == WorkspaceCapabilityReadiness.blocked,
+        modelAliases: const <String>[],
+        allowedSkills: const <String>[],
+        allowedPersonalConnections: const <String>[],
+        canConfigureStyle: false,
+        canConfigureMemory: false,
+        canConfigureWorkspace: false,
+        memberImpact: weaver.memberImpact,
+      );
+    }
+
+    return WeaverMemberUxState(
+      available: true,
+      isBlocked: false,
+      modelAliases: _labelsForPrefix(weaver, 'weaver.model_alias.'),
+      allowedSkills: _labelsForPrefix(weaver, 'weaver.skill.'),
+      allowedPersonalConnections: _labelsForPrefix(
+        weaver,
+        'weaver.personal_connection.',
+      ),
+      canConfigureStyle: weaver.grants('weaver.configure_style'),
+      canConfigureMemory: weaver.grants('weaver.configure_memory'),
+      canConfigureWorkspace: weaver.grants('weaver.configure_workspace'),
+      memberImpact: weaver.memberImpact,
+    );
+  }
+
+  final bool available;
+  final bool isBlocked;
+  final List<String> modelAliases;
+  final List<String> allowedSkills;
+  final List<String> allowedPersonalConnections;
+  final bool canConfigureStyle;
+  final bool canConfigureMemory;
+  final bool canConfigureWorkspace;
+  final String? memberImpact;
+
+  bool get hasAnyPersonalSetting =>
+      canConfigureStyle || canConfigureMemory || canConfigureWorkspace;
+
+  static List<String> _labelsForPrefix(
+    WorkspaceCapabilityState weaver,
+    String prefix,
+  ) {
+    final labels =
+        weaver.grantedCapabilities
+            .where((grant) => grant.startsWith(prefix))
+            .map((grant) => _humanizeGrant(grant.substring(prefix.length)))
+            .where((label) => label.isNotEmpty)
+            .toSet()
+            .toList()
+          ..sort();
+    return labels;
+  }
+
+  static String _humanizeGrant(String rawValue) {
+    final words = rawValue
+        .replaceAll(RegExp(r'[_\-]+'), ' ')
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((word) => word.isNotEmpty)
+        .toList();
+    return words
+        .map(
+          (word) => word.length == 1
+              ? word.toUpperCase()
+              : '${word[0].toUpperCase()}${word.substring(1)}',
+        )
+        .join(' ');
   }
 }

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -18,6 +18,7 @@ import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
 import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
+import 'package:weave/features/agents/domain/entities/agent_capability_policy.dart';
 import 'package:weave/features/agents/presentation/providers/agent_capability_policy_provider.dart';
 import 'package:weave/features/agents/presentation/widgets/agent_capability_policy_card.dart';
 import 'package:weave/features/app/presentation/providers/workspace_connection_provider.dart';
@@ -74,6 +75,8 @@ class SettingsScreen extends ConsumerWidget {
                   const _WorkspaceReadinessCard(),
                   const SizedBox(height: 32),
                   const _AgentCapabilityPolicySection(),
+                  const SizedBox(height: 32),
+                  const _WeaverMemberSettingsSection(),
                   const SizedBox(height: 32),
                   const _SettingsHelpCard(),
                   const SizedBox(height: 32),
@@ -469,6 +472,335 @@ class _AgentCapabilityPolicySection extends ConsumerWidget {
         icon: Icons.admin_panel_settings_outlined,
       ),
     };
+  }
+}
+
+class _WeaverMemberSettingsSection extends ConsumerWidget {
+  const _WeaverMemberSettingsSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final policy = ref.watch(agentCapabilityPolicyProvider);
+
+    return switch (policy) {
+      AsyncData(value: final value) => _WeaverMemberSettingsCard(
+        state: value.weaverMemberUx,
+      ),
+      AsyncError() => _WeaverMemberSettingsCard(
+        state: WeaverMemberUxState.blockedState,
+        statusOverride: l10n.weaverMemberStatusUnavailable,
+      ),
+      _ => LoadingState(
+        message: l10n.weaverMemberLoading,
+        icon: Icons.auto_awesome_outlined,
+      ),
+    };
+  }
+}
+
+class _WeaverMemberSettingsCard extends StatelessWidget {
+  const _WeaverMemberSettingsCard({required this.state, this.statusOverride});
+
+  final WeaverMemberUxState state;
+  final String? statusOverride;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final available = state.available;
+    final title = available
+        ? l10n.weaverMemberTitle
+        : l10n.weaverMemberUnavailableTitle;
+    final description = available
+        ? l10n.weaverMemberDescription
+        : state.memberImpact ?? l10n.weaverMemberUnavailableDescription;
+
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surfaceContainerLow,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(24),
+        side: BorderSide(color: theme.colorScheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Semantics(
+          container: true,
+          explicitChildNodes: true,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    available
+                        ? Icons.auto_awesome_outlined
+                        : Icons.lock_outline,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Semantics(
+                          header: true,
+                          child: Text(title, style: theme.textTheme.titleLarge),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          description,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Chip(
+                    avatar: Icon(
+                      available ? Icons.verified_user_outlined : Icons.policy,
+                      size: 18,
+                    ),
+                    label: Text(
+                      statusOverride ??
+                          (available
+                              ? l10n.weaverMemberStatusAvailable
+                              : state.isBlocked
+                              ? l10n.weaverMemberStatusUnavailable
+                              : l10n.weaverMemberStatusDisabled),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              if (available) ...[
+                _AdminApprovedModelAliasPicker(aliases: state.modelAliases),
+                const SizedBox(height: 16),
+                _WeaverPersonalSettingsList(state: state),
+                const SizedBox(height: 16),
+                _WeaverAllowedItemsWrap(
+                  title: l10n.weaverMemberAllowedSkillsTitle,
+                  emptyLabel: l10n.weaverMemberNoAllowedSkills,
+                  items: state.allowedSkills,
+                ),
+                const SizedBox(height: 12),
+                _WeaverAllowedItemsWrap(
+                  title: l10n.weaverMemberAllowedConnectionsTitle,
+                  emptyLabel: l10n.weaverMemberNoAllowedConnections,
+                  items: state.allowedPersonalConnections,
+                ),
+                const SizedBox(height: 16),
+                _WeaverBoundaryNotice(text: l10n.weaverMemberBoundaryNotice),
+              ] else
+                _WeaverBoundaryNotice(
+                  text: l10n.weaverMemberDisabledBoundaryNotice,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AdminApprovedModelAliasPicker extends StatefulWidget {
+  const _AdminApprovedModelAliasPicker({required this.aliases});
+
+  final List<String> aliases;
+
+  @override
+  State<_AdminApprovedModelAliasPicker> createState() =>
+      _AdminApprovedModelAliasPickerState();
+}
+
+class _AdminApprovedModelAliasPickerState
+    extends State<_AdminApprovedModelAliasPicker> {
+  String? _selectedAlias;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final aliases = widget.aliases.isEmpty
+        ? <String>[l10n.weaverMemberWorkspaceDefaultAlias]
+        : widget.aliases;
+    _selectedAlias ??= aliases.first;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.weaverMemberModelAliasTitle,
+          style: theme.textTheme.titleMedium,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          l10n.weaverMemberModelAliasDescription,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 8),
+        RadioGroup<String>(
+          groupValue: _selectedAlias,
+          onChanged: (value) => setState(() => _selectedAlias = value),
+          child: Column(
+            children: [
+              for (final alias in aliases)
+                RadioListTile<String>.adaptive(
+                  contentPadding: EdgeInsets.zero,
+                  value: alias,
+                  title: Text(alias),
+                  subtitle: Text(l10n.weaverMemberApprovedByAdmin),
+                  controlAffinity: ListTileControlAffinity.leading,
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _WeaverPersonalSettingsList extends StatelessWidget {
+  const _WeaverPersonalSettingsList({required this.state});
+
+  final WeaverMemberUxState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.weaverMemberPersonalSettingsTitle,
+          style: theme.textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        _WeaverSettingRow(
+          label: l10n.weaverMemberStyleSetting,
+          enabled: state.canConfigureStyle,
+        ),
+        _WeaverSettingRow(
+          label: l10n.weaverMemberMemorySetting,
+          enabled: state.canConfigureMemory,
+        ),
+        _WeaverSettingRow(
+          label: l10n.weaverMemberWorkspaceSetting,
+          enabled: state.canConfigureWorkspace,
+        ),
+      ],
+    );
+  }
+}
+
+class _WeaverSettingRow extends StatelessWidget {
+  const _WeaverSettingRow({required this.label, required this.enabled});
+
+  final String label;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return CheckboxListTile.adaptive(
+      contentPadding: EdgeInsets.zero,
+      value: enabled,
+      onChanged: null,
+      title: Text(label),
+      subtitle: Text(
+        enabled
+            ? l10n.weaverMemberSettingAllowed
+            : l10n.weaverMemberSettingDisabled,
+      ),
+      controlAffinity: ListTileControlAffinity.leading,
+    );
+  }
+}
+
+class _WeaverAllowedItemsWrap extends StatelessWidget {
+  const _WeaverAllowedItemsWrap({
+    required this.title,
+    required this.emptyLabel,
+    required this.items,
+  });
+
+  final String title;
+  final String emptyLabel;
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        if (items.isEmpty)
+          Text(
+            emptyLabel,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          )
+        else
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final item in items)
+                Chip(
+                  avatar: const Icon(Icons.check_circle_outline, size: 18),
+                  label: Text(item),
+                ),
+            ],
+          ),
+      ],
+    );
+  }
+}
+
+class _WeaverBoundaryNotice extends StatelessWidget {
+  const _WeaverBoundaryNotice({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return MergeSemantics(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.22),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: theme.colorScheme.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                Icons.privacy_tip_outlined,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(width: 10),
+              Expanded(child: Text(text, style: theme.textTheme.bodyMedium)),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -1072,6 +1072,103 @@
   "@agentCapabilityPolicyLoading": {
     "description": "Loading message for AI agent capability policy settings section"
   },
+
+  "weaverMemberTitle": "Mein Weaver",
+  "@weaverMemberTitle": {
+    "description": "Title for the governed member Weaver settings entry point"
+  },
+  "weaverMemberUnavailableTitle": "Weaver nicht verfügbar",
+  "@weaverMemberUnavailableTitle": {
+    "description": "Title when the governed Weaver member settings entry point is unavailable"
+  },
+  "weaverMemberDescription": "Wähle aus adminfreigegebenen Modell-Aliasen und prüfe die persönlichen Einstellungen, die deine Workspace-Richtlinie erlaubt.",
+  "@weaverMemberDescription": {
+    "description": "Description for available governed Weaver member settings"
+  },
+  "weaverMemberUnavailableDescription": "Dein Workspace hat für dieses Konto kein gesteuertes Weaver-Profil aktiviert.",
+  "@weaverMemberUnavailableDescription": {
+    "description": "Description when Weaver is unavailable for the member"
+  },
+  "weaverMemberStatusAvailable": "Durch Richtlinie aktiviert",
+  "@weaverMemberStatusAvailable": {
+    "description": "Status chip for available Weaver member settings"
+  },
+  "weaverMemberStatusDisabled": "Durch Richtlinie deaktiviert",
+  "@weaverMemberStatusDisabled": {
+    "description": "Status chip for disabled Weaver member settings"
+  },
+  "weaverMemberStatusUnavailable": "Nicht verfügbar",
+  "@weaverMemberStatusUnavailable": {
+    "description": "Status chip for unavailable Weaver member settings"
+  },
+  "weaverMemberLoading": "Weaver-Richtlinie wird geprüft…",
+  "@weaverMemberLoading": {
+    "description": "Loading message for Weaver member policy"
+  },
+  "weaverMemberModelAliasTitle": "Modell-Alias",
+  "@weaverMemberModelAliasTitle": {
+    "description": "Title for choosing a Weaver model alias"
+  },
+  "weaverMemberModelAliasDescription": "Hier erscheinen nur Aliase, die deine Workspace-Richtlinie freigegeben hat.",
+  "@weaverMemberModelAliasDescription": {
+    "description": "Description for admin-approved model alias choices"
+  },
+  "weaverMemberWorkspaceDefaultAlias": "Workspace-Standard",
+  "@weaverMemberWorkspaceDefaultAlias": {
+    "description": "Fallback model alias label when no explicit alias names are exposed"
+  },
+  "weaverMemberApprovedByAdmin": "Durch Workspace-Richtlinie freigegeben",
+  "@weaverMemberApprovedByAdmin": {
+    "description": "Subtitle for an approved Weaver setting"
+  },
+  "weaverMemberPersonalSettingsTitle": "Persönliche Einstellungen",
+  "@weaverMemberPersonalSettingsTitle": {
+    "description": "Title for personal Weaver settings"
+  },
+  "weaverMemberStyleSetting": "Stilpräferenzen",
+  "@weaverMemberStyleSetting": {
+    "description": "Weaver style preference setting label"
+  },
+  "weaverMemberMemorySetting": "Speichersteuerung",
+  "@weaverMemberMemorySetting": {
+    "description": "Weaver memory control setting label"
+  },
+  "weaverMemberWorkspaceSetting": "Workspace-Personalisierung",
+  "@weaverMemberWorkspaceSetting": {
+    "description": "Weaver workspace personalization setting label"
+  },
+  "weaverMemberSettingAllowed": "Für dein Profil erlaubt",
+  "@weaverMemberSettingAllowed": {
+    "description": "Subtitle for an allowed Weaver personal setting"
+  },
+  "weaverMemberSettingDisabled": "Für dein Profil nicht aktiviert",
+  "@weaverMemberSettingDisabled": {
+    "description": "Subtitle for a disabled Weaver personal setting"
+  },
+  "weaverMemberAllowedSkillsTitle": "Erlaubte Skills",
+  "@weaverMemberAllowedSkillsTitle": {
+    "description": "Title for allowed Weaver skills"
+  },
+  "weaverMemberNoAllowedSkills": "Für dein Profil sind keine optionalen Skills aktiviert.",
+  "@weaverMemberNoAllowedSkills": {
+    "description": "Empty state for allowed Weaver skills"
+  },
+  "weaverMemberAllowedConnectionsTitle": "Erlaubte persönliche Verbindungen",
+  "@weaverMemberAllowedConnectionsTitle": {
+    "description": "Title for approved personal Weaver connections"
+  },
+  "weaverMemberNoAllowedConnections": "Für dein Profil sind keine persönlichen Verbindungsabläufe aktiviert.",
+  "@weaverMemberNoAllowedConnections": {
+    "description": "Empty state for allowed Weaver personal connections"
+  },
+  "weaverMemberBoundaryNotice": "Administration von Providern, Zugangsdaten, Connector-Einrichtung und Laufzeitdateien bleibt außerhalb der Mitgliedereinstellungen; Mitglieder sehen nur richtlinienfreigegebene Auswahl.",
+  "@weaverMemberBoundaryNotice": {
+    "description": "Boundary notice for available Weaver member settings"
+  },
+  "weaverMemberDisabledBoundaryNotice": "Es werden keine Provider-Secrets oder Laufzeitkonfigurationen angezeigt. Kontaktiere deine Workspace-Eigentümerin, wenn du Weaver-Zugriff erwartet hast.",
+  "@weaverMemberDisabledBoundaryNotice": {
+    "description": "Boundary notice when Weaver is disabled for a member"
+  },
   "workflowPreviewTitle": "Aktive Workflows",
   "workflowPreviewDescription": "Eine lineare Ansicht der aktuellen Schritte, Verantwortlichen, Blockaden und Evidenz. Diagramme können später dazukommen; diese Ansicht muss zuerst mit Tastatur und Screenreadern funktionieren.",
   "workflowPreviewLinearViewChip": "Lineare Ansicht zuerst",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -4017,6 +4017,103 @@
   "@agentCapabilityPolicyLoading": {
     "description": "Loading message for AI agent capability policy settings section"
   },
+
+  "weaverMemberTitle": "Mein Weaver",
+  "@weaverMemberTitle": {
+    "description": "Title for the governed member Weaver settings entry point"
+  },
+  "weaverMemberUnavailableTitle": "Weaver unavailable",
+  "@weaverMemberUnavailableTitle": {
+    "description": "Title when the governed Weaver member settings entry point is unavailable"
+  },
+  "weaverMemberDescription": "Choose from admin-approved model aliases and review the personal settings your workspace policy allows.",
+  "@weaverMemberDescription": {
+    "description": "Description for available governed Weaver member settings"
+  },
+  "weaverMemberUnavailableDescription": "Your workspace has not enabled a governed Weaver profile for this account.",
+  "@weaverMemberUnavailableDescription": {
+    "description": "Description when Weaver is unavailable for the member"
+  },
+  "weaverMemberStatusAvailable": "Enabled by policy",
+  "@weaverMemberStatusAvailable": {
+    "description": "Status chip for available Weaver member settings"
+  },
+  "weaverMemberStatusDisabled": "Disabled by policy",
+  "@weaverMemberStatusDisabled": {
+    "description": "Status chip for disabled Weaver member settings"
+  },
+  "weaverMemberStatusUnavailable": "Unavailable",
+  "@weaverMemberStatusUnavailable": {
+    "description": "Status chip for unavailable Weaver member settings"
+  },
+  "weaverMemberLoading": "Checking Weaver policy…",
+  "@weaverMemberLoading": {
+    "description": "Loading message for Weaver member policy"
+  },
+  "weaverMemberModelAliasTitle": "Model alias",
+  "@weaverMemberModelAliasTitle": {
+    "description": "Title for choosing a Weaver model alias"
+  },
+  "weaverMemberModelAliasDescription": "Only aliases approved by your workspace policy are shown here.",
+  "@weaverMemberModelAliasDescription": {
+    "description": "Description for admin-approved model alias choices"
+  },
+  "weaverMemberWorkspaceDefaultAlias": "Workspace default",
+  "@weaverMemberWorkspaceDefaultAlias": {
+    "description": "Fallback model alias label when no explicit alias names are exposed"
+  },
+  "weaverMemberApprovedByAdmin": "Approved by workspace policy",
+  "@weaverMemberApprovedByAdmin": {
+    "description": "Subtitle for an approved Weaver setting"
+  },
+  "weaverMemberPersonalSettingsTitle": "Personal settings",
+  "@weaverMemberPersonalSettingsTitle": {
+    "description": "Title for personal Weaver settings"
+  },
+  "weaverMemberStyleSetting": "Style preferences",
+  "@weaverMemberStyleSetting": {
+    "description": "Weaver style preference setting label"
+  },
+  "weaverMemberMemorySetting": "Memory controls",
+  "@weaverMemberMemorySetting": {
+    "description": "Weaver memory control setting label"
+  },
+  "weaverMemberWorkspaceSetting": "Workspace personalization",
+  "@weaverMemberWorkspaceSetting": {
+    "description": "Weaver workspace personalization setting label"
+  },
+  "weaverMemberSettingAllowed": "Allowed for your profile",
+  "@weaverMemberSettingAllowed": {
+    "description": "Subtitle for an allowed Weaver personal setting"
+  },
+  "weaverMemberSettingDisabled": "Not enabled for your profile",
+  "@weaverMemberSettingDisabled": {
+    "description": "Subtitle for a disabled Weaver personal setting"
+  },
+  "weaverMemberAllowedSkillsTitle": "Allowed skills",
+  "@weaverMemberAllowedSkillsTitle": {
+    "description": "Title for allowed Weaver skills"
+  },
+  "weaverMemberNoAllowedSkills": "No optional skills are enabled for your profile.",
+  "@weaverMemberNoAllowedSkills": {
+    "description": "Empty state for allowed Weaver skills"
+  },
+  "weaverMemberAllowedConnectionsTitle": "Allowed personal connections",
+  "@weaverMemberAllowedConnectionsTitle": {
+    "description": "Title for approved personal Weaver connections"
+  },
+  "weaverMemberNoAllowedConnections": "No personal connection flows are enabled for your profile.",
+  "@weaverMemberNoAllowedConnections": {
+    "description": "Empty state for allowed Weaver personal connections"
+  },
+  "weaverMemberBoundaryNotice": "Administration of providers, credentials, connector setup, and runtime files stays outside member settings; members only see policy-approved choices.",
+  "@weaverMemberBoundaryNotice": {
+    "description": "Boundary notice for available Weaver member settings"
+  },
+  "weaverMemberDisabledBoundaryNotice": "No provider secrets or runtime configuration are exposed. Contact your workspace owner if you expected Weaver access.",
+  "@weaverMemberDisabledBoundaryNotice": {
+    "description": "Boundary notice when Weaver is disabled for a member"
+  },
   "workflowPreviewTitle": "Active workflows",
   "@workflowPreviewTitle": {
     "description": "Title for the context-driven workflow preview panel"

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -5598,6 +5598,150 @@ abstract class AppLocalizations {
   /// **'Checking agent capability policy…'**
   String get agentCapabilityPolicyLoading;
 
+  /// Title for the governed member Weaver settings entry point
+  ///
+  /// In en, this message translates to:
+  /// **'Mein Weaver'**
+  String get weaverMemberTitle;
+
+  /// Title when the governed Weaver member settings entry point is unavailable
+  ///
+  /// In en, this message translates to:
+  /// **'Weaver unavailable'**
+  String get weaverMemberUnavailableTitle;
+
+  /// Description for available governed Weaver member settings
+  ///
+  /// In en, this message translates to:
+  /// **'Choose from admin-approved model aliases and review the personal settings your workspace policy allows.'**
+  String get weaverMemberDescription;
+
+  /// Description when Weaver is unavailable for the member
+  ///
+  /// In en, this message translates to:
+  /// **'Your workspace has not enabled a governed Weaver profile for this account.'**
+  String get weaverMemberUnavailableDescription;
+
+  /// Status chip for available Weaver member settings
+  ///
+  /// In en, this message translates to:
+  /// **'Enabled by policy'**
+  String get weaverMemberStatusAvailable;
+
+  /// Status chip for disabled Weaver member settings
+  ///
+  /// In en, this message translates to:
+  /// **'Disabled by policy'**
+  String get weaverMemberStatusDisabled;
+
+  /// Status chip for unavailable Weaver member settings
+  ///
+  /// In en, this message translates to:
+  /// **'Unavailable'**
+  String get weaverMemberStatusUnavailable;
+
+  /// Loading message for Weaver member policy
+  ///
+  /// In en, this message translates to:
+  /// **'Checking Weaver policy…'**
+  String get weaverMemberLoading;
+
+  /// Title for choosing a Weaver model alias
+  ///
+  /// In en, this message translates to:
+  /// **'Model alias'**
+  String get weaverMemberModelAliasTitle;
+
+  /// Description for admin-approved model alias choices
+  ///
+  /// In en, this message translates to:
+  /// **'Only aliases approved by your workspace policy are shown here.'**
+  String get weaverMemberModelAliasDescription;
+
+  /// Fallback model alias label when no explicit alias names are exposed
+  ///
+  /// In en, this message translates to:
+  /// **'Workspace default'**
+  String get weaverMemberWorkspaceDefaultAlias;
+
+  /// Subtitle for an approved Weaver setting
+  ///
+  /// In en, this message translates to:
+  /// **'Approved by workspace policy'**
+  String get weaverMemberApprovedByAdmin;
+
+  /// Title for personal Weaver settings
+  ///
+  /// In en, this message translates to:
+  /// **'Personal settings'**
+  String get weaverMemberPersonalSettingsTitle;
+
+  /// Weaver style preference setting label
+  ///
+  /// In en, this message translates to:
+  /// **'Style preferences'**
+  String get weaverMemberStyleSetting;
+
+  /// Weaver memory control setting label
+  ///
+  /// In en, this message translates to:
+  /// **'Memory controls'**
+  String get weaverMemberMemorySetting;
+
+  /// Weaver workspace personalization setting label
+  ///
+  /// In en, this message translates to:
+  /// **'Workspace personalization'**
+  String get weaverMemberWorkspaceSetting;
+
+  /// Subtitle for an allowed Weaver personal setting
+  ///
+  /// In en, this message translates to:
+  /// **'Allowed for your profile'**
+  String get weaverMemberSettingAllowed;
+
+  /// Subtitle for a disabled Weaver personal setting
+  ///
+  /// In en, this message translates to:
+  /// **'Not enabled for your profile'**
+  String get weaverMemberSettingDisabled;
+
+  /// Title for allowed Weaver skills
+  ///
+  /// In en, this message translates to:
+  /// **'Allowed skills'**
+  String get weaverMemberAllowedSkillsTitle;
+
+  /// Empty state for allowed Weaver skills
+  ///
+  /// In en, this message translates to:
+  /// **'No optional skills are enabled for your profile.'**
+  String get weaverMemberNoAllowedSkills;
+
+  /// Title for approved personal Weaver connections
+  ///
+  /// In en, this message translates to:
+  /// **'Allowed personal connections'**
+  String get weaverMemberAllowedConnectionsTitle;
+
+  /// Empty state for allowed Weaver personal connections
+  ///
+  /// In en, this message translates to:
+  /// **'No personal connection flows are enabled for your profile.'**
+  String get weaverMemberNoAllowedConnections;
+
+  /// Boundary notice for available Weaver member settings
+  ///
+  /// In en, this message translates to:
+  /// **'Administration of providers, credentials, connector setup, and runtime files stays outside member settings; members only see policy-approved choices.'**
+  String get weaverMemberBoundaryNotice;
+
+  /// Boundary notice when Weaver is disabled for a member
+  ///
+  /// In en, this message translates to:
+  /// **'No provider secrets or runtime configuration are exposed. Contact your workspace owner if you expected Weaver access.'**
+  String get weaverMemberDisabledBoundaryNotice;
+
   /// Title for the context-driven workflow preview panel
   ///
   /// In en, this message translates to:

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -3443,6 +3443,87 @@ class AppLocalizationsDe extends AppLocalizations {
       'Agenten-Funktionsrichtlinie wird geprüft…';
 
   @override
+  String get weaverMemberTitle => 'Mein Weaver';
+
+  @override
+  String get weaverMemberUnavailableTitle => 'Weaver nicht verfügbar';
+
+  @override
+  String get weaverMemberDescription =>
+      'Wähle aus adminfreigegebenen Modell-Aliasen und prüfe die persönlichen Einstellungen, die deine Workspace-Richtlinie erlaubt.';
+
+  @override
+  String get weaverMemberUnavailableDescription =>
+      'Dein Workspace hat für dieses Konto kein gesteuertes Weaver-Profil aktiviert.';
+
+  @override
+  String get weaverMemberStatusAvailable => 'Durch Richtlinie aktiviert';
+
+  @override
+  String get weaverMemberStatusDisabled => 'Durch Richtlinie deaktiviert';
+
+  @override
+  String get weaverMemberStatusUnavailable => 'Nicht verfügbar';
+
+  @override
+  String get weaverMemberLoading => 'Weaver-Richtlinie wird geprüft…';
+
+  @override
+  String get weaverMemberModelAliasTitle => 'Modell-Alias';
+
+  @override
+  String get weaverMemberModelAliasDescription =>
+      'Hier erscheinen nur Aliase, die deine Workspace-Richtlinie freigegeben hat.';
+
+  @override
+  String get weaverMemberWorkspaceDefaultAlias => 'Workspace-Standard';
+
+  @override
+  String get weaverMemberApprovedByAdmin =>
+      'Durch Workspace-Richtlinie freigegeben';
+
+  @override
+  String get weaverMemberPersonalSettingsTitle => 'Persönliche Einstellungen';
+
+  @override
+  String get weaverMemberStyleSetting => 'Stilpräferenzen';
+
+  @override
+  String get weaverMemberMemorySetting => 'Speichersteuerung';
+
+  @override
+  String get weaverMemberWorkspaceSetting => 'Workspace-Personalisierung';
+
+  @override
+  String get weaverMemberSettingAllowed => 'Für dein Profil erlaubt';
+
+  @override
+  String get weaverMemberSettingDisabled => 'Für dein Profil nicht aktiviert';
+
+  @override
+  String get weaverMemberAllowedSkillsTitle => 'Erlaubte Skills';
+
+  @override
+  String get weaverMemberNoAllowedSkills =>
+      'Für dein Profil sind keine optionalen Skills aktiviert.';
+
+  @override
+  String get weaverMemberAllowedConnectionsTitle =>
+      'Erlaubte persönliche Verbindungen';
+
+  @override
+  String get weaverMemberNoAllowedConnections =>
+      'Für dein Profil sind keine persönlichen Verbindungsabläufe aktiviert.';
+
+  @override
+  String get weaverMemberBoundaryNotice =>
+      'Administration von Providern, Zugangsdaten, Connector-Einrichtung und Laufzeitdateien bleibt außerhalb der Mitgliedereinstellungen; Mitglieder sehen nur richtlinienfreigegebene Auswahl.';
+
+  @override
+  String get weaverMemberDisabledBoundaryNotice =>
+      'Es werden keine Provider-Secrets oder Laufzeitkonfigurationen angezeigt. Kontaktiere deine Workspace-Eigentümerin, wenn du Weaver-Zugriff erwartet hast.';
+
+  @override
   String get workflowPreviewTitle => 'Aktive Workflows';
 
   @override

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -3395,6 +3395,86 @@ class AppLocalizationsEn extends AppLocalizations {
       'Checking agent capability policy…';
 
   @override
+  String get weaverMemberTitle => 'Mein Weaver';
+
+  @override
+  String get weaverMemberUnavailableTitle => 'Weaver unavailable';
+
+  @override
+  String get weaverMemberDescription =>
+      'Choose from admin-approved model aliases and review the personal settings your workspace policy allows.';
+
+  @override
+  String get weaverMemberUnavailableDescription =>
+      'Your workspace has not enabled a governed Weaver profile for this account.';
+
+  @override
+  String get weaverMemberStatusAvailable => 'Enabled by policy';
+
+  @override
+  String get weaverMemberStatusDisabled => 'Disabled by policy';
+
+  @override
+  String get weaverMemberStatusUnavailable => 'Unavailable';
+
+  @override
+  String get weaverMemberLoading => 'Checking Weaver policy…';
+
+  @override
+  String get weaverMemberModelAliasTitle => 'Model alias';
+
+  @override
+  String get weaverMemberModelAliasDescription =>
+      'Only aliases approved by your workspace policy are shown here.';
+
+  @override
+  String get weaverMemberWorkspaceDefaultAlias => 'Workspace default';
+
+  @override
+  String get weaverMemberApprovedByAdmin => 'Approved by workspace policy';
+
+  @override
+  String get weaverMemberPersonalSettingsTitle => 'Personal settings';
+
+  @override
+  String get weaverMemberStyleSetting => 'Style preferences';
+
+  @override
+  String get weaverMemberMemorySetting => 'Memory controls';
+
+  @override
+  String get weaverMemberWorkspaceSetting => 'Workspace personalization';
+
+  @override
+  String get weaverMemberSettingAllowed => 'Allowed for your profile';
+
+  @override
+  String get weaverMemberSettingDisabled => 'Not enabled for your profile';
+
+  @override
+  String get weaverMemberAllowedSkillsTitle => 'Allowed skills';
+
+  @override
+  String get weaverMemberNoAllowedSkills =>
+      'No optional skills are enabled for your profile.';
+
+  @override
+  String get weaverMemberAllowedConnectionsTitle =>
+      'Allowed personal connections';
+
+  @override
+  String get weaverMemberNoAllowedConnections =>
+      'No personal connection flows are enabled for your profile.';
+
+  @override
+  String get weaverMemberBoundaryNotice =>
+      'Administration of providers, credentials, connector setup, and runtime files stays outside member settings; members only see policy-approved choices.';
+
+  @override
+  String get weaverMemberDisabledBoundaryNotice =>
+      'No provider secrets or runtime configuration are exposed. Contact your workspace owner if you expected Weaver access.';
+
+  @override
   String get workflowPreviewTitle => 'Active workflows';
 
   @override

--- a/client/test/features/agents/domain/agent_capability_policy_test.dart
+++ b/client/test/features/agents/domain/agent_capability_policy_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/features/agents/domain/entities/agent_capability_policy.dart';
+import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 
 void main() {
   group('AgentCapabilityPolicy', () {
@@ -43,5 +44,63 @@ void main() {
       );
       expect(policy.stateFor(AgentCapability.channelAgent).canStart, isFalse);
     });
+
+    test(
+      'maps governed Weaver grants into member UX without raw runtime config',
+      () {
+        const snapshot = WorkspaceCapabilitySnapshot(
+          shellAccess: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.shellAccess,
+            readiness: WorkspaceCapabilityReadiness.ready,
+            policyState: WorkspaceCapabilityPolicyState.allowed,
+          ),
+          chat: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.chat,
+            readiness: WorkspaceCapabilityReadiness.ready,
+            policyState: WorkspaceCapabilityPolicyState.allowed,
+          ),
+          files: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.files,
+            readiness: WorkspaceCapabilityReadiness.ready,
+            policyState: WorkspaceCapabilityPolicyState.allowed,
+          ),
+          calendar: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.calendar,
+            readiness: WorkspaceCapabilityReadiness.unavailable,
+          ),
+          boards: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.boards,
+            readiness: WorkspaceCapabilityReadiness.unavailable,
+          ),
+          weaver: WorkspaceCapabilityState(
+            capability: WorkspaceCapability.weaver,
+            readiness: WorkspaceCapabilityReadiness.ready,
+            policyState: WorkspaceCapabilityPolicyState.allowed,
+            grantedCapabilities: [
+              'weaver.enabled',
+              'weaver.model_alias.fast_local',
+              'weaver.skill.summarize_notes',
+              'weaver.personal_connection.calendar_import',
+              'weaver.configure_style',
+            ],
+          ),
+        );
+
+        final policy = AgentCapabilityPolicy.fromWorkspaceCapabilities(
+          canManageCapabilities: false,
+          workspaceCapabilities: snapshot,
+        );
+
+        expect(policy.canStartAnyCapability, isTrue);
+        expect(policy.weaverMemberUx.available, isTrue);
+        expect(policy.weaverMemberUx.modelAliases, ['Fast Local']);
+        expect(policy.weaverMemberUx.allowedSkills, ['Summarize Notes']);
+        expect(policy.weaverMemberUx.allowedPersonalConnections, [
+          'Calendar Import',
+        ]);
+        expect(policy.weaverMemberUx.canConfigureStyle, isTrue);
+        expect(policy.weaverMemberUx.canConfigureMemory, isFalse);
+      },
+    );
   });
 }

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -147,6 +147,56 @@ AsyncValue<WorkspaceCapabilitySnapshot> _workspaceCapabilitySnapshot() {
   );
 }
 
+AsyncValue<WorkspaceCapabilitySnapshot>
+_workspaceCapabilitySnapshotWithWeaver() {
+  return const AsyncData(
+    WorkspaceCapabilitySnapshot(
+      shellAccess: WorkspaceCapabilityState(
+        capability: WorkspaceCapability.shellAccess,
+        readiness: WorkspaceCapabilityReadiness.ready,
+        connectionStatus: IntegrationConnectionStatus.connected,
+        policyState: WorkspaceCapabilityPolicyState.allowed,
+      ),
+      chat: WorkspaceCapabilityState(
+        capability: WorkspaceCapability.chat,
+        readiness: WorkspaceCapabilityReadiness.ready,
+        connectionStatus: IntegrationConnectionStatus.connected,
+        policyState: WorkspaceCapabilityPolicyState.allowed,
+      ),
+      files: WorkspaceCapabilityState(
+        capability: WorkspaceCapability.files,
+        readiness: WorkspaceCapabilityReadiness.ready,
+        connectionStatus: IntegrationConnectionStatus.connected,
+        policyState: WorkspaceCapabilityPolicyState.allowed,
+      ),
+      calendar: WorkspaceCapabilityState(
+        capability: WorkspaceCapability.calendar,
+        readiness: WorkspaceCapabilityReadiness.unavailable,
+      ),
+      boards: WorkspaceCapabilityState(
+        capability: WorkspaceCapability.boards,
+        readiness: WorkspaceCapabilityReadiness.unavailable,
+      ),
+      weaver: WorkspaceCapabilityState(
+        capability: WorkspaceCapability.weaver,
+        readiness: WorkspaceCapabilityReadiness.ready,
+        policyState: WorkspaceCapabilityPolicyState.allowed,
+        memberImpact:
+            'Mein Weaver is available with workspace-approved choices.',
+        grantedCapabilities: [
+          'weaver.enabled',
+          'weaver.model_alias.fast_local',
+          'weaver.model_alias.careful_cloud',
+          'weaver.configure_style',
+          'weaver.configure_memory',
+          'weaver.skill.summarize_notes',
+          'weaver.personal_connection.calendar_import',
+        ],
+      ),
+    ),
+  );
+}
+
 ProviderStatusSnapshot _providerStatus({
   required String module,
   required String providerKey,
@@ -433,6 +483,74 @@ void main() {
         findsNothing,
       );
     });
+
+    testWidgets(
+      'shows governed Mein Weaver choices without raw runtime surfaces',
+      (tester) async {
+        final capabilities = _workspaceCapabilitySnapshotWithWeaver();
+        final container = ProviderContainer.test(
+          overrides: [
+            preferencesStoreProvider.overrideWith(
+              (ref) => InMemoryPreferencesStore(buildStoredConfiguration()),
+            ),
+            chatSecurityRepositoryProvider.overrideWithValue(
+              FakeChatSecurityRepository(),
+            ),
+            workspaceConnectionStateProvider.overrideWithValue(
+              _workspaceConnectionState(),
+            ),
+            workspaceCapabilitySnapshotProvider.overrideWithValue(capabilities),
+            weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+              (ref) async => capabilities.requireValue,
+            ),
+            weaveBackendConnectionStateProvider.overrideWithValue(
+              WeaveBackendConnectionState.connected,
+            ),
+            weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
+              (ref) async => _matrixDiagnostic,
+            ),
+            userProfileProvider.overrideWith((ref) async => _memberProfile),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: SettingsScreen()),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.scrollUntilVisible(
+          find.text('Mein Weaver'),
+          300,
+          scrollable: find.byType(Scrollable).first,
+        );
+        expect(find.text('Mein Weaver'), findsOneWidget);
+        expect(find.text('Enabled by policy'), findsOneWidget);
+        expect(find.text('Careful Cloud'), findsOneWidget);
+        expect(find.text('Fast Local'), findsOneWidget);
+        expect(find.text('Style preferences'), findsOneWidget);
+        expect(find.text('Memory controls'), findsOneWidget);
+        expect(find.text('Summarize Notes'), findsOneWidget);
+        expect(find.text('Calendar Import'), findsOneWidget);
+        expect(
+          find.textContaining('members only see policy-approved choices'),
+          findsOneWidget,
+        );
+        expect(find.textContaining('OpenClaw'), findsNothing);
+        expect(find.textContaining('openclaw.json'), findsNothing);
+        expect(find.textContaining('channel tokens'), findsNothing);
+        expect(find.textContaining('provider secrets'), findsNothing);
+        expect(find.textContaining('raw MCP'), findsNothing);
+        expect(find.text('Server Configuration'), findsNothing);
+      },
+    );
 
     testWidgets('keeps provider diagnostics admin-only for members', (
       tester,


### PR DESCRIPTION
Related: #525

## Summary
- Adds a governed Mein Weaver settings section for normal members based on workspace RuntimeProfile capability grants.
- Maps model aliases, optional style/memory controls, approved skills, and approved personal connection flows into bounded member UX.
- Keeps raw OpenClaw/runtime configuration, provider secrets, channel/plugin/MCP controls, and admin/provider diagnostics out of member settings copy and tests.

## Evidence
- `./gradlew clientCi acceptanceContract --console=plain`

## Release notes
- release-notes-minor
