### PR TITLE
test: add Matrix chat portability lifecycle fixture

### DIFF
--- a/docs/matrix-chat-migration-proof.md
+++ b/docs/matrix-chat-migration-proof.md
@@ -1,6 +1,6 @@
 # Matrix Chat migration proof boundary
 
-Status: Sprint 14 contract seed for issues [#537](https://github.com/masssi164/weave/issues/537), [#538](https://github.com/masssi164/weave/issues/538), [#541](https://github.com/masssi164/weave/issues/541), and [#542](https://github.com/masssi164/weave/issues/542). This page defines the conservative proof target and is backed by the machine-readable fixture `specs/0006-portability-contract/matrix-synapse-chat-migration-proof.json`, validated by `./gradlew portabilityContractCheck`.
+Status: Sprint 14 contract seed for issues [#537](https://github.com/masssi164/weave/issues/537), [#538](https://github.com/masssi164/weave/issues/538), [#541](https://github.com/masssi164/weave/issues/541), and [#542](https://github.com/masssi164/weave/issues/542). This page defines the conservative proof target and is backed by the machine-readable fixtures `specs/0006-portability-contract/matrix-synapse-chat-migration-proof.json` and `specs/0006-portability-contract/matrix-synapse-chat-lifecycle-fixture.json`, validated by `./gradlew portabilityContractCheck`.
 
 ## Goal
 
@@ -50,7 +50,7 @@ Each dry-run or fixture proof must produce support-safe artifacts aligned with t
 | RollbackRetentionReport | Source retention, target rollback feasibility, archive retention, restore-smoke expectations. | Rollback limitations must be shown before cutover confirmation. |
 | MigrationAuditRef | Dry-run/apply/rollback request refs, actor class, timestamps, decision, profile/adapter versions. | Audit output remains support-safe. |
 
-The Sprint 14 fixture currently proves classification and apply blocking only. Its sample dry-run is intentionally `blocked` because E2EE history, power-level parity, and media durability decisions require explicit admin/operator review before any apply path can be enabled.
+The Sprint 14 fixtures currently prove classification, preflight, apply blocking, and rollback-retention evidence only. The sample dry-run and apply attempt are intentionally `blocked` because E2EE history, power-level parity, and media durability decisions require explicit admin/operator review before any apply path can be enabled. The lifecycle fixture must keep `encrypted-room-detection-complete` blocked/`unsupported`, apply attempts at zero applied objects, and rollback limited to source retention plus target cleanup/restore-smoke evidence; it must not claim lossless migration, legal compliance, or E2EE history migration.
 
 ## Admin provider-switch journey
 

--- a/specs/0006-portability-contract/matrix-synapse-chat-lifecycle-fixture.json
+++ b/specs/0006-portability-contract/matrix-synapse-chat-lifecycle-fixture.json
@@ -1,0 +1,106 @@
+{
+  "proofId": "sprint-14-matrix-synapse-chat-lifecycle-fixture-v1",
+  "domainKey": "chat",
+  "sourceProvider": "matrix-synapse",
+  "targetProvider": "weave-chat-domain",
+  "preflight": {
+    "runId": "preflight:s14:matrix-synapse-chat:redacted",
+    "state": "preflight_failed",
+    "checks": [
+      {
+        "checkKey": "matrix-api-reachable",
+        "decision": "passed",
+        "fieldClass": "portable",
+        "evidenceRef": "audit:s14:matrix-chat:preflight:api-reachable:redacted"
+      },
+      {
+        "checkKey": "export-permission-present",
+        "decision": "passed",
+        "fieldClass": "portable",
+        "evidenceRef": "audit:s14:matrix-chat:preflight:export-permission:redacted"
+      },
+      {
+        "checkKey": "audit-sink-ready",
+        "decision": "passed",
+        "fieldClass": "portable",
+        "evidenceRef": "audit:s14:matrix-chat:preflight:audit-sink:redacted"
+      },
+      {
+        "checkKey": "media-retention-policy-declared",
+        "decision": "manual_review",
+        "fieldClass": "manual_review",
+        "evidenceRef": "audit:s14:matrix-chat:preflight:media-retention:redacted"
+      },
+      {
+        "checkKey": "encrypted-room-detection-complete",
+        "decision": "blocked",
+        "fieldClass": "unsupported",
+        "reason": "Encrypted room history is counted and blocked; server-side Matrix migration cannot decrypt encrypted history until a client-side key/export strategy exists.",
+        "evidenceRef": "audit:s14:matrix-chat:preflight:e2ee-detected:redacted"
+      },
+      {
+        "checkKey": "rollback-archive-ready",
+        "decision": "passed",
+        "fieldClass": "archive_only",
+        "evidenceRef": "audit:s14:matrix-chat:preflight:rollback-archive:redacted"
+      }
+    ],
+    "memberImpactStates": [
+      "degraded",
+      "coming_later"
+    ],
+    "redaction": "support_safe"
+  },
+  "dryRun": {
+    "runId": "migration:s14:matrix-synapse-chat:dry-run-blocked-lifecycle",
+    "domainKey": "chat",
+    "state": "blocked",
+    "dryRunReportRef": "dry-run:s14:matrix-synapse-chat:lifecycle:redacted",
+    "providerMappingRef": "mapping:s14:matrix-synapse-chat:redacted",
+    "objectCounts": {
+      "rooms": 2,
+      "plainMessages": 8,
+      "encryptedEvents": 5,
+      "mediaReferences": 2
+    },
+    "contentHashes": [
+      "sha256:6d61747269782d636861742d6c6966656379636c652d7331340000000000"
+    ],
+    "auditRefs": [
+      "audit:s14:matrix-chat:dry-run:lifecycle:redacted"
+    ],
+    "applyAllowed": false,
+    "blockedReasons": [
+      "encrypted-room-history remains unsupported until client-side key/export strategy exists",
+      "matrix_power_levels require manual review before cutover",
+      "media retention must be acknowledged before apply"
+    ],
+    "redaction": "support_safe"
+  },
+  "applyAttempt": {
+    "runId": "apply:s14:matrix-synapse-chat:blocked-lifecycle",
+    "state": "blocked",
+    "applyAllowed": false,
+    "appliedObjects": 0,
+    "auditRefs": [
+      "audit:s14:matrix-chat:apply-blocked:lifecycle:redacted"
+    ],
+    "denialMessage": "Apply is blocked until unsupported encrypted history, Matrix power-level review, and media retention decisions are resolved.",
+    "redaction": "support_safe"
+  },
+  "rollbackPlan": {
+    "reportId": "rollback:s14:matrix-synapse-chat:lifecycle:redacted",
+    "domainKey": "chat",
+    "rollbackArchiveRef": "archive:s14:matrix-synapse-chat:lifecycle:redacted",
+    "sourceRetentionRequired": true,
+    "targetCleanupPlanRef": "cleanup:s14:weave-chat-import:lifecycle:redacted",
+    "restoreSmokeRequired": true,
+    "limitations": [
+      "Rollback can disable or clean target Weave Chat imports, but it cannot decrypt or migrate unsupported E2EE history.",
+      "Exact Matrix power-level parity is not guaranteed; admin/operator review remains required."
+    ],
+    "redaction": "support_safe"
+  },
+  "claimBoundary": "This lifecycle fixture proves preflight/apply blocking and rollback-retention evidence only. It does not prove lossless migration, legal compliance, or E2EE history migration.",
+  "redaction": "support_safe"
+}

--- a/specs/0006-portability-contract/tasks.md
+++ b/specs/0006-portability-contract/tasks.md
@@ -4,3 +4,4 @@
 - [x] Add no-unaccounted-data-loss documentation.
 - [x] Add dry-run success and apply-blocked fixtures.
 - [x] Add portability contract validation task.
+- [x] Add Sprint 14 Matrix Chat preflight/apply-blocked/rollback lifecycle fixture and executable validation.

--- a/specs/0006-portability-contract/traceability.yaml
+++ b/specs/0006-portability-contract/traceability.yaml
@@ -7,6 +7,8 @@ artifacts:
   fixtures:
     - specs/0006-portability-contract/migration-run-dry-run-success.json
     - specs/0006-portability-contract/migration-run-apply-blocked.json
+    - specs/0006-portability-contract/matrix-synapse-chat-migration-proof.json
+    - specs/0006-portability-contract/matrix-synapse-chat-lifecycle-fixture.json
   validation:
     - tools/portability_contract_check.py
   docs:

--- a/tools/portability_contract_check.py
+++ b/tools/portability_contract_check.py
@@ -104,6 +104,44 @@ def main():
  boundary=matrix.get('claimBoundary', '').lower()
  for phrase in ['does not prove lossless migration', 'legal compliance', 'e2ee history migration']:
   if phrase not in boundary: fail(f'Matrix proof claim boundary missing {phrase}')
+ lifecycle_fixture=load(FIXTURES/'matrix-synapse-chat-lifecycle-fixture.json')
+ if lifecycle_fixture.get('domainKey')!='chat' or lifecycle_fixture.get('sourceProvider')!='matrix-synapse' or lifecycle_fixture.get('targetProvider')!='weave-chat-domain' or lifecycle_fixture.get('redaction')!='support_safe':
+  fail('Matrix lifecycle fixture must be support_safe chat-domain evidence for matrix-synapse to weave-chat-domain')
+ lifecycle_raw=json.dumps(lifecycle_fixture).lower()
+ for forbidden in ['access_token','refresh_token','clientsecret','password','homeserverurl','mxc://','https://matrix']:
+  if forbidden in lifecycle_raw: fail(f'Matrix lifecycle fixture must not leak raw provider credential or endpoint data: {forbidden}')
+ preflight=lifecycle_fixture.get('preflight', {})
+ if preflight.get('state')!='preflight_failed' or preflight.get('redaction')!='support_safe':
+  fail('Matrix lifecycle preflight must fail closed with support_safe redaction')
+ checks={item.get('checkKey'): item for item in preflight.get('checks', [])}
+ for required_check in ['matrix-api-reachable','export-permission-present','audit-sink-ready','media-retention-policy-declared','encrypted-room-detection-complete','rollback-archive-ready']:
+  if required_check not in checks: fail(f'Matrix lifecycle preflight missing {required_check}')
+ e2ee=checks.get('encrypted-room-detection-complete', {})
+ if e2ee.get('decision')!='blocked' or e2ee.get('fieldClass')!='unsupported' or 'client-side key/export strategy' not in e2ee.get('reason',''):
+  fail('Matrix lifecycle preflight must block unsupported encrypted-room history until client-side key/export strategy exists')
+ if checks.get('media-retention-policy-declared', {}).get('fieldClass')!='manual_review':
+  fail('Matrix lifecycle preflight must keep media retention under manual review')
+ for state in preflight.get('memberImpactStates', []):
+  if state not in ['available','disabled_by_policy','not_configured','degraded','unavailable','coming_later']:
+   fail(f'Matrix lifecycle preflight uses non-canonical member impact state {state}')
+ dry_run=lifecycle_fixture.get('dryRun', {})
+ if dry_run.get('state')!='blocked' or dry_run.get('applyAllowed') is not False or not dry_run.get('dryRunReportRef') or dry_run.get('redaction')!='support_safe':
+  fail('Matrix lifecycle dry-run must record blocked post-dry-run evidence before apply')
+ blocked_reasons=' '.join(dry_run.get('blockedReasons', [])).lower()
+ for phrase in ['encrypted-room-history', 'matrix_power_levels', 'media retention']:
+  if phrase not in blocked_reasons: fail(f'Matrix lifecycle dry-run missing blocked reason {phrase}')
+ apply_attempt=lifecycle_fixture.get('applyAttempt', {})
+ if apply_attempt.get('state')!='blocked' or apply_attempt.get('applyAllowed') is not False or apply_attempt.get('appliedObjects')!=0:
+  fail('Matrix lifecycle apply attempt must remain blocked with zero applied objects')
+ rollback=lifecycle_fixture.get('rollbackPlan', {})
+ if rollback.get('restoreSmokeRequired') is not True or rollback.get('sourceRetentionRequired') is not True or rollback.get('redaction')!='support_safe':
+  fail('Matrix lifecycle rollback plan must require source retention, restore smoke, and support_safe redaction')
+ rollback_limits=' '.join(rollback.get('limitations', [])).lower()
+ for phrase in ['cannot decrypt', 'unsupported e2ee history', 'power-level parity']:
+  if phrase not in rollback_limits: fail(f'Matrix lifecycle rollback plan missing limitation {phrase}')
+ lifecycle_boundary=lifecycle_fixture.get('claimBoundary', '').lower()
+ for phrase in ['does not prove lossless migration', 'legal compliance', 'e2ee history migration']:
+  if phrase not in lifecycle_boundary: fail(f'Matrix lifecycle claim boundary missing {phrase}')
  success=load(FIXTURES/'migration-run-dry-run-success.json')
  blocked=load(FIXTURES/'migration-run-apply-blocked.json')
  for fixture in [success, blocked]:


### PR DESCRIPTION
## Summary

Adds the next executable Sprint 14 Matrix Chat portability contract slice for #541/#538/#542:

- introduces a support-safe Matrix Chat lifecycle fixture for preflight, blocked apply, and rollback-retention evidence;
- extends `portabilityContractCheck` to fail closed on missing preflight checks, unsupported E2EE-history blocking, zero-object apply blocking, rollback source retention/restore-smoke requirements, canonical member impact states, and raw secret/provider URL leakage;
- updates traceability and the Matrix migration proof doc to name the new lifecycle fixture and preserve conservative claim boundaries.

## User/admin/operator impact

Admins/operators get stronger checked evidence for Matrix Chat provider replacement before any apply path is allowed. Normal members remain on Weave Chat capability states only. This does not claim lossless migration, legal compliance, or E2EE history migration.

## Checks run

```text
python3 tools/portability_contract_check.py
./gradlew portabilityContractCheck docsCheck --no-daemon
./gradlew specContract --no-daemon
```

Refs #541, #538, #542.
