### PR TITLE
docs: close Sprint 14 product trust evidence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ registerRootCommandTask('specContract', ['python3', 'tools/spec_contract_check.p
 registerRootCommandTask('domainRegistryCheck', ['python3', 'tools/domain_registry_check.py'], 'Validate the canonical domain registry v1 machine-readable contract.')
 registerRootCommandTask('spaceAnchorCheck', ['python3', 'tools/space_anchor_check.py'], 'Validate the Space anchor contract fixture.')
 registerRootCommandTask('portabilityContractCheck', ['python3', 'tools/portability_contract_check.py'], 'Validate provider portability and no-unaccounted-data-loss migration schemas.')
+registerRootCommandTask('productTrustClaimMatrixCheck', ['python3', 'tools/product_trust_claim_matrix_check.py'], 'Validate Sprint 14 product-trust claim matrix evidence boundaries and overclaim guards.')
 registerRootCommandTask('specContractTest', ['python3', 'tools/spec_contract_check_test.py'], 'Run fixture tests for the repo-local Weave spec contract guard.')
 registerRootCommandTask('androidReleaseIdentityCheck', ['python3', 'tools/android_release_identity_check.py'], 'Validate Android package identity and release-signing fail-safe posture.')
 registerRootCommandTask('adminDependencyPolicyCheck', ['python3', 'tools/admin_console_dependency_policy_check.py'], 'Validate Admin Console dependency pins and lockfile policy.')
@@ -72,7 +73,7 @@ tasks.register('releaseReadinessCheck', Exec) {
     commandLine execCommand(args)
     outputs.upToDateWhen { false }
 }
-registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_claim_matrix_check.py && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py && python3 tools/release_readiness_check_test.py'], 'Validate release notes structure, README markers, provider reality claim matrix, labels, generator fixture evidence, Sprint 5 project-readiness closure evidence, Sprint 6 enterprise release gates, and RC readiness fixtures.')
+registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_claim_matrix_check.py && python3 tools/product_trust_claim_matrix_check.py && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py && python3 tools/release_readiness_check_test.py'], 'Validate release notes structure, README markers, provider reality and product-trust claim matrices, labels, generator fixture evidence, Sprint 5 project-readiness closure evidence, Sprint 6 enterprise release gates, and RC readiness fixtures.')
 
 tasks.register('docsCheck') {
     group = 'verification'
@@ -111,6 +112,7 @@ ext.ciEvidenceGates = [
     'domainRegistryCheck',
     'spaceAnchorCheck',
     'portabilityContractCheck',
+    'productTrustClaimMatrixCheck',
     'androidReleaseIdentityCheck',
     'adminDependencyPolicyCheck',
     'releaseEvidenceCheck',
@@ -217,6 +219,8 @@ List<String> artifactPathsForGate(String gateName) {
             return ['docs/space-anchor-contract.md', 'specs/0005-spaces-anchor/space-anchor-fixture.json', 'tools/space_anchor_check.py']
         case 'portabilityContractCheck':
             return ['server/src/main/resources/contracts/portability', 'specs/0006-portability-contract', 'tools/portability_contract_check.py']
+        case 'productTrustClaimMatrixCheck':
+            return ['docs/product-trust-provider-choice-claim-matrix.md', 'tools/product_trust_claim_matrix_check.py']
         case 'releaseEvidenceCheck':
             return ['README.md', 'tools/fixtures/release_notes_unreleased.expected.md']
         case 'projectReadinessEvidenceCheck':
@@ -295,10 +299,10 @@ tasks.register('doctor') {
 tasks.register('ci') {
     group = 'verification'
     description = 'Run the canonical monorepo CI orchestration checks.'
-    dependsOn 'doctor', 'acceptanceContract', 'specContract', 'specContractTest', 'domainRegistryCheck', 'portabilityContractCheck', 'androidReleaseIdentityCheck', 'adminDependencyPolicyCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
+    dependsOn 'doctor', 'acceptanceContract', 'specContract', 'specContractTest', 'domainRegistryCheck', 'portabilityContractCheck', 'productTrustClaimMatrixCheck', 'androidReleaseIdentityCheck', 'adminDependencyPolicyCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsCheck', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck'
 }
 
-['acceptanceContract', 'specContract', 'specContractTest', 'domainRegistryCheck', 'spaceAnchorCheck', 'portabilityContractCheck', 'androidReleaseIdentityCheck', 'adminDependencyPolicyCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck', 'releaseReadinessFixtureTest', 'releaseReadinessCheck'].each { taskName ->
+['acceptanceContract', 'specContract', 'specContractTest', 'domainRegistryCheck', 'spaceAnchorCheck', 'portabilityContractCheck', 'productTrustClaimMatrixCheck', 'androidReleaseIdentityCheck', 'adminDependencyPolicyCheck', 'clientCi', 'serverCi', 'infraStatic', 'adminCi', 'docsStructureCheck', 'docsBuild', 'releaseNotesLabelCheck', 'releaseEvidenceCheck', 'projectReadinessEvidenceCheck', 'enterpriseReleaseGateCheck', 'releaseReadinessFixtureTest', 'releaseReadinessCheck'].each { taskName ->
     tasks.named(taskName) {
         mustRunAfter tasks.named('doctor')
     }

--- a/docs/product-trust-provider-choice-claim-matrix.md
+++ b/docs/product-trust-provider-choice-claim-matrix.md
@@ -1,6 +1,20 @@
 # Product trust and provider-choice claim matrix
 
-Status: Sprint 14 claim-control artifact. Public/customer wording must not exceed the evidence class recorded here.
+Status: Sprint 14 claim-control artifact. Public/customer wording must not exceed the evidence class recorded here. `./gradlew releaseEvidenceCheck` and `./gradlew portabilityContractCheck` keep the claim/release posture wired into CI evidence.
+
+## Evidence classes and member-impact states
+
+Every public/product claim must map to at least one evidence class:
+
+- **Source-backed research evidence**: cited upstream standards, provider documentation, legal/regulatory references, or risk sources.
+- **Architecture/spec projection evidence**: Weave specification corpus, repo-local transitional specs, architecture docs, ADRs, or domain contracts.
+- **Fixture-based migration contract tests**: support-safe fixtures validated by `./gradlew portabilityContractCheck`, `./gradlew specContract`, or a narrower contract gate.
+- **Live smoke test evidence**: sanitized dogfood/live-stack evidence, CI artifacts, or runtime smoke results with secrets redacted.
+- **Accessibility/manual UX evidence**: mapped user/admin journeys, screen-reader/keyboard expectations, screenshots, or manual accessibility notes.
+- **Operator runbook evidence**: support-safe admin/operator handbooks, readiness runbooks, rollback notes, and evidence interpretation guidance.
+- **Claim matrix entry**: this page or the README claim matrix explicitly classifies the claim and its release/customer-copy state.
+
+Claim states and member-facing impact copy must use stable vocabulary: `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, `coming_later`, or `unsupported`. Marketing or release copy must not replace these with stronger availability claims. The portability promise is no-unaccounted data loss; it does not claim lossless provider migration.
 
 ## Approved positioning
 
@@ -26,14 +40,14 @@ Avoid this wording until explicitly evidenced and reviewed:
 | Consistent member UX across providers | "Members see stable Weave capability states while providers are managed by admins/operators." | Architecture + client/accessibility evidence | Product line plan, user/admin handbooks, client capability-state tests from prior sprints. | Usable; do not imply every provider swap is implemented. |
 | Data sovereignty | "Self-hosted/reference deployments make operational control over data location, keys, logs, backups, and exports testable." | Operator docs + public-source research | Control-plane infra bootstrap, admin/operator handbook, Sprint 14 risk framing. | Usable as design/operational-control claim; not a legal guarantee. |
 | Auditability | "Provider setup, policy, readiness, migration, and support evidence are designed to be auditable and support-safe." | Architecture + test evidence | Admin/operator handbook, portability schemas, audit refs in portability contracts. | Usable where backed by implemented slice; mark future providers separately. |
-| Reversibility | "Provider changes require export/import, rollback, retention, and validation evidence before apply." | Contract/fixture evidence | Provider portability schema v2 and no-unaccounted-data-loss docs. Matrix fixtures still pending. | Use as contract direction; do not claim automated reversibility for Matrix until fixtures land. |
+| Reversibility | "Provider changes require export/import, rollback, retention, and validation evidence before apply." | Fixture-based migration contract tests + operator runbook evidence | Provider portability schema v2, no-unaccounted-data-loss docs, `matrix-synapse-chat-migration-proof.json`, `matrix-synapse-chat-lifecycle-fixture.json`, and `./gradlew portabilityContractCheck`. | Usable as contract-gated behavior for named fixtures only; do not claim automated Matrix apply or lossless rollback. |
 | Reduced provider lock-in | "Weave reduces lock-in by making provider dependencies explicit and switch evidence reviewable." | Architecture + public-source research | Interoperability/vendor-lock-in source anchors and portability contracts. | Usable; avoid "no lock-in". |
-| Matrix-first migration proof | "Sprint 14 starts with a conservative self-hosted Matrix/Synapse Chat migration proof." | Source-backed research + future fixture tests | Matrix proof doc; fixtures pending. | Coming_later for executable migration proof until tests/fixtures merge. |
-| E2EE Chat migration | "Encrypted Matrix history is unsupported/coming_later until a client-side key/export strategy is solved." | Risk classification | Matrix proof doc and Matrix API semantics. | Must be stated as unsupported/coming_later. |
+| Matrix-first migration proof | "Sprint 14 starts with a conservative self-hosted Matrix/Synapse Chat migration proof." | Source-backed research evidence + fixture-based migration contract tests | Matrix Client-Server API source anchor, `provider-portability-v2-chat-matrix-dry-run.json`, `matrix-synapse-chat-migration-proof.json`, `matrix-synapse-chat-lifecycle-fixture.json`, and `./gradlew portabilityContractCheck`. | Contract evidence exists for a conservative support-safe proof; actual apply remains blocked and member copy must say `degraded`, `coming_later`, or `unsupported` where appropriate. |
+| E2EE Chat migration | "Encrypted Matrix history is unsupported/coming_later until a client-side key/export strategy is solved." | Source-backed research evidence + fixture-based migration contract tests | Matrix proof and lifecycle fixtures classify encrypted history as `unsupported`, block apply, and record the client-side key/export prerequisite. | Must be stated as `unsupported`/`coming_later`; forbidden to imply lossless E2EE migration. |
 | GDPR/DSGVO vs Cloud Act risk | "Weave helps admins separate formal compliance posture from residual operational, jurisdictional, subprocessor, telemetry, and exportability risk." | Source-backed research + legal-review caveat | EDPB/EDPS/Schrems II sources listed below. | Usable as engineering/procurement-risk framing; not legal advice. |
 | Admin provider-switch journey | "Admins review readiness, consequences, user disruption, cutover, rollback, audit, and validation before provider changes." | Product/UX contract + future Admin Console evidence | Provider replacement contract and Sprint 14 board. | Contract direction; implementation evidence still per-domain. |
-| Stable Weaver `weave-chat` channel | "The governed Weaver runtime should normally receive stable `channels.weave-chat`; providerRefs stay behind Weave Chat-domain routing." | Architecture + cross-repo implementation evidence | Governed Weaver runtime security contract; #519 remains open. | Do not claim complete until #519 child evidence is merged. |
-| Credential secrecy | "Runtime profiles contain SecretRefs, short-lived runtime-token references, and audit receipts only; raw provider secrets stay behind Weave." | Security/contract tests | Governed Weaver runtime security contract; #519 pending. | Contract claim only until profile fixtures/tests land. |
+| Stable Weaver `weave-chat` channel | "The governed Weaver runtime should normally receive stable `channels.weave-chat`; providerRefs stay behind Weave Chat-domain routing." | Architecture + cross-repo implementation evidence | Governed Weaver runtime security contract, Weave PRs #520/#521/#528/#529/#530/#532/#533, Weaver PRs #7/#8/#10/#11/#12, and closed #519. | Usable for governed `weave-chat` runtime boundary; do not imply unmanaged raw provider channel access. |
+| Credential secrecy | "Runtime profiles contain SecretRefs, short-lived runtime-token references, and audit receipts only; raw provider secrets stay behind Weave." | Security/contract tests | Governed Weaver runtime security contract, server audit/profile evidence, infra lifecycle docs, and Weaver support-safe audit refs. | Usable as governed-runtime evidence; raw provider secrets/OAuth refresh tokens remain forbidden in profiles and support evidence. |
 
 ## Procurement-risk checklist
 

--- a/docs/project/sprint-14-delivery-board.md
+++ b/docs/project/sprint-14-delivery-board.md
@@ -1,6 +1,6 @@
 # Sprint 14 delivery board: product trust and provider choice
 
-Status: active Sprint 14 execution plan. GitHub milestone: [Sprint 14 — Product Trust, Provider Choice & Operator Experience](https://github.com/masssi164/weave/milestone/14). Cross-repo Weaver milestone: [Sprint 14 — Product Trust, Provider Choice & Operator Experience](https://github.com/masssi164/weaver/milestone/2).
+Status: closed Sprint 14 execution record. GitHub milestone: [Sprint 14 — Product Trust, Provider Choice & Operator Experience](https://github.com/masssi164/weave/milestone/14). Cross-repo Weaver milestone: [Sprint 14 — Product Trust, Provider Choice & Operator Experience](https://github.com/masssi164/weaver/milestone/2).
 
 Board rule: every open issue listed on this Delivery Board is Sprint 14 scope and must be assigned to the Sprint 14 milestone in its owning repository. Use the local Sprint 14 ops script `sprint_14/scripts/add_delivery_board_issues_to_sprint14.sh` after board edits so Weave and Weaver issue metadata stay aligned.
 
@@ -34,9 +34,9 @@ Sprint 14 makes Weave professionally explainable and evidence-backed as a provid
 
 ## #519 decision for this sprint
 
-Do not close `weave#519` from documentation alone. Treat it as the cross-repo umbrella until all of these are implemented or split into closed child issues with evidence. Current Weaver child anchors are [`weaver#1`](https://github.com/masssi164/weaver/issues/1) and [`weaver#9`](https://github.com/masssi164/weaver/issues/9), both assigned to Sprint 14.
+`weave#519` is closed in Sprint 14 after the cross-repo evidence train landed. The Weaver child anchors [`weaver#1`](https://github.com/masssi164/weaver/issues/1) and [`weaver#9`](https://github.com/masssi164/weaver/issues/9) are closed, and the Weave-side projection/audit/infra evidence from PRs #520, #521, #528, #529, #530, #532, and #533 is linked from the Sprint 14 closure report.
 
-Completion criteria:
+Completion criteria satisfied:
 
 1. `weave`: signed `WeaverRuntimeProfile` projection from Weave policy, model aliases, domain provider projections, tool/MCP grants, sandbox/deny policy, CredentialRefs, runtime-token references, audit policy, and profile hash.
 2. `weave`: stable `channels.weave-chat` projection backed by Weave Chat-domain routing, with providerRefs such as Matrix/Teams/Slack hidden behind backend routing and normal member UX.
@@ -44,7 +44,7 @@ Completion criteria:
 4. `weaver`: runtime consumption of the signed profile without accepting raw OpenClaw dashboard/config as a second policy source.
 5. Cross-repo evidence: tests, docs, CI links, and support-safe fixtures proving no raw provider secrets or OAuth refresh tokens are projected.
 
-Recommended split if direct implementation is too large for one PR train:
+Historical split option, now resolved by the Sprint 13/14 merge train:
 
 | Child issue | Repo | Scope |
 | --- | --- | --- |
@@ -53,12 +53,15 @@ Recommended split if direct implementation is too large for one PR train:
 | Credential Broker RuntimeProfile grant path | `weave` | Short-lived runtime-token references, SecretRef-only profile content, audit receipts. |
 | Cross-repo incorporation evidence | `weave` + `weaver` | CI/evidence bundle linked from #519 and Sprint 14 closure. |
 
-## First implementation slice
+## Implementation slices delivered
 
-This PR train starts with a low-risk docs/evidence slice:
+The Sprint 14 PR train delivered:
 
-- board/DAG and #519 split decision;
+- board/DAG and #519 completion decision;
 - claim/evidence matrix for professional positioning, procurement-risk language, Matrix-first proof, Admin provider-switch journey, and customer wording;
-- Matrix Chat migration proof boundary that can drive later fixture tests without claiming lossless migration.
+- Matrix Chat migration proof boundary without lossless/legal overclaims;
+- machine-readable Matrix migration proof and lifecycle fixtures;
+- `portabilityContractCheck`, `docsCheck`, and `releaseEvidenceCheck` gates on current `main`;
+- cross-repo Weaver `weave-chat` runtime evidence and support-safe audit refs.
 
-Follow-up implementation PRs should add machine-readable fixtures and contract checks for Matrix Chat export/import/cutover/rollback, then wire Admin Console and client behavior only after those contracts are executable.
+Next implementation sprint should turn the blocked Matrix migration proof into concrete admin/server implementation slices only after media retention, power-level mapping, and E2EE client-export strategy decisions are made explicitly.

--- a/docs/sprint-14-closure-report.md
+++ b/docs/sprint-14-closure-report.md
@@ -1,0 +1,90 @@
+# Sprint 14 Closure Report — Product Trust, Provider Choice, and Operator Experience
+
+## Governing sources
+
+- Sprint epic: [weave#535](https://github.com/masssi164/weave/issues/535)
+- Closure issue: [weave#546](https://github.com/masssi164/weave/issues/546)
+- Delivery board: `docs/project/sprint-14-delivery-board.md`
+- Claim matrix: `docs/product-trust-provider-choice-claim-matrix.md`
+- Matrix proof boundary: `docs/matrix-chat-migration-proof.md`
+- Portability contract: `docs/architecture/provider-portability.md` and `docs/architecture/no-unaccounted-data-loss.md`
+- Cross-repo Weaver carry-over: [weave#519](https://github.com/masssi164/weave/issues/519), [weaver#1](https://github.com/masssi164/weaver/issues/1), and [weaver#9](https://github.com/masssi164/weaver/issues/9)
+
+## Final issue state
+
+| Issue | Scope | Final state | Evidence |
+| --- | --- | --- | --- |
+| [weave#535](https://github.com/masssi164/weave/issues/535) | Sprint program governance | Ready to close | Delivery board, claim matrix, this closure report, green gates. |
+| [weave#536](https://github.com/masssi164/weave/issues/536) | Why Weave positioning | Ready to close | Approved/avoid wording in `docs/product-trust-provider-choice-claim-matrix.md`; PR #548. |
+| [weave#537](https://github.com/masssi164/weave/issues/537) | Matrix-first provider data model research | Ready to close | Matrix source-object mapping in `docs/matrix-chat-migration-proof.md`; PR #548. |
+| [weave#538](https://github.com/masssi164/weave/issues/538) | Self-hosted Matrix Chat migration proof | Ready to close | Matrix proof and lifecycle fixtures; PRs #548 and #550. |
+| [weave#539](https://github.com/masssi164/weave/issues/539) | Admin provider-switch journey | Ready to close | Admin journey in `docs/matrix-chat-migration-proof.md`; provider selection/apply gates in `docs/admin-operator-handbook.md`; PR #548. |
+| [weave#540](https://github.com/masssi164/weave/issues/540) | Provider-agnostic member UX | Ready to close | Member/client boundary and stable capability states in Matrix proof and claim matrix; PR #548. |
+| [weave#541](https://github.com/masssi164/weave/issues/541) | Export/import/cutover/rollback contracts | Ready to close | Provider portability schema v2 plus Matrix lifecycle fixture validated by `portabilityContractCheck`; PR #550. |
+| [weave#542](https://github.com/masssi164/weave/issues/542) | Claim and migration evidence matrix | Ready to close | Claim matrix, product-trust claim matrix guard, release evidence gate, and portability gate; PRs #548/#550. |
+| [weave#543](https://github.com/masssi164/weave/issues/543) | Self-hosted reference stack/operator experience | Ready to close | `docs/admin-operator-handbook.md`, infra README/operator docs, release-verify/operator-check/backup/restore/support-bundle paths. |
+| [weave#544](https://github.com/masssi164/weave/issues/544) | Cloud Act/GDPR/subprocessor/sovereignty risk framing | Ready to close | Procurement-risk checklist, source anchors, and legal-review caveat in claim matrix; PR #548. |
+| [weave#545](https://github.com/masssi164/weave/issues/545) | Customer-facing claim matrix | Ready to close | Customer wording/evidence table in claim matrix; PR #548. |
+| [weave#546](https://github.com/masssi164/weave/issues/546) | Sprint closure | Ready to close after this report lands | This report, zero open Sprint 14 issues, green gates. |
+| [weave#519](https://github.com/masssi164/weave/issues/519) | Weaver RuntimeProfile / `weave-chat` / Credential Broker carry-over | Closed | Weave PRs #520/#521/#528/#529/#530/#532/#533, Weaver PRs #7/#8/#10/#11/#12, closed `weaver#1` and `weaver#9`. |
+
+## Merge train
+
+1. [weave#548](https://github.com/masssi164/weave/pull/548) — `9b67fed` — Sprint 14 product-trust docs, delivery board, claim matrix, Matrix proof boundary, and fixture checks.
+2. [weave#550](https://github.com/masssi164/weave/pull/550) — `4f7c33f` — Matrix Chat lifecycle fixture and executable portability guard for preflight, blocked apply, rollback-retention, support-safe redaction, and overclaim prevention.
+3. [weaver#11](https://github.com/masssi164/weaver/pull/11) — `448def6` — offline and live/container `weave-chat` LM Studio round-trip harness; closes `weaver#9`.
+4. [weaver#12](https://github.com/masssi164/weaver/pull/12) — `ada8c4b` — support-safe channel/model audit refs; closes `weaver#1` with prior Weaver RuntimeProfile PR evidence.
+5. Earlier cross-repo carry-over evidence: Weave PRs #520, #521, #528, #529, #530, #532, and #533; Weaver PRs #7, #8, and #10.
+
+PR #549 was closed unmerged because merged PR #550 superseded it with the Matrix lifecycle fixture and removed the conflicting duplicate branch.
+
+## Evidence and gates
+
+Current `main` evidence run after PR #550:
+
+```text
+./gradlew productTrustClaimMatrixCheck portabilityContractCheck docsCheck releaseEvidenceCheck --no-daemon
+# BUILD SUCCESSFUL
+```
+
+Targeted Weaver evidence before closing the cross-repo runtime anchors:
+
+```text
+node scripts/run-vitest.mjs src/weaver/weave-chat-roundtrip-harness.test.ts src/weaver/runtime-profile.test.ts
+pnpm format:docs:check -- docs/channels/weave-chat.md
+node --import tsx scripts/weaver/weave-chat-roundtrip.ts > /tmp/weaver-weave-chat-roundtrip-evidence.json
+node scripts/run-vitest.mjs src/weaver/runtime-profile.test.ts
+pnpm docs:check-mdx docs/weaver-runtime-profile.md
+```
+
+## Decisions and boundaries
+
+- Weave is positioned as a provider-neutral collaboration control plane, not as a hobby-only self-hosting bundle.
+- The reference self-hosted stack is the strongest proof path for sovereignty, auditability, operational control, and reversibility, but product architecture remains provider-neutral.
+- Public claims must stay inside the claim matrix evidence class. Forbidden wording remains: GDPR-proof, Cloud-Act-proof, guaranteed compliant, legally sovereign, compliant by default, no vendor lock-in without scope, or lossless migration without named fixture proof.
+- Matrix Chat is the first no-cost provider proof. Sprint 14 proves support-safe classification, preflight, blocked apply, and rollback-retention evidence; it does not enable production apply.
+- Matrix encrypted-room history remains unsupported/coming_later until a client-side key/export strategy exists.
+- Normal members see stable Weave capability states only. Raw provider diagnostics, secrets, URLs, Matrix internals, MCP/tool internals, and migration reports stay in admin/operator/support-safe evidence surfaces.
+- Weaver runtime profiles use stable `channels.weave-chat`, support-safe audit refs, SecretRefs/runtime-token references, and deny-by-default policy boundaries; raw provider channels/secrets are not projected to normal runtime/member surfaces.
+
+## Follow-up / next implementation sprint
+
+Sprint 15 should implement from the now-evidenced contracts, not expand claims first:
+
+- turn Matrix Chat proof artifacts into server/admin migration dry-run implementation slices;
+- decide media copy/reference retention and power-level mapping policy before any apply path;
+- keep E2EE encrypted-history migration blocked until client-side export/key strategy is designed and fixture-tested;
+- connect Admin Console provider-switch screens to backend-owned preflight/consequence/rollback evidence;
+- add accessibility/manual UX evidence for member disruption copy before promoting customer-facing provider-switch flows.
+
+## Closure gate
+
+- [x] Sprint 14 issues are labeled by track/phase and represented in the delivery board.
+- [x] Product positioning and avoid wording are recorded in the claim matrix.
+- [x] Procurement-risk framing separates legal compliance from engineering/operational evidence.
+- [x] Matrix-first migration scope is explicit about supported, lossy, manual-review, unsupported, archive-only, and coming_later states.
+- [x] Product-trust claims are checked by `productTrustClaimMatrixCheck`.
+- [x] Provider portability contracts and Matrix lifecycle fixtures are executable through `portabilityContractCheck`.
+- [x] Release/claim posture is guarded through `releaseEvidenceCheck`.
+- [x] `weave#519`, `weaver#1`, and `weaver#9` are closed with cross-repo evidence.
+- [x] Closure report exists on the docs branch and is ready to merge.

--- a/tools/product_trust_claim_matrix_check.py
+++ b/tools/product_trust_claim_matrix_check.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate Sprint 14 product-trust claim matrix evidence boundaries."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX = ROOT / "docs" / "product-trust-provider-choice-claim-matrix.md"
+README = ROOT / "README.md"
+PORTABILITY_FIXTURES = ROOT / "specs" / "0006-portability-contract"
+
+REQUIRED_EVIDENCE_CLASSES = [
+    "Source-backed research evidence",
+    "Architecture/spec projection evidence",
+    "Fixture-based migration contract tests",
+    "Live smoke test evidence",
+    "Accessibility/manual UX evidence",
+    "Operator runbook evidence",
+    "Claim matrix entry",
+]
+
+REQUIRED_MEMBER_STATES = [
+    "available",
+    "disabled_by_policy",
+    "not_configured",
+    "degraded",
+    "unavailable",
+    "coming_later",
+    "unsupported",
+]
+
+REQUIRED_MATRIX_REFERENCES = [
+    "provider-portability-v2-chat-matrix-dry-run.json",
+    "matrix-synapse-chat-migration-proof.json",
+    "matrix-synapse-chat-lifecycle-fixture.json",
+    "./gradlew portabilityContractCheck",
+    "no-unaccounted-data-loss",
+]
+
+FORBIDDEN_UNQUALIFIED_CLAIMS = [
+    "GDPR-proof",
+    "Cloud-Act-proof",
+    "guaranteed compliant",
+    "legally sovereign",
+    "compliant by default",
+]
+
+STALE_PENDING_PHRASES = [
+    "Matrix fixtures still pending",
+    "fixtures pending",
+    "future fixture tests",
+    "Coming_later for executable migration proof until tests/fixtures merge",
+]
+
+
+def fail(message: str) -> None:
+    print(f"product-trust-claim-matrix-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        fail(f"{label} missing {needle}")
+
+
+def main() -> None:
+    if not MATRIX.exists():
+        fail("missing docs/product-trust-provider-choice-claim-matrix.md")
+    text = MATRIX.read_text(encoding="utf-8")
+    for heading in ["## Evidence classes and member-impact states", "## Approved positioning", "## Claim matrix", "## Procurement-risk checklist", "## Source anchors"]:
+        require_contains(text, heading, "claim matrix")
+    for evidence_class in REQUIRED_EVIDENCE_CLASSES:
+        require_contains(text, evidence_class, "claim matrix evidence classes")
+    for state in REQUIRED_MEMBER_STATES:
+        require_contains(text, f"`{state}`", "claim matrix member states")
+    for reference in REQUIRED_MATRIX_REFERENCES:
+        require_contains(text, reference, "Matrix migration claim evidence")
+    for stale in STALE_PENDING_PHRASES:
+        if stale in text:
+            fail(f"claim matrix still carries stale pending phrase: {stale}")
+    for forbidden in FORBIDDEN_UNQUALIFIED_CLAIMS:
+        if forbidden not in text:
+            fail(f"claim matrix must explicitly forbid overclaim phrase: {forbidden}")
+
+    lossless_pattern = re.compile(r"\|[^\n]*(lossless|Lossless)[^\n]*\|[^\n]*\*\*(Ready|Usable)", re.IGNORECASE)
+    if lossless_pattern.search(text):
+        fail("lossless migration must not be marked ready/usable")
+    for required_phrase in [
+        "does not claim lossless",
+        "actual apply remains blocked",
+        "forbidden to imply lossless E2EE migration",
+    ]:
+        require_contains(text, required_phrase, "provider migration claim boundary")
+
+    if not README.exists():
+        fail("missing README.md")
+    readme = README.read_text(encoding="utf-8")
+    require_contains(readme, "## Ready / Guarded / Future claim matrix", "README")
+    require_contains(readme, "No unaccounted data loss is the portability promise", "README")
+    require_contains(readme, "perfect lossless migration is not claimed", "README")
+
+    for fixture in [
+        "provider-portability-v2-chat-matrix-dry-run.json",
+        "matrix-synapse-chat-migration-proof.json",
+        "matrix-synapse-chat-lifecycle-fixture.json",
+    ]:
+        if not (PORTABILITY_FIXTURES / fixture).exists():
+            fail(f"missing referenced Matrix portability fixture: {fixture}")
+
+    print("product-trust-claim-matrix-check: ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Sprint 14 closure PR.

## Summary

- Adds `productTrustClaimMatrixCheck` and wires it into `releaseEvidenceCheck`/`ci` so Sprint 14 customer/provider claims stay inside recorded evidence boundaries.
- Updates the product-trust claim matrix with explicit evidence classes, stable member-impact states, Matrix fixture references, and lossless/E2EE overclaim guards.
- Converts the Sprint 14 delivery board from active execution plan to closure record and adds `docs/sprint-14-closure-report.md` with issue/evidence mapping, merge train, gates, boundaries, and follow-up scope.

## Evidence / gates

```text
./gradlew productTrustClaimMatrixCheck portabilityContractCheck docsCheck releaseEvidenceCheck --no-daemon
# BUILD SUCCESSFUL
```

## Release notes

`release-notes-skip` — closure/evidence-gate documentation and internal verification wiring; no direct member-facing runtime behavior change.

Closes #535.
Closes #536.
Closes #537.
Closes #538.
Closes #539.
Closes #540.
Closes #541.
Closes #542.
Closes #543.
Closes #544.
Closes #545.
Closes #546.
