### PR TITLE
docs: clarify Sprint 14 closure evidence wording

### DIFF
--- a/docs/sprint-14-closure-report.md
+++ b/docs/sprint-14-closure-report.md
@@ -40,7 +40,7 @@ PR #549 was closed unmerged because merged PR #550 superseded it with the Matrix
 
 ## Evidence and gates
 
-Current `main` evidence run after PR #550:
+Closure PR branch evidence run based on current `origin/main` after PR #550:
 
 ```text
 ./gradlew productTrustClaimMatrixCheck portabilityContractCheck docsCheck releaseEvidenceCheck --no-daemon


### PR DESCRIPTION
## Summary

- Corrects Sprint 14 closure-report evidence provenance after PR #551 merged before the wording fix landed.
- Clarifies that `productTrustClaimMatrixCheck` evidence was run on the closure PR branch based on `origin/main` after PR #550, not on `main` before the task existed.

## Evidence / gates

```text
./gradlew docsStructureCheck productTrustClaimMatrixCheck --no-daemon
```

## Release notes

Use `release-notes-skip`: documentation accuracy fix only.
