### PR TITLE
docs: finalize Sprint 14 closure state

### DIFF
--- a/docs/project/sprint-14-delivery-board.md
+++ b/docs/project/sprint-14-delivery-board.md
@@ -1,6 +1,6 @@
 # Sprint 14 delivery board: product trust and provider choice
 
-Status: open Sprint 14 execution record. GitHub milestone: [Sprint 14 — Product Trust, Provider Choice & Operator Experience](https://github.com/masssi164/weave/milestone/14). Cross-repo Weaver milestone: [Sprint 14 — Product Trust, Provider Choice & Operator Experience](https://github.com/masssi164/weaver/milestone/2). Sprint 14 stays open while any Weave Delivery Board item remains open, including reopened `weave#519`.
+Status: closed Sprint 14 execution record. GitHub milestone: [Sprint 14 — Product Trust, Provider Choice & Operator Experience](https://github.com/masssi164/weave/milestone/14) is closed with zero open issues. Cross-repo Weaver milestone: [Sprint 14 — Product Trust, Provider Choice & Operator Experience](https://github.com/masssi164/weaver/milestone/2) is closed with the Weaver runtime anchors completed.
 
 Board rule: every open issue listed on this Delivery Board is Sprint 14 scope and must be assigned to the Sprint 14 milestone in its owning repository. Use the local Sprint 14 ops script `sprint_14/scripts/add_delivery_board_issues_to_sprint14.sh` after board edits so Weave and Weaver issue metadata stay aligned.
 
@@ -34,7 +34,7 @@ Sprint 14 makes Weave professionally explainable and evidence-backed as a provid
 
 ## #519 decision for this sprint
 
-`weave#519` is open in Sprint 14 after acceptance review. The cross-repo runtime seam is partially evidenced: the Weaver child anchors [`weaver#1`](https://github.com/masssi164/weaver/issues/1) and [`weaver#9`](https://github.com/masssi164/weaver/issues/9) are closed, and the Weave-side projection/audit/infra evidence from PRs #520, #521, #528, #529, #530, #532, and #533 is linked from the Sprint 14 closure report. PR #553 adds the Weave-side PA Weaver chat facade and configurable HTTP bridge slice, including service-level live Weave Chat evidence for: PA Weaver option -> send message -> governed Weaver bridge -> LM Studio -> assistant response. Sprint 14 remains open until PR #553 is merged, the delivery-board item is closed, and the GitHub milestone closure gate verifies zero open Sprint 14 issues.
+`weave#519` is closed for Sprint 14. The cross-repo runtime seam is evidenced by closed Weaver child anchors [`weaver#1`](https://github.com/masssi164/weaver/issues/1) and [`weaver#9`](https://github.com/masssi164/weaver/issues/9), Weave-side projection/audit/infra evidence from PRs #520, #521, #528, #529, #530, #532, and #533, and merged PR #553. PR #553 adds the Weave-side PA Weaver chat facade and configurable HTTP bridge slice, including service-level live Weave Chat evidence for: PA Weaver option -> send message -> governed Weaver bridge -> LM Studio -> assistant response. Sprint 14 is closed after PR #553 merged, `weave#519` closed, and the GitHub milestone closure gate verified zero open Sprint 14 issues.
 
 Current evidence status:
 
@@ -46,7 +46,7 @@ Current evidence status:
 6. `weave`: container trust for the local HTTPS LM Studio endpoint was verified with the mkcert root CA mounted read-only and `CURL_CA_BUNDLE=/tmp/mkcert-rootCA.pem`; unsafe TLS-disable flags are not part of the final evidence path.
 7. `weaver`: runtime consumption of the signed profile without accepting raw OpenClaw dashboard/config as a second policy source is covered by the closed Weaver child issues.
 8. Cross-repo evidence: tests, docs, CI links, and support-safe fixtures prove no raw provider secrets or OAuth refresh tokens are projected.
-9. Remaining blocker: merge PR #553, close `weave#519` with the merged evidence, and verify the Sprint 14 milestone has zero open issues.
+9. Final closure: PR #553 is merged, `weave#519` is closed with merged evidence, and the Sprint 14 milestone has zero open issues.
 
 Historical split option, now resolved by the Sprint 13/14 merge train:
 
@@ -59,13 +59,14 @@ Historical split option, now resolved by the Sprint 13/14 merge train:
 
 ## Implementation slices delivered
 
-The Sprint 14 PR train has delivered so far:
+The Sprint 14 PR train delivered:
 
 - board/DAG and #519 completion decision;
 - claim/evidence matrix for professional positioning, procurement-risk language, Matrix-first proof, Admin provider-switch journey, and customer wording;
 - Matrix Chat migration proof boundary without lossless/legal overclaims;
 - machine-readable Matrix migration proof and lifecycle fixtures;
 - `portabilityContractCheck`, `docsCheck`, and `releaseEvidenceCheck` gates on current `main`;
-- cross-repo Weaver `weave-chat` runtime evidence and support-safe audit refs.
+- cross-repo Weaver `weave-chat` runtime evidence and support-safe audit refs;
+- merged PR #553 and closed `weave#519` with zero open Sprint 14 milestone issues.
 
 Next implementation sprint should turn the blocked Matrix migration proof into concrete admin/server implementation slices only after media retention, power-level mapping, and E2EE client-export strategy decisions are made explicitly.

--- a/docs/sprint-14-closure-report.md
+++ b/docs/sprint-14-closure-report.md
@@ -14,19 +14,19 @@
 
 | Issue | Scope | Final state | Evidence |
 | --- | --- | --- | --- |
-| [weave#535](https://github.com/masssi164/weave/issues/535) | Sprint program governance | Ready to close | Delivery board, claim matrix, this closure report, green gates. |
-| [weave#536](https://github.com/masssi164/weave/issues/536) | Why Weave positioning | Ready to close | Approved/avoid wording in `docs/product-trust-provider-choice-claim-matrix.md`; PR #548. |
-| [weave#537](https://github.com/masssi164/weave/issues/537) | Matrix-first provider data model research | Ready to close | Matrix source-object mapping in `docs/matrix-chat-migration-proof.md`; PR #548. |
-| [weave#538](https://github.com/masssi164/weave/issues/538) | Self-hosted Matrix Chat migration proof | Ready to close | Matrix proof and lifecycle fixtures; PRs #548 and #550. |
-| [weave#539](https://github.com/masssi164/weave/issues/539) | Admin provider-switch journey | Ready to close | Admin journey in `docs/matrix-chat-migration-proof.md`; provider selection/apply gates in `docs/admin-operator-handbook.md`; PR #548. |
-| [weave#540](https://github.com/masssi164/weave/issues/540) | Provider-agnostic member UX | Ready to close | Member/client boundary and stable capability states in Matrix proof and claim matrix; PR #548. |
-| [weave#541](https://github.com/masssi164/weave/issues/541) | Export/import/cutover/rollback contracts | Ready to close | Provider portability schema v2 plus Matrix lifecycle fixture validated by `portabilityContractCheck`; PR #550. |
-| [weave#542](https://github.com/masssi164/weave/issues/542) | Claim and migration evidence matrix | Ready to close | Claim matrix, product-trust claim matrix guard, release evidence gate, and portability gate; PRs #548/#550. |
-| [weave#543](https://github.com/masssi164/weave/issues/543) | Self-hosted reference stack/operator experience | Ready to close | `docs/admin-operator-handbook.md`, infra README/operator docs, release-verify/operator-check/backup/restore/support-bundle paths. |
-| [weave#544](https://github.com/masssi164/weave/issues/544) | Cloud Act/GDPR/subprocessor/sovereignty risk framing | Ready to close | Procurement-risk checklist, source anchors, and legal-review caveat in claim matrix; PR #548. |
-| [weave#545](https://github.com/masssi164/weave/issues/545) | Customer-facing claim matrix | Ready to close | Customer wording/evidence table in claim matrix; PR #548. |
-| [weave#546](https://github.com/masssi164/weave/issues/546) | Sprint closure | Ready to close after PR #553 merges and `weave#519` closes | This report, zero open Sprint 14 issues, green gates. |
-| [weave#519](https://github.com/masssi164/weave/issues/519) | Weaver RuntimeProfile / `weave-chat` / Credential Broker carry-over | Pending PR #553 merge | Weave PRs #520/#521/#528/#529/#530/#532/#533 and PR #553, Weaver PRs #7/#8/#10/#11/#12, closed `weaver#1` and `weaver#9`. |
+| [weave#535](https://github.com/masssi164/weave/issues/535) | Sprint program governance | Closed | Delivery board, claim matrix, this closure report, green gates. |
+| [weave#536](https://github.com/masssi164/weave/issues/536) | Why Weave positioning | Closed | Approved/avoid wording in `docs/product-trust-provider-choice-claim-matrix.md`; PR #548. |
+| [weave#537](https://github.com/masssi164/weave/issues/537) | Matrix-first provider data model research | Closed | Matrix source-object mapping in `docs/matrix-chat-migration-proof.md`; PR #548. |
+| [weave#538](https://github.com/masssi164/weave/issues/538) | Self-hosted Matrix Chat migration proof | Closed | Matrix proof and lifecycle fixtures; PRs #548 and #550. |
+| [weave#539](https://github.com/masssi164/weave/issues/539) | Admin provider-switch journey | Closed | Admin journey in `docs/matrix-chat-migration-proof.md`; provider selection/apply gates in `docs/admin-operator-handbook.md`; PR #548. |
+| [weave#540](https://github.com/masssi164/weave/issues/540) | Provider-agnostic member UX | Closed | Member/client boundary and stable capability states in Matrix proof and claim matrix; PR #548. |
+| [weave#541](https://github.com/masssi164/weave/issues/541) | Export/import/cutover/rollback contracts | Closed | Provider portability schema v2 plus Matrix lifecycle fixture validated by `portabilityContractCheck`; PR #550. |
+| [weave#542](https://github.com/masssi164/weave/issues/542) | Claim and migration evidence matrix | Closed | Claim matrix, product-trust claim matrix guard, release evidence gate, and portability gate; PRs #548/#550. |
+| [weave#543](https://github.com/masssi164/weave/issues/543) | Self-hosted reference stack/operator experience | Closed | `docs/admin-operator-handbook.md`, infra README/operator docs, release-verify/operator-check/backup/restore/support-bundle paths. |
+| [weave#544](https://github.com/masssi164/weave/issues/544) | Cloud Act/GDPR/subprocessor/sovereignty risk framing | Closed | Procurement-risk checklist, source anchors, and legal-review caveat in claim matrix; PR #548. |
+| [weave#545](https://github.com/masssi164/weave/issues/545) | Customer-facing claim matrix | Closed | Customer wording/evidence table in claim matrix; PR #548. |
+| [weave#546](https://github.com/masssi164/weave/issues/546) | Sprint closure | Closed | This report, zero open Sprint 14 issues, green gates, merged PR #553, and closed `weave#519`. |
+| [weave#519](https://github.com/masssi164/weave/issues/519) | Weaver RuntimeProfile / `weave-chat` / Credential Broker carry-over | Closed | Weave PRs #520/#521/#528/#529/#530/#532/#533 and merged PR #553, Weaver PRs #7/#8/#10/#11/#12, closed `weaver#1` and `weaver#9`. |
 
 ## Merge train
 
@@ -35,7 +35,7 @@
 3. [weaver#11](https://github.com/masssi164/weaver/pull/11) — `448def6` — offline and live/container `weave-chat` LM Studio round-trip harness; closes `weaver#9`.
 4. [weaver#12](https://github.com/masssi164/weaver/pull/12) — `ada8c4b` — support-safe channel/model audit refs; closes `weaver#1` with prior Weaver RuntimeProfile PR evidence.
 5. Earlier cross-repo carry-over evidence: Weave PRs #520, #521, #528, #529, #530, #532, and #533; Weaver PRs #7, #8, and #10.
-6. Pending final Weave carry-over PR: [weave#553](https://github.com/masssi164/weave/pull/553) — PA Weaver Chat facade, configurable governed bridge, support-safe service-level live evidence for `channels.weave-chat` -> Weaver -> LM Studio -> assistant response, and review coverage ensuring the user-facing send response reflects actual completion evidence.
+6. Final Weave carry-over PR: [weave#553](https://github.com/masssi164/weave/pull/553) — merged as `0e3eea6`; PA Weaver Chat facade, configurable governed bridge, support-safe service-level live evidence for `channels.weave-chat` -> Weaver -> LM Studio -> assistant response, and review coverage ensuring the user-facing send response reflects actual completion evidence.
 
 PR #549 was closed unmerged because merged PR #550 superseded it with the Matrix lifecycle fixture and removed the conflicting duplicate branch.
 
@@ -108,5 +108,5 @@ Sprint 15 should implement from the now-evidenced contracts, not expand claims f
 - [x] Product-trust claims are checked by `productTrustClaimMatrixCheck`.
 - [x] Provider portability contracts and Matrix lifecycle fixtures are executable through `portabilityContractCheck`.
 - [x] Release/claim posture is guarded through `releaseEvidenceCheck`.
-- [ ] `weave#519`, `weaver#1`, and `weaver#9` are closed with cross-repo evidence. `weaver#1` and `weaver#9` are closed; `weave#519` closes after PR #553 merges and the milestone closure gate verifies zero open Sprint 14 issues.
-- [x] Closure report exists on the docs branch and is ready to merge.
+- [x] `weave#519`, `weaver#1`, and `weaver#9` are closed with cross-repo evidence. PR #553 is merged, `weave#519` is closed, and the Sprint 14 milestone closure gate verifies zero open Sprint 14 issues.
+- [x] Closure report exists on `origin/main` with Sprint 14 closed.


### PR DESCRIPTION
## Summary
- mark Sprint 14 closure report and delivery board as closed after PR #553 merge
- record #519/#weaver anchors closed and zero open Sprint 14 issues

## Validation
- ./gradlew docsCheck releaseEvidenceCheck --console=plain --no-daemon

## Notes
- Documentation-only final state sync; no runtime/contract changes.