### PR TITLE
docs: record Sprint 14 post-merge E2E evidence

### DIFF
--- a/docs/sprint-14-closure-report.md
+++ b/docs/sprint-14-closure-report.md
@@ -82,12 +82,18 @@ WEAVE_WEAVER_PA_CHAT_LIVE=true ./gradlew test --tests 'com.massimotter.weave.bac
 Post-merge `main` closure evidence:
 
 ```text
-CI run https://github.com/masssi164/weave/actions/runs/26735924061
-# head=0e3eea6, workflow=CI, conclusion=success
+CI run https://github.com/masssi164/weave/actions/runs/26738067087
+# head=e4af279, workflow=CI, conclusion=success
 
-Live Stack E2E run https://github.com/masssi164/weave/actions/runs/26736542604
-# head=0e3eea6, workflow=Live Stack E2E, conclusion=success,
-# job=Bootstrap Stack And Run App E2E, completed at 2026-06-01T05:26:26Z.
+Live Stack E2E run https://github.com/masssi164/weave/actions/runs/26738076622
+# head=e4af279, workflow=Live Stack E2E, conclusion=success,
+# artifact=weave-live-stack-acceptance-evidence, id=7324563895, size=26917, expired=false.
+# manifest: valid=true, scenarioCount=41, mappingCount=41,
+# liveRuntimeMappingCount=8, offlineSpecMappingCount=33,
+# runtimeEvidenceCollected=true, findings=[].
+# observed markers: AUTH_RESULT, PROFILE_RESULT, CHAT_RESULT, MATRIX_RESULT,
+# E2EE_RESULT, FILES_RESULT, PROVIDER_STACK_RESULT, CALENDAR_RESULT,
+# BOARDS_RESULT, PROVIDER_REALITY_RESULT.
 ```
 
 ## Decisions and boundaries

--- a/docs/sprint-14-closure-report.md
+++ b/docs/sprint-14-closure-report.md
@@ -79,6 +79,17 @@ WEAVE_WEAVER_PA_CHAT_LIVE=true ./gradlew test --tests 'com.massimotter.weave.bac
 # BUILD SUCCESSFUL; asserts admin-owned model provider selection and support-safe Weaver distribution projection.
 ```
 
+Post-merge `main` closure evidence:
+
+```text
+CI run https://github.com/masssi164/weave/actions/runs/26735924061
+# head=0e3eea6, workflow=CI, conclusion=success
+
+Live Stack E2E run https://github.com/masssi164/weave/actions/runs/26736542604
+# head=0e3eea6, workflow=Live Stack E2E, conclusion=success,
+# job=Bootstrap Stack And Run App E2E, completed at 2026-06-01T05:26:26Z.
+```
+
 ## Decisions and boundaries
 
 - Weave is positioned as a provider-neutral collaboration control plane, not as a hobby-only self-hosting bundle.

--- a/docs/sprint-14-closure-report.md
+++ b/docs/sprint-14-closure-report.md
@@ -86,14 +86,14 @@ CI run https://github.com/masssi164/weave/actions/runs/26738067087
 # head=e4af279, workflow=CI, conclusion=success
 
 Live Stack E2E run https://github.com/masssi164/weave/actions/runs/26738076622
-# head=e4af279, workflow=Live Stack E2E, conclusion=success,
-# artifact=weave-live-stack-acceptance-evidence, id=7324563895, size=26917, expired=false.
-# manifest: valid=true, scenarioCount=41, mappingCount=41,
-# liveRuntimeMappingCount=8, offlineSpecMappingCount=33,
-# runtimeEvidenceCollected=true, findings=[].
-# observed markers: AUTH_RESULT, PROFILE_RESULT, CHAT_RESULT, MATRIX_RESULT,
-# E2EE_RESULT, FILES_RESULT, PROVIDER_STACK_RESULT, CALENDAR_RESULT,
-# BOARDS_RESULT, PROVIDER_REALITY_RESULT.
+# head=e4af279, workflow=Live Stack E2E, conclusion=success
+# artifact=weave-live-stack-acceptance-evidence, id=7324563895, size=26917, expired=false
+# manifest: valid=true, scenarioCount=41, mappingCount=41
+# liveRuntimeMappingCount=8, offlineSpecMappingCount=33
+# runtimeEvidenceCollected=true, findings=[]
+# observed markers: AUTH_RESULT, PROFILE_RESULT, CHAT_RESULT, MATRIX_RESULT
+# E2EE_RESULT, FILES_RESULT, PROVIDER_STACK_RESULT, CALENDAR_RESULT
+# BOARDS_RESULT, PROVIDER_REALITY_RESULT
 ```
 
 ## Decisions and boundaries


### PR DESCRIPTION
## Intent
Record the strongest post-merge Sprint 14 closure evidence on current `main` so the closure report points at the latest successful CI and Live Stack E2E acceptance artifact rather than the older immediately-post-merge run.

## Impact
- Updates `docs/sprint-14-closure-report.md` only.
- Documents current-main CI success and Live Stack E2E artifact metadata for Sprint 14 closure.
- No product, runtime, infrastructure, or release-note impact.

## Contract / evidence
- Current `main` commit: `e4af2794f59074ebe94260416d271bfd7d024e70`.
- CI run: https://github.com/masssi164/weave/actions/runs/26738067087 (`success`).
- Live Stack E2E run: https://github.com/masssi164/weave/actions/runs/26738076622 (`success`).
- Acceptance artifact: `weave-live-stack-acceptance-evidence`, id `7324563895`, size `26917`, not expired.
- Manifest: `valid=true`, `scenarioCount=41`, `mappingCount=41`, `liveRuntimeMappingCount=8`, `offlineSpecMappingCount=33`, `runtimeEvidenceCollected=true`, `findings=[]`.

## Gates
- `make docs-check`
