### PR TITLE
feat: deliver Sprint 16 setup control plane and suite facades

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Added
 - Sprint 15 adds organization-embedding and provider-neutral replacement evidence: backend-owned effective-policy/readiness boundaries, support-safe Admin Console consequence copy, Matrix Chat as the first dry-run proof slice, an operator runbook, and accessibility evidence template while keeping provider apply/cutover blocked.
+- Sprint 16 adds a support-safe organization go-live readiness summary, suite facade readiness rows for Files/Documents, Boards/Tasks, and Calendar, and a governed Weaver RuntimeProfile projection preview while keeping provider apply/cutover and runtime execution guarded.
 
 - Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
 - Contextual meetings now have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -975,6 +975,113 @@ export default function App({
               </Card>
 
               {canInspectReadiness ? (
+                <Card component="section" aria-labelledby="go-live-heading">
+                  <CardContent>
+                    <Typography
+                      id="go-live-heading"
+                      variant="h2"
+                      sx={{ fontSize: "1.35rem", mb: 2 }}
+                    >
+                      Organization go-live readiness
+                    </Typography>
+                    <Alert
+                      severity={
+                        controlPlane.goLiveReadiness.state === "ready" &&
+                        controlPlane.goLiveReadiness.supportSafe &&
+                        !controlPlane.goLiveReadiness
+                          .normalMembersMayAccessSetupControls &&
+                        !controlPlane.goLiveReadiness.rawProviderDiagnosticsExposed
+                          ? "success"
+                          : "warning"
+                      }
+                      sx={{ mb: 2 }}
+                    >
+                      State: {readableState(controlPlane.goLiveReadiness.state)};
+                      member preview: {controlPlane.goLiveReadiness.memberPreviewState};
+                      setup controls exposed to normal members: {" "}
+                      {controlPlane.goLiveReadiness
+                        .normalMembersMayAccessSetupControls
+                        ? "yes"
+                        : "no"}
+                      ; raw provider diagnostics exposed: {" "}
+                      {controlPlane.goLiveReadiness.rawProviderDiagnosticsExposed
+                        ? "yes"
+                        : "no"}
+                      .
+                    </Alert>
+                    <Typography>
+                      Blockers: {controlPlane.goLiveReadiness.blockers.join(", ") || "none"}
+                    </Typography>
+                    <Typography>
+                      Admin actions: {controlPlane.goLiveReadiness.adminActions.join(" ")}
+                    </Typography>
+                    <Typography>
+                      Audit refs: {controlPlane.goLiveReadiness.auditRefs.join(", ") || "backend audit required"}
+                    </Typography>
+                  </CardContent>
+                </Card>
+              ) : null}
+
+              {canInspectReadiness ? (
+                <Card component="section" aria-labelledby="suite-facades-heading">
+                  <CardContent>
+                    <Typography
+                      id="suite-facades-heading"
+                      variant="h2"
+                      sx={{ fontSize: "1.35rem", mb: 2 }}
+                    >
+                      Suite facade readiness
+                    </Typography>
+                    <Typography sx={{ mb: 2 }}>
+                      Files/Documents, Boards/Tasks, and Calendar readiness is
+                      projected through provider-neutral Weave facades. The
+                      backend owns provider mappings; normal member flows never
+                      receive raw provider setup or credential-bearing config.
+                    </Typography>
+                    <Stack direction={{ xs: "column", md: "row" }} spacing={2} useFlexGap sx={{ flexWrap: "wrap" }}>
+                      {controlPlane.suiteDomainReadiness.map((domain) => (
+                        <Card key={domain.domain} variant="outlined" sx={{ flex: "1 1 280px" }}>
+                          <CardContent>
+                            <Typography variant="h3" sx={{ fontSize: "1.05rem" }}>
+                              {domain.label} suite facade
+                            </Typography>
+                            <Chip
+                              sx={{ mt: 1 }}
+                              color={stateColor[domain.adminReadiness]}
+                              label={`Admin readiness: ${readableState(domain.adminReadiness)}`}
+                            />
+                            <List dense aria-label={`${domain.label} suite facade evidence`}>
+                              <ListItem disableGutters>
+                                <ListItemText primary="Member state" secondary={domain.memberState} />
+                              </ListItem>
+                              <ListItem disableGutters>
+                                <ListItemText primary="Selected adapter posture" secondary={domain.selectedAdapterPosture} />
+                              </ListItem>
+                              <ListItem disableGutters>
+                                <ListItemText primary="Source of truth" secondary={domain.sourceOfTruthMode} />
+                              </ListItem>
+                              <ListItem disableGutters>
+                                <ListItemText primary="Canonical objects" secondary={domain.canonicalObjectKinds.join(", ") || "backend contract required"} />
+                              </ListItem>
+                              <ListItem disableGutters>
+                                <ListItemText primary="Portability notes" secondary={domain.portabilityNotes.join("; ") || "none"} />
+                              </ListItem>
+                              <ListItem disableGutters>
+                                <ListItemText primary="Next action" secondary={domain.nextAction} />
+                              </ListItem>
+                            </List>
+                            <Typography variant="body2">
+                              Facade owned by backend: {domain.backendOwnedFacade ? "yes" : "no"}; server-owned mapping: {domain.providerMappingOwnedByServer ? "yes" : "no"}; raw member config exposed: {domain.rawProviderConfigExposedToMembers ? "yes" : "no"}.
+                            </Typography>
+                          </CardContent>
+                        </Card>
+                      ))}
+                    </Stack>
+                  </CardContent>
+                </Card>
+              ) : null}
+
+              {canInspectReadiness ? (
                 <Card
                   component="section"
                   aria-labelledby="identity-readiness-heading"

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -180,9 +180,42 @@ export interface WeaverRuntimeProjection {
   supportSafe: boolean;
   providerDiagnosticsRedacted: boolean;
   rawRuntimeInternalsExposed: boolean;
+  disabledByDefault: boolean;
+  groupChatConsentRequired: boolean;
+  sandboxPosture: string;
   pendingRevocationRefs: string[];
   auditReceiptRefs: string[];
   items: WeaverProjectionItem[];
+}
+
+export interface SuiteDomainReadiness {
+  domain: string;
+  label: string;
+  adminReadiness: CapabilityState;
+  memberState: MemberCapabilityState;
+  selectedAdapterPosture: string;
+  sourceOfTruthMode: string;
+  providerCategoryKeys: string[];
+  canonicalObjectKinds: string[];
+  capabilityStates: string[];
+  supportSafeErrors: string[];
+  portabilityNotes: string[];
+  auditRefs: string[];
+  nextAction: string;
+  backendOwnedFacade: boolean;
+  providerMappingOwnedByServer: boolean;
+  rawProviderConfigExposedToMembers: boolean;
+}
+
+export interface GoLiveReadiness {
+  state: CapabilityState;
+  memberPreviewState: MemberCapabilityState;
+  blockers: string[];
+  adminActions: string[];
+  auditRefs: string[];
+  supportSafe: boolean;
+  normalMembersMayAccessSetupControls: boolean;
+  rawProviderDiagnosticsExposed: boolean;
 }
 
 export type MemberCapabilityState =
@@ -299,6 +332,8 @@ export interface ControlPlaneResponse {
   providerCategories: ProviderCategory[];
   identityProviderReadiness: IdentityProviderReadiness;
   weaverRuntimeProjection: WeaverRuntimeProjection;
+  suiteDomainReadiness: SuiteDomainReadiness[];
+  goLiveReadiness: GoLiveReadiness;
   whitelistPolicy: WhitelistPolicy;
   weaverDistributionPolicy: WeaverDistributionPolicy;
   auditEvents: AuditEvent[];
@@ -358,6 +393,8 @@ interface ServerControlPlaneResponse {
   weaverDistributionPolicy?: ServerWeaverDistributionPolicy;
   identityProviderReadiness?: ServerIdentityProviderReadiness;
   weaverRuntimeProjection?: ServerWeaverRuntimeProjection;
+  suiteDomainReadiness?: ServerSuiteDomainReadiness[];
+  goLiveReadiness?: ServerGoLiveReadiness;
   secretRefs?: Array<{ ref?: string; providerKey?: string }>;
 }
 
@@ -407,6 +444,9 @@ interface ServerWeaverRuntimeProjection {
   supportSafe?: boolean;
   providerDiagnosticsRedacted?: boolean;
   rawRuntimeInternalsExposed?: boolean;
+  disabledByDefault?: boolean;
+  groupChatConsentRequired?: boolean;
+  sandboxPosture?: string;
   pendingRevocationRefs?: string[];
   auditReceiptRefs?: string[];
   items?: Array<{
@@ -422,6 +462,36 @@ interface ServerWeaverRuntimeProjection {
     defaultSelected?: boolean;
     fallbackOrder?: number;
   }>;
+}
+
+interface ServerSuiteDomainReadiness {
+  domain?: string;
+  label?: string;
+  adminReadiness?: string;
+  memberState?: string;
+  selectedAdapterPosture?: string;
+  sourceOfTruthMode?: string;
+  providerCategoryKeys?: string[];
+  canonicalObjectKinds?: string[];
+  capabilityStates?: string[];
+  supportSafeErrors?: string[];
+  portabilityNotes?: string[];
+  auditRefs?: string[];
+  nextAction?: string;
+  backendOwnedFacade?: boolean;
+  providerMappingOwnedByServer?: boolean;
+  rawProviderConfigExposedToMembers?: boolean;
+}
+
+interface ServerGoLiveReadiness {
+  state?: string;
+  memberPreviewState?: string;
+  blockers?: string[];
+  adminActions?: string[];
+  auditRefs?: string[];
+  supportSafe?: boolean;
+  normalMembersMayAccessSetupControls?: boolean;
+  rawProviderDiagnosticsExposed?: boolean;
 }
 
 interface ServerIdentityProviderReadiness {
@@ -741,12 +811,71 @@ function normalizeControlPlane(
     weaverRuntimeProjection: normalizeWeaverRuntimeProjection(
       controlPlane.weaverRuntimeProjection,
     ),
+    suiteDomainReadiness: normalizeSuiteDomainReadiness(
+      controlPlane.suiteDomainReadiness,
+    ),
+    goLiveReadiness: normalizeGoLiveReadiness(controlPlane.goLiveReadiness),
     whitelistPolicy: normalizeWhitelist(controlPlane.whitelist),
     weaverDistributionPolicy: normalizeWeaverDistributionPolicy(
       controlPlane.weaverDistributionPolicy,
       sampleWeaverDistributionPolicy,
     ),
     auditEvents,
+  };
+}
+
+function normalizeSuiteDomainReadiness(
+  readiness?: ServerSuiteDomainReadiness[],
+): SuiteDomainReadiness[] {
+  const domains = (readiness ?? []).map((domain) => ({
+    domain: domain.domain ?? "suite-domain",
+    label: domain.label ?? domain.domain ?? "Suite domain",
+    adminReadiness: normalizeState(domain.adminReadiness),
+    memberState:
+      normalizeMemberCapabilityState(domain.memberState) ??
+      memberStableStateFromCapability(normalizeState(domain.adminReadiness)),
+    selectedAdapterPosture:
+      domain.selectedAdapterPosture ?? "awaiting_admin_selection",
+    sourceOfTruthMode:
+      domain.sourceOfTruthMode ??
+      "backend-owned facade; provider details redacted",
+    providerCategoryKeys: domain.providerCategoryKeys ?? [],
+    canonicalObjectKinds: domain.canonicalObjectKinds ?? [],
+    capabilityStates: domain.capabilityStates ?? [],
+    supportSafeErrors: domain.supportSafeErrors ?? [
+      "support-safe-errors-required",
+    ],
+    portabilityNotes: domain.portabilityNotes ?? [],
+    auditRefs: domain.auditRefs ?? [],
+    nextAction:
+      domain.nextAction ??
+      "Resolve backend readiness evidence before member go-live.",
+    backendOwnedFacade: domain.backendOwnedFacade ?? true,
+    providerMappingOwnedByServer: domain.providerMappingOwnedByServer ?? true,
+    rawProviderConfigExposedToMembers:
+      domain.rawProviderConfigExposedToMembers ?? false,
+  }));
+  return domains.length > 0 ? domains : sampleSuiteDomainReadiness;
+}
+
+function normalizeGoLiveReadiness(
+  readiness?: ServerGoLiveReadiness,
+): GoLiveReadiness {
+  return {
+    state: normalizeState(readiness?.state ?? "admin-action-required"),
+    memberPreviewState:
+      normalizeMemberCapabilityState(readiness?.memberPreviewState) ??
+      "degraded",
+    blockers: readiness?.blockers ?? ["backend-go-live-readiness-required"],
+    adminActions: readiness?.adminActions ?? [
+      "Run backend readiness checks before member go-live.",
+    ],
+    auditRefs: readiness?.auditRefs ?? [],
+    supportSafe: readiness?.supportSafe ?? false,
+    normalMembersMayAccessSetupControls:
+      readiness?.normalMembersMayAccessSetupControls ?? false,
+    rawProviderDiagnosticsExposed:
+      readiness?.rawProviderDiagnosticsExposed ?? false,
   };
 }
 
@@ -905,6 +1034,11 @@ function normalizeWeaverRuntimeProjection(
     supportSafe: projection?.supportSafe ?? false,
     providerDiagnosticsRedacted: projection?.providerDiagnosticsRedacted ?? false,
     rawRuntimeInternalsExposed: projection?.rawRuntimeInternalsExposed ?? false,
+    disabledByDefault: projection?.disabledByDefault ?? true,
+    groupChatConsentRequired: projection?.groupChatConsentRequired ?? true,
+    sandboxPosture:
+      projection?.sandboxPosture ??
+      "sandbox-readiness-recorded-runtime-execution-disabled",
     pendingRevocationRefs: projection?.pendingRevocationRefs ?? [
       "runtime-profile-revocation-check-required",
     ],
@@ -1163,6 +1297,86 @@ function sampleDomain(
     ...overrides,
   };
 }
+
+const sampleSuiteDomainReadiness: SuiteDomainReadiness[] = [
+  {
+    domain: "files-docs",
+    label: "Files and Documents",
+    adminReadiness: "degraded",
+    memberState: "degraded",
+    selectedAdapterPosture:
+      "files=nextcloud-files, documents-collaboration=collabora-wopi",
+    sourceOfTruthMode:
+      "backend-owned file/document facade with guarded editor sessions",
+    providerCategoryKeys: ["files", "documents-collaboration"],
+    canonicalObjectKinds: ["drive", "folder", "file", "document-session"],
+    capabilityStates: ["files.read", "files.write", "documents.edit"],
+    supportSafeErrors: [
+      "support-safe-error-codes-only",
+      "raw-provider-bodies-redacted",
+    ],
+    portabilityNotes: [
+      "Export manifests required before provider replacement",
+      "Credential-bearing editor URLs remain blocked from support views",
+    ],
+    auditRefs: ["receipt://suite/files-docs/readiness"],
+    nextAction:
+      "Confirm checksum, permission, and editor-launch evidence before member writes.",
+    backendOwnedFacade: true,
+    providerMappingOwnedByServer: true,
+    rawProviderConfigExposedToMembers: false,
+  },
+  {
+    domain: "boards-tasks",
+    label: "Boards and Tasks",
+    adminReadiness: "policy-blocked",
+    memberState: "disabled_by_policy",
+    selectedAdapterPosture: "boards-tasks=openproject-primary",
+    sourceOfTruthMode:
+      "local workspace writes; provider sync/write promotion gated by contract evidence",
+    providerCategoryKeys: ["boards-tasks"],
+    canonicalObjectKinds: ["board", "task", "lane", "comment"],
+    capabilityStates: ["boards.read", "boards.write", "tasks.complete"],
+    supportSafeErrors: [
+      "support-safe-error-codes-only",
+      "raw-provider-bodies-redacted",
+    ],
+    portabilityNotes: [
+      "Lossy mapping and conflict reports are required before provider-write apply",
+    ],
+    auditRefs: ["receipt://suite/boards-tasks/readiness"],
+    nextAction:
+      "Verify keyboard task flows, conflict states, and audit events before writes.",
+    backendOwnedFacade: true,
+    providerMappingOwnedByServer: true,
+    rawProviderConfigExposedToMembers: false,
+  },
+  {
+    domain: "calendar-meetings",
+    label: "Calendar",
+    adminReadiness: "degraded",
+    memberState: "degraded",
+    selectedAdapterPosture: "calendar=nextcloud-caldav",
+    sourceOfTruthMode:
+      "workspace/team/channel calendar facade; private personal calendars blocked",
+    providerCategoryKeys: ["calendar"],
+    canonicalObjectKinds: ["calendar", "event", "reminder", "conference-link"],
+    capabilityStates: ["calendar.read", "calendar.write"],
+    supportSafeErrors: [
+      "support-safe-error-codes-only",
+      "raw-provider-bodies-redacted",
+    ],
+    portabilityNotes: [
+      "Private calendar ingestion and credential profile downloads are out of scope",
+    ],
+    auditRefs: ["receipt://suite/calendar-meetings/readiness"],
+    nextAction:
+      "Confirm workspace/team/channel event readiness and private-calendar blockers.",
+    backendOwnedFacade: true,
+    providerMappingOwnedByServer: true,
+    rawProviderConfigExposedToMembers: false,
+  },
+];
 
 function normalizeRuntimeProfileStatus(
   value?: string,
@@ -1749,6 +1963,20 @@ export const sampleControlPlane: ControlPlaneResponse = {
       },
     ),
   ],
+  suiteDomainReadiness: sampleSuiteDomainReadiness,
+  goLiveReadiness: {
+    state: "admin-action-required",
+    memberPreviewState: "degraded",
+    blockers: ["files-docs:degraded", "boards-tasks:policy-blocked"],
+    adminActions: [
+      "Resolve suite readiness blockers before member go-live.",
+      "Run effective policy simulation for representative users/groups.",
+    ],
+    auditRefs: ["receipt://admin-control-plane/go-live-readiness"],
+    supportSafe: true,
+    normalMembersMayAccessSetupControls: false,
+    rawProviderDiagnosticsExposed: false,
+  },
   weaverRuntimeProjection: {
     profileVersion: "weaver-runtime-profile-v1",
     runtimeProfileHash: "sha256:profile-projection-sample",
@@ -1757,6 +1985,9 @@ export const sampleControlPlane: ControlPlaneResponse = {
     supportSafe: true,
     providerDiagnosticsRedacted: true,
     rawRuntimeInternalsExposed: false,
+    disabledByDefault: true,
+    groupChatConsentRequired: true,
+    sandboxPosture: "sandbox-readiness-recorded-runtime-execution-disabled",
     pendingRevocationRefs: ["receipt://weaver/runtime/revocation-preview"],
     auditReceiptRefs: ["receipt://weaver/runtime/profile-regeneration"],
     items: sampleWeaverProjectionItems,

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,6 +116,7 @@ Release and evidence docs:
 - [Sprint 6 closure report](sprint-6-closure-report.md)
 - [Sprint 8 delivery board policy](project/sprint-8-delivery-board.md)
 - [Sprint 9 product-readiness waterfall evidence](sprint-9-product-readiness-waterfall.md)
+- [Sprint 16 closure report](sprint-16-closure-report.md)
 
 Historical/context docs:
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -4,6 +4,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Added
 - Sprint 15 adds organization-embedding and provider-neutral replacement evidence: backend-owned effective-policy/readiness boundaries, support-safe Admin Console consequence copy, Matrix Chat as the first dry-run proof slice, an operator runbook, and accessibility evidence template while keeping provider apply/cutover blocked.
+- Sprint 16 adds a support-safe organization go-live readiness summary, suite facade readiness rows for Files/Documents, Boards/Tasks, and Calendar, and a governed Weaver RuntimeProfile projection preview while keeping provider apply/cutover and runtime execution guarded.
 
 - Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
 - Contextual meetings now have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.

--- a/docs/sprint-16-closure-report.md
+++ b/docs/sprint-16-closure-report.md
@@ -1,0 +1,52 @@
+# Sprint 16 closure report — Organization Setup Control Plane & Suite Facade Expansion
+
+Date: 2026-06-01
+
+## Scope delivered
+
+Sprint 16 promotes the admin control plane from provider-category status into a pre-member-go-live readiness surface while keeping provider setup and secrets out of member flows.
+
+- Admin setup/readiness control plane: `AdminControlPlaneResponse` now includes support-safe `goLiveReadiness`, identity readiness, suite domain readiness, SecretRef inventory, provider selections, policy preview, and Weaver runtime projection in one backend-owned response.
+- Suite facades: Files/Documents, Boards/Tasks, and Calendar readiness rows expose canonical object kinds, capability states, portability/loss notes, selected adapter posture, audit refs, and next actions without raw provider config or credential-bearing URLs.
+- Governed Weaver runtime projection: Admin Console and backend expose a signed-profile-preview shape with projected chat/model/tool/MCP items, audit receipts, revocation refs, sandbox posture, consent requirement, and disabled-by-default runtime posture. Runtime execution remains guarded and is not released by this sprint.
+- Admin Console: owners/admins/operators see organization go-live readiness, suite facade readiness, identity readiness, provider replacement dry-run evidence, and Weaver projection details; members still do not receive provider setup controls.
+
+## Evidence
+
+Implementation evidence:
+
+- `server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java`
+- `server/src/main/java/com/massimotter/weave/backend/model/admin/GoLiveReadinessResponse.java`
+- `server/src/main/java/com/massimotter/weave/backend/model/admin/SuiteDomainReadinessResponse.java`
+- `server/src/main/java/com/massimotter/weave/backend/model/admin/WeaverRuntimeProjectionResponse.java`
+- `server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java`
+- `admin-console/src/api.ts`
+- `admin-console/src/App.tsx`
+
+Test evidence:
+
+- `server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java` verifies suite/go-live/Weaver projection support-safe boundaries and absence of raw runtime/provider tokens in serialized output.
+- `./gradlew serverCi` — passing locally on 2026-06-01.
+- `./gradlew adminCi` — passing locally on 2026-06-01.
+- `make docs-check` — passing locally on 2026-06-01.
+- `./gradlew specContract acceptanceContract portabilityContractCheck releaseEvidenceCheck` — passing locally on 2026-06-01.
+- `./gradlew ci --console=plain` — passing locally on 2026-06-01.
+
+## Issue mapping
+
+- #573 — covered by backend/admin organization go-live readiness, identity readiness linkage, SecretRef-safe admin API routes, and member setup-control denial.
+- #574 — covered by suite domain readiness rows for Files/Documents, Boards/Tasks, and Calendar with backend-owned facades, canonical objects, portability notes, and safe member states.
+- #575 — covered by governed Weaver RuntimeProfile projection preview, disabled-by-default runtime posture, sandbox/consent/audit fields, approval-required tool markers, and redaction boundaries.
+
+## Boundaries and non-claims
+
+- No production provider cutover or live migration apply is claimed.
+- No legal compliance, lossless migration, or E2EE history migration claim is made.
+- No raw provider setup, provider tokens, credential-bearing URLs, raw downstream bodies, SecretRef payloads, or OpenClaw runtime config is exposed to members.
+- Weaver runtime execution remains guarded; this sprint delivers readiness/profile/tool/audit projection foundations only.
+
+## Remaining risks / carryovers
+
+- CI must pass on the PR branch before merge.
+- The readiness rows are control-plane evidence and gating surfaces; live provider-specific apply remains blocked until future domain-specific apply evidence is added.
+- RuntimeProfile hash is a preview/regeneration contract placeholder until the future signing pipeline produces production hashes.

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
@@ -23,12 +23,16 @@ public record AdminControlPlaneResponse(
         List<ProviderSelectionResponse> selectedProviderMappings,
         CapabilityWhitelistResponse whitelist,
         WeaverDistributionPolicyResponse weaverDistributionPolicy,
+        WeaverRuntimeProjectionResponse weaverRuntimeProjection,
         IdentityProviderReadinessResponse identityProviderReadiness,
+        List<SuiteDomainReadinessResponse> suiteDomainReadiness,
+        GoLiveReadinessResponse goLiveReadiness,
         List<SecretRefResponse> secretRefs,
         Map<String, String> adminApiRoutes) {
     public AdminControlPlaneResponse {
         categories = categories == null ? List.of() : List.copyOf(categories);
         selectedProviderMappings = selectedProviderMappings == null ? List.of() : List.copyOf(selectedProviderMappings);
+        suiteDomainReadiness = suiteDomainReadiness == null ? List.of() : List.copyOf(suiteDomainReadiness);
         secretRefs = secretRefs == null ? List.of() : List.copyOf(secretRefs);
         adminApiRoutes = adminApiRoutes == null ? Map.of() : Map.copyOf(adminApiRoutes);
     }

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/GoLiveReadinessResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/GoLiveReadinessResponse.java
@@ -1,0 +1,21 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Support-safe organization go-live readiness summary for owners/admins.")
+public record GoLiveReadinessResponse(
+        String state,
+        String memberPreviewState,
+        List<String> blockers,
+        List<String> adminActions,
+        List<String> auditRefs,
+        boolean supportSafe,
+        boolean normalMembersMayAccessSetupControls,
+        boolean rawProviderDiagnosticsExposed) {
+    public GoLiveReadinessResponse {
+        blockers = blockers == null ? List.of() : List.copyOf(blockers);
+        adminActions = adminActions == null ? List.of() : List.copyOf(adminActions);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/SuiteDomainReadinessResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/SuiteDomainReadinessResponse.java
@@ -1,0 +1,35 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Map;
+
+@Schema(description = "Support-safe suite domain readiness row for Admin Console go-live decisions.")
+public record SuiteDomainReadinessResponse(
+        String domain,
+        String label,
+        String adminReadiness,
+        String memberState,
+        String selectedAdapterPosture,
+        String sourceOfTruthMode,
+        List<String> providerCategoryKeys,
+        List<String> canonicalObjectKinds,
+        List<String> capabilityStates,
+        List<String> supportSafeErrors,
+        List<String> portabilityNotes,
+        List<String> auditRefs,
+        String nextAction,
+        boolean backendOwnedFacade,
+        boolean providerMappingOwnedByServer,
+        boolean rawProviderConfigExposedToMembers,
+        Map<String, Object> evidence) {
+    public SuiteDomainReadinessResponse {
+        providerCategoryKeys = providerCategoryKeys == null ? List.of() : List.copyOf(providerCategoryKeys);
+        canonicalObjectKinds = canonicalObjectKinds == null ? List.of() : List.copyOf(canonicalObjectKinds);
+        capabilityStates = capabilityStates == null ? List.of() : List.copyOf(capabilityStates);
+        supportSafeErrors = supportSafeErrors == null ? List.of() : List.copyOf(supportSafeErrors);
+        portabilityNotes = portabilityNotes == null ? List.of() : List.copyOf(portabilityNotes);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+        evidence = evidence == null ? Map.of() : Map.copyOf(evidence);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/WeaverRuntimeProjectionItemResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/WeaverRuntimeProjectionItemResponse.java
@@ -1,0 +1,21 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "One support-safe item projected into a governed Weaver RuntimeProfile preview.")
+public record WeaverRuntimeProjectionItemResponse(
+        String id,
+        String category,
+        String label,
+        String state,
+        String memberImpact,
+        String policyImpact,
+        String readinessSummary,
+        List<String> receiptRefs,
+        boolean discoverableToRuntime,
+        boolean approvalRequired) {
+    public WeaverRuntimeProjectionItemResponse {
+        receiptRefs = receiptRefs == null ? List.of() : List.copyOf(receiptRefs);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/WeaverRuntimeProjectionResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/WeaverRuntimeProjectionResponse.java
@@ -1,0 +1,26 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Signed Weaver RuntimeProfile projection preview; contains hashes/refs only, never runtime config or secrets.")
+public record WeaverRuntimeProjectionResponse(
+        String profileVersion,
+        String runtimeProfileHash,
+        String expiresAt,
+        String regeneratedAt,
+        boolean supportSafe,
+        boolean providerDiagnosticsRedacted,
+        boolean rawRuntimeInternalsExposed,
+        boolean disabledByDefault,
+        boolean groupChatConsentRequired,
+        String sandboxPosture,
+        List<String> pendingRevocationRefs,
+        List<String> auditReceiptRefs,
+        List<WeaverRuntimeProjectionItemResponse> items) {
+    public WeaverRuntimeProjectionResponse {
+        pendingRevocationRefs = pendingRevocationRefs == null ? List.of() : List.copyOf(pendingRevocationRefs);
+        auditReceiptRefs = auditReceiptRefs == null ? List.of() : List.copyOf(auditReceiptRefs);
+        items = items == null ? List.of() : List.copyOf(items);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -28,6 +28,7 @@ import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateReques
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
 import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationResponse;
+import com.massimotter.weave.backend.model.admin.GoLiveReadinessResponse;
 import com.massimotter.weave.backend.model.admin.IdentityProviderReadinessCardResponse;
 import com.massimotter.weave.backend.model.admin.IdentityProviderReadinessResponse;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
@@ -39,10 +40,13 @@ import com.massimotter.weave.backend.model.admin.ProviderReplacementDryRunRespon
 import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
 import com.massimotter.weave.backend.model.admin.ProviderSelectionResponse;
 import com.massimotter.weave.backend.model.admin.SecretRefResponse;
+import com.massimotter.weave.backend.model.admin.SuiteDomainReadinessResponse;
 import com.massimotter.weave.backend.model.admin.WeaverDistributionPolicyResponse;
 import com.massimotter.weave.backend.model.admin.WeaverMcpGrantResponse;
 import com.massimotter.weave.backend.model.admin.WeaverModelAliasResponse;
 import com.massimotter.weave.backend.model.admin.WeaverRuntimeProfileChangeResponse;
+import com.massimotter.weave.backend.model.admin.WeaverRuntimeProjectionItemResponse;
+import com.massimotter.weave.backend.model.admin.WeaverRuntimeProjectionResponse;
 import com.massimotter.weave.backend.provider.ProviderCapabilityContracts;
 import com.massimotter.weave.backend.provider.ProviderCategoryCatalog;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
@@ -52,6 +56,7 @@ import com.massimotter.weave.backend.provider.ProviderSelection;
 import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import com.massimotter.weave.backend.provider.ProviderState;
 import com.massimotter.weave.backend.provider.ProviderStatusResponse;
+import com.massimotter.weave.backend.domainfacade.CanonicalDomainDefinition;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -191,6 +196,8 @@ public class AdminControlPlaneService {
     public AdminControlPlaneResponse overview(Jwt jwt) {
         workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "overview");
         ProviderRegistryResponse registry = providerRegistry.status();
+        IdentityProviderReadinessResponse identityReadiness = identityProviderReadiness(registry, jwt);
+        List<SuiteDomainReadinessResponse> suiteReadiness = suiteDomainReadiness(registry);
         return new AdminControlPlaneResponse(
                 "admin-control-plane-v1",
                 organizationId(jwt),
@@ -209,19 +216,24 @@ public class AdminControlPlaneService {
                         .toList(),
                 whitelist(jwt),
                 weaverDistributionPolicy(registry),
-                identityProviderReadiness(registry, jwt),
+                weaverRuntimeProjection(registry),
+                identityReadiness,
+                suiteReadiness,
+                goLiveReadiness(identityReadiness, suiteReadiness),
                 secretRefs(registry),
-                Map.of(
-                        "providers", "/api/providers/status",
-                        "policy", "/api/admin/policies/capability-whitelist",
-                        "audit", "/api/admin/audit/events",
-                        "readinessTest", "/api/admin/providers/readiness-tests",
-                        "providerReplacementDryRun", "/api/admin/providers/replacements/dry-run",
-                        "identityReadiness", "/api/admin/identity/readiness",
-                        "identityRealmDryRun", "/api/admin/identity/realm/dry-run",
-                        "identityRealmApply", "/api/admin/identity/realm/apply",
-                        "effectivePolicySimulation", "/api/admin/policies/effective/simulations",
-                        "providerSelections", "/api/admin/providers/selections"));
+                Map.ofEntries(
+                        Map.entry("providers", "/api/providers/status"),
+                        Map.entry("policy", "/api/admin/policies/capability-whitelist"),
+                        Map.entry("audit", "/api/admin/audit/events"),
+                        Map.entry("readinessTest", "/api/admin/providers/readiness-tests"),
+                        Map.entry("providerReplacementDryRun", "/api/admin/providers/replacements/dry-run"),
+                        Map.entry("identityReadiness", "/api/admin/identity/readiness"),
+                        Map.entry("identityRealmDryRun", "/api/admin/identity/realm/dry-run"),
+                        Map.entry("identityRealmApply", "/api/admin/identity/realm/apply"),
+                        Map.entry("effectivePolicySimulation", "/api/admin/policies/effective/simulations"),
+                        Map.entry("providerSelections", "/api/admin/providers/selections"),
+                        Map.entry("suiteReadiness", "/api/admin/control-plane#suiteDomainReadiness"),
+                        Map.entry("weaverRuntimeProjection", "/api/admin/control-plane#weaverRuntimeProjection")));
     }
 
     public IdentityProviderReadinessResponse identityProviderReadiness(Jwt jwt) {
@@ -1349,6 +1361,176 @@ public class AdminControlPlaneService {
                 readiness,
                 providerSelectionRepository.persistencePosture(),
                 selection.selectedAt());
+    }
+
+    private List<SuiteDomainReadinessResponse> suiteDomainReadiness(ProviderRegistryResponse registry) {
+        return List.of(
+                suiteDomain(CanonicalDomainDefinition.FILES_DOCS, registry,
+                        "backend-owned file/document facade with guarded editor sessions",
+                        List.of("Export manifests required before provider replacement", "Document editing remains guarded until WOPI session evidence is fresh"),
+                        "Select/test files and documents providers, then attach support-safe export/delete evidence."),
+                suiteDomain(CanonicalDomainDefinition.BOARDS_TASKS, registry,
+                        "local workspace writes; provider sync/write promotion gated by contract evidence",
+                        List.of("Provider-write apply is refused until read-sync, conflict, and rollback evidence pass", "Keyboard create/move/complete flows are required before member promotion"),
+                        "Verify board/task workspace contract, accessible workflows, conflict states, and audit events."),
+                suiteDomain(CanonicalDomainDefinition.CALENDAR_MEETINGS, registry,
+                        "workspace/team/channel calendar facade; private personal calendars blocked",
+                        List.of("Secret-free setup metadata only", "Private calendar ingestion and credential profile downloads are out of scope"),
+                        "Confirm workspace/team/channel event readiness and keep private-calendar setup blocked."));
+    }
+
+    private SuiteDomainReadinessResponse suiteDomain(
+            CanonicalDomainDefinition definition,
+            ProviderRegistryResponse registry,
+            String sourceOfTruthMode,
+            List<String> portabilityNotes,
+            String nextAction) {
+        List<String> readinessStates = definition.providerCategoryKeys().stream()
+                .map(category -> readinessFor(category, registry))
+                .filter(state -> !"unknown".equals(state))
+                .toList();
+        String adminReadiness = aggregateDomainReadiness(readinessStates);
+        return new SuiteDomainReadinessResponse(
+                definition.domain(),
+                definition.label(),
+                adminReadiness,
+                memberStateForAdminReadiness(adminReadiness),
+                selectedAdapterPosture(definition.providerCategoryKeys(), registry),
+                sourceOfTruthMode,
+                definition.providerCategoryKeys(),
+                definition.canonicalObjectKinds(),
+                Stream.concat(definition.readCapabilities().stream(), definition.writeCapabilities().stream()).toList(),
+                List.of("support-safe-error-codes-only", "raw-provider-bodies-redacted", "credential-bearing-urls-blocked"),
+                portabilityNotes,
+                List.of("audit://suite/" + definition.domain() + "/readiness"),
+                nextAction,
+                true,
+                true,
+                false,
+                Map.of(
+                        "providerCategoryCount", definition.providerCategoryKeys().size(),
+                        "supportSafe", true,
+                        "rawProviderConfigReturned", false,
+                        "memberProviderSetupControlsReturned", false));
+    }
+
+    private String aggregateDomainReadiness(List<String> states) {
+        if (states.isEmpty()) {
+            return "not_configured";
+        }
+        if (states.contains("misconfigured") || states.contains("admin-action-required")) {
+            return "admin-action-required";
+        }
+        if (states.contains("policy-blocked") || states.contains("disabled")) {
+            return "disabled";
+        }
+        if (states.contains("degraded")) {
+            return "degraded";
+        }
+        if (states.stream().allMatch(state -> state.equals("ready") || state.equals("configured"))) {
+            return "ready";
+        }
+        return "admin-action-required";
+    }
+
+    private String memberStateForAdminReadiness(String state) {
+        return switch (state) {
+            case "ready", "configured" -> "available";
+            case "disabled", "policy-blocked" -> "disabled_by_policy";
+            case "not_configured" -> "not_configured";
+            case "unsupported" -> "unavailable";
+            default -> "degraded";
+        };
+    }
+
+    private String selectedAdapterPosture(List<String> categories, ProviderRegistryResponse registry) {
+        return categories.stream()
+                .map(category -> category + "=" + registry.selectedProviderMappings().stream()
+                        .filter(selection -> selection.category().equals(category))
+                        .map(ProviderSelection::providerKey)
+                        .findFirst()
+                        .orElse("awaiting_admin_selection"))
+                .collect(java.util.stream.Collectors.joining(", "));
+    }
+
+    private GoLiveReadinessResponse goLiveReadiness(
+            IdentityProviderReadinessResponse identityReadiness,
+            List<SuiteDomainReadinessResponse> suiteReadiness) {
+        List<String> blockers = new ArrayList<>();
+        if (!"ready".equals(identityReadiness.overallState())) {
+            blockers.add("identity-idm:" + identityReadiness.overallState());
+        }
+        suiteReadiness.stream()
+                .filter(domain -> !"ready".equals(domain.adminReadiness()))
+                .map(domain -> domain.domain() + ":" + domain.adminReadiness())
+                .forEach(blockers::add);
+        String state = blockers.isEmpty() ? "ready" : "admin-action-required";
+        return new GoLiveReadinessResponse(
+                state,
+                blockers.isEmpty() ? "available" : "degraded",
+                blockers,
+                blockers.isEmpty()
+                        ? List.of("Invite members only while audit and readiness evidence remains fresh.")
+                        : List.of("Resolve listed readiness blockers before member go-live.", "Run effective policy simulation for representative users/groups."),
+                List.of("audit://admin-control-plane/go-live-readiness"),
+                true,
+                false,
+                false);
+    }
+
+    private WeaverRuntimeProjectionResponse weaverRuntimeProjection(ProviderRegistryResponse registry) {
+        Instant generatedAt = Instant.now(clock);
+        String modelProviderKey = registry.selectedProviderMappings().stream()
+                .filter(selection -> selection.category().equals("model"))
+                .map(ProviderSelection::providerKey)
+                .findFirst()
+                .orElse("lmstudio");
+        String chatProviderKey = registry.selectedProviderMappings().stream()
+                .filter(selection -> selection.category().equals("chat"))
+                .map(ProviderSelection::providerKey)
+                .findFirst()
+                .orElse("matrix-chat");
+        return new WeaverRuntimeProjectionResponse(
+                "weaver-runtime-profile-v1",
+                "runtime-profile-hash-pending-live-regeneration",
+                generatedAt.plusSeconds(3600).toString(),
+                generatedAt.toString(),
+                true,
+                true,
+                false,
+                true,
+                true,
+                "sandbox-readiness-recorded-runtime-execution-disabled",
+                List.of(),
+                List.of("audit://weaver/runtime-profile/projection"),
+                List.of(
+                        projectionItem("chat-route", "chat", "channels.weave-chat via " + chatProviderKey, "ready", "available", "Stable chat route only; provider rooms stay behind Weave Chat.", false),
+                        projectionItem("model-alias-general", "model", "general-assistant via " + modelProviderKey, readinessFor("model", registry), "disabled_by_policy", "Alias is admin-selected but runtime remains disabled by default.", false),
+                        projectionItem("tool-calendar-search", "tool", "calendar.search_events", readinessFor("calendar", registry), "disabled_by_policy", "Read-only discovery requires weaver.calendar_read and calendar.read grants.", false),
+                        projectionItem("tool-boards-comment", "tool", "boards.comment", readinessFor("boards-tasks", registry), "disabled_by_policy", "Write-like tool requires explicit approval receipt and audit.", true),
+                        projectionItem("consent-shared-space", "mcp", "shared-space consent gate", "admin-action-required", "disabled_by_policy", "Group chat/shared-space participation requires org policy and consent evidence.", true)));
+    }
+
+    private WeaverRuntimeProjectionItemResponse projectionItem(
+            String id,
+            String category,
+            String label,
+            String state,
+            String memberImpact,
+            String policyImpact,
+            boolean approvalRequired) {
+        String safeState = "unknown".equals(state) ? "admin-action-required" : state;
+        return new WeaverRuntimeProjectionItemResponse(
+                id,
+                category,
+                label,
+                safeState,
+                memberImpact,
+                policyImpact,
+                "Projected through Weave domain policy; raw OpenClaw config, provider credentials, and downstream payloads are not exposed.",
+                List.of("audit://weaver/runtime-profile/" + id),
+                false,
+                approvalRequired);
     }
 
     private WeaverDistributionPolicyResponse weaverDistributionPolicy(ProviderRegistryResponse registry) {

--- a/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
@@ -430,6 +430,50 @@ class AdminControlPlaneServiceTest {
     }
 
     @Test
+    void overviewIncludesSprint16SuiteGoLiveAndWeaverProjectionContracts() throws Exception {
+        WorkspaceCapabilityService workspaceCapabilityService = workspaceCapabilityService();
+        InMemoryProviderSelectionRepository selectionRepository = new InMemoryProviderSelectionRepository();
+        selectionRepository.save(new ProviderSelection(
+                "chat",
+                "synapse-homeserver",
+                "recommended_self_hosted_default",
+                "secretref://weave/provider/synapse-homeserver",
+                "actor:admin-123",
+                Instant.parse("2026-05-31T08:00:00Z"),
+                true,
+                true,
+                false,
+                List.of()));
+        ProviderRegistry providerRegistry = new ProviderRegistry(List.of(), workspaceCapabilityService, selectionRepository);
+        AdminControlPlaneService service = new AdminControlPlaneService(
+                providerRegistry,
+                workspaceCapabilityService,
+                selectionRepository,
+                new InMemoryOrganizationBootstrapRepository(),
+                new InMemoryAuditEventPublisher(),
+                Clock.fixed(Instant.parse("2026-05-31T08:00:00Z"), ZoneOffset.UTC));
+
+        var response = service.overview(jwt("admin"));
+
+        assertThat(response.suiteDomainReadiness()).extracting(domain -> domain.domain())
+                .containsExactly("files-docs", "boards-tasks", "calendar-meetings");
+        assertThat(response.suiteDomainReadiness()).allSatisfy(domain -> {
+            assertThat(domain.backendOwnedFacade()).isTrue();
+            assertThat(domain.providerMappingOwnedByServer()).isTrue();
+            assertThat(domain.rawProviderConfigExposedToMembers()).isFalse();
+            assertThat(domain.supportSafeErrors()).contains("raw-provider-bodies-redacted");
+        });
+        assertThat(response.goLiveReadiness().supportSafe()).isTrue();
+        assertThat(response.goLiveReadiness().normalMembersMayAccessSetupControls()).isFalse();
+        assertThat(response.weaverRuntimeProjection().disabledByDefault()).isTrue();
+        assertThat(response.weaverRuntimeProjection().rawRuntimeInternalsExposed()).isFalse();
+        assertThat(response.weaverRuntimeProjection().items()).extracting(item -> item.id())
+                .contains("chat-route", "tool-calendar-search", "tool-boards-comment", "consent-shared-space");
+        assertThat(new ObjectMapper().findAndRegisterModules().writeValueAsString(response))
+                .doesNotContain("openclaw.json", "Bearer ", "access_token", "rawProviderPayload");
+    }
+
+    @Test
     void checkedInApplyFixtureIsSupportSafeDecisionOnlyEvidence() throws Exception {
         ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
         try (InputStream input = getClass().getResourceAsStream("/identity-realm-apply/guarded-safe-accepted.json")) {


### PR DESCRIPTION
## Summary

Closes #573.
Closes #574.
Closes #575.

Sprint 16 delivers one coherent organization setup/control-plane increment:

- adds backend-owned admin go-live readiness, suite domain readiness, and governed Weaver runtime projection response models
- promotes Files/Documents, Boards/Tasks, and Calendar through support-safe suite facade readiness rows
- expands Admin Console normalization/UI for org readiness, domain facades, and Weaver RuntimeProfile projection preview
- records closure evidence without claiming production provider cutover, lossless migration, or autonomous Weaver runtime release

## Evidence / gates

- `./gradlew serverCi --console=plain` ✅
- `./gradlew adminCi --console=plain` ✅
- `make docs-check` ✅
- `./gradlew specContract acceptanceContract` ✅
- `./gradlew portabilityContractCheck` ✅
- `./gradlew releaseEvidenceCheck` ✅
- `./gradlew ci --console=plain` ✅

Closure report: `docs/sprint-16-closure-report.md`

## Safety boundaries

- no production provider cutover or live migration apply
- no legal compliance or lossless migration claim
- no raw provider setup, provider tokens, credential-bearing URLs, raw downstream bodies, SecretRef payloads, or OpenClaw runtime config in member UX
- Weaver runtime execution remains guarded; this PR delivers readiness/profile/tool/audit projection foundations only
