### PR TITLE
docs: add Sprint 16 MCP tool contract

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -60,6 +60,7 @@ For a real single-host deployment, start here:
 - [CalDAV/CardDAV external clients](docs/calendar-caldav-external-clients.md): DAV discovery, safe external-client credential path, and blocked private calendar/addressbook/profile flows.
 - [Connector runtime guardrails](docs/connector-runtime-guardrails.md): disabled-by-default connector runtime, callback, secret, and support-bundle boundaries.
 - [Weaver runtime lifecycle](docs/weaver-runtime-lifecycle.md): signed RuntimeProfile input, one active per-user runtime container boundary, internal-only network, reload/restart/rollback/revocation gates, and support-safe evidence; execution remains disabled by default.
+- [Weave MCP tool contract](docs/weave-mcp-tool-contract.md): disabled-by-default design foundation for future FastMCP-style governed Weave domain tools under infra, with backend authority and support-safe outputs only.
 - [OpenProject Boards runtime](docs/openproject-boards-runtime.md): optional provider-backed validation setup and live E2E gate; off by default.
 
 After installation, verify public and host-local state:
@@ -112,6 +113,7 @@ Optional providers are fail-closed by default:
 - `weave-workspace/release-verify.sh`: public endpoint verification for non-local single-host installs.
 - `weave-workspace/operator-check.sh`: host-local container and health checks.
 - `weave-workspace/backup.sh`, `restore-smoke.sh`, `support-bundle.sh`: operator support and recovery helpers.
+- `weave-workspace/weave-mcp-tool-contract.json`: support-safe canonical domain tool contract for future governed MCP gateway proof slices.
 - `weave-workspace/01-infrastructure`: Docker runtime, generated config, and service modules.
 - `weave-workspace/02-keycloak-setup`: Keycloak tenant configuration stage.
 

--- a/infra/docs/weave-mcp-tool-contract.md
+++ b/infra/docs/weave-mcp-tool-contract.md
@@ -1,0 +1,54 @@
+# Weave MCP tool contract
+
+Status: Sprint 16 design foundation, disabled by default.
+
+This document records the MCP refinement for Sprint 16 without turning MCP into the product API. The Java/Kotlin backend remains the product and control-plane authority. A future MCP gateway under `infra/weave-workspace` may expose governed Weave domain tools to approved Weaver runtimes, but only as infra glue over backend-owned contracts.
+
+## Placement
+
+Use `infra/weave-workspace` for the first contract because it is the operator/runtime area that already owns Weaver lifecycle evidence and internal network boundaries. Candidate future package names are `infra/weave-workspace/weave-mcp` or `infra/weave-workspace/mcp-gateway`.
+
+FastMCP with Python `@tool` remains an implementation candidate only. Sprint 16 should not commit the product architecture to a Python MCP server until the backend facade, policy, audit, and RuntimeProfile contracts prove the shape.
+
+## Authority boundary
+
+- Weave backend is authoritative for product domains, provider choices, policy decisions, readiness, audit, and SecretRef/CredentialRef handling.
+- MCP exposes governed actions for approved runtimes; it does not replace backend APIs.
+- Runtime containers must not call provider APIs directly.
+- Normal members must not configure providers, secrets, endpoint URLs, or raw OpenClaw/MCP server config through MCP.
+- All tool calls are deny-by-default, audited, and filtered by Weave capability policy plus RuntimeProfile grants.
+
+## Canonical MCP domains
+
+The canonical domain sketch is captured in `../weave-workspace/weave-mcp-tool-contract.json`:
+
+- `calendar`: event CRUD, calendar CRUD where appropriate, free/busy, invite/RSVP, recurrence, provider source mapping.
+- `files_documents`: file/folder CRUD, search, metadata, version/content reads, permissions/share links, document actions.
+- `boards_tasks`: board/list/card/task CRUD, assignments, labels, statuses, due dates, comments/activity.
+- `chat_comms`: channels/rooms/messages, membership, send/read/search where allowed, support-safe provider abstraction.
+- `people_identity_org`: users, groups, roles, org units, effective rights/policy, readiness.
+- `admin_setup_providers`: provider registry, category mapping, readiness checks, dry-runs, capability mapping, SecretRef references only.
+- `audit_policy`: audit events, redaction/support-safe views, policy simulation, permission scopes.
+- `weaver_runtime_governance`: org tool allowlists, capability bundles, consent policy, sandbox/package projection, runtime audit handoff.
+
+## Support-safe rules
+
+Every future `@tool` must return Weave domain objects or support-safe refs only. It must not return:
+
+- raw provider internals, raw downstream request/response bodies, or raw provider errors;
+- bearer tokens, cookies, OAuth access/refresh tokens, private keys, or SecretRef values;
+- credential-bearing URLs, direct provider admin URLs, room IDs/event IDs, or filenames in support-safe bundles;
+- `openclaw.json`, raw MCP server config, runtime tokens, sandbox bypass controls, or exec policy bypasses.
+
+Write/delete/external-send/provider-switch actions require approval receipts. Routine reads may be grant-based when the user has normal Weave rights and the organization has granted that tool class.
+
+## Sprint 16 slice
+
+Do not build every provider adapter in Sprint 16. The safe proof slice is:
+
+1. keep backend-owned Admin Console/readiness and suite facade contracts as the source of truth;
+2. record the MCP contract and test its fail-closed, support-safe domain shape;
+3. project Weaver RuntimeProfile/tool governance from those domains while disabled by default;
+4. optionally add one or two mock/in-memory proof tools later only after the backend contract is stable.
+
+This is a scope adjustment to the Weaver/runtime and suite-facade design foundation, not a runtime launch or production MCP gateway claim.

--- a/infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh
+++ b/infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_DIR="$(cd -- "${ROOT_DIR}/../.." && pwd)"
+CONTRACT="${ROOT_DIR}/weave-mcp-tool-contract.json"
+DOC="${ROOT_DIR}/../docs/weave-mcp-tool-contract.md"
+PRODUCT_PLAN="${REPO_DIR}/docs/product-line-and-weaver-plan.md"
+
+fail() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  grep -Fq -- "${needle}" "${file}" || fail "Expected ${file} to contain: ${needle}"
+}
+
+[[ -f "${CONTRACT}" ]] || fail "Missing Weave MCP tool contract: ${CONTRACT}"
+[[ -f "${DOC}" ]] || fail "Missing Weave MCP tool contract doc: ${DOC}"
+
+jq -e '
+  .schema == "weave-mcp-tool-contract-v1"
+  and .status == "design-foundation-disabled"
+  and .placement.area == "infra/weave-workspace"
+  and (.placement.futurePackageCandidates | index("infra/weave-workspace/weave-mcp"))
+  and (.placement.implementationHint | test("FastMCP"))
+  and .authorityBoundary.productAuthority == "weave-backend"
+  and .authorityBoundary.canonicalApiRemainsAuthoritative == true
+  and .authorityBoundary.runtimeDirectProviderAccessAllowed == false
+  and .authorityBoundary.memberMayConfigureProvidersThroughMcp == false
+  and .globalControls.defaultExposeTools == false
+  and .globalControls.denyUnknownTools == true
+  and .globalControls.supportSafeOutputsOnly == true
+  and .globalControls.secretRefOnly == true
+  and .globalControls.rawProviderInternalsReturned == false
+  and .globalControls.rawProviderPayloadsReturned == false
+  and .globalControls.credentialBearingUrlsReturned == false
+  and .globalControls.auditRequiredForEveryToolCall == true
+  and .globalControls.approvalReceiptRequiredForWriteDeleteExternalSendProviderSwitch == true
+  and (.canonicalDomains | length) == 8
+  and ([.canonicalDomains[].key] | index("calendar"))
+  and ([.canonicalDomains[].key] | index("files_documents"))
+  and ([.canonicalDomains[].key] | index("boards_tasks"))
+  and ([.canonicalDomains[].key] | index("chat_comms"))
+  and ([.canonicalDomains[].key] | index("people_identity_org"))
+  and ([.canonicalDomains[].key] | index("admin_setup_providers"))
+  and ([.canonicalDomains[].key] | index("audit_policy"))
+  and ([.canonicalDomains[].key] | index("weaver_runtime_governance"))
+  and ([.canonicalDomains[] | select(.key == "admin_setup_providers") | .forbiddenOutputs[]] | index("SecretRefValues"))
+  and ([.canonicalDomains[] | select(.key == "weaver_runtime_governance") | .forbiddenOutputs[]] | index("openclawJson"))
+  and ([.canonicalDomains[] | select(.key == "chat_comms") | .forbiddenOutputs[]] | index("mxcUris"))
+  and ([.canonicalDomains[].writeToolsRequireApproval | length] | all(. > 0))
+  and .sprint16ProofSlice.implementAllAdapters == false
+  and .sprint16ProofSlice.allowedProofAdaptersMax <= 2
+' "${CONTRACT}" >/dev/null || fail "Weave MCP tool contract is missing required support-safe/fail-closed controls"
+
+assert_contains "${DOC}" "MCP exposes governed actions for approved runtimes; it does not replace backend APIs."
+assert_contains "${DOC}" 'FastMCP with Python `@tool` remains an implementation candidate only.'
+assert_contains "${DOC}" "SecretRef/CredentialRef handling"
+assert_contains "${DOC}" "Do not build every provider adapter in Sprint 16."
+assert_contains "${PRODUCT_PLAN}" "Weave is planned product-first, not agent-first."
+assert_contains "${PRODUCT_PLAN}" "OpenClaw configuration remains an implementation target, not the product model."
+
+printf '%s\n' 'weave MCP tool contract tests passed'

--- a/infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh
+++ b/infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh
@@ -37,6 +37,7 @@ jq -e '
   and .globalControls.denyUnknownTools == true
   and .globalControls.supportSafeOutputsOnly == true
   and .globalControls.secretRefOnly == true
+  and .globalControls.credentialRefOnly == true
   and .globalControls.rawProviderInternalsReturned == false
   and .globalControls.rawProviderPayloadsReturned == false
   and .globalControls.credentialBearingUrlsReturned == false
@@ -52,7 +53,7 @@ jq -e '
   and ([.canonicalDomains[].key] | index("audit_policy"))
   and ([.canonicalDomains[].key] | index("weaver_runtime_governance"))
   and ([.canonicalDomains[] | select(.key == "admin_setup_providers") | .forbiddenOutputs[]] | index("SecretRefValues"))
-  and ([.canonicalDomains[] | select(.key == "weaver_runtime_governance") | .forbiddenOutputs[]] | index("openclawJson"))
+  and ([.canonicalDomains[] | select(.key == "weaver_runtime_governance") | .forbiddenOutputs[]] | index("openclaw.json"))
   and ([.canonicalDomains[] | select(.key == "chat_comms") | .forbiddenOutputs[]] | index("mxcUris"))
   and ([.canonicalDomains[].writeToolsRequireApproval | length] | all(. > 0))
   and .sprint16ProofSlice.implementAllAdapters == false

--- a/infra/weave-workspace/weave-mcp-tool-contract.json
+++ b/infra/weave-workspace/weave-mcp-tool-contract.json
@@ -21,6 +21,7 @@
     "denyUnknownTools": true,
     "supportSafeOutputsOnly": true,
     "secretRefOnly": true,
+    "credentialRefOnly": true,
     "rawProviderInternalsReturned": false,
     "rawProviderPayloadsReturned": false,
     "credentialBearingUrlsReturned": false,
@@ -91,7 +92,7 @@
       "toolFamilies": ["tool_allowlists", "capability_bundles", "consent_policy", "sandbox_package_projection", "runtime_audit_handoff"],
       "allowedProofTools": ["weaver.runtime_profile.preview", "weaver.tools.list_granted"],
       "writeToolsRequireApproval": ["weaver.enable_for_group", "weaver.revoke_runtime", "weaver.approve_tool_bundle"],
-      "forbiddenOutputs": ["openclawJson", "runtimeTokens", "rawMcpServerConfig", "execPolicyBypass"]
+      "forbiddenOutputs": ["openclaw.json", "runtimeTokens", "rawMcpServerConfig", "execPolicyBypass"]
     }
   ],
   "sprint16ProofSlice": {

--- a/infra/weave-workspace/weave-mcp-tool-contract.json
+++ b/infra/weave-workspace/weave-mcp-tool-contract.json
@@ -1,0 +1,107 @@
+{
+  "schema": "weave-mcp-tool-contract-v1",
+  "status": "design-foundation-disabled",
+  "placement": {
+    "area": "infra/weave-workspace",
+    "futurePackageCandidates": [
+      "infra/weave-workspace/weave-mcp",
+      "infra/weave-workspace/mcp-gateway"
+    ],
+    "implementationHint": "FastMCP Python @tool is an implementation candidate, not product API authority"
+  },
+  "authorityBoundary": {
+    "productAuthority": "weave-backend",
+    "mcpRole": "infra glue exposing governed Weave domain actions to approved runtimes",
+    "canonicalApiRemainsAuthoritative": true,
+    "runtimeDirectProviderAccessAllowed": false,
+    "memberMayConfigureProvidersThroughMcp": false
+  },
+  "globalControls": {
+    "defaultExposeTools": false,
+    "denyUnknownTools": true,
+    "supportSafeOutputsOnly": true,
+    "secretRefOnly": true,
+    "rawProviderInternalsReturned": false,
+    "rawProviderPayloadsReturned": false,
+    "credentialBearingUrlsReturned": false,
+    "authorizationSource": "Weave capability policy and RuntimeProfile grants",
+    "auditRequiredForEveryToolCall": true,
+    "approvalReceiptRequiredForWriteDeleteExternalSendProviderSwitch": true
+  },
+  "canonicalDomains": [
+    {
+      "key": "calendar",
+      "label": "Calendar",
+      "toolFamilies": ["calendar.crud", "calendar.availability", "calendar.invite_rsvp", "calendar.recurrence", "calendar.provider_source_mapping"],
+      "allowedProofTools": ["calendar.search_events", "calendar.read_event"],
+      "writeToolsRequireApproval": ["calendar.create_event", "calendar.update_event", "calendar.delete_event", "calendar.invite_attendee"],
+      "forbiddenOutputs": ["privateCalendarTokens", "providerNativeCredentials", "rawCalDavPayloads"]
+    },
+    {
+      "key": "files_documents",
+      "label": "Files and documents",
+      "toolFamilies": ["files.crud", "files.search", "files.metadata", "files.version_content", "files.permissions", "documents.actions"],
+      "allowedProofTools": ["files.search", "files.read_metadata"],
+      "writeToolsRequireApproval": ["files.upload", "files.delete", "files.share_link", "documents.request_edit_session"],
+      "forbiddenOutputs": ["providerNativeShareSecret", "rawStorageCredentials", "credentialBearingDownloadUrl"]
+    },
+    {
+      "key": "boards_tasks",
+      "label": "Boards and tasks",
+      "toolFamilies": ["boards.crud", "tasks.crud", "tasks.assignment", "tasks.labels_status_due_dates", "comments.activity"],
+      "allowedProofTools": ["boards.search_tasks", "boards.read_task"],
+      "writeToolsRequireApproval": ["boards.create_task", "boards.move_task", "boards.comment", "boards.update_status"],
+      "forbiddenOutputs": ["rawProjectAdminPayload", "providerWorkflowMutationBody"]
+    },
+    {
+      "key": "chat_comms",
+      "label": "Chat and communications",
+      "toolFamilies": ["channels.rooms", "messages", "membership", "send_read_search"],
+      "allowedProofTools": ["chat.search_messages", "chat.read_channel_summary"],
+      "writeToolsRequireApproval": ["chat.send_message", "chat.invite_member", "chat.create_channel"],
+      "forbiddenOutputs": ["rawRoomIds", "rawEventIds", "mxcUris", "homeserverTokens", "rawMatrixBodies"]
+    },
+    {
+      "key": "people_identity_org",
+      "label": "People, identity, and organization",
+      "toolFamilies": ["users", "groups", "roles", "org_units", "effective_rights", "readiness"],
+      "allowedProofTools": ["people.search", "identity.read_effective_rights"],
+      "writeToolsRequireApproval": ["identity.assign_role", "identity.deprovision_user", "identity.update_group"],
+      "forbiddenOutputs": ["rawClaimsDump", "idmTokens", "credentialExport"]
+    },
+    {
+      "key": "admin_setup_providers",
+      "label": "Admin setup and providers",
+      "toolFamilies": ["provider_registry", "category_mapping", "readiness_checks", "dry_run", "capability_mapping", "secret_ref_refs"],
+      "allowedProofTools": ["admin.providers.list_categories", "admin.providers.readiness_summary"],
+      "writeToolsRequireApproval": ["admin.providers.select_provider", "admin.providers.run_replacement_dry_run", "admin.providers.apply_mapping"],
+      "forbiddenOutputs": ["SecretRefValues", "providerAdminTokens", "rawDownstreamErrors"]
+    },
+    {
+      "key": "audit_policy",
+      "label": "Audit and policy",
+      "toolFamilies": ["audit_events", "redaction_views", "policy_simulation", "permission_scopes"],
+      "allowedProofTools": ["audit.search_support_safe", "policy.simulate_effective_rights"],
+      "writeToolsRequireApproval": ["policy.update_profile", "policy.grant_capability", "policy.revoke_capability"],
+      "forbiddenOutputs": ["unredactedAuditPayload", "memberPrivateMemory", "rawProviderDiagnostics"]
+    },
+    {
+      "key": "weaver_runtime_governance",
+      "label": "Weaver runtime and governance",
+      "toolFamilies": ["tool_allowlists", "capability_bundles", "consent_policy", "sandbox_package_projection", "runtime_audit_handoff"],
+      "allowedProofTools": ["weaver.runtime_profile.preview", "weaver.tools.list_granted"],
+      "writeToolsRequireApproval": ["weaver.enable_for_group", "weaver.revoke_runtime", "weaver.approve_tool_bundle"],
+      "forbiddenOutputs": ["openclawJson", "runtimeTokens", "rawMcpServerConfig", "execPolicyBypass"]
+    }
+  ],
+  "sprint16ProofSlice": {
+    "implementAllAdapters": false,
+    "preferredEvidence": [
+      "contract schema",
+      "support-safe mock/in-memory facade responses",
+      "server-owned readiness projection",
+      "disabled-by-default runtime profile preview"
+    ],
+    "allowedProofAdaptersMax": 2
+  }
+}


### PR DESCRIPTION
## Summary
- Add a disabled-by-default Weave MCP tool contract under `infra/weave-workspace` for Sprint 16's architecture refinement.
- Document that future FastMCP-style `@tool` exposure is infra/runtime glue only; the backend remains product/control-plane authority.
- Cover canonical org-suite domains (`calendar`, `files_documents`, `boards_tasks`, `chat_comms`, `people_identity_org`, `admin_setup_providers`, `audit_policy`, `weaver_runtime_governance`) with support-safe/SecretRef-only guardrails.
- Add a shell contract test wired into `infraStatic` to keep MCP design fail-closed and non-provider-leaky.

## Issue / spec context
Follow-up to Sprint 16 / #575 after the architecture refinement. This does not reopen runtime execution scope and does not claim a production MCP gateway.

## User/admin/operator impact
Admins/operators get a checked-in design contract for future governed Weaver MCP tooling. Normal members still cannot configure providers, secrets, raw MCP server config, or OpenClaw runtime internals.

## Checks run
- `bash infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh`
- `./gradlew serverCi infraStatic docsCheck --no-daemon`
- `./gradlew adminCi acceptanceContract --no-daemon`
- `./gradlew specContract portabilityContractCheck --no-daemon`
- after cherry-picking onto current `origin/main`: `./gradlew infraStatic docsCheck --no-daemon`

## Boundaries
- No production provider cutover.
- No provider adapter marketplace claim.
- No raw provider internals/secrets/credential-bearing URLs.
- No autonomous Weaver runtime launch; MCP remains design-foundation-disabled.
