### PR TITLE
docs: align MCP FastMCP placement

### DIFF
--- a/infra/docs/weave-mcp-tool-contract.md
+++ b/infra/docs/weave-mcp-tool-contract.md
@@ -2,13 +2,13 @@
 
 Status: Sprint 16 design foundation, disabled by default.
 
-This document records the MCP refinement for Sprint 16 without turning MCP into the product API. The Java/Kotlin backend remains the product and control-plane authority. A future MCP gateway under `infra/weave-workspace` may expose governed Weave domain tools to approved Weaver runtimes, but only as infra glue over backend-owned contracts.
+This document records the MCP refinement for Sprint 16 without turning MCP into the product API. The Java/Kotlin backend remains the product and control-plane authority. A future MCP gateway under `infra/weave-mcp` may expose governed Weave domain tools to approved Weaver runtimes, but only as infra glue over backend-owned contracts.
 
 ## Placement
 
-Use `infra/weave-workspace` for the first contract because it is the operator/runtime area that already owns Weaver lifecycle evidence and internal network boundaries. Candidate future package names are `infra/weave-workspace/weave-mcp` or `infra/weave-workspace/mcp-gateway`.
+Keep the Sprint 16 machine-readable contract under `infra/weave-workspace` because that operator/runtime area already owns Weaver lifecycle evidence and internal network boundaries. Use `infra/weave-mcp/` for any future Python FastMCP server package so the runnable MCP gateway stays clearly separated from workspace contracts and local lifecycle fixtures.
 
-FastMCP with Python `@tool` remains an implementation candidate only. Sprint 16 should not commit the product architecture to a Python MCP server until the backend facade, policy, audit, and RuntimeProfile contracts prove the shape.
+FastMCP with Python `@tool` remains an implementation candidate only. Its architecture principle is `MCP = governed tool projection over Weave APIs`: validate typed input, derive org/user/runtime context, check RuntimeProfile grants plus effective policy, call backend facade APIs, redact output, and emit audit evidence.
 
 ## Authority boundary
 
@@ -49,6 +49,6 @@ Do not build every provider adapter in Sprint 16. The safe proof slice is:
 1. keep backend-owned Admin Console/readiness and suite facade contracts as the source of truth;
 2. record the MCP contract and test its fail-closed, support-safe domain shape;
 3. project Weaver RuntimeProfile/tool governance from those domains while disabled by default;
-4. optionally add one or two mock/in-memory proof tools later only after the backend contract is stable.
+4. if a runnable proof is added later, place it under `infra/weave-mcp/` with read-only tools such as `admin.get_readiness`, `weaver.get_runtime_profile_projection`, and one suite-domain search, plus an approval-required write stub that fails closed without an approval receipt.
 
 This is a scope adjustment to the Weaver/runtime and suite-facade design foundation, not a runtime launch or production MCP gateway claim.

--- a/infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh
+++ b/infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh
@@ -26,9 +26,10 @@ assert_contains() {
 jq -e '
   .schema == "weave-mcp-tool-contract-v1"
   and .status == "design-foundation-disabled"
-  and .placement.area == "infra/weave-workspace"
-  and (.placement.futurePackageCandidates | index("infra/weave-workspace/weave-mcp"))
+  and .placement.contractArea == "infra/weave-workspace"
+  and .placement.futureServerPackage == "infra/weave-mcp"
   and (.placement.implementationHint | test("FastMCP"))
+  and (.placement.architecturePrinciple | test("governed tool projection over Weave APIs"))
   and .authorityBoundary.productAuthority == "weave-backend"
   and .authorityBoundary.canonicalApiRemainsAuthoritative == true
   and .authorityBoundary.runtimeDirectProviderAccessAllowed == false

--- a/infra/weave-workspace/weave-mcp-tool-contract.json
+++ b/infra/weave-workspace/weave-mcp-tool-contract.json
@@ -2,12 +2,10 @@
   "schema": "weave-mcp-tool-contract-v1",
   "status": "design-foundation-disabled",
   "placement": {
-    "area": "infra/weave-workspace",
-    "futurePackageCandidates": [
-      "infra/weave-workspace/weave-mcp",
-      "infra/weave-workspace/mcp-gateway"
-    ],
-    "implementationHint": "FastMCP Python @tool is an implementation candidate, not product API authority"
+    "contractArea": "infra/weave-workspace",
+    "futureServerPackage": "infra/weave-mcp",
+    "implementationHint": "FastMCP Python @tool is an implementation candidate under infra/weave-mcp, not product API authority",
+    "architecturePrinciple": "MCP = governed tool projection over Weave APIs"
   },
   "authorityBoundary": {
     "productAuthority": "weave-backend",


### PR DESCRIPTION
## Summary
- Align the Sprint 16 MCP contract with the FastMCP research refinement: future runnable Python server lives under `infra/weave-mcp/`.
- Keep the machine-readable Sprint 16 contract under `infra/weave-workspace` as lifecycle/operator evidence.
- Record the architecture principle: `MCP = governed tool projection over Weave APIs`.
- Update the contract test so `infraStatic` enforces the placement split and principle.

## Issue / spec context
Follow-up evidence adjustment for Sprint 16 / #575 after the MCP/FastMCP domain-tool research result. This does not reopen Sprint 16 runtime execution scope.

## Checks run
- `bash infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh`
- `./gradlew infraStatic docsCheck --no-daemon`

## Boundaries
- No production MCP gateway.
- No provider adapters.
- No raw provider internals/secrets/credential-bearing URLs.
- Backend remains product/control-plane authority; MCP remains infra/runtime projection.
