### PR TITLE
feat: add reachable MCP admin binding skeleton

### DIFF
--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -328,6 +328,9 @@ describe("Admin Console MVP", () => {
     expect(screen.getByText(/chat summary read tool/i)).toBeInTheDocument();
     expect(screen.getByText(/workspace triage skill package/i)).toBeInTheDocument();
     expect(screen.getByText(/approved knowledge connector/i)).toBeInTheDocument();
+    expect(screen.getByText(/admin-bound MCP server registry/i)).toBeInTheDocument();
+    expect(screen.getByText(/weave governed domain tools \(streamable-http\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/members never wire raw MCP endpoints/i)).toBeInTheDocument();
     expect(screen.getByText(/provider changes preserve the stable weave chat projection/i)).toBeInTheDocument();
     expect(screen.getByText(/user selectable: yes; default: yes; fallback order: 1/i)).toBeInTheDocument();
     expect(screen.getAllByText(/receipt:\/\/weaver\//i).length).toBeGreaterThan(0);
@@ -336,7 +339,7 @@ describe("Admin Console MVP", () => {
         name: /weaver runtimeprofile projection/i,
       }),
     ).not.toHaveTextContent(
-      /client_secret|access_token|refresh token|bearer|openclaw\.json|credential=/i,
+      /client_secret|access_token|refresh token|bearer|openclaw\.json|credential=|rawMcpServerConfig/i,
     );
   });
 

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -1776,6 +1776,27 @@ export default function App({
                       <Card variant="outlined">
                         <CardContent>
                           <Typography variant="h3" sx={{ fontSize: "1.05rem" }}>
+                            Admin-bound MCP server registry
+                          </Typography>
+                          <Alert severity="info" sx={{ my: 1 }}>
+                            Admins bind Streamable HTTP MCP servers for Weaver here;
+                            members never wire raw MCP endpoints or runtime tokens.
+                          </Alert>
+                          <List aria-label="Admin-bound MCP server registry">
+                            {controlPlane.mcpServerBindings.map((binding) => (
+                              <ListItem key={binding.serverKey} disableGutters>
+                                <ListItemText
+                                  primary={`${binding.displayName} (${binding.transport}) — ${readableState(binding.readinessState)}`}
+                                  secondary={`Endpoint ref: ${binding.endpointRef}; enabled: ${binding.enabled ? "yes" : "no"}; tools: ${binding.allowedTools.join(", ")}; auth: ${binding.authRef}; raw endpoint exposed: ${binding.rawEndpointExposed ? "yes" : "no"}`}
+                                />
+                              </ListItem>
+                            ))}
+                          </List>
+                        </CardContent>
+                      </Card>
+                      <Card variant="outlined">
+                        <CardContent>
+                          <Typography variant="h3" sx={{ fontSize: "1.05rem" }}>
                             Effective RuntimeProfile policy preview
                           </Typography>
                           <List aria-label="Effective Weaver RuntimeProfile policy preview">

--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -112,6 +112,25 @@ export interface WeaverMcpGrant {
   approvalRequired: boolean;
 }
 
+export interface McpServerBinding {
+  serverKey: string;
+  displayName: string;
+  transport: "streamable-http";
+  endpointRef: string;
+  authRef: string;
+  allowedTools: string[];
+  allowedCapabilities: string[];
+  approvalRequiredForWrites: boolean;
+  enabled: boolean;
+  readinessState: CapabilityState;
+  supportSafe: boolean;
+  rawEndpointExposed: boolean;
+  rawServerConfigExposed: boolean;
+  secretValuesExposed: boolean;
+  auditRefs: string[];
+  nextActions: string[];
+}
+
 export interface WeaverRuntimeProfileChange {
   version: string;
   runtimeProfileHash: string;
@@ -336,6 +355,7 @@ export interface ControlPlaneResponse {
   goLiveReadiness: GoLiveReadiness;
   whitelistPolicy: WhitelistPolicy;
   weaverDistributionPolicy: WeaverDistributionPolicy;
+  mcpServerBindings: McpServerBinding[];
   auditEvents: AuditEvent[];
 }
 
@@ -396,6 +416,26 @@ interface ServerControlPlaneResponse {
   suiteDomainReadiness?: ServerSuiteDomainReadiness[];
   goLiveReadiness?: ServerGoLiveReadiness;
   secretRefs?: Array<{ ref?: string; providerKey?: string }>;
+  mcpServerBindings?: ServerMcpServerBinding[];
+}
+
+interface ServerMcpServerBinding {
+  serverKey?: string;
+  displayName?: string;
+  transport?: string;
+  endpointRef?: string;
+  authRef?: string;
+  allowedTools?: string[];
+  allowedCapabilities?: string[];
+  approvalRequiredForWrites?: boolean;
+  enabled?: boolean;
+  readinessState?: string;
+  supportSafe?: boolean;
+  rawEndpointExposed?: boolean;
+  rawServerConfigExposed?: boolean;
+  secretValuesExposed?: boolean;
+  auditRefs?: string[];
+  nextActions?: string[];
 }
 
 interface ServerWeaverDistributionPolicy {
@@ -820,8 +860,38 @@ function normalizeControlPlane(
       controlPlane.weaverDistributionPolicy,
       sampleWeaverDistributionPolicy,
     ),
+    mcpServerBindings: normalizeMcpServerBindings(controlPlane.mcpServerBindings),
     auditEvents,
   };
+}
+
+function normalizeMcpServerBindings(
+  bindings?: ServerMcpServerBinding[],
+): McpServerBinding[] {
+  const normalized = (bindings ?? []).map((binding) => ({
+    serverKey: binding.serverKey ?? "weave-domain-tools",
+    displayName: binding.displayName ?? binding.serverKey ?? "Weave domain tools",
+    transport: "streamable-http" as const,
+    endpointRef: binding.endpointRef ?? "internal://weave-mcp/streamable-http",
+    authRef:
+      binding.authRef ??
+      "credentialref://weave/mcp/weave-domain-tools/runtime-token",
+    allowedTools: binding.allowedTools ?? [],
+    allowedCapabilities: binding.allowedCapabilities ?? [],
+    approvalRequiredForWrites: binding.approvalRequiredForWrites ?? true,
+    enabled: binding.enabled ?? false,
+    readinessState: normalizeState(binding.readinessState),
+    supportSafe: binding.supportSafe ?? true,
+    rawEndpointExposed: binding.rawEndpointExposed ?? false,
+    rawServerConfigExposed: binding.rawServerConfigExposed ?? false,
+    secretValuesExposed: binding.secretValuesExposed ?? false,
+    auditRefs: binding.auditRefs ?? [],
+    nextActions:
+      binding.nextActions ?? [
+        "Enable only after org policy, runtime grants, Streamable HTTP auth, and approvals are configured.",
+      ],
+  }));
+  return normalized.length > 0 ? normalized : sampleMcpServerBindings;
 }
 
 function normalizeSuiteDomainReadiness(
@@ -1699,6 +1769,39 @@ function supportSafeSummary(event: ServerAuditEvent): string {
   return `${event.action ?? "audit"} for ${target}; payload is redacted and support-safe.`;
 }
 
+export const sampleMcpServerBindings: McpServerBinding[] = [
+  {
+    serverKey: "weave-domain-tools",
+    displayName: "Weave governed domain tools",
+    transport: "streamable-http",
+    endpointRef: "internal://weave-mcp/streamable-http",
+    authRef: "credentialref://weave/mcp/weave-domain-tools/runtime-token",
+    allowedTools: [
+      "admin.get_readiness",
+      "weaver.get_runtime_profile_projection",
+      "calendar.search_events",
+      "boards.comment",
+    ],
+    allowedCapabilities: [
+      "weaver.admin_readiness_read",
+      "weaver.runtime_profile_read",
+      "weaver.calendar_read",
+      "weaver.boards_write",
+    ],
+    approvalRequiredForWrites: true,
+    enabled: false,
+    readinessState: "disabled",
+    supportSafe: true,
+    rawEndpointExposed: false,
+    rawServerConfigExposed: false,
+    secretValuesExposed: false,
+    auditRefs: ["audit://weaver/mcp/weave-domain-tools/binding-preview"],
+    nextActions: [
+      "Enable only after org policy, runtime grants, Streamable HTTP auth, and approval receipts are configured.",
+    ],
+  },
+];
+
 const sampleWeaverDistributionPolicy: WeaverDistributionPolicy = {
   enabledByDefault: false,
   chatProviderKey: "synapse-homeserver",
@@ -2081,6 +2184,7 @@ export const sampleControlPlane: ControlPlaneResponse = {
     blockedCapabilities: ["provider.direct_call", "provider.secret_export"],
   },
   weaverDistributionPolicy: sampleWeaverDistributionPolicy,
+  mcpServerBindings: sampleMcpServerBindings,
   auditEvents: [
     {
       id: "audit-1",

--- a/docs/sprint-16-closure-report.md
+++ b/docs/sprint-16-closure-report.md
@@ -9,8 +9,9 @@ Sprint 16 promotes the admin control plane from provider-category status into a 
 - Admin setup/readiness control plane: `AdminControlPlaneResponse` now includes support-safe `goLiveReadiness`, identity readiness, suite domain readiness, SecretRef inventory, provider selections, policy preview, and Weaver runtime projection in one backend-owned response.
 - Suite facades: Files/Documents, Boards/Tasks, and Calendar readiness rows expose canonical object kinds, capability states, portability/loss notes, selected adapter posture, audit refs, and next actions without raw provider config or credential-bearing URLs.
 - Governed Weaver runtime projection: Admin Console and backend expose a signed-profile-preview shape with projected chat/model/tool/MCP items, audit receipts, revocation refs, sandbox posture, consent requirement, and disabled-by-default runtime posture. Runtime execution remains guarded and is not released by this sprint.
-- MCP design foundation: Sprint 16 records a fail-closed, support-safe MCP tool contract and FastMCP placement decision. The contract is evidence for future governed tool projection over Weave APIs; it is not a reachable MCP gateway, runtime binding, or admin-configurable MCP server registry.
-- Admin Console: owners/admins/operators see organization go-live readiness, suite facade readiness, identity readiness, provider replacement dry-run evidence, and Weaver projection details; members still do not receive provider setup controls.
+- MCP design foundation: Sprint 16 records a fail-closed, support-safe MCP tool contract and FastMCP placement decision for governed tool projection over Weave APIs.
+- Reachable MCP/admin binding skeleton: `infra/weave-mcp/` now provides a minimal disabled-by-default Streamable HTTP MCP gateway package with optional FastMCP entrypoint, tool discovery, fail-closed invocation, support-safe redaction, and the proof tools `admin.get_readiness`, `weaver.get_runtime_profile_projection`, `calendar.search_events`, and approval-gated `boards.comment`. Backend/admin and Admin Console now expose an admin-controlled MCP server binding path using server keys, `transport="streamable-http"`, endpoint refs, CredentialRef auth refs, allowed tools/capabilities, disabled state, readiness, audit refs, and redaction flags.
+- Admin Console: owners/admins/operators see organization go-live readiness, suite facade readiness, identity readiness, provider replacement dry-run evidence, Weaver projection details, and the admin-bound MCP server registry; members still do not receive provider setup or raw MCP endpoint controls.
 
 ## Evidence
 
@@ -20,18 +21,26 @@ Implementation evidence:
 - `server/src/main/java/com/massimotter/weave/backend/model/admin/GoLiveReadinessResponse.java`
 - `server/src/main/java/com/massimotter/weave/backend/model/admin/SuiteDomainReadinessResponse.java`
 - `server/src/main/java/com/massimotter/weave/backend/model/admin/WeaverRuntimeProjectionResponse.java`
+- `server/src/main/java/com/massimotter/weave/backend/model/admin/McpServerBindingResponse.java`
 - `server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java`
+- `server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java`
 - `admin-console/src/api.ts`
 - `admin-console/src/App.tsx`
 - `infra/docs/weave-mcp-tool-contract.md`
 - `infra/weave-workspace/weave-mcp-tool-contract.json`
 - `infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh`
+- `infra/weave-workspace/tests/weave-mcp-server-test.sh`
+- `infra/weave-mcp/pyproject.toml`
+- `infra/weave-mcp/src/weave_mcp/app.py`
+- `infra/weave-mcp/src/weave_mcp/fastmcp_app.py`
+- `infra/weave-mcp/src/weave_mcp/tools/registry.py`
 
 Merged PR evidence:
 
 - #576 — Sprint 16 setup control plane and suite facades: `4ef947dd1909dfec83c897cda03181d38efbd0bc`.
 - #577 — Sprint 16 MCP tool contract design foundation: `8277c69f864157908a4afd4e526f8ab4ef5710a2`.
 - #578 — FastMCP placement alignment for future `infra/weave-mcp/` server package: `7e2ce3e5e1aabf9032537eff9dc1edb06c283bd6`.
+- Reachable Streamable HTTP MCP/admin binding implementation PR — pending for this branch.
 
 Test evidence:
 
@@ -42,27 +51,30 @@ Test evidence:
 - `./gradlew specContract acceptanceContract portabilityContractCheck releaseEvidenceCheck` — passing locally on 2026-06-01.
 - `./gradlew ci --console=plain` — passing locally on 2026-06-01.
 - `bash infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh` — passing locally on 2026-06-01 for the MCP contract.
-- `./gradlew infraStatic docsCheck --no-daemon` — passing locally on 2026-06-01 after the MCP contract and FastMCP placement updates.
-- GitHub main CI passed after #577 and #578.
+- `bash infra/weave-workspace/tests/weave-mcp-server-test.sh` — passing locally on 2026-06-01 for Streamable HTTP config, discovery, fail-closed invocation, approval gating, and support-safe redaction.
+- `./gradlew serverCi adminCi --no-daemon` — passing locally on 2026-06-01 after backend/admin MCP binding updates.
+- `./gradlew infraStatic --no-daemon` — passing locally on 2026-06-01 after the reachable MCP gateway skeleton and contract tests.
+- GitHub main CI passed after #577 and #578; implementation PR CI remains the closure gate.
 
 ## Issue mapping
 
 - #573 — covered by backend/admin organization go-live readiness, identity readiness linkage, SecretRef-safe admin API routes, and member setup-control denial.
 - #574 — covered by suite domain readiness rows for Files/Documents, Boards/Tasks, and Calendar with backend-owned facades, canonical objects, portability notes, and safe member states.
-- #575 — covered by governed Weaver RuntimeProfile projection preview, disabled-by-default runtime posture, sandbox/consent/audit fields, approval-required tool markers, redaction boundaries, and the MCP design/contract foundation. Reachable MCP runtime/admin binding remains carryover, not Sprint 16 delivered scope.
+- #575 — covered by governed Weaver RuntimeProfile projection preview, disabled-by-default runtime posture, sandbox/consent/audit fields, approval-required tool markers, redaction boundaries, MCP contract foundation, and the minimal reachable Streamable HTTP MCP/admin binding skeleton.
+- #579 — covered by the disabled-by-default `infra/weave-mcp/` gateway skeleton with stdlib and optional FastMCP entrypoints.
+- #580 — covered by backend/admin MCP server binding response and Admin Console operator registry surface.
+- #581 — covered by RuntimeProfile support-safe MCP bindings/tool grants plus server-side fail-closed discovery/invocation tests.
 
 ## Boundaries and non-claims
 
 - No production provider cutover or live migration apply is claimed.
 - No legal compliance, lossless migration, or E2EE history migration claim is made.
 - No raw provider setup, provider tokens, credential-bearing URLs, raw downstream bodies, SecretRef payloads, or OpenClaw runtime config is exposed to members.
-- Weaver runtime execution remains guarded; this sprint delivers readiness/profile/tool/audit projection foundations only.
-- MCP is not reachable or usable by Weaver in Sprint 16: there is no production FastMCP server, no admin MCP server registry, no runtime transport/auth binding, and no admin-configurable arbitrary MCP server setup. Sprint 16 delivers only the disabled-by-default MCP design contract and placement decision.
+- Weaver runtime execution remains guarded; this sprint delivers readiness/profile/tool/audit projection foundations and a minimal disabled-by-default MCP gateway/binding skeleton only.
+- MCP is reachable in local/infra test mode through Streamable HTTP, but it is not a production Weaver runtime launch. Invocation remains fail-closed unless org policy, runtime profile grants, runtime auth, and approval receipts permit it. Admins bind MCP servers via backend/admin policy; members do not wire raw endpoints.
 
 ## Remaining risks / carryovers
 
 - The readiness rows are control-plane evidence and gating surfaces; live provider-specific apply remains blocked until future domain-specific apply evidence is added.
 - RuntimeProfile hash is a preview/regeneration contract placeholder until the future signing pipeline produces production hashes.
-- Carryover #579: disabled FastMCP gateway skeleton under `infra/weave-mcp/`.
-- Carryover #580: admin MCP server registry and Weaver binding controls.
-- Carryover #581: runtime profile binding to approved MCP tool discovery/invocation.
+- Future work remains to turn the disabled gateway skeleton into production operations: signed/runtime-issued tokens, full backend adapters, arbitrary admin-managed MCP server CRUD, richer policy simulation, and live Weaver runtime invocation evidence.

--- a/infra/weave-mcp/README.md
+++ b/infra/weave-mcp/README.md
@@ -1,0 +1,41 @@
+# Weave MCP gateway skeleton
+
+Status: Sprint 16 reachable skeleton, disabled by default.
+
+`infra/weave-mcp/` contains the minimal governed MCP server package for Weaver. It is a Streamable HTTP runtime path over Weave-owned backend/domain facade APIs. It is not a second backend and it does not own provider adapters or secrets. The deterministic stdlib entrypoint is `weave-mcp`; the optional FastMCP adapter entrypoint is `weave-mcp-fastmcp` when `weave-mcp[fastmcp]` is installed.
+
+## Runtime boundary
+
+- Primary transport: `streamable-http`.
+- Backend authority: `weave-backend` owns domains, policy, readiness, audit, provider registry, and SecretRef/CredentialRef handling.
+- Admins bind this server to Weaver through the backend/admin registry contract; members never paste raw MCP endpoints or tokens into member UX.
+- The server is disabled/fail-closed unless org policy, runtime profile grants, runtime token auth, and approval receipts permit discovery/invocation.
+- Output is support-safe only: no provider internals, raw downstream payloads, raw endpoint secrets, runtime tokens, `openclaw.json`, or SecretRef/CredentialRef values.
+
+## Local development
+
+```sh
+cd infra/weave-mcp
+PYTHONPATH=src WEAVE_MCP_ENABLED=true python3 -m weave_mcp.app --host 127.0.0.1 --port 8765
+```
+
+Discovery requires runtime context headers and grants:
+
+- `Authorization: Bearer <runtime token>`
+- `X-Weave-Org-Id`
+- `X-Weave-User-Ref`
+- `X-Weave-Runtime-Profile`
+- `X-Weave-Capabilities`
+
+The Sprint 16 proof tools are:
+
+- `admin.get_readiness` (read-only)
+- `weaver.get_runtime_profile_projection` (read-only)
+- `calendar.search_events` (read-only domain proof)
+- `boards.comment` (write/action stub; fails closed without `approvalReceiptRef`)
+
+Run tests through the infra gate:
+
+```sh
+bash infra/weave-workspace/tests/weave-mcp-server-test.sh
+```

--- a/infra/weave-mcp/pyproject.toml
+++ b/infra/weave-mcp/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "weave-mcp"
+version = "0.1.0"
+description = "Disabled-by-default governed MCP tool projection over Weave backend APIs"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+fastmcp = ["fastmcp>=2.0"]
+
+test = []
+
+[project.scripts]
+weave-mcp = "weave_mcp.app:main"
+weave-mcp-fastmcp = "weave_mcp.fastmcp_app:main"
+
+[tool.weave-mcp]
+primary_transport = "streamable-http"
+status = "disabled-by-default"
+backend_authority = "weave-backend"

--- a/infra/weave-mcp/src/weave_mcp/__init__.py
+++ b/infra/weave-mcp/src/weave_mcp/__init__.py
@@ -1,0 +1,9 @@
+"""Governed Weave MCP tool projection.
+
+This package is a minimal Sprint 16 skeleton. It is reachable over
+Streamable HTTP for local/discovery tests, but disabled/fail-closed by default
+and never owns provider adapters or secrets.
+"""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/infra/weave-mcp/src/weave_mcp/app.py
+++ b/infra/weave-mcp/src/weave_mcp/app.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from .client import WeaveBackendClient
+from .config import WeaveMcpConfig
+from .schemas.common import McpDenied, RuntimeContext
+from .tools.registry import discover, invoke
+
+
+class WeaveMcpGateway:
+    def __init__(self, config: WeaveMcpConfig):
+        config.validate()
+        self.config = config
+        self.client = WeaveBackendClient(config.backend_base_url)
+
+    @property
+    def server_info(self) -> dict[str, Any]:
+        return {
+            "name": "Weave Governed Domain Tools",
+            "serverKey": self.config.server_key,
+            "transport": self.config.transport,
+            "enabled": self.config.enabled,
+            "backendAuthority": "weave-backend",
+            "endpointRef": self.config.internal_endpoint_ref,
+            "rawEndpointExposed": False,
+        }
+
+    def context_from_headers(self, headers: dict[str, str]) -> RuntimeContext:
+        if not self.config.enabled:
+            raise McpDenied("mcp-server-disabled-by-org-policy")
+        return RuntimeContext.from_headers(headers, self.config.runtime_token)
+
+    def discover_tools(self, headers: dict[str, str]) -> dict[str, Any]:
+        ctx = self.context_from_headers(headers)
+        tools = [tool for tool in discover(ctx) if tool["enabledForRuntime"]]
+        return {"serverInfo": self.server_info, "tools": tools, "supportSafe": True}
+
+    def invoke_tool(self, headers: dict[str, str], body: dict[str, Any]) -> dict[str, Any]:
+        ctx = self.context_from_headers(headers)
+        name = str(body.get("tool", ""))
+        payload = body.get("input") if isinstance(body.get("input"), dict) else {}
+        return {"result": invoke(name, ctx, payload, self.client), "supportSafe": True}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    gateway: WeaveMcpGateway
+
+    def _headers(self) -> dict[str, str]:
+        return {key.lower(): value for key, value in self.headers.items()}
+
+    def _send(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("X-Weave-MCP-Transport", "streamable-http")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _error(self, status: int, reason: str) -> None:
+        self._send(status, {"error": reason, "supportSafe": True})
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler name
+        try:
+            if self.path == "/health":
+                self._send(200, {"status": "ok", **self.gateway.server_info})
+            elif self.path == "/mcp/discover":
+                self._send(200, self.gateway.discover_tools(self._headers()))
+            else:
+                self._error(404, "not-found")
+        except McpDenied as error:
+            self._error(403, error.reason)
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler name
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(length).decode("utf-8") or "{}")
+            if self.path == "/mcp/invoke":
+                self._send(200, self.gateway.invoke_tool(self._headers(), body))
+            else:
+                self._error(404, "not-found")
+        except McpDenied as error:
+            self._error(403, error.reason)
+        except json.JSONDecodeError:
+            self._error(400, "invalid-json")
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        return
+
+
+def make_handler(gateway: WeaveMcpGateway) -> type[_Handler]:
+    class Handler(_Handler):
+        pass
+
+    Handler.gateway = gateway
+    return Handler
+
+
+def serve(config: WeaveMcpConfig, host: str = "127.0.0.1", port: int = 8765) -> ThreadingHTTPServer:
+    gateway = WeaveMcpGateway(config)
+    return ThreadingHTTPServer((host, port), make_handler(gateway))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Weave MCP Streamable HTTP gateway")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    args = parser.parse_args()
+    httpd = serve(WeaveMcpConfig.from_env(), args.host, args.port)
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/weave-mcp/src/weave_mcp/client.py
+++ b/infra/weave-mcp/src/weave_mcp/client.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .schemas.common import RuntimeContext, ToolResult
+
+
+@dataclass(frozen=True)
+class WeaveBackendClient:
+    """Typed support-safe client facade.
+
+    Sprint 16 keeps this as a deterministic fixture client. A later adapter may
+    call backend endpoints, but backend APIs remain authoritative for domain
+    data, policy, provider readiness, audit, and secrets.
+    """
+
+    backend_base_url: str
+
+    def admin_readiness(self, ctx: RuntimeContext) -> ToolResult:
+        return ToolResult(
+            {
+                "organizationId": ctx.org_id,
+                "state": "disabled-by-default",
+                "transport": "streamable-http",
+                "backendAuthority": "weave-backend",
+                "normalMembersMayConfigureMcpServers": False,
+                "providerDiagnosticsRedacted": True,
+            },
+            "audit://mcp/admin-readiness/support-safe",
+        )
+
+    def runtime_profile_projection(self, ctx: RuntimeContext) -> ToolResult:
+        return ToolResult(
+            {
+                "runtimeProfileHash": ctx.runtime_profile_hash,
+                "mcpServerBindings": [
+                    {
+                        "serverKey": "weave-domain-tools",
+                        "transport": "streamable-http",
+                        "endpointRef": "internal://weave-mcp/streamable-http",
+                        "enabled": False,
+                        "discoverableTools": [
+                            "admin.get_readiness",
+                            "weaver.get_runtime_profile_projection",
+                            "calendar.search_events",
+                            "boards.comment",
+                        ],
+                        "rawEndpointExposed": False,
+                        "credentialRef": "credentialref://weave/mcp/weave-domain-tools/runtime-token",
+                    }
+                ],
+                "supportSafe": True,
+            },
+            "audit://mcp/runtime-profile-projection/support-safe",
+        )
+
+    def calendar_search_events(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
+        return ToolResult(
+            {
+                "queryRef": "query://calendar/support-safe/" + str(abs(hash(repr(sorted(query.items()))))),
+                "items": [],
+                "redactedItems": True,
+                "providerSourceMappedByBackend": True,
+            },
+            "audit://mcp/calendar-search/support-safe",
+        )
+
+    def boards_comment(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
+        return ToolResult(
+            {
+                "decision": "accepted-for-backend-action-request",
+                "taskRef": str(query.get("taskRef", "task://support-safe/unknown")),
+                "commentRef": "comment://pending/support-safe",
+                "providerMutationPerformedByMcp": False,
+            },
+            "audit://mcp/boards-comment/support-safe",
+        )

--- a/infra/weave-mcp/src/weave_mcp/config.py
+++ b/infra/weave-mcp/src/weave_mcp/config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass(frozen=True)
+class WeaveMcpConfig:
+    enabled: bool = False
+    transport: str = "streamable-http"
+    backend_base_url: str = "http://weave-backend.internal/api"
+    runtime_token: str = "dev-runtime-token"
+    server_key: str = "weave-domain-tools"
+    internal_endpoint_ref: str = "internal://weave-mcp/streamable-http"
+
+    @staticmethod
+    def from_env() -> "WeaveMcpConfig":
+        return WeaveMcpConfig(
+            enabled=os.environ.get("WEAVE_MCP_ENABLED", "false").lower() == "true",
+            transport=os.environ.get("WEAVE_MCP_TRANSPORT", "streamable-http"),
+            backend_base_url=os.environ.get("WEAVE_BACKEND_BASE_URL", "http://weave-backend.internal/api"),
+            runtime_token=os.environ.get("WEAVE_MCP_RUNTIME_TOKEN", "dev-runtime-token"),
+            server_key=os.environ.get("WEAVE_MCP_SERVER_KEY", "weave-domain-tools"),
+            internal_endpoint_ref=os.environ.get("WEAVE_MCP_ENDPOINT_REF", "internal://weave-mcp/streamable-http"),
+        )
+
+    def validate(self) -> None:
+        if self.transport != "streamable-http":
+            raise ValueError("Weave MCP runtime transport must be streamable-http")
+        if self.backend_base_url.startswith(("http://", "https://")) is False:
+            raise ValueError("backend_base_url must be an HTTP(S) URL")

--- a/infra/weave-mcp/src/weave_mcp/fastmcp_app.py
+++ b/infra/weave-mcp/src/weave_mcp/fastmcp_app.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .app import WeaveMcpGateway
+from .config import WeaveMcpConfig
+from .schemas.common import McpDenied
+
+try:  # pragma: no cover - optional dependency adapter
+    from fastmcp import FastMCP
+except ImportError:  # pragma: no cover - exercised by dependency-free tests
+    FastMCP = None  # type: ignore[assignment]
+
+
+def build_fastmcp(config: WeaveMcpConfig | None = None) -> Any:
+    """Build the optional FastMCP app without making FastMCP a test dependency.
+
+    The stdlib Streamable HTTP app in ``weave_mcp.app`` is the deterministic
+    local test harness. This adapter is the implementation candidate used when
+    the optional ``fastmcp`` extra is installed. Both paths share the same
+    gateway, auth, discovery, fail-closed invocation, and support-safe redaction.
+    """
+
+    if FastMCP is None:
+        raise RuntimeError("Install weave-mcp[fastmcp] to run the FastMCP adapter")
+
+    gateway = WeaveMcpGateway(config or WeaveMcpConfig.from_env())
+    mcp = FastMCP("Weave Governed Domain Tools")
+
+    def _headers(ctx: dict[str, str] | None) -> dict[str, str]:
+        return {str(key).lower(): str(value) for key, value in (ctx or {}).items()}
+
+    @mcp.tool(name="admin.get_readiness")
+    def admin_get_readiness(context_headers: dict[str, str]) -> dict[str, Any]:
+        return gateway.invoke_tool(_headers(context_headers), {"tool": "admin.get_readiness", "input": {}})
+
+    @mcp.tool(name="weaver.get_runtime_profile_projection")
+    def weaver_get_runtime_profile_projection(context_headers: dict[str, str]) -> dict[str, Any]:
+        return gateway.invoke_tool(_headers(context_headers), {"tool": "weaver.get_runtime_profile_projection", "input": {}})
+
+    @mcp.tool(name="calendar.search_events")
+    def calendar_search_events(context_headers: dict[str, str], query: str = "") -> dict[str, Any]:
+        return gateway.invoke_tool(_headers(context_headers), {"tool": "calendar.search_events", "input": {"query": query}})
+
+    @mcp.tool(name="boards.comment")
+    def boards_comment(
+        context_headers: dict[str, str],
+        task_ref: str,
+        body: str,
+        approval_receipt_ref: str | None = None,
+    ) -> dict[str, Any]:
+        payload = {"taskRef": task_ref, "body": body}
+        if approval_receipt_ref:
+            payload["approvalReceiptRef"] = approval_receipt_ref
+        return gateway.invoke_tool(_headers(context_headers), {"tool": "boards.comment", "input": payload})
+
+    return mcp
+
+
+def main() -> None:  # pragma: no cover - optional runtime adapter
+    mcp = build_fastmcp()
+    try:
+        mcp.run(transport="streamable-http")
+    except McpDenied:
+        raise
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/infra/weave-mcp/src/weave_mcp/redaction.py
+++ b/infra/weave-mcp/src/weave_mcp/redaction.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+FORBIDDEN_NEEDLES = (
+    "Bearer ",
+    "access_token",
+    "refresh_token",
+    "openclaw.json",
+    "rawProviderPayload",
+    "credentialBearingDownloadUrl",
+    "secretValue",
+)
+
+
+def assert_support_safe(payload: Any) -> None:
+    text = repr(payload)
+    leaked = [needle for needle in FORBIDDEN_NEEDLES if needle in text]
+    if leaked:
+        raise ValueError(f"MCP payload is not support-safe: {', '.join(leaked)}")
+
+
+def redact_string(value: str) -> str:
+    if value.startswith(("http://", "https://")):
+        return "endpoint-ref://redacted"
+    return value

--- a/infra/weave-mcp/src/weave_mcp/schemas/common.py
+++ b/infra/weave-mcp/src/weave_mcp/schemas/common.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class McpDenied(PermissionError):
+    """Fail-closed MCP denial with a support-safe reason."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class RuntimeContext:
+    org_id: str
+    user_ref: str
+    runtime_profile_hash: str
+    token_ref: str
+    capability_grants: frozenset[str]
+
+    @staticmethod
+    def from_headers(headers: dict[str, str], configured_token: str) -> "RuntimeContext":
+        auth = headers.get("authorization", "")
+        if not configured_token or auth != f"Bearer {configured_token}":
+            raise McpDenied("missing-or-invalid-runtime-token")
+        org_id = headers.get("x-weave-org-id", "").strip()
+        user_ref = headers.get("x-weave-user-ref", "").strip()
+        profile = headers.get("x-weave-runtime-profile", "").strip()
+        grants = frozenset(
+            grant.strip()
+            for grant in headers.get("x-weave-capabilities", "").split(",")
+            if grant.strip()
+        )
+        if not org_id or not user_ref or not profile:
+            raise McpDenied("missing-runtime-org-user-or-profile")
+        return RuntimeContext(org_id, user_ref, profile, "credentialref://weave/runtime/short-lived", grants)
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    data: dict[str, Any]
+    audit_ref: str
+
+    def support_safe(self) -> dict[str, Any]:
+        return {
+            "supportSafe": True,
+            "rawProviderInternalsReturned": False,
+            "credentialBearingUrlsReturned": False,
+            "auditRef": self.audit_ref,
+            **self.data,
+        }
+
+
+@dataclass(frozen=True)
+class ToolDefinition:
+    name: str
+    capability: str
+    domain: str
+    read_only: bool
+    approval_required: bool
+    description: str
+    input_schema: dict[str, Any] = field(default_factory=dict)
+
+    def discovery(self, granted: bool) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "enabledForRuntime": granted,
+            "annotations": {
+                "readOnlyHint": self.read_only,
+                "destructiveHint": False,
+                "openWorldHint": False,
+            },
+            "meta": {
+                "domain": self.domain,
+                "capability": self.capability,
+                "transport": "streamable-http",
+                "approval": "required" if self.approval_required else "not-required-for-read",
+                "version": "v1",
+            },
+            "inputSchema": self.input_schema,
+        }
+
+
+def require_capability(ctx: RuntimeContext, capability: str) -> None:
+    if capability not in ctx.capability_grants:
+        raise McpDenied("capability-not-granted")
+
+
+def require_approval(payload: dict[str, Any], action: str) -> str:
+    receipt = str(payload.get("approvalReceiptRef", "")).strip()
+    if not receipt.startswith("approval://"):
+        raise McpDenied(f"approval-required-for-{action}")
+    return receipt

--- a/infra/weave-mcp/src/weave_mcp/tools/__init__.py
+++ b/infra/weave-mcp/src/weave_mcp/tools/__init__.py
@@ -1,0 +1,3 @@
+from .registry import TOOL_DEFINITIONS, discover, invoke
+
+__all__ = ["TOOL_DEFINITIONS", "discover", "invoke"]

--- a/infra/weave-mcp/src/weave_mcp/tools/registry.py
+++ b/infra/weave-mcp/src/weave_mcp/tools/registry.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ..client import WeaveBackendClient
+from ..schemas.common import McpDenied, RuntimeContext, ToolDefinition, require_approval, require_capability
+from ..redaction import assert_support_safe
+
+Handler = Callable[[RuntimeContext, dict[str, Any], WeaveBackendClient], dict[str, Any]]
+
+TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
+    "admin.get_readiness": ToolDefinition(
+        name="admin.get_readiness",
+        capability="weaver.admin_readiness_read",
+        domain="admin_setup_providers",
+        read_only=True,
+        approval_required=False,
+        description="Read support-safe admin readiness from the Weave backend control plane.",
+    ),
+    "weaver.get_runtime_profile_projection": ToolDefinition(
+        name="weaver.get_runtime_profile_projection",
+        capability="weaver.runtime_profile_read",
+        domain="weaver_runtime_governance",
+        read_only=True,
+        approval_required=False,
+        description="Read support-safe MCP bindings projected into the Weaver RuntimeProfile.",
+    ),
+    "calendar.search_events": ToolDefinition(
+        name="calendar.search_events",
+        capability="weaver.calendar_read",
+        domain="calendar",
+        read_only=True,
+        approval_required=False,
+        description="Search calendar events via the backend Calendar facade with redacted support-safe output.",
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+    ),
+    "boards.comment": ToolDefinition(
+        name="boards.comment",
+        capability="weaver.boards_write",
+        domain="boards_tasks",
+        read_only=False,
+        approval_required=True,
+        description="Approval-required write stub for adding a board/task comment through backend action requests.",
+        input_schema={"type": "object", "required": ["taskRef", "body", "approvalReceiptRef"]},
+    ),
+}
+
+
+def _admin_get_readiness(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    return client.admin_readiness(ctx).support_safe()
+
+
+def _runtime_profile(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    return client.runtime_profile_projection(ctx).support_safe()
+
+
+def _calendar_search(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    return client.calendar_search_events(ctx, payload).support_safe()
+
+
+def _boards_comment(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    require_approval(payload, "boards.comment")
+    return client.boards_comment(ctx, payload).support_safe()
+
+
+HANDLERS: dict[str, Handler] = {
+    "admin.get_readiness": _admin_get_readiness,
+    "weaver.get_runtime_profile_projection": _runtime_profile,
+    "calendar.search_events": _calendar_search,
+    "boards.comment": _boards_comment,
+}
+
+
+def discover(ctx: RuntimeContext | None) -> list[dict[str, Any]]:
+    grants = ctx.capability_grants if ctx is not None else frozenset()
+    return [definition.discovery(definition.capability in grants) for definition in TOOL_DEFINITIONS.values()]
+
+
+def invoke(name: str, ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    definition = TOOL_DEFINITIONS.get(name)
+    if definition is None:
+        raise McpDenied("unknown-tool")
+    require_capability(ctx, definition.capability)
+    result = HANDLERS[name](ctx, payload, client)
+    assert_support_safe(result)
+    return result

--- a/infra/weave-mcp/tests/test_weave_mcp.py
+++ b/infra/weave-mcp/tests/test_weave_mcp.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from weave_mcp.app import WeaveMcpGateway, serve
+from weave_mcp.config import WeaveMcpConfig
+from weave_mcp.schemas.common import McpDenied
+
+
+HEADERS = {
+    "Authorization": "Bearer dev-runtime-token",
+    "X-Weave-Org-Id": "org:dogfood",
+    "X-Weave-User-Ref": "user:support-safe",
+    "X-Weave-Runtime-Profile": "sha256:runtime-profile",
+    "X-Weave-Capabilities": "weaver.admin_readiness_read,weaver.runtime_profile_read,weaver.calendar_read,weaver.boards_write",
+}
+
+
+class WeaveMcpGatewayTest(unittest.TestCase):
+    def gateway(self, enabled: bool = True) -> WeaveMcpGateway:
+        return WeaveMcpGateway(WeaveMcpConfig(enabled=enabled))
+
+    def test_streamable_http_config_is_primary_runtime_transport(self) -> None:
+        gateway = self.gateway()
+        self.assertEqual(gateway.server_info["transport"], "streamable-http")
+        self.assertFalse(gateway.server_info["rawEndpointExposed"])
+        self.assertEqual(gateway.server_info["backendAuthority"], "weave-backend")
+
+    def test_discovery_filters_by_runtime_capability_grants(self) -> None:
+        body = self.gateway().discover_tools({key.lower(): value for key, value in HEADERS.items()})
+        tools = {tool["name"]: tool for tool in body["tools"]}
+        self.assertIn("admin.get_readiness", tools)
+        self.assertIn("weaver.get_runtime_profile_projection", tools)
+        self.assertIn("calendar.search_events", tools)
+        self.assertIn("boards.comment", tools)
+        self.assertTrue(tools["boards.comment"]["meta"]["approval"] == "required")
+        self.assertTrue(all(tool["meta"]["transport"] == "streamable-http" for tool in tools.values()))
+
+    def test_disabled_or_missing_context_fails_closed(self) -> None:
+        with self.assertRaises(McpDenied):
+            self.gateway(enabled=False).discover_tools({key.lower(): value for key, value in HEADERS.items()})
+        with self.assertRaises(McpDenied):
+            self.gateway(enabled=True).discover_tools({"authorization": "Bearer dev-runtime-token"})
+
+    def test_invocation_is_support_safe_and_write_stub_requires_approval(self) -> None:
+        headers = {key.lower(): value for key, value in HEADERS.items()}
+        readiness = self.gateway().invoke_tool(headers, {"tool": "admin.get_readiness", "input": {}})
+        self.assertTrue(readiness["result"]["supportSafe"])
+        self.assertFalse(readiness["result"]["normalMembersMayConfigureMcpServers"])
+        self.assertNotIn("Bearer ", repr(readiness))
+        self.assertNotIn("openclaw.json", repr(readiness))
+
+        with self.assertRaises(McpDenied):
+            self.gateway().invoke_tool(headers, {"tool": "boards.comment", "input": {"taskRef": "task://one", "body": "ok"}})
+
+        accepted = self.gateway().invoke_tool(
+            headers,
+            {"tool": "boards.comment", "input": {"taskRef": "task://one", "body": "ok", "approvalReceiptRef": "approval://board-comment/1"}},
+        )
+        self.assertEqual(accepted["result"]["decision"], "accepted-for-backend-action-request")
+        self.assertFalse(accepted["result"]["providerMutationPerformedByMcp"])
+
+    def test_local_streamable_http_server_discovery_and_invocation(self) -> None:
+        httpd = serve(WeaveMcpConfig(enabled=True), port=0)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        try:
+            base = f"http://127.0.0.1:{httpd.server_address[1]}"
+            req = Request(base + "/mcp/discover", headers=HEADERS)
+            with urlopen(req, timeout=5) as response:
+                self.assertEqual(response.headers["X-Weave-MCP-Transport"], "streamable-http")
+                payload = json.loads(response.read())
+            self.assertEqual(payload["serverInfo"]["transport"], "streamable-http")
+            self.assertIn("calendar.search_events", {tool["name"] for tool in payload["tools"]})
+
+            invoke = Request(
+                base + "/mcp/invoke",
+                method="POST",
+                headers={**HEADERS, "Content-Type": "application/json"},
+                data=json.dumps({"tool": "calendar.search_events", "input": {"query": "demo"}}).encode(),
+            )
+            with urlopen(invoke, timeout=5) as response:
+                result = json.loads(response.read())
+            self.assertTrue(result["supportSafe"])
+            self.assertTrue(result["result"]["redactedItems"])
+
+            denied = Request(
+                base + "/mcp/invoke",
+                method="POST",
+                headers={**HEADERS, "Content-Type": "application/json"},
+                data=json.dumps({"tool": "boards.comment", "input": {"taskRef": "task://one"}}).encode(),
+            )
+            with self.assertRaises(HTTPError) as raised:
+                urlopen(denied, timeout=5)
+            self.assertEqual(raised.exception.code, 403)
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/weave-workspace/tests/weave-mcp-server-test.sh
+++ b/infra/weave-workspace/tests/weave-mcp-server-test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)"
+MCP_DIR="${REPO_DIR}/infra/weave-mcp"
+
+[[ -f "${MCP_DIR}/pyproject.toml" ]] || {
+  printf '%s\n' "Missing infra/weave-mcp/pyproject.toml" >&2
+  exit 1
+}
+
+python3 - <<'PY' "${MCP_DIR}/pyproject.toml"
+import pathlib
+import sys
+text = pathlib.Path(sys.argv[1]).read_text()
+required = [
+    'primary_transport = "streamable-http"',
+    'backend_authority = "weave-backend"',
+    'weave-mcp = "weave_mcp.app:main"',
+    'weave-mcp-fastmcp = "weave_mcp.fastmcp_app:main"',
+]
+missing = [needle for needle in required if needle not in text]
+if missing:
+    raise SystemExit("missing MCP pyproject contract entries: " + ", ".join(missing))
+PY
+
+PYTHONPATH="${MCP_DIR}/src" python3 -m unittest discover -s "${MCP_DIR}/tests" -p 'test_*.py'
+
+printf '%s\n' 'weave MCP streamable-http server tests passed'

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/AdminControlPlaneResponse.java
@@ -28,12 +28,14 @@ public record AdminControlPlaneResponse(
         List<SuiteDomainReadinessResponse> suiteDomainReadiness,
         GoLiveReadinessResponse goLiveReadiness,
         List<SecretRefResponse> secretRefs,
+        List<McpServerBindingResponse> mcpServerBindings,
         Map<String, String> adminApiRoutes) {
     public AdminControlPlaneResponse {
         categories = categories == null ? List.of() : List.copyOf(categories);
         selectedProviderMappings = selectedProviderMappings == null ? List.of() : List.copyOf(selectedProviderMappings);
         suiteDomainReadiness = suiteDomainReadiness == null ? List.of() : List.copyOf(suiteDomainReadiness);
         secretRefs = secretRefs == null ? List.of() : List.copyOf(secretRefs);
+        mcpServerBindings = mcpServerBindings == null ? List.of() : List.copyOf(mcpServerBindings);
         adminApiRoutes = adminApiRoutes == null ? Map.of() : Map.copyOf(adminApiRoutes);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/McpServerBindingResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/McpServerBindingResponse.java
@@ -1,0 +1,43 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Support-safe admin binding for an approved MCP server projected to Weaver runtimes.")
+public record McpServerBindingResponse(
+        String serverKey,
+        String displayName,
+        String transport,
+        String endpointRef,
+        String authRef,
+        List<String> allowedTools,
+        List<String> allowedCapabilities,
+        boolean approvalRequiredForWrites,
+        boolean enabled,
+        String readinessState,
+        boolean supportSafe,
+        boolean rawEndpointExposed,
+        boolean rawServerConfigExposed,
+        boolean secretValuesExposed,
+        List<String> auditRefs,
+        List<String> nextActions) {
+    public McpServerBindingResponse {
+        serverKey = serverKey == null || serverKey.isBlank() ? "unnamed-mcp-server" : serverKey.trim();
+        displayName = displayName == null || displayName.isBlank() ? serverKey : displayName.trim();
+        transport = transport == null || transport.isBlank() ? "streamable-http" : transport.trim();
+        endpointRef = endpointRef == null || endpointRef.isBlank() ? "internal://weave-mcp/streamable-http" : endpointRef.trim();
+        authRef = authRef == null || authRef.isBlank() ? "credentialref://weave/mcp/" + serverKey + "/runtime-token" : authRef.trim();
+        allowedTools = allowedTools == null ? List.of() : allowedTools.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
+        allowedCapabilities = allowedCapabilities == null ? List.of() : allowedCapabilities.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+        nextActions = nextActions == null ? List.of() : List.copyOf(nextActions);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -31,6 +31,7 @@ import com.massimotter.weave.backend.model.admin.EffectivePolicySimulationRespon
 import com.massimotter.weave.backend.model.admin.GoLiveReadinessResponse;
 import com.massimotter.weave.backend.model.admin.IdentityProviderReadinessCardResponse;
 import com.massimotter.weave.backend.model.admin.IdentityProviderReadinessResponse;
+import com.massimotter.weave.backend.model.admin.McpServerBindingResponse;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapRequest;
 import com.massimotter.weave.backend.model.admin.OrganizationBootstrapResponse;
 import com.massimotter.weave.backend.model.admin.ProviderReadinessTestRequest;
@@ -221,6 +222,7 @@ public class AdminControlPlaneService {
                 suiteReadiness,
                 goLiveReadiness(identityReadiness, suiteReadiness),
                 secretRefs(registry),
+                mcpServerBindings(registry),
                 Map.ofEntries(
                         Map.entry("providers", "/api/providers/status"),
                         Map.entry("policy", "/api/admin/policies/capability-whitelist"),
@@ -233,6 +235,7 @@ public class AdminControlPlaneService {
                         Map.entry("effectivePolicySimulation", "/api/admin/policies/effective/simulations"),
                         Map.entry("providerSelections", "/api/admin/providers/selections"),
                         Map.entry("suiteReadiness", "/api/admin/control-plane#suiteDomainReadiness"),
+                        Map.entry("mcpServerBindings", "/api/admin/control-plane#mcpServerBindings"),
                         Map.entry("weaverRuntimeProjection", "/api/admin/control-plane#weaverRuntimeProjection")));
     }
 
@@ -1508,6 +1511,7 @@ public class AdminControlPlaneService {
                         projectionItem("model-alias-general", "model", "general-assistant via " + modelProviderKey, readinessFor("model", registry), "disabled_by_policy", "Alias is admin-selected but runtime remains disabled by default.", false),
                         projectionItem("tool-calendar-search", "tool", "calendar.search_events", readinessFor("calendar", registry), "disabled_by_policy", "Read-only discovery requires weaver.calendar_read and calendar.read grants.", false),
                         projectionItem("tool-boards-comment", "tool", "boards.comment", readinessFor("boards-tasks", registry), "disabled_by_policy", "Write-like tool requires explicit approval receipt and audit.", true),
+                        projectionItem("mcp-weave-domain-tools", "mcp", "weave-domain-tools via streamable-http", "configured", "disabled_by_policy", "Admin-bound MCP server is discoverable only to granted RuntimeProfiles and remains disabled until org policy enables Weaver.", true),
                         projectionItem("consent-shared-space", "mcp", "shared-space consent gate", "admin-action-required", "disabled_by_policy", "Group chat/shared-space participation requires org policy and consent evidence.", true)));
     }
 
@@ -1590,6 +1594,26 @@ public class AdminControlPlaneService {
                 .map(value -> value.readiness().value())
                 .findFirst()
                 .orElse("unknown");
+    }
+
+    private List<McpServerBindingResponse> mcpServerBindings(ProviderRegistryResponse registry) {
+        return List.of(new McpServerBindingResponse(
+                "weave-domain-tools",
+                "Weave governed domain tools",
+                "streamable-http",
+                "internal://weave-mcp/streamable-http",
+                "credentialref://weave/mcp/weave-domain-tools/runtime-token",
+                List.of("admin.get_readiness", "weaver.get_runtime_profile_projection", "calendar.search_events", "boards.comment"),
+                List.of("weaver.admin_readiness_read", "weaver.runtime_profile_read", "weaver.calendar_read", "weaver.boards_write"),
+                true,
+                false,
+                "disabled-by-default",
+                true,
+                false,
+                false,
+                false,
+                List.of("audit://weaver/mcp/weave-domain-tools/binding-preview"),
+                List.of("Enable only after org policy, runtime grants, Streamable HTTP auth, and approval receipts are configured.")));
     }
 
     private List<SecretRefResponse> secretRefs(ProviderRegistryResponse registry) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -277,7 +277,17 @@ public class WeaverRuntimeService {
                 "runtimeTokenRef", "credentialref://weave/runtime/weave-chat/" + userRef.replace("user:", ""),
                 "reloadStrategy", "reload-or-restart-stable-channel",
                 "rawProviderChannelConfigsRendered", false,
-                "memberMaySwitchProviderAdapters", false);
+                "memberMaySwitchProviderAdapters", false,
+                "mcpServerBindings", List.of(Map.ofEntries(
+                        Map.entry("serverKey", "weave-domain-tools"),
+                        Map.entry("transport", "streamable-http"),
+                        Map.entry("endpointRef", "internal://weave-mcp/streamable-http"),
+                        Map.entry("credentialRef", "credentialref://weave/mcp/weave-domain-tools/runtime-token"),
+                        Map.entry("enabled", false),
+                        Map.entry("supportSafe", true),
+                        Map.entry("rawEndpointExposed", false),
+                        Map.entry("allowedTools", List.of("admin.get_readiness", "weaver.get_runtime_profile_projection", "calendar.search_events", "boards.comment")),
+                        Map.entry("approvalRequiredFor", List.of("boards.comment")))));
     }
 
     private Map<String, Object> credentialBrokerContract(String userRef) {

--- a/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
@@ -468,9 +468,20 @@ class AdminControlPlaneServiceTest {
         assertThat(response.weaverRuntimeProjection().disabledByDefault()).isTrue();
         assertThat(response.weaverRuntimeProjection().rawRuntimeInternalsExposed()).isFalse();
         assertThat(response.weaverRuntimeProjection().items()).extracting(item -> item.id())
-                .contains("chat-route", "tool-calendar-search", "tool-boards-comment", "consent-shared-space");
+                .contains("chat-route", "tool-calendar-search", "tool-boards-comment", "mcp-weave-domain-tools", "consent-shared-space");
+        assertThat(response.mcpServerBindings()).singleElement().satisfies(binding -> {
+            assertThat(binding.serverKey()).isEqualTo("weave-domain-tools");
+            assertThat(binding.transport()).isEqualTo("streamable-http");
+            assertThat(binding.enabled()).isFalse();
+            assertThat(binding.supportSafe()).isTrue();
+            assertThat(binding.rawEndpointExposed()).isFalse();
+            assertThat(binding.rawServerConfigExposed()).isFalse();
+            assertThat(binding.secretValuesExposed()).isFalse();
+            assertThat(binding.allowedTools()).contains("admin.get_readiness", "weaver.get_runtime_profile_projection", "calendar.search_events", "boards.comment");
+            assertThat(binding.authRef()).startsWith("credentialref://");
+        });
         assertThat(new ObjectMapper().findAndRegisterModules().writeValueAsString(response))
-                .doesNotContain("openclaw.json", "Bearer ", "access_token", "rawProviderPayload");
+                .doesNotContain("openclaw.json", "Bearer ", "access_token", "rawProviderPayload", "rawMcpServerConfig");
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -92,7 +92,11 @@ class WeaverRuntimeServiceTest {
                 .containsEntry("channelId", "channels.weave-chat")
                 .containsEntry("providerRef", "provider:chat:selected-by-admin")
                 .containsEntry("rawProviderChannelConfigsRendered", false)
-                .containsEntry("memberMaySwitchProviderAdapters", false);
+                .containsEntry("memberMaySwitchProviderAdapters", false)
+                .containsKey("mcpServerBindings");
+        assertThat(profile.channelProjection().get("mcpServerBindings").toString())
+                .contains("weave-domain-tools", "streamable-http", "calendar.search_events", "boards.comment")
+                .doesNotContain("Bearer ", "openclaw.json", "rawMcpServerConfig");
         assertThat(profile.credentialBrokerContract())
                 .containsEntry("broker", "weave-credential-broker")
                 .containsEntry("shortLivedAccess", true)


### PR DESCRIPTION
## Summary
- add a minimal disabled-by-default Weave MCP package under `infra/weave-mcp` with Streamable HTTP runtime transport, optional FastMCP entrypoint, support-safe redaction, local discovery/invocation, and proof tools
- add backend/admin MCP server binding contract plus RuntimeProfile support-safe MCP binding projection
- surface the admin-bound MCP registry in Admin Console operator UX without exposing raw endpoints, tokens, provider internals, or member configuration controls
- update Sprint 16 closure evidence to distinguish PR #576 product readiness, PR #577 MCP contract, and this reachable Streamable HTTP MCP/admin binding skeleton

## Scope and non-claims
- MCP remains a governed tool projection over Weave backend APIs, not a second backend.
- Runtime execution remains disabled/fail-closed unless org policy, runtime profile grants, auth, and approval receipts permit it.
- This is not a production Weaver runtime launch.

## Evidence / gates
- `bash infra/weave-workspace/tests/weave-mcp-server-test.sh`
- `./gradlew serverCi --no-daemon`
- `./gradlew adminCi --no-daemon`
- `./gradlew infraStatic --no-daemon`
- `./gradlew docsCheck --no-daemon`
- `./gradlew releaseEvidenceCheck --no-daemon`

## Issue mapping
- Closes #579
- Closes #580
- Closes #581
- Refines #575 follow-through with reachable disabled-by-default MCP/admin binding evidence
