### PR TITLE
docs: align public docs with rc3 evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,61 +92,41 @@ v0.1 is dogfood-production, not preview. A normal member should see Weave-owned 
 
 ## Release notes
 
-The managed block below is the README-facing draft of merged changes after the latest tagged prerelease. The published `v0.1.0-rc.2` notes live in [v0.1 release notes](docs/release-notes/v0.1.md). Maintainers update this block with checked-in release-note tooling; do not edit inside the markers by hand.
+The managed block below is the README-facing draft of merged changes after the latest tagged prerelease. The published `v0.1.0-rc.3` notes live in [v0.1 release notes](docs/release-notes/v0.1.md), with the audit in [v0.1.0-rc.3 release evidence](docs/release-v0.1-rc3-evidence.md). Maintainers update this block with checked-in release-note tooling; do not edit inside the markers by hand.
 
 
 <!-- WEAVE_RELEASE_NOTES_START -->
 _Generated release notes are review artifacts. A release maintainer may update this block with `python3 tools/readme_release_notes.py --update --source <generated-notes>` before opening the release-draft review._
 
-Use this page for release-affecting changes that have merged but are not included in a tagged release yet.
+Use this page for release-affecting changes that have merged but are not included in a tagged release yet. `v0.1.0-rc.3` is the latest published prerelease; older post-RC2 entries moved into the versioned v0.1 release notes and RC3 evidence audit.
 
 ## Added
-- Sprint 15 adds organization-embedding and provider-neutral replacement evidence: backend-owned effective-policy/readiness boundaries, support-safe Admin Console consequence copy, Matrix Chat as the first dry-run proof slice, an operator runbook, and accessibility evidence template while keeping provider apply/cutover blocked.
-- Sprint 16 adds a support-safe organization go-live readiness summary, suite facade readiness rows for Files/Documents, Boards/Tasks, and Calendar, and a governed Weaver RuntimeProfile projection preview while keeping provider apply/cutover and runtime execution guarded.
-- Sprint 18 release-trust claim control now records #591 as the manual assistive-technology blocker for critical member Workspace, admin migration/recovery, admin go-live, and governed Weaver approval/revocation flows until real reviewer evidence replaces the support-safe blocker artifact.
 
-- Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
-- Contextual meetings now have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
-- Sprint 8/Sprint 9 acceptance now includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
-- Sprint 11 Live Stack acceptance now maps a provider-reality vertical for Files, Calendar, Boards, Calls, and Documents with live-runtime evidence separated from manual accessibility accounting.
-- Sprint 12 adds provider portability schema v2 fixtures and reports for Files, Calendar, Boards, and Chat, plus Office/WOPI, Weaver isolation, Weaver registry, identity lifecycle, accessibility, and operator lifecycle contracts.
-- Weaver/OpenClaw release documentation now clarifies the signed RuntimeProfile boundary: Weave projects a stable `channels.weave-chat` channel backed by Weave Chat-domain routing, model aliases, MCP/tool/skill grants, CredentialRefs and short-lived runtime token references, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
-- Sprint 14 starts product-trust and provider-choice evidence with a cross-repo Weave/Weaver delivery board, professional claim matrix, procurement-risk wording boundaries, and a conservative Matrix Chat migration proof fixture that keeps apply blocked until no-unaccounted-data-loss evidence exists.
+- No post-`v0.1.0-rc.3` release-note additions yet.
 
 ## Changed
 
-- Chat readiness and release evidence now lock Matrix/Synapse as the current real provider path, keep non-Matrix chat providers contract-only until promoted, and document Matrix portability/E2EE boundaries.
-- Provider registry and release evidence now distinguish `contract_only`, `configured_readiness`, `live_adapter_read`, `live_adapter_write`, `migration_apply_ready`, and `release_ready` providers so contract-only seams cannot appear generally available to members.
-- Portability language now uses `portable`, `lossy`, `unsupported`, `manual_review`, `vendor_locked`, and `archive_only` field classes and forbids lossless-migration marketing claims.
+- Public docs and README evidence pointers now identify `v0.1.0-rc.3` as the latest published prerelease and link the RC3 evidence audit.
 
 ## Fixed
 
-- Chat Matrix error handling and member room UI now keep load/send/read-marker failures, encrypted timeline placeholders, unsupported messages, failed sends, and retry states support-safe and accessible.
-- Nextcloud Files and Calendar adapters now have stronger release-quality coverage for WebDAV/CalDAV error redaction, invalid path rejection, quota/permission/conflict handling, all-day event preservation, and explicit recurrence blocking until a recurrence contract exists.
+- No post-`v0.1.0-rc.3` bugfix release notes yet.
 
 ## Security
 
-- Product-readiness evidence now records provider-switching, OpenClaw runtime isolation, Weaver tool approval, RBAC, redaction, scan, and support-bundle expectations as explicit release blockers.
-- Weaver runtime remains disabled-by-default behind isolation, SecretRef/OAuth broker, signed manifest, egress, audit, and support-bundle redaction contracts.
-- Sprint 14 delivers the stable `weave-chat` channel plugin projection and Credential Broker implementation for governed Weaver RuntimeProfiles while keeping broad runtime execution and raw OpenClaw dashboard/config access out of member UX.
+- No post-`v0.1.0-rc.3` security release notes yet.
 
 ## Accessibility
 
-- Sprint 9 release readiness now treats admin setup, provider switching/report review, Calls/LiveKit states, Weaver approvals, and member capability states as release-blocking accessibility flows.
-- Sprint 11 now carries a manual assistive-technology evidence template for replacing the Sprint 10 accessibility waiver before v0.1 RC promotion; the template is explicitly not pass evidence until real tester results are recorded.
-- Sprint 12 introduces a permanent machine-readable accessibility release gate with expiring issue-linked waivers only.
-- Sprint 18 manual AT signoff is explicitly blocked by #591; automated tests, support-bundle refs, audit/export refs, release notes, CI, and Live Stack pointers cannot be used as a substitute for real assistive-technology reviewer evidence.
+- Sprint 18 release-trust claim control keeps manual assistive-technology signoff explicitly blocked by #591; automated tests, support-safe artifacts, release notes, and green Live Stack E2E cannot substitute for real AT reviewer evidence.
 
 ## Migration/Operator Notes
 
-- Admin Console provider setup now shows domain-first reality level, evidence freshness, restart-survival evidence, and blocks provider apply/switch actions without fresh backend dry-run evidence, consequence confirmation, audit/rollback gates, and provider-neutral member impact preview.
-- Chat provider-replacement evidence is operator-review-only in Sprint 15: encrypted Matrix history remains unsupported/coming_later, Matrix power-level and media-retention parity remain manual-review blockers, and no release note may imply lossless migration, E2EE history migration, or production cutover.
-- Self-hosted operations now define provider-aware backup, restore, upgrade, schema migration, support-bundle redaction, observability, and restore-smoke evidence expectations.
-- Release claim control now blocks RC/prod wording when manual accessibility, CI, Live Stack, support bundle, audit/export, migration, Weaver, release notes, or open-blocker evidence is missing, stale, sample-only, or unresolved.
+- No production provider cutover, migration apply, Terraform/live infrastructure change, or public production release has been performed after `v0.1.0-rc.3`.
 
 ## Known Issues
 
-- Nothing yet.
+- #591 remains the current release blocker: actual manual assistive-technology signoff is required before Sprint 18 milestone closure or public/production release signoff, unless release ownership explicitly splits the remaining manual signoff into a separate accepted blocker.
 <!-- WEAVE_RELEASE_NOTES_END -->
 
 ## Product screenshots
@@ -193,7 +173,7 @@ Gherkin scenarios are product contracts. For behavior changes, update product-la
 
 1. Read [v0.1 Golden Path readiness](docs/v0.1-golden-path.md) for what can be evaluated today.
 2. Read [Canonical domains](docs/architecture/canonical-domains.md) and [Provider portability contract](docs/architecture/provider-portability.md) for the foundation vocabulary.
-3. Read [Quality and acceptance evidence](docs/quality-and-evidence.md) and [v0.1.0-rc.2 release evidence](docs/release-v0.1-rc2-evidence.md) for evidence handling and the latest published prerelease audit.
+3. Read [Quality and acceptance evidence](docs/quality-and-evidence.md) and [v0.1.0-rc.3 release evidence](docs/release-v0.1-rc3-evidence.md) for evidence handling and the latest published prerelease audit.
 4. Build docs locally:
 
    ```bash

--- a/docs/enterprise-release-foundation.md
+++ b/docs/enterprise-release-foundation.md
@@ -97,7 +97,7 @@ This makes evidence portable: a release owner can inspect one artifact directory
 
 ## Repeatable RC readiness check
 
-Use the local/CI-safe readiness check before creating or promoting an RC tag. The latest published audit is [`v0.1.0-rc.2`](release-v0.1-rc2-evidence.md); the command below is an example shape and each promotion must pass explicit candidate values:
+Use the local/CI-safe readiness check before creating or promoting an RC tag. The latest published audit is [`v0.1.0-rc.3`](release-v0.1-rc3-evidence.md); the command below is an example shape and each promotion must pass explicit candidate values. Current post-RC3 release readiness is still blocked by #591 until actual manual assistive-technology evidence (or an accepted release-owner scope split) exists:
 
 ```sh
 ./gradlew releaseReadinessCheck \

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ Start with:
 2. [v0.1 Golden Path readiness](v0.1-golden-path.md) — what is available, guarded, disabled by policy, degraded, unavailable, or future.
 3. [Canonical domains](architecture/canonical-domains.md) and [Provider portability contract](architecture/provider-portability.md) — foundation vocabulary and no-unaccounted-data-loss boundaries.
 4. [Product acceptance flows](product-acceptance-flows.md) — product-language acceptance paths.
-5. [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md) — exact candidate commit, gates, signoff, and post-release documentation corrections.
-6. [Sprint 6 closure report](sprint-6-closure-report.md) — final RC/provider-ops foundation evidence and first-release entry criteria, with a post-closure pointer to RC2.
+5. [v0.1.0-rc.3 release evidence](release-v0.1-rc3-evidence.md) — latest published prerelease candidate commit, gates, release-draft evidence, and Live Stack E2E links.
+6. [v0.1 release notes](release-notes/v0.1.md) — durable release notes for the dogfood-production line, with guarded/future surfaces kept explicit.
 7. [Sprint 5 closure report](sprint-5-closure-report.md) — project-readiness evidence and release-candidate gaps.
 8. [Enterprise release foundation](enterprise-release-foundation.md) — release lanes, RC gate, waiver semantics, and support-safe artifacts.
 9. [Sprint 6 epic closure report](sprint-6-epic-closure-report.md) — #212/#233 acceptance evidence after the merged identity/admin slices.
@@ -112,6 +112,7 @@ Release and evidence docs:
 - [Sprint 5 closure report](sprint-5-closure-report.md)
 - [Sprint 6 kickoff plan](sprint-6-kickoff-plan.md)
 - [Sprint 6 epic closure report](sprint-6-epic-closure-report.md)
+- [v0.1.0-rc.3 release evidence](release-v0.1-rc3-evidence.md)
 - [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md)
 - [Sprint 6 closure report](sprint-6-closure-report.md)
 - [Sprint 8 delivery board policy](project/sprint-8-delivery-board.md)
@@ -130,7 +131,7 @@ The canonical product/domain truth is the pinned Weave Specification Corpus refe
 
 Weaver remains optional, governed, auditable, support-safe, and disabled by default. Any future per-user PA runtime must be generated from Weave organization policy as an isolated OpenClaw-derived profile and follow the rule: user-rights, organization-whitelisted capabilities. See [Governed Weaver runtime security contract](governed-weaver-runtime-security-contract.md) for the runtime/model/tool-provider split, approval receipts, and support-safe evidence boundary.
 
-v0.1 is dogfood-production, not a preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets. The shortest status summary for reviewers is [v0.1 Golden Path readiness](v0.1-golden-path.md). The latest published prerelease audit is [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md).
+v0.1 is dogfood-production, not a preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets. The shortest status summary for reviewers is [v0.1 Golden Path readiness](v0.1-golden-path.md). The latest published prerelease audit is [v0.1.0-rc.3 release evidence](release-v0.1-rc3-evidence.md); current post-publication release readiness still blocks on #591 manual assistive-technology evidence.
 
 ## Documentation stack
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -5,7 +5,7 @@ Release notes are the durable, user/admin/operator-facing record of what changed
 ## Files
 
 - [Unreleased](unreleased.md) collects changes that have merged but are not cut into a tagged release yet.
-- [v0.1](v0.1.md) records the dogfood-production release notes, including the published `v0.1.0-rc.2` prerelease facts and evidence links.
+- [v0.1](v0.1.md) records the dogfood-production release notes, including the latest published `v0.1.0-rc.3` prerelease facts and evidence links.
 
 ## Categories
 
@@ -39,6 +39,6 @@ GH_TOKEN=... python3 tools/release_notes_generate.py --repo masssi164/weave --si
 
 Use `--dry-run` to inspect output without writing, and use `--input tools/fixtures/release_notes_prs.json` for deterministic local checks. Issue #293 tracks the remaining automation to publish GitHub release drafts from this source of truth. Checked-in release notes pages remain concise, user/admin/operator-oriented drafts linked to deeper docs when needed.
 
-At release cut, generated notes should move into the versioned release notes file and `unreleased.md` should reset to empty category headings. `v0.1.0-rc.2` follows this pattern: versioned notes hold the release facts, while Unreleased is reset for later changes. Run `make release-notes-check` or `make docs-check` before requesting review.
+At release cut, generated notes should move into the versioned release notes file and `unreleased.md` should reset to empty category headings plus any current known blockers. `v0.1.0-rc.3` follows this pattern: versioned notes hold the release facts, while Unreleased is reset for later changes and the current #591 manual assistive-technology blocker. Run `make release-notes-check` or `make docs-check` before requesting review.
 
 Release notes must stay honest about shipped, gated, disabled, degraded, or future behavior. Do not describe preview-only or guarded surfaces as generally available.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,51 +1,31 @@
 # Unreleased
 
-Use this page for release-affecting changes that have merged but are not included in a tagged release yet.
+Use this page for release-affecting changes that have merged but are not included in a tagged release yet. `v0.1.0-rc.3` is the latest published prerelease; older post-RC2 entries moved into the versioned v0.1 release notes and RC3 evidence audit.
 
 ## Added
-- Sprint 15 adds organization-embedding and provider-neutral replacement evidence: backend-owned effective-policy/readiness boundaries, support-safe Admin Console consequence copy, Matrix Chat as the first dry-run proof slice, an operator runbook, and accessibility evidence template while keeping provider apply/cutover blocked.
-- Sprint 16 adds a support-safe organization go-live readiness summary, suite facade readiness rows for Files/Documents, Boards/Tasks, and Calendar, and a governed Weaver RuntimeProfile projection preview while keeping provider apply/cutover and runtime execution guarded.
-- Sprint 18 release-trust claim control now records #591 as the manual assistive-technology blocker for critical member Workspace, admin migration/recovery, admin go-live, and governed Weaver approval/revocation flows until real reviewer evidence replaces the support-safe blocker artifact.
 
-- Context-driven workflow primitives now have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
-- Contextual meetings now have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
-- Sprint 8/Sprint 9 acceptance now includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
-- Sprint 11 Live Stack acceptance now maps a provider-reality vertical for Files, Calendar, Boards, Calls, and Documents with live-runtime evidence separated from manual accessibility accounting.
-- Sprint 12 adds provider portability schema v2 fixtures and reports for Files, Calendar, Boards, and Chat, plus Office/WOPI, Weaver isolation, Weaver registry, identity lifecycle, accessibility, and operator lifecycle contracts.
-- Weaver/OpenClaw release documentation now clarifies the signed RuntimeProfile boundary: Weave projects a stable `channels.weave-chat` channel backed by Weave Chat-domain routing, model aliases, MCP/tool/skill grants, CredentialRefs and short-lived runtime token references, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
-- Sprint 14 starts product-trust and provider-choice evidence with a cross-repo Weave/Weaver delivery board, professional claim matrix, procurement-risk wording boundaries, and a conservative Matrix Chat migration proof fixture that keeps apply blocked until no-unaccounted-data-loss evidence exists.
+- No post-`v0.1.0-rc.3` release-note additions yet.
 
 ## Changed
 
-- Chat readiness and release evidence now lock Matrix/Synapse as the current real provider path, keep non-Matrix chat providers contract-only until promoted, and document Matrix portability/E2EE boundaries.
-- Provider registry and release evidence now distinguish `contract_only`, `configured_readiness`, `live_adapter_read`, `live_adapter_write`, `migration_apply_ready`, and `release_ready` providers so contract-only seams cannot appear generally available to members.
-- Portability language now uses `portable`, `lossy`, `unsupported`, `manual_review`, `vendor_locked`, and `archive_only` field classes and forbids lossless-migration marketing claims.
+- Public docs and README evidence pointers now identify `v0.1.0-rc.3` as the latest published prerelease and link the RC3 evidence audit.
 
 ## Fixed
 
-- Chat Matrix error handling and member room UI now keep load/send/read-marker failures, encrypted timeline placeholders, unsupported messages, failed sends, and retry states support-safe and accessible.
-- Nextcloud Files and Calendar adapters now have stronger release-quality coverage for WebDAV/CalDAV error redaction, invalid path rejection, quota/permission/conflict handling, all-day event preservation, and explicit recurrence blocking until a recurrence contract exists.
+- No post-`v0.1.0-rc.3` bugfix release notes yet.
 
 ## Security
 
-- Product-readiness evidence now records provider-switching, OpenClaw runtime isolation, Weaver tool approval, RBAC, redaction, scan, and support-bundle expectations as explicit release blockers.
-- Weaver runtime remains disabled-by-default behind isolation, SecretRef/OAuth broker, signed manifest, egress, audit, and support-bundle redaction contracts.
-- Sprint 14 delivers the stable `weave-chat` channel plugin projection and Credential Broker implementation for governed Weaver RuntimeProfiles while keeping broad runtime execution and raw OpenClaw dashboard/config access out of member UX.
+- No post-`v0.1.0-rc.3` security release notes yet.
 
 ## Accessibility
 
-- Sprint 9 release readiness now treats admin setup, provider switching/report review, Calls/LiveKit states, Weaver approvals, and member capability states as release-blocking accessibility flows.
-- Sprint 11 now carries a manual assistive-technology evidence template for replacing the Sprint 10 accessibility waiver before v0.1 RC promotion; the template is explicitly not pass evidence until real tester results are recorded.
-- Sprint 12 introduces a permanent machine-readable accessibility release gate with expiring issue-linked waivers only.
-- Sprint 18 manual AT signoff is explicitly blocked by #591; automated tests, support-bundle refs, audit/export refs, release notes, CI, and Live Stack pointers cannot be used as a substitute for real assistive-technology reviewer evidence.
+- Sprint 18 release-trust claim control keeps manual assistive-technology signoff explicitly blocked by #591; automated tests, support-safe artifacts, release notes, and green Live Stack E2E cannot substitute for real AT reviewer evidence.
 
 ## Migration/Operator Notes
 
-- Admin Console provider setup now shows domain-first reality level, evidence freshness, restart-survival evidence, and blocks provider apply/switch actions without fresh backend dry-run evidence, consequence confirmation, audit/rollback gates, and provider-neutral member impact preview.
-- Chat provider-replacement evidence is operator-review-only in Sprint 15: encrypted Matrix history remains unsupported/coming_later, Matrix power-level and media-retention parity remain manual-review blockers, and no release note may imply lossless migration, E2EE history migration, or production cutover.
-- Self-hosted operations now define provider-aware backup, restore, upgrade, schema migration, support-bundle redaction, observability, and restore-smoke evidence expectations.
-- Release claim control now blocks RC/prod wording when manual accessibility, CI, Live Stack, support bundle, audit/export, migration, Weaver, release notes, or open-blocker evidence is missing, stale, sample-only, or unresolved.
+- No production provider cutover, migration apply, Terraform/live infrastructure change, or public production release has been performed after `v0.1.0-rc.3`.
 
 ## Known Issues
 
-- Nothing yet.
+- #591 remains the current release blocker: actual manual assistive-technology signoff is required before Sprint 18 milestone closure or public/production release signoff, unless release ownership explicitly splits the remaining manual signoff into a separate accepted blocker.

--- a/docs/release-notes/v0.1.md
+++ b/docs/release-notes/v0.1.md
@@ -2,56 +2,82 @@
 
 v0.1 is the dogfood-production release line. Entries below reflect shipped, evidence-backed behavior only. Guarded, disabled, or future surfaces are named as such.
 
-Latest published prerelease: [`v0.1.0-rc.2`](https://github.com/masssi164/weave/releases/tag/v0.1.0-rc.2), published on 2026-05-28 from `9409ae44a07f38864a45a203d90a842b22c6a82d` on protected `main`.
+Latest published prerelease: [`v0.1.0-rc.3`](https://github.com/masssi164/weave/releases/tag/v0.1.0-rc.3), published on 2026-06-01 from `2f0794c46cf8ecc91697b930d27b443c12fdeec2` on protected `main`.
 
-Evidence for `v0.1.0-rc.2`:
+Evidence for `v0.1.0-rc.3`:
 
-- Main CI: [`26598506323`](https://github.com/masssi164/weave/actions/runs/26598506323), success.
-- Credentialed Live Stack E2E: [`26598646805`](https://github.com/masssi164/weave/actions/runs/26598646805), success, artifact `weave-live-stack-acceptance-evidence`.
-- Release draft workflow: [`26599654278`](https://github.com/masssi164/weave/actions/runs/26599654278), success.
-- Tag CI: [`26599820660`](https://github.com/masssi164/weave/actions/runs/26599820660), success.
-- Release-owner signoff and blocker closure: issue #379.
-- Detailed audit: [v0.1.0-rc.2 release evidence](../release-v0.1-rc2-evidence.md).
+- Main CI: [`26761284816`](https://github.com/masssi164/weave/actions/runs/26761284816), success.
+- Release draft workflow: [`26762480045`](https://github.com/masssi164/weave/actions/runs/26762480045), success, artifact `release-draft-review-v0.1.0-rc.3`.
+- Credentialed Live Stack E2E: [`26762479975`](https://github.com/masssi164/weave/actions/runs/26762479975), success, artifact `weave-live-stack-acceptance-evidence`.
+- Fresh Live Stack E2E rerun: [`26764652300`](https://github.com/masssi164/weave/actions/runs/26764652300), success, artifact `weave-live-stack-acceptance-evidence` id `7335979752`.
+- Release blocker refresh/signoff trail: issue #557.
+- Detailed audit: [v0.1.0-rc.3 release evidence](../release-v0.1-rc3-evidence.md).
 
 ## Added
 
-- Identity realm dry-run contracts for admin-owned provider setup and review.
-- Repeatable RC readiness checks for candidate input, CI summary, release notes, Live Stack evidence, release blockers, support-safety, and explicit waivers.
-- Workspace Health identity provider readiness facade through backend Admin Console APIs.
-- Admin/operator effective policy simulation before provider or realm changes apply.
-- Guarded identity realm apply decision path with explicit confirmation, last-admin protection, rollback evidence gates, and support-safe audit counts.
-- Sprint 6 identity epic closure evidence for #212 and #233.
-- Sprint 6 closure report for the release-candidate/provider-ops foundation.
-- Provider-neutral Weave product positioning for identity, chat, files, calendar, boards/tasks, meetings, documents/collaboration, and later Weaver runtime.
-- Canonical feature model and facade architecture documentation for server/admin/infra implementation planning.
-- Quality and acceptance evidence documentation for release gating.
+- Organization-embedded provider-neutral suite foundation: Spaces, Chat, Files/Documents, Calendar, Boards/Tasks, Admin Health/Ops, and provider reality levels behind Weave-owned domain facades.
+- Guided Admin setup and go-live readiness surfaces with support-safe provider evidence, policy boundaries, release claim control, and explicit blockers.
+- Governed Weaver RuntimeProfile and MCP direction: Weaver can be projected through Weave-generated policy, grants, audit, and Streamable HTTP MCP bindings instead of raw provider or OpenClaw config exposure.
+- Sprint 17 RC workspace slice: governed MCP/runtime invocation evidence, Space-centered Chat/Calendar/Boards/Files flow, and Admin RC go-live claim control.
+- Context-driven workflow primitives have a provider-neutral, linear-first preview contract with explicit context references, blocker/evidence metadata, sample workflows, and dry-run-only governed agent participation.
+- Contextual meetings have a fail-closed architecture contract preserving LiveKit as the active meetings provider contract while documenting encryption boundaries, consent defaults, and accessible join requirements before media controls are enabled.
+- Sprint 8/Sprint 9 acceptance includes mapped product-readiness waterfall evidence for domain registry review, Keycloak dry-run, provider apply blocking, portability reports, Calls/LiveKit readiness, Weaver approvals, member opt-in, and support-safe release blockers.
+- Sprint 11 Live Stack acceptance maps a provider-reality vertical for Files, Calendar, Boards, Calls, and Documents with live-runtime evidence separated from manual accessibility accounting.
+- Sprint 12 adds provider portability schema v2 fixtures and reports for Files, Calendar, Boards, and Chat, plus Office/WOPI, Weaver isolation, Weaver registry, identity lifecycle, accessibility, and operator lifecycle contracts.
+- Sprint 14 starts product-trust and provider-choice evidence with a cross-repo Weave/Weaver delivery board, professional claim matrix, procurement-risk wording boundaries, and a conservative Matrix Chat migration proof fixture that keeps apply blocked until no-unaccounted-data-loss evidence exists.
+- Sprint 15 adds organization-embedding and provider-neutral replacement evidence: backend-owned effective-policy/readiness boundaries, support-safe Admin Console consequence copy, Matrix Chat as the first dry-run proof slice, an operator runbook, and accessibility evidence template while keeping provider apply/cutover blocked.
+- Sprint 16 adds a support-safe organization go-live readiness summary, suite facade readiness rows for Files/Documents, Boards/Tasks, and Calendar, and a governed Weaver RuntimeProfile projection preview while keeping provider apply/cutover and runtime execution guarded.
 
 ## Changed
 
-- WEAVE-SPEC-0001 is accepted as the product-core baseline for a first-class Admin-Suite plus provider neutrality. It is included in the candidate as specification and issue-DAG work, not runtime implementation.
-- PRs #344 and #382 are present in the RC2 candidate; #382 uses `release-notes-skip` because it is spec-only and follow-up implementation remains in #386-#389.
-- Normal member setup is admin-provisioned: members join with an organization auth URL, invite, or deep link rather than configuring raw providers.
+- Release evidence separates offline contract/spec gates from credentialed Live Stack E2E evidence and keeps release promotion blocked without explicit green evidence or release-owner waiver.
+- Provider portability wording uses conservative states (`contract_only`, `configured_readiness`, `live_adapter_read`, `live_adapter_write`, `migration_apply_ready`, `release_ready`) to prevent overclaiming.
+- Matrix/Synapse remains the current real Chat provider path; other chat providers remain contract-only until separately promoted.
+- Chat readiness and release evidence lock Matrix/Synapse as the current real provider path, keep non-Matrix chat providers contract-only until promoted, and document Matrix portability/E2EE boundaries.
+- Portability language uses `portable`, `lossy`, `unsupported`, `manual_review`, `vendor_locked`, and `archive_only` field classes and forbids lossless-migration marketing claims.
+- Weaver/OpenClaw release documentation clarifies the signed RuntimeProfile boundary: Weave projects a stable `channels.weave-chat` channel backed by Weave Chat-domain routing, model aliases, MCP/tool/skill grants, CredentialRefs and short-lived runtime token references, sandbox policy, and audit requirements into the OpenClaw-derived runtime while keeping raw OpenClaw configuration out of member UX.
 
 ## Fixed
 
-- Live Stack E2E failure diagnostics now generate support-safe manifests, marker summaries, and redacted failure artifacts.
-- Audited workspace writes fail closed before provider mutation when required evidence is missing.
+- Support-safe redaction and error handling for Matrix chat readiness, Nextcloud Files/Calendar adapters, Office/WOPI unavailable posture, OpenProject boards writes, and release evidence mapping.
+- Android release identity and admin dependency policy checks are hardened.
+- Chat Matrix error handling and member room UI keep load/send/read-marker failures, encrypted timeline placeholders, unsupported messages, failed sends, and retry states support-safe and accessible.
+- Nextcloud Files and Calendar adapters have stronger release-quality coverage for WebDAV/CalDAV error redaction, invalid path rejection, quota/permission/conflict handling, all-day event preservation, and explicit recurrence blocking until a recurrence contract exists.
 
 ## Security
 
-- Provider secrets, tokens, raw downstream provider errors, credential-bearing URLs, and private keys stay out of member clients and support artifacts by contract.
+- Provider secrets, runtime tokens, raw provider errors, credential-bearing URLs, and private keys stay out of member clients, Admin support surfaces, and release evidence by contract.
+- Weaver runtime/tool access remains governed by org policy, runtime grants, approvals, audit, sandboxing, and support-safe redaction boundaries.
+- Product-readiness evidence records provider-switching, OpenClaw runtime isolation, Weaver tool approval, RBAC, redaction, scan, and support-bundle expectations as explicit release blockers.
+- Weaver runtime remains disabled-by-default behind isolation, SecretRef/OAuth broker, signed manifest, egress, audit, and support-bundle redaction contracts.
+- Sprint 14 delivers the stable `weave-chat` channel plugin projection and Credential Broker implementation for governed Weaver RuntimeProfiles while keeping broad runtime execution and raw OpenClaw dashboard/config access out of member UX.
 
 ## Accessibility
 
-- Accessibility remains a release blocker, with documented evidence gates for perceptibility, keyboard/screen-reader paths, and localized support-safe copy.
+- Admin setup, provider readiness, capability states, Weaver approvals, and workspace recovery flows remain release-blocking accessibility surfaces.
+- Automated accessibility/copy gates are included; manual assistive-technology evidence remains a required promotion consideration.
+- Sprint 9 release readiness treats admin setup, provider switching/report review, Calls/LiveKit states, Weaver approvals, and member capability states as release-blocking accessibility flows.
+- Sprint 11 carries a manual assistive-technology evidence template for replacing the Sprint 10 accessibility waiver before v0.1 RC promotion; the template is explicitly not pass evidence until real tester results are recorded.
+- Sprint 12 introduces a permanent machine-readable accessibility release gate with expiring issue-linked waivers only.
 
 ## Migration/Operator Notes
 
-- OpenTofu is the operator-facing infrastructure language for Weave workflows.
-- Provider/category readiness, SecretRefs, audit, support bundles, backup/restore, and whitelisting are admin/operator-owned surfaces.
+- No production provider cutover, migration apply, Terraform/live infrastructure change, or public production release was performed by `v0.1.0-rc.3`.
+- Provider replacement/apply remains admin/operator controlled and blocked unless fresh dry-run/apply/rollback/support-safe evidence exists for the target domain.
+- MCP evidence is RC-shaped local Streamable HTTP discovery/invocation/fail-closed proof, not a production Weaver rollout.
+- Admin Console provider setup shows domain-first reality level, evidence freshness, restart-survival evidence, and blocks provider apply/switch actions without fresh backend dry-run evidence, consequence confirmation, audit/rollback gates, and provider-neutral member impact preview.
+- Chat provider-replacement evidence is operator-review-only: encrypted Matrix history remains unsupported/coming_later, Matrix power-level and media-retention parity remain manual-review blockers, and no release note may imply lossless migration, E2EE history migration, or production cutover.
+- Self-hosted operations define provider-aware backup, restore, upgrade, schema migration, support-bundle redaction, observability, and restore-smoke evidence expectations.
+- Release claim control blocks RC/prod wording when manual accessibility, CI, Live Stack, support bundle, audit/export, migration, Weaver, release notes, or open-blocker evidence is missing, stale, sample-only, or unresolved.
 
 ## Known Issues
 
-- Live-stack E2E requires the dedicated self-hosted live runner and configured test credentials.
-- The WEAVE-SPEC-0001 implementation DAG remains follow-up work: #386, #387, #388, and #389.
-- Weaver/AI runtime remains out of WEAVE-SPEC-0001 and is still disabled/future scope.
+- Production-grade RuntimeProfile projection signing/fetch-by-hash and live runtime token issuance remain future hardening.
+- Live provider CRUD/migration apply and public release publication require separate release-owner decisions and fresh evidence.
+- Documents/Office WOPI remains unavailable/guarded until backend runtime, callback/session security, storage binding, permission model, health checks, and release gates exist.
+- Post-RC3 Sprint 18 accounting keeps #591 open as the current release blocker: actual manual assistive-technology signoff is still required before Sprint 18 milestone closure or public/production release signoff.
+
+## Earlier RC evidence
+
+- [`v0.1.0-rc.2`](https://github.com/masssi164/weave/releases/tag/v0.1.0-rc.2), published on 2026-05-28 from `9409ae44a07f38864a45a203d90a842b22c6a82d`; detailed audit: [v0.1.0-rc.2 release evidence](../release-v0.1-rc2-evidence.md).
+- `v0.1.0-rc.2` included the accepted WEAVE-SPEC-0001 product-core baseline and PRs #344 and #382; follow-up implementation continued through later sprint evidence.

--- a/docs/release-v0.1-dogfood-plan.md
+++ b/docs/release-v0.1-dogfood-plan.md
@@ -2,7 +2,7 @@
 
 Status: implementation baseline for the monorepo refoundation.
 
-Latest prerelease audit: `v0.1.0-rc.2` was published on 2026-05-28 from `9409ae44a07f38864a45a203d90a842b22c6a82d` with green PR-safe CI, credentialed Live Stack E2E, release-owner signoff, and no open release blockers. See [v0.1.0-rc.2 release evidence](release-v0.1-rc2-evidence.md).
+Latest prerelease audit: `v0.1.0-rc.3` was published on 2026-06-01 from `2f0794c46cf8ecc91697b930d27b443c12fdeec2` with green PR-safe CI, credentialed Live Stack E2E, release-draft evidence, and release-owner blocker refresh in #557. See [v0.1.0-rc.3 release evidence](release-v0.1-rc3-evidence.md). Post-publication Sprint 18 accounting keeps #591 open as the current manual assistive-technology release blocker before public/production release signoff.
 
 ## Goal
 

--- a/docs/release-v0.1-rc3-evidence.md
+++ b/docs/release-v0.1-rc3-evidence.md
@@ -1,0 +1,52 @@
+# v0.1.0-rc.3 release evidence
+
+Status: published prerelease evidence, 2026-06-01.
+
+## Release facts
+
+- Release: [`v0.1.0-rc.3`](https://github.com/masssi164/weave/releases/tag/v0.1.0-rc.3)
+- Published at: `2026-06-01T16:13:33Z`
+- Candidate commit: `2f0794c46cf8ecc91697b930d27b443c12fdeec2` on protected `main`
+- Tag target: `v0.1.0-rc.3` -> `2f0794c46cf8ecc91697b930d27b443c12fdeec2`
+- Draft: `false`
+- Prerelease: `true`
+
+## Scope audit
+
+`v0.1.0-rc.3` is a post-`v0.1.0-rc.2` rollup for the dogfood-production line. It includes provider-neutral Admin/Suite foundation work from Sprints 8-17 and the first RC-shaped governed Workspace/Weaver slice. Guarded or disabled surfaces remain named as such; this release does not claim production provider cutover, broad runtime execution, public GA readiness, or a production release.
+
+The release closed the stale RC3 draft blocker #557 after refreshing the candidate, evidence, and release notes. Publication did not mutate live infrastructure, perform provider migration apply/cutover, or publish a final production release.
+
+## Evidence reviewed
+
+- Main CI on candidate commit: [`26761284816`](https://github.com/masssi164/weave/actions/runs/26761284816), success, for `2f0794c46cf8ecc91697b930d27b443c12fdeec2`.
+- Local `./gradlew ci` on candidate commit: passed, with sanitized `build/evidence/ci-summary.json`.
+- Release draft workflow: [`26762480045`](https://github.com/masssi164/weave/actions/runs/26762480045), success, artifact `release-draft-review-v0.1.0-rc.3` id `7334742373`.
+- Credentialed Live Stack E2E on candidate commit: [`26762479975`](https://github.com/masssi164/weave/actions/runs/26762479975), success, artifact `weave-live-stack-acceptance-evidence`.
+- Fresh Live Stack E2E rerun on the same candidate commit: [`26764652300`](https://github.com/masssi164/weave/actions/runs/26764652300), success, artifact `weave-live-stack-acceptance-evidence` id `7335979752`.
+- Release blocker refresh/signoff trail: issue #557.
+- RC readiness command shape: `./gradlew releaseReadinessCheck -PcandidateVersion=0.1.0-rc.3 -PcandidateTag=v0.1.0-rc.3 -PcandidateCommit=2f0794c46cf8ecc91697b930d27b443c12fdeec2 ...`.
+
+## Release note summary
+
+### Added
+
+- Organization-embedded provider-neutral suite foundation: Spaces, Chat, Files/Documents, Calendar, Boards/Tasks, Admin Health/Ops, and provider reality levels behind Weave-owned domain facades.
+- Guided Admin setup and go-live readiness surfaces with support-safe provider evidence, policy boundaries, release claim control, and explicit blockers.
+- Governed Weaver RuntimeProfile and MCP direction through Weave-generated policy, grants, audit, and Streamable HTTP MCP bindings instead of raw provider or OpenClaw config exposure.
+- Sprint 17 RC workspace slice with governed MCP/runtime invocation evidence, Space-centered Chat/Calendar/Boards/Files flow, and Admin RC go-live claim control.
+
+### Changed
+
+- Release evidence now separates offline contract/spec gates from credentialed Live Stack E2E evidence and keeps release promotion blocked without explicit green evidence or release-owner waiver.
+- Provider portability wording uses conservative states (`contract_only`, `configured_readiness`, `live_adapter_read`, `live_adapter_write`, `migration_apply_ready`, `release_ready`) to prevent overclaiming.
+- Matrix/Synapse remains the current real Chat provider path; other chat providers remain contract-only until separately promoted.
+
+### Fixed
+
+- Support-safe redaction and error handling for Matrix chat readiness, Nextcloud Files/Calendar adapters, Office/WOPI unavailable posture, OpenProject boards writes, and release evidence mapping.
+- Android release identity and admin dependency policy checks are hardened.
+
+## Current post-publication blockers
+
+After RC3 publication, Sprint 18 added stronger workspace/migration/trust evidence and closed the live-stack evidence gap in PR #596. The remaining release-blocking carryover is #591: actual manual assistive-technology signoff is still required before Sprint 18 milestone closure or public/production release signoff. Automated tests, support-safe artifacts, release notes, and green Live Stack E2E cannot substitute for real AT reviewer evidence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Sprint 8 closure audit: sprint-8-closure-report.md
       - Sprint 9 closure audit: sprint-9-closure-report.md
       - Sprint 14 delivery board: project/sprint-14-delivery-board.md
+      - v0.1.0-rc.3 release evidence: release-v0.1-rc3-evidence.md
       - v0.1.0-rc.2 release evidence: release-v0.1-rc2-evidence.md
       - Accessibility release gate: accessibility-release-gate.md
       - ISO 9241-110 dogfood UX gate: iso-9241-110-dogfood-ux-gate.md


### PR DESCRIPTION
## Summary
- add a durable `v0.1.0-rc.3` release-evidence audit page with candidate, CI, release-draft, and Live Stack E2E evidence
- update README/docs/release entry points from RC2-latest wording to RC3-latest wording
- reset Unreleased to post-RC3 state while preserving the current #591 manual AT release blocker

Closes #595.

## Gates
- `./gradlew docsCheck releaseEvidenceCheck --console=plain`
