### PR TITLE
feat: prove Sprint 25 Weaver customization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ registerRootCommandTask('productRealityClaimGateCheck', ['python3', 'tools/produ
 registerRootCommandTask('providerLabCheck', ['python3', 'tools/provider_lab_check.py'], 'Validate Sprint 22 free-provider-lab manifests, fixture completeness, redaction evidence, and Sprint 23 entry gate scoreboard.')
 registerRootCommandTask('chatProviderSwitchCheck', ['python3', 'tools/chat_provider_switch_check.py'], 'Validate Sprint 23 Chat Provider Switch canonical object coverage, LossyFieldReport enforcement, and ProviderRef redaction fixtures.')
 registerRootCommandTask('weaverRuntimeFactoryCheck', ['python3', 'tools/weaver_runtime_factory_check.py'], 'Validate Sprint 24 Weaver Runtime Factory lifecycle, reconciliation, isolation, and claim-gate fixtures.')
+registerRootCommandTask('weaverCustomizationCheck', ['python3', 'tools/weaver_customization_check.py'], 'Validate Sprint 25 Weaver customization profile, policy, tool approval, and claim-gate fixtures.')
 registerRootCommandTask('specContractTest', ['python3', 'tools/spec_contract_check_test.py'], 'Run fixture tests for the repo-local Weave spec contract guard.')
 registerRootCommandTask('androidReleaseIdentityCheck', ['python3', 'tools/android_release_identity_check.py'], 'Validate Android package identity and release-signing fail-safe posture.')
 registerRootCommandTask('adminDependencyPolicyCheck', ['python3', 'tools/admin_console_dependency_policy_check.py'], 'Validate Admin Console dependency pins and lockfile policy.')
@@ -77,7 +78,7 @@ tasks.register('releaseReadinessCheck', Exec) {
     commandLine execCommand(args)
     outputs.upToDateWhen { false }
 }
-registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_claim_matrix_check.py && python3 tools/product_trust_claim_matrix_check.py && python3 tools/product_reality_claim_gate_check.py && python3 tools/provider_lab_check.py && python3 tools/chat_provider_switch_check.py && python3 tools/weaver_runtime_factory_check.py && python3 tools/release_trust_claim_control_check.py && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py && python3 tools/release_readiness_check_test.py'], 'Validate release notes structure, README markers, provider reality, product-reality, Sprint 22 provider-lab gate, Sprint 23 chat-switch contract fixtures, Sprint 24 Weaver runtime factory fixtures, product-trust and release-trust claim matrices, labels, generator fixture evidence, Sprint 5 project-readiness closure evidence, Sprint 6 enterprise release gates, and RC readiness fixtures.')
+registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_claim_matrix_check.py && python3 tools/product_trust_claim_matrix_check.py && python3 tools/product_reality_claim_gate_check.py && python3 tools/provider_lab_check.py && python3 tools/chat_provider_switch_check.py && python3 tools/weaver_runtime_factory_check.py && python3 tools/weaver_customization_check.py && python3 tools/release_trust_claim_control_check.py && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py && python3 tools/release_readiness_check_test.py'], 'Validate release notes structure, README markers, provider reality, product-reality, Sprint 22 provider-lab gate, Sprint 23 chat-switch contract fixtures, Sprint 24 Weaver runtime factory fixtures, product-trust and release-trust claim matrices, labels, generator fixture evidence, Sprint 5 project-readiness closure evidence, Sprint 6 enterprise release gates, and RC readiness fixtures.')
 
 tasks.register('docsCheck') {
     group = 'verification'
@@ -119,6 +120,7 @@ ext.ciEvidenceGates = [
     'productTrustClaimMatrixCheck',
     'productRealityClaimGateCheck',
     'weaverRuntimeFactoryCheck',
+    'weaverCustomizationCheck',
     'androidReleaseIdentityCheck',
     'adminDependencyPolicyCheck',
     'releaseEvidenceCheck',
@@ -231,6 +233,8 @@ List<String> artifactPathsForGate(String gateName) {
             return ['docs/product-trust-provider-choice-claim-matrix.md', 'tools/product_trust_claim_matrix_check.py']
         case 'productRealityClaimGateCheck':
             return ['docs/product-reality-foundation.md', 'release/product-reality-gates.json', 'tools/product_reality_claim_gate_check.py']
+        case 'weaverCustomizationCheck':
+            return ['release/provider-lab/weaver-runtime/sprint-25-scoreboard.json', 'release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json', 'tools/weaver_customization_check.py']
         case 'releaseEvidenceCheck':
             return ['README.md', 'tools/fixtures/release_notes_unreleased.expected.md']
         case 'projectReadinessEvidenceCheck':

--- a/docs/evidence/weaver-customization-report.md
+++ b/docs/evidence/weaver-customization-report.md
@@ -1,0 +1,24 @@
+# Weaver customization evidence report
+
+Status: Sprint 25 provider-lab evidence, support-safe.
+
+## Scope
+
+This report covers Sprint 25 issues #635, #636, #637, and #638. It proves a bounded customization slice only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts, rollback restores a previous profile hash, and customized-Weaver claims are gated by matching scoreboard evidence.
+
+## Evidence artifacts
+
+- `release/provider-lab/weaver-runtime/profile-customization-proof.fixture.json` — #635 profile version/hash and rollback proof.
+- `release/provider-lab/weaver-runtime/policy-boundary-proof.fixture.json` — #636 forbidden customization block/audit proof.
+- `release/provider-lab/weaver-runtime/tool-approval-gate-proof.fixture.json` — #637 read/write/approval/revocation/expiry/consent grant proof.
+- `release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json` — #638 accepted scoped claim and rejected overclaim set.
+- `release/provider-lab/weaver-runtime/sprint-25-scoreboard.json` — #635-#638 green scoreboard with no release blockers.
+
+## Executable gates
+
+- `cd server && ./gradlew test --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest' --tests 'com.massimotter.weave.backend.weaver.WeaverToolRegistryTest' --console=plain`
+- `python3 tools/weaver_customization_check.py`
+
+## Claim boundary
+
+This evidence does not claim customer-ready Weaver, production PA availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, raw memory export, raw secrets, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab Sprint 25 artifacts.

--- a/docs/sprint-25-closure-report.md
+++ b/docs/sprint-25-closure-report.md
@@ -1,0 +1,37 @@
+# Sprint 25 closure report — Weaver Customization
+
+Status: implementation/evidence closure candidate.
+
+## Governing scope
+
+Sprint 25 covers #635, #636, #637, and #638 under the governed Weaver runtime contract. The sprint follows the product-line boundary: Weave remains provider-neutral first, Admin Console/control-plane policy owns setup and policy, and Weaver customization is optional, governed, and disabled unless organization policy enables it.
+
+## Issue DAG final state
+
+1. #635 profile versioning and rollback proof.
+2. #636 admin policy boundary enforcement depends on the RuntimeProfile customization seam from #635.
+3. #637 tool approval gates are independent server/tool-registry proof, but their result feeds #638.
+4. #638 customized Weaver claim gate depends on #635, #636, and #637 evidence.
+
+## Evidence artifacts
+
+- `release/provider-lab/weaver-runtime/profile-customization-proof.fixture.json` — #635.
+- `release/provider-lab/weaver-runtime/policy-boundary-proof.fixture.json` — #636.
+- `release/provider-lab/weaver-runtime/tool-approval-gate-proof.fixture.json` — #637.
+- `release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json` — #638.
+- `release/provider-lab/weaver-runtime/sprint-25-scoreboard.json` — #635, #636, #637, #638 scoreboard.
+- `docs/evidence/weaver-customization-report.md` — support-safe evidence summary for #635, #636, #637, and #638.
+
+## Local gates
+
+- `cd server && ./gradlew test --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest' --tests 'com.massimotter.weave.backend.weaver.WeaverToolRegistryTest' --console=plain`
+- `python3 tools/weaver_customization_check.py`
+- `./gradlew releaseEvidenceCheck` after the Sprint 25 validator is wired into release evidence.
+
+## Claim boundary
+
+Sprint 25 may claim only provider-lab, support-safe Weaver customization proof. It must not claim customer-ready Weaver, production PA availability, raw OpenClaw config access, arbitrary MCP/plugin execution, raw secrets, raw memory, public release readiness, or Teams/Slack implementation.
+
+## Next sprint seam
+
+The setup-flow/Forgejo proof belongs in Sprint 26/#659 after Sprint 25 closure. Sprint 25 does not require local Forgejo runner mutation; it only establishes RuntimeProfile, policy, approval, and claim gates that the Admin Console CI/CD-backed setup proof must preserve.

--- a/release/provider-lab/weaver-runtime/policy-boundary-proof.fixture.json
+++ b/release/provider-lab/weaver-runtime/policy-boundary-proof.fixture.json
@@ -1,0 +1,43 @@
+{
+  "artifactKind": "weave-weaver-runtime-sprint-25-policy-boundary-proof",
+  "supportSafe": true,
+  "issue": 636,
+  "forbiddenCustomizationAttempts": [
+    {
+      "field": "rawOpenClawConfig",
+      "decision": "blocked",
+      "policyReason": "admin_policy_forbids_raw_openclaw_config"
+    },
+    {
+      "field": "arbitraryMcpServer",
+      "decision": "blocked",
+      "policyReason": "admin_policy_forbids_arbitrary_mcp_server"
+    },
+    {
+      "field": "ownSecrets",
+      "decision": "blocked",
+      "policyReason": "admin_policy_forbids_own_secrets"
+    },
+    {
+      "field": "teamWideAction",
+      "decision": "blocked",
+      "policyReason": "admin_policy_forbids_team_wide_action"
+    }
+  ],
+  "auditRequiredFields": [
+    "user",
+    "action",
+    "domain",
+    "decision",
+    "policyReason",
+    "requestedFields",
+    "supportSafe"
+  ],
+  "rawOpenClawConfigAccepted": false,
+  "rawSecretsAccepted": false,
+  "uncheckedPluginsAccepted": false,
+  "teamWideActionsAccepted": false,
+  "evidenceRefs": [
+    "server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java#blocksForbiddenCustomizationAttemptsAndAuditsPolicyReason"
+  ]
+}

--- a/release/provider-lab/weaver-runtime/profile-customization-proof.fixture.json
+++ b/release/provider-lab/weaver-runtime/profile-customization-proof.fixture.json
@@ -1,0 +1,35 @@
+{
+  "artifactKind": "weave-weaver-runtime-sprint-25-profile-customization-proof",
+  "supportSafe": true,
+  "issue": 635,
+  "profileChange": {
+    "baseProfileVersion": "v1-baseline",
+    "customizedProfileVersion": "v2-customization",
+    "baseProfileHash": "sha256:sprint25baseprofile000000000000000000000000000000000000000000000000",
+    "customizedProfileHash": "sha256:sprint25customprofile00000000000000000000000000000000000000000000",
+    "previousProfileHash": "sha256:sprint25baseprofile000000000000000000000000000000000000000000000000",
+    "versionIncremented": true,
+    "hashChanged": true
+  },
+  "allowedCustomizationFields": [
+    "displayName",
+    "style",
+    "language",
+    "answerStyle",
+    "workingHours",
+    "notifications",
+    "personalNotes",
+    "memoryOptIn",
+    "allowedSkills",
+    "workspaceStructure"
+  ],
+  "rollback": {
+    "rollbackProfileHash": "sha256:sprint25baseprofile000000000000000000000000000000000000000000000000",
+    "restoredProfileVersion": "v1-baseline",
+    "auditAction": "weaver.runtime_profile.rolled_back",
+    "restored": true
+  },
+  "evidenceRefs": [
+    "server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java#versionsProfileCustomizationsAndRollsBackToPreviousProfile"
+  ]
+}

--- a/release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json
+++ b/release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json
@@ -1,0 +1,31 @@
+{
+  "artifactKind": "weave-weaver-runtime-sprint-25-claim-gate",
+  "supportSafe": true,
+  "acceptedClaim": {
+    "claim": "Sprint 25 proves support-safe Weaver customization in provider-lab evidence: RuntimeProfile versions change for allowed personal settings, forbidden customization is blocked by admin policy, write-like domain tools require validated ApprovalReceipts, rollback restores a previous profile hash, and user-personalized availability claims remain scoped to these artifacts.",
+    "expectedOutcome": "accept"
+  },
+  "rejectedClaims": [
+    {
+      "claim": "Weaver customization is customer-ready for all organizations.",
+      "expectedOutcome": "reject",
+      "reason": "No production PA/customer-ready evidence is claimed."
+    },
+    {
+      "claim": "Members may edit raw OpenClaw config, add arbitrary MCP servers, or bring their own secrets.",
+      "expectedOutcome": "reject",
+      "reason": "Admin policy boundaries block those attempts."
+    },
+    {
+      "claim": "Weaver can write to tools without approval receipts.",
+      "expectedOutcome": "reject",
+      "reason": "Write-like tools require validated ApprovalReceipts."
+    },
+    {
+      "claim": "Sprint 25 proves Teams, Slack, or public production provider rollout.",
+      "expectedOutcome": "reject",
+      "reason": "Provider-specific rollout is outside Sprint 25 evidence."
+    }
+  ],
+  "claimBoundary": "Provider-lab Sprint 25 evidence only. The gate requires profile version proof, policy-boundary proof, tool-approval proof, and rollback proof before scoped user-personalized Weaver wording. It does not claim production PA availability, customer-ready Weaver, raw OpenClaw config access, arbitrary MCP/plugin execution, raw memory, raw secrets, or public release readiness."
+}

--- a/release/provider-lab/weaver-runtime/sprint-25-scoreboard.json
+++ b/release/provider-lab/weaver-runtime/sprint-25-scoreboard.json
@@ -1,0 +1,26 @@
+{
+  "artifactKind": "weave-weaver-runtime-sprint-25-scoreboard",
+  "supportSafe": true,
+  "sprint": 25,
+  "fields": {
+    "profileVersioning": "green",
+    "policyBoundaries": "green",
+    "toolApprovalGates": "green",
+    "claimSafety": "green"
+  },
+  "issues": {
+    "635": "green",
+    "636": "green",
+    "637": "green",
+    "638": "green"
+  },
+  "requiredArtifacts": [
+    "release/provider-lab/weaver-runtime/profile-customization-proof.fixture.json",
+    "release/provider-lab/weaver-runtime/policy-boundary-proof.fixture.json",
+    "release/provider-lab/weaver-runtime/tool-approval-gate-proof.fixture.json",
+    "release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json"
+  ],
+  "openReleaseBlockers": [],
+  "sprint25ExitGate": "green",
+  "claimBoundary": "provider-lab evidence only; no customer-ready or production PA availability claim"
+}

--- a/release/provider-lab/weaver-runtime/tool-approval-gate-proof.fixture.json
+++ b/release/provider-lab/weaver-runtime/tool-approval-gate-proof.fixture.json
@@ -1,0 +1,37 @@
+{
+  "artifactKind": "weave-weaver-runtime-sprint-25-tool-approval-gate-proof",
+  "supportSafe": true,
+  "issue": 637,
+  "scenarios": {
+    "readOnlyAllowed": "passed",
+    "writeWithoutApproval": "approval_required",
+    "writeWithApproval": "ok",
+    "revokedToolBlocked": "runtime_profile_revoked",
+    "expiredTokenBlocked": "runtime_token_expired",
+    "overbroadGrantBlocked": "overbroad_grant",
+    "missingConsentBlocked": "consent_required"
+  },
+  "approvalReceipt": {
+    "requiredFields": [
+      "receiptRef",
+      "actorRef",
+      "action",
+      "scopeRefs",
+      "policyVersion",
+      "expiresAt",
+      "auditRef"
+    ],
+    "validatedBeforeInvocation": true,
+    "auditRefRecorded": true
+  },
+  "permittedWriteAudit": {
+    "decision": "invoked",
+    "approvalReceiptValidated": true,
+    "approvalReceiptAuditRefRecorded": true,
+    "supportSafe": true
+  },
+  "evidenceRefs": [
+    "server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java#requiresApprovalReceiptForWriteLikeToolsBeforeInvocation",
+    "server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java#failsClosedForUnsignedRevokedExpiredMismatchedConsentAndOverbroadGovernance"
+  ]
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -33,6 +33,10 @@ public class WeaverRuntimeService {
 
     private final ConcurrentMap<String, WeaverRuntimeProfileResponse> issuedProfiles = new ConcurrentHashMap<>();
     private final ConcurrentMap<String, WeaverRuntimeInstance> runtimeInstances = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> latestProfileHashByUser = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> profileFingerprintByUser = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Integer> profileSequenceByUser = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Map<String, Object>> customizationByUser = new ConcurrentHashMap<>();
 
     private final WorkspaceCapabilityService workspaceCapabilityService;
     private final WorkspaceCapabilityProperties workspaceCapabilityProperties;
@@ -77,10 +81,11 @@ public class WeaverRuntimeService {
         List<String> toolAllowlist = weaverRuntimeProperties.toolAllowlist();
         boolean execEnabled = weaverRuntimeProperties.execEnabled() && grantedCapabilities.contains("weaver.exec_enabled");
         boolean elevatedEnabled = weaverRuntimeProperties.elevatedEnabled() && grantedCapabilities.contains("weaver.elevated_enabled");
-        String profileVersion = profileVersion(userRef, allowedCapabilities);
+        Map<String, Object> customization = customizationByUser.getOrDefault(userRef, Map.of());
+        String profileVersion = profileVersion(userRef, profileFingerprint(allowedCapabilities, pluginAllowlist, toolAllowlist, execEnabled, elevatedEnabled, customization));
         String expiresAt = Instant.now().plus(1, ChronoUnit.HOURS).toString();
         String runtimeTokenExpiresAt = Instant.now().plus(10, ChronoUnit.MINUTES).toString();
-        String previousProfileHash = previousProfileHash(userRef, profileVersion);
+        String previousProfileHash = latestProfileHashByUser.getOrDefault(userRef, "none");
         String runtimeProfileHash = runtimeProfileHash(
                 userRef,
                 profileVersion,
@@ -129,7 +134,7 @@ public class WeaverRuntimeService {
                 elevatedEnabled,
                 weaverRuntimeProperties.auditRequired(),
                 weaverRuntimeProperties.forkRequired(),
-                channelProjection(runtimeProfileHash, profileVersion, userRef, expiresAt, runtimeTokenExpiresAt),
+                channelProjection(runtimeProfileHash, profileVersion, previousProfileHash, userRef, expiresAt, runtimeTokenExpiresAt),
                 credentialBrokerContract(userRef),
                 auditPolicy(runtimeProfileHash, userRef),
                 supportSafeProfileReceipt(profileVersion, runtimeProfileHash, signature, expiresAt, runtimeTokenExpiresAt, false, "active"),
@@ -139,7 +144,34 @@ public class WeaverRuntimeService {
                 "Weaver runtime profile is governed by organization policy; unavailable tools are hidden from the runtime.");
         auditGeneratedProfile(response);
         issuedProfiles.put(runtimeProfileHash, response);
+        latestProfileHashByUser.put(userRef, runtimeProfileHash);
         return response;
+    }
+
+    public WeaverRuntimeCustomizationDecision applyRuntimeCustomization(Jwt jwt, Map<String, Object> requestedCustomization) {
+        String userRef = supportSafeUserRef(jwt);
+        Map<String, Object> request = requestedCustomization == null ? Map.of() : Map.copyOf(requestedCustomization);
+        String denial = customizationDenial(request);
+        if (denial != null) {
+            auditCustomization(userRef, denial, false, request.keySet().stream().sorted().toList(), "blocked");
+            return new WeaverRuntimeCustomizationDecision(false, denial, null, "Forbidden Weaver customization attempt was blocked by admin policy.");
+        }
+        customizationByUser.put(userRef, request);
+        WeaverRuntimeProfileResponse profile = profileFor(jwt);
+        auditCustomization(userRef, "allowed_user_customization", true, request.keySet().stream().sorted().toList(), profile.runtimeProfileHash());
+        return new WeaverRuntimeCustomizationDecision(true, "allowed_user_customization", profile, "Customization accepted inside organization policy boundaries.");
+    }
+
+    public WeaverRuntimeProfileResponse rollbackRuntimeProfile(Jwt jwt, String rollbackProfileHash) {
+        String userRef = supportSafeUserRef(jwt);
+        WeaverRuntimeProfileResponse rollback = issuedProfiles.get(rollbackProfileHash == null ? "" : rollbackProfileHash.strip());
+        if (rollback == null || !rollback.userRef().equals(userRef) || rollback.revoked()) {
+            auditRollback(userRef, rollbackProfileHash, "rollback_denied");
+            return disabledProfile(userRef, "runtime-profile-rollback-denied", "RuntimeProfile rollback failed closed.");
+        }
+        latestProfileHashByUser.put(userRef, rollback.runtimeProfileHash());
+        auditRollback(userRef, rollback.runtimeProfileHash(), "rollback_restored");
+        return rollback;
     }
 
     public WeaverRuntimeProfileResponse profileByHash(Jwt jwt, String runtimeProfileHash) {
@@ -319,7 +351,7 @@ public class WeaverRuntimeService {
                 false,
                 true,
                 false,
-                channelProjection(runtimeProfileHash, profileVersion, userRef, expiresAt, expiresAt),
+                channelProjection(runtimeProfileHash, profileVersion, "none", userRef, expiresAt, expiresAt),
                 credentialBrokerContract(userRef),
                 auditPolicy(runtimeProfileHash, userRef),
                 supportSafeProfileReceipt(
@@ -428,9 +460,58 @@ public class WeaverRuntimeService {
         return weaverRuntimeProperties.workspaceRootTemplate().replace("{userId}", userRef.replace("user:", ""));
     }
 
-    private String profileVersion(String userRef, List<String> allowedCapabilities) {
-        return "v" + sha256(String.join("|", userRef, allowedCapabilities.toString(), weaverRuntimeProperties.baselineProfile()))
-                .substring(0, 16);
+    private String profileFingerprint(
+            List<String> allowedCapabilities,
+            List<String> pluginAllowlist,
+            List<String> toolAllowlist,
+            boolean execEnabled,
+            boolean elevatedEnabled,
+            Map<String, Object> customization) {
+        return sha256(String.join("|",
+                allowedCapabilities.toString(),
+                pluginAllowlist.toString(),
+                toolAllowlist.toString(),
+                Boolean.toString(execEnabled),
+                Boolean.toString(elevatedEnabled),
+                weaverRuntimeProperties.baselineProfile(),
+                weaverRuntimeProperties.image(),
+                weaverRuntimeProperties.workspaceRootTemplate(),
+                weaverRuntimeProperties.isolatedAgentDirectory(),
+                weaverRuntimeProperties.dockerNetworkMode(),
+                customization.toString()));
+    }
+
+    private String profileVersion(String userRef, String fingerprint) {
+        String previous = profileFingerprintByUser.put(userRef, fingerprint);
+        if (!fingerprint.equals(previous)) {
+            profileSequenceByUser.merge(userRef, 1, Integer::sum);
+        }
+        int sequence = profileSequenceByUser.getOrDefault(userRef, 1);
+        return "v" + sequence + "-" + fingerprint.substring(0, 12);
+    }
+
+    private String customizationDenial(Map<String, Object> request) {
+        for (String key : request.keySet()) {
+            String normalized = key == null ? "" : key.toLowerCase(Locale.ROOT).replace("_", "-");
+            String compact = normalized.replace("-", "");
+            Map<String, String> forbiddenReasons = Map.ofEntries(
+                    Map.entry("rawopenclawconfig", "admin_policy_forbids_raw_openclaw_config"),
+                    Map.entry("openclawjson", "admin_policy_forbids_raw_openclaw_config"),
+                    Map.entry("arbitrarymcpserver", "admin_policy_forbids_arbitrary_mcp_server"),
+                    Map.entry("ownsecret", "admin_policy_forbids_own_secrets"),
+                    Map.entry("ownsecrets", "admin_policy_forbids_own_secrets"),
+                    Map.entry("unlimitedtools", "admin_policy_forbids_unlimited_tools"),
+                    Map.entry("uncheckedplugin", "admin_policy_forbids_unchecked_plugins"),
+                    Map.entry("uncheckedplugins", "admin_policy_forbids_unchecked_plugins"),
+                    Map.entry("teamwideaction", "admin_policy_forbids_team_wide_action"),
+                    Map.entry("providersecret", "admin_policy_forbids_own_secrets"),
+                    Map.entry("execenabled", "admin_policy_forbids_exec_enabled"),
+                    Map.entry("maxdataaccess", "admin_policy_forbids_max_data_access"));
+            if (forbiddenReasons.containsKey(compact)) {
+                return forbiddenReasons.get(compact);
+            }
+        }
+        return null;
     }
 
     private String runtimeProfileHash(
@@ -481,13 +562,10 @@ public class WeaverRuntimeService {
         return "weave-signature:v1:" + sha256(runtimeProfileHash + ":" + profileVersion + ":support-safe");
     }
 
-    private String previousProfileHash(String userRef, String profileVersion) {
-        return "sha256:" + sha256(userRef + ":previous:" + profileVersion);
-    }
-
     private Map<String, Object> channelProjection(
             String runtimeProfileHash,
             String profileVersion,
+            String previousProfileHash,
             String userRef,
             String expiresAt,
             String runtimeTokenExpiresAt) {
@@ -497,7 +575,7 @@ public class WeaverRuntimeService {
                 "runtimeProfileHash", runtimeProfileHash,
                 "profileVersion", profileVersion,
                 "expiresAt", expiresAt,
-                "previousProfileHash", previousProfileHash(userRef, profileVersion),
+                "previousProfileHash", previousProfileHash,
                 "signatureRequired", true,
                 "signatureAlgorithm", "weave-signature:v1",
                 "revocationChecked", true,
@@ -629,6 +707,46 @@ public class WeaverRuntimeService {
                         Map.entry("supportSafe", true))));
     }
 
+    private void auditCustomization(String userRef, String reason, boolean accepted, List<String> requestedFields, String profileRef) {
+        auditEventPublisher.publish(new AuditEvent(
+                "tenant:workspace",
+                null,
+                userRef,
+                "weaver-runtime-policy",
+                AuditAction.ADMIN_POLICY_UPDATED,
+                Instant.now(),
+                "weaver-customization:" + userRef,
+                AuditRedactionLevel.SUPPORT_SAFE,
+                Map.ofEntries(
+                        Map.entry("user", userRef),
+                        Map.entry("action", "runtime-profile.customization"),
+                        Map.entry("domain", "weaver-runtime"),
+                        Map.entry("decision", accepted ? "accepted" : "blocked"),
+                        Map.entry("policyReason", reason),
+                        Map.entry("requestedFields", requestedFields),
+                        Map.entry("profileRef", profileRef),
+                        Map.entry("supportSafe", true))));
+    }
+
+    private void auditRollback(String userRef, String runtimeProfileHash, String decision) {
+        auditEventPublisher.publish(new AuditEvent(
+                "tenant:workspace",
+                null,
+                userRef,
+                "weaver-runtime-policy",
+                AuditAction.WEAVER_RUNTIME_PROFILE_ROLLED_BACK,
+                Instant.now(),
+                "weaver-profile:" + userRef + ":rollback",
+                AuditRedactionLevel.SUPPORT_SAFE,
+                Map.ofEntries(
+                        Map.entry("user", userRef),
+                        Map.entry("runtimeProfileHash", runtimeProfileHash == null ? "none" : runtimeProfileHash),
+                        Map.entry("action", "profile.rollback"),
+                        Map.entry("domain", "weaver-runtime"),
+                        Map.entry("decision", decision),
+                        Map.entry("supportSafe", true))));
+    }
+
     public record WeaverRuntimeInstance(
             String userRef,
             String containerId,
@@ -672,5 +790,12 @@ public class WeaverRuntimeService {
             String actualRuntimeProfileHash,
             String desiredPolicyVersion,
             String actualPolicyVersion) {
+    }
+
+    public record WeaverRuntimeCustomizationDecision(
+            boolean accepted,
+            String policyReason,
+            WeaverRuntimeProfileResponse profile,
+            String memberImpact) {
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverApprovalReceipt.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverApprovalReceipt.java
@@ -1,0 +1,46 @@
+package com.massimotter.weave.backend.weaver;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+public record WeaverApprovalReceipt(
+        String receiptRef,
+        String actorRef,
+        String action,
+        List<String> scopeRefs,
+        String policyVersion,
+        String expiresAt,
+        String auditRef) {
+
+    public WeaverApprovalReceipt {
+        receiptRef = safe(receiptRef);
+        actorRef = safe(actorRef);
+        action = safe(action);
+        scopeRefs = List.copyOf(scopeRefs == null ? List.of() : scopeRefs);
+        policyVersion = safe(policyVersion);
+        expiresAt = safe(expiresAt);
+        auditRef = safe(auditRef);
+    }
+
+    public boolean validFor(String actorRef, String action) {
+        return !receiptRef.isBlank()
+                && this.actorRef.equals(actorRef)
+                && this.action.equals(action)
+                && !policyVersion.isBlank()
+                && auditRef.startsWith("audit://")
+                && expiresInFuture();
+    }
+
+    private boolean expiresInFuture() {
+        try {
+            return Instant.parse(expiresAt).isAfter(Instant.now());
+        } catch (DateTimeParseException ignored) {
+            return false;
+        }
+    }
+
+    private static String safe(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolInvocationRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolInvocationRequest.java
@@ -16,7 +16,8 @@ public record WeaverToolInvocationRequest(
         List<String> grantedCapabilities,
         List<String> scopedToolGrants,
         Map<String, Object> input,
-        String approvalReceiptRef) {
+        String approvalReceiptRef,
+        WeaverApprovalReceipt approvalReceipt) {
 
     public WeaverToolInvocationRequest(
             String toolName,
@@ -37,7 +38,37 @@ public record WeaverToolInvocationRequest(
                 grantedCapabilities,
                 List.of(toolName == null ? "" : toolName),
                 input,
-                approvalReceiptRef);
+                approvalReceiptRef,
+                null);
+    }
+
+    public WeaverToolInvocationRequest(
+            String toolName,
+            String userRef,
+            String runtimeProfileHash,
+            String runtimeProfileUserRef,
+            String runtimeProfileSignature,
+            boolean runtimeProfileRevoked,
+            String runtimeTokenExpiresAt,
+            boolean consentGranted,
+            List<String> grantedCapabilities,
+            List<String> scopedToolGrants,
+            Map<String, Object> input,
+            String approvalReceiptRef) {
+        this(
+                toolName,
+                userRef,
+                runtimeProfileHash,
+                runtimeProfileUserRef,
+                runtimeProfileSignature,
+                runtimeProfileRevoked,
+                runtimeTokenExpiresAt,
+                consentGranted,
+                grantedCapabilities,
+                scopedToolGrants,
+                input,
+                approvalReceiptRef,
+                null);
     }
 
     public WeaverToolInvocationRequest {
@@ -52,5 +83,8 @@ public record WeaverToolInvocationRequest(
         grantedCapabilities = List.copyOf(grantedCapabilities == null ? List.of() : grantedCapabilities);
         scopedToolGrants = List.copyOf(scopedToolGrants == null ? List.of() : scopedToolGrants);
         input = Map.copyOf(input == null ? Map.of() : input);
+        if ((approvalReceiptRef == null || approvalReceiptRef.isBlank()) && approvalReceipt != null) {
+            approvalReceiptRef = approvalReceipt.receiptRef();
+        }
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -52,25 +52,35 @@ public class WeaverToolRegistry {
                     "auditRef", auditRef(request.toolName(), "scoped_grant_missing")));
             return blocked(request.toolName(), "scoped_grant_missing", "Tool is not included in the signed scoped grant.");
         }
-        if (definition.writeLike() && (request.approvalReceiptRef() == null || request.approvalReceiptRef().isBlank())) {
-            audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), "approval_required", Map.of(
-                    "domain", definition.domain(),
-                    "auditRef", auditRef(request.toolName(), "approval_required")));
-            return new WeaverToolInvocationResult(
-                    request.toolName(),
-                    "approval_required",
-                    true,
-                    true,
-                    Map.of(
-                            "approvalPolicy", definition.approvalRequirement().name(),
-                            "auditRef", auditRef(request.toolName(), "approval_required")),
-                    "This action requires an approval receipt before Weaver may continue.");
+        boolean approvalReceiptValidated = false;
+        if (definition.writeLike()) {
+            WeaverApprovalReceipt approvalReceipt = request.approvalReceipt();
+            if (approvalReceipt == null || !approvalReceipt.validFor(request.userRef(), request.toolName())) {
+                audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), "approval_required", Map.of(
+                        "domain", definition.domain(),
+                        "approvalReceiptValidated", false,
+                        "auditRef", auditRef(request.toolName(), "approval_required")));
+                return new WeaverToolInvocationResult(
+                        request.toolName(),
+                        "approval_required",
+                        true,
+                        true,
+                        Map.of(
+                                "approvalPolicy", definition.approvalRequirement().name(),
+                                "approvalReceiptValidated", false,
+                                "auditRef", auditRef(request.toolName(), "approval_required")),
+                        "This action requires a valid approval receipt before Weaver may continue.");
+            }
+            approvalReceiptValidated = true;
         }
         audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), "invoked", Map.of(
                 "domain", definition.domain(),
                 "mode", definition.mode().name(),
                 "consentGranted", true,
                 "approvalReceiptRef", request.approvalReceiptRef() == null ? "none" : request.approvalReceiptRef(),
+                "approvalReceiptAuditRef", request.approvalReceipt() == null ? "none" : request.approvalReceipt().auditRef(),
+                "approvalReceiptPolicyVersion", request.approvalReceipt() == null ? "none" : request.approvalReceipt().policyVersion(),
+                "approvalReceiptValidated", approvalReceiptValidated,
                 "auditRef", auditRef(request.toolName(), "invoked")));
         return new WeaverToolInvocationResult(
                 request.toolName(),
@@ -81,6 +91,7 @@ public class WeaverToolRegistry {
                         "domain", definition.domain(),
                         "result", "support-safe-placeholder",
                         "canonicalRefs", canonicalRefs(request.input()),
+                        "approvalReceiptAuditRef", request.approvalReceipt() == null ? "none" : request.approvalReceipt().auditRef(),
                         "rawProviderPayload", "redacted",
                         "auditRef", auditRef(request.toolName(), "invoked")),
                 "Tool invocation went through a Weave domain capability boundary; raw provider APIs are not exposed.");

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -77,7 +77,7 @@ class WeaverRuntimeServiceTest {
         assertThat(profile.signature()).startsWith("weave-signature:v1:");
         assertThat(profile.revoked()).isFalse();
         assertThat(profile.revocationStatus()).isEqualTo("active");
-        assertThat(profile.previousProfileHash()).startsWith("sha256:");
+        assertThat(profile.previousProfileHash()).isEqualTo("none");
         assertThat(profile.workspacePath()).startsWith("/var/lib/weave/weaver/");
         assertThat(profile.isolatedAgentDirectory()).isEqualTo(".weaver/agents");
         assertThat(profile.dockerNetworkMode()).isEqualTo("none");
@@ -151,6 +151,54 @@ class WeaverRuntimeServiceTest {
         assertThat(regenerated.channelProjection()).containsEntry("channelId", "channels.weave-chat");
         assertThat(regenerated.channelProjection()).containsEntry("providerRef", "provider:chat:selected-by-admin");
         assertThat(regenerated.supportSafeProfileReceipt()).containsEntry("regeneratesOnPolicyOrProviderChange", true);
+    }
+
+    @Test
+    void versionsProfileCustomizationsAndRollsBackToPreviousProfile() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverRuntimeService service = service(true, runtimeProperties(true), audit);
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+
+        var base = service.profileFor(member);
+        var customized = service.applyRuntimeCustomization(member, Map.of(
+                "displayName", "Otter Weaver",
+                "style", "concise",
+                "language", "en",
+                "memoryOptIn", true));
+
+        assertThat(customized.accepted()).isTrue();
+        assertThat(customized.profile().profileVersion()).isNotEqualTo(base.profileVersion());
+        assertThat(customized.profile().runtimeProfileHash()).isNotEqualTo(base.runtimeProfileHash());
+        assertThat(customized.profile().previousProfileHash()).isEqualTo(base.runtimeProfileHash());
+
+        var rolledBack = service.rollbackRuntimeProfile(member, base.runtimeProfileHash());
+
+        assertThat(rolledBack.runtimeProfileHash()).isEqualTo(base.runtimeProfileHash());
+        assertThat(rolledBack.profileVersion()).isEqualTo(base.profileVersion());
+        assertThat(audit.events()).extracting(event -> event.action())
+                .contains(AuditAction.ADMIN_POLICY_UPDATED, AuditAction.WEAVER_RUNTIME_PROFILE_ROLLED_BACK);
+        assertThat(audit.events().toString()).doesNotContain("member@example.invalid", "openclaw.json", "Bearer ");
+    }
+
+    @Test
+    void blocksForbiddenCustomizationAttemptsAndAuditsPolicyReason() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverRuntimeService service = service(true, runtimeProperties(true), audit);
+
+        var decision = service.applyRuntimeCustomization(
+                jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime")),
+                Map.of("rawOpenClawConfig", "openclaw.json {\"apiKey\":\"sk-secret\"}"));
+
+        assertThat(decision.accepted()).isFalse();
+        assertThat(decision.policyReason()).isEqualTo("admin_policy_forbids_raw_openclaw_config");
+        assertThat(decision.profile()).isNull();
+        assertThat(audit.events()).hasSize(1);
+        assertThat(audit.events().get(0).action()).isEqualTo(AuditAction.ADMIN_POLICY_UPDATED);
+        assertThat(audit.events().get(0).payload())
+                .containsEntry("decision", "blocked")
+                .containsEntry("policyReason", "admin_policy_forbids_raw_openclaw_config")
+                .containsEntry("supportSafe", true);
+        assertThat(audit.events().toString()).doesNotContain("sk-secret", "Bearer ", "refresh_token");
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -84,17 +84,32 @@ class WeaverToolRegistryTest {
                 "boards.comment",
                 "user:abc123",
                 "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "user:abc123",
+                signature(),
+                false,
+                future(),
+                true,
                 List.of("weaver.boards_write"),
+                List.of("boards.comment"),
                 Map.of(
                         "spaceRef", "space:control-room",
                         "decisionRef", "decision:governed-weaver",
                         "boardTaskRef", "board-task:WEAVE-601",
                         "body", "Looks good"),
-                "approval:abc123"));
+                "approval:abc123",
+                new WeaverApprovalReceipt(
+                        "approval:abc123",
+                        "user:abc123",
+                        "boards.comment",
+                        List.of("board-task:WEAVE-601"),
+                        "policy:test",
+                        future(),
+                        "audit://weaver-approval/test")));
 
         assertThat(approved.status()).isEqualTo("ok");
         assertThat(approved.approvalRequired()).isFalse();
         assertThat(approved.redactedResult()).containsEntry("rawProviderPayload", "redacted");
+        assertThat(approved.redactedResult()).containsEntry("approvalReceiptAuditRef", "audit://weaver-approval/test");
         assertThat(approved.redactedResult().get("canonicalRefs").toString())
                 .contains("space:control-room", "decision:governed-weaver", "board-task:WEAVE-601")
                 .doesNotContain("Looks good", "providerRoom", "matrix");
@@ -102,6 +117,10 @@ class WeaverToolRegistryTest {
         assertThat(audit.events()).allSatisfy(event -> assertThat(event.payload()).containsEntry("supportSafe", true));
         assertThat(audit.events()).allSatisfy(event -> assertThat(event.payload())
                 .containsKeys("runtimeProfileHash", "user", "tool", "action", "domain", "providerRef", "credentialRef", "decision", "auditRef"));
+        assertThat(audit.events().get(1).payload())
+                .containsEntry("approvalReceiptValidated", true)
+                .containsEntry("approvalReceiptAuditRef", "audit://weaver-approval/test")
+                .containsEntry("approvalReceiptPolicyVersion", "policy:test");
     }
 
     @Test

--- a/tools/weaver_customization_check.py
+++ b/tools/weaver_customization_check.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Validate Sprint 25 Weaver customization evidence, scoreboard, and claim gates."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_DIR = ROOT / "release" / "provider-lab" / "weaver-runtime"
+PROFILE = ARTIFACT_DIR / "profile-customization-proof.fixture.json"
+POLICY = ARTIFACT_DIR / "policy-boundary-proof.fixture.json"
+TOOLS = ARTIFACT_DIR / "tool-approval-gate-proof.fixture.json"
+CLAIMS = ARTIFACT_DIR / "sprint-25-claim-gate.fixture.json"
+SCOREBOARD = ARTIFACT_DIR / "sprint-25-scoreboard.json"
+EVIDENCE = ROOT / "docs" / "evidence" / "weaver-customization-report.md"
+CLOSURE = ROOT / "docs" / "sprint-25-closure-report.md"
+
+SECRET_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"bearer\s+[a-z0-9._-]+",
+        r"refresh[_-]?token\s*[:=]\s*[^\s,}\"]+",
+        r"api[_-]?key\s*[:=]",
+        r"secret\s*[:=]",
+        r"rawProviderPayload\s*[:=]",
+        r"openclaw\.json\s*[{:]",
+        r"memory://",
+        r"https?://[^\s)\"]*@",
+    ]
+]
+
+
+def fail(message: str) -> None:
+    print(f"weaver-customization-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing {path.relative_to(ROOT)}")
+    except json.JSONDecodeError as error:
+        fail(f"invalid JSON in {path.relative_to(ROOT)}: {error}")
+    if not isinstance(value, dict):
+        fail(f"{path.relative_to(ROOT)} must contain a JSON object")
+    return value
+
+
+def assert_support_safe(value: Any, label: str) -> None:
+    text = json.dumps(value, sort_keys=True)
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(text):
+            fail(f"{label} contains forbidden support-unsafe pattern {pattern.pattern!r}")
+
+
+def validate_profile(artifact: dict[str, Any]) -> None:
+    if artifact.get("artifactKind") != "weave-weaver-runtime-sprint-25-profile-customization-proof":
+        fail("profile customization artifact kind mismatch")
+    change = artifact.get("profileChange", {})
+    if change.get("versionIncremented") is not True or change.get("hashChanged") is not True:
+        fail("profile customization must increment version and change profile hash")
+    if change.get("previousProfileHash") != change.get("baseProfileHash"):
+        fail("customized profile must point at the previous profile hash")
+    rollback = artifact.get("rollback", {})
+    if rollback.get("restored") is not True or rollback.get("rollbackProfileHash") != change.get("baseProfileHash"):
+        fail("rollback must restore the previous profile hash")
+    allowed = set(artifact.get("allowedCustomizationFields", []))
+    required = {"displayName", "style", "language", "answerStyle", "workingHours", "notifications", "personalNotes", "memoryOptIn", "allowedSkills", "workspaceStructure"}
+    if not required.issubset(allowed):
+        fail("allowed customization field list is incomplete")
+
+
+def validate_policy(artifact: dict[str, Any]) -> None:
+    if artifact.get("artifactKind") != "weave-weaver-runtime-sprint-25-policy-boundary-proof":
+        fail("policy boundary artifact kind mismatch")
+    attempts = artifact.get("forbiddenCustomizationAttempts")
+    if not isinstance(attempts, list) or len(attempts) < 4:
+        fail("policy boundary proof must list forbidden customization attempts")
+    if any(attempt.get("decision") != "blocked" or not attempt.get("policyReason") for attempt in attempts):
+        fail("every forbidden customization attempt must be blocked with a policy reason")
+    for key in ["rawOpenClawConfigAccepted", "rawSecretsAccepted", "uncheckedPluginsAccepted", "teamWideActionsAccepted"]:
+        if artifact.get(key) is not False:
+            fail(f"{key} must be false")
+    required_audit = {"user", "action", "domain", "decision", "policyReason", "requestedFields", "supportSafe"}
+    if set(artifact.get("auditRequiredFields", [])) != required_audit:
+        fail("policy audit required fields must be exact")
+
+
+def validate_tools(artifact: dict[str, Any]) -> None:
+    if artifact.get("artifactKind") != "weave-weaver-runtime-sprint-25-tool-approval-gate-proof":
+        fail("tool approval artifact kind mismatch")
+    scenarios = artifact.get("scenarios", {})
+    expected = {
+        "readOnlyAllowed": "passed",
+        "writeWithoutApproval": "approval_required",
+        "writeWithApproval": "ok",
+        "revokedToolBlocked": "runtime_profile_revoked",
+        "expiredTokenBlocked": "runtime_token_expired",
+        "overbroadGrantBlocked": "overbroad_grant",
+        "missingConsentBlocked": "consent_required",
+    }
+    for key, value in expected.items():
+        if scenarios.get(key) != value:
+            fail(f"tool scenario {key} must be {value}")
+    receipt = artifact.get("approvalReceipt", {})
+    required = {"receiptRef", "actorRef", "action", "scopeRefs", "policyVersion", "expiresAt", "auditRef"}
+    if set(receipt.get("requiredFields", [])) != required:
+        fail("approval receipt required fields must be exact")
+    if receipt.get("validatedBeforeInvocation") is not True or receipt.get("auditRefRecorded") is not True:
+        fail("approval receipt must be validated and audited before invocation")
+
+
+def validate_claims(artifact: dict[str, Any]) -> None:
+    if artifact.get("artifactKind") != "weave-weaver-runtime-sprint-25-claim-gate":
+        fail("claim gate artifact kind mismatch")
+    claim = artifact.get("acceptedClaim", {}).get("claim", "")
+    for term in ["Sprint 25", "support-safe", "Weaver customization", "RuntimeProfile", "ApprovalReceipts", "rollback"]:
+        if term not in claim:
+            fail(f"accepted claim missing {term!r}")
+    rejected_text = "\n".join(item.get("claim", "") for item in artifact.get("rejectedClaims", []))
+    for forbidden in ["customer-ready", "raw OpenClaw config", "without approval receipts", "Teams"]:
+        if forbidden.lower() not in rejected_text.lower():
+            fail(f"claim gate missing rejected overclaim {forbidden!r}")
+    boundary = artifact.get("claimBoundary", "").lower()
+    for phrase in ["provider-lab", "production pa availability", "customer-ready weaver", "raw openclaw config", "raw secrets"]:
+        if phrase not in boundary:
+            fail(f"claim boundary missing {phrase}")
+
+
+def validate_scoreboard(scoreboard: dict[str, Any]) -> None:
+    if scoreboard.get("artifactKind") != "weave-weaver-runtime-sprint-25-scoreboard":
+        fail("scoreboard artifact kind mismatch")
+    for key in ["profileVersioning", "policyBoundaries", "toolApprovalGates", "claimSafety"]:
+        if scoreboard.get("fields", {}).get(key) != "green":
+            fail(f"scoreboard field {key} must be green")
+    for issue in ["635", "636", "637", "638"]:
+        if scoreboard.get("issues", {}).get(issue) != "green":
+            fail(f"scoreboard issue {issue} must be green")
+    if scoreboard.get("openReleaseBlockers") != [] or scoreboard.get("sprint25ExitGate") != "green":
+        fail("Sprint 25 exit gate must be green with no release blockers")
+    for relpath in scoreboard.get("requiredArtifacts", []):
+        if not (ROOT / relpath).exists():
+            fail(f"scoreboard references missing artifact {relpath}")
+
+
+def validate_docs() -> None:
+    for path in [EVIDENCE, CLOSURE]:
+        if not path.exists():
+            fail(f"missing {path.relative_to(ROOT)}")
+        text = path.read_text(encoding="utf-8")
+        for issue in ["#635", "#636", "#637", "#638"]:
+            if issue not in text:
+                fail(f"{path.relative_to(ROOT)} missing {issue}")
+        for artifact in [PROFILE, POLICY, TOOLS, CLAIMS, SCOREBOARD]:
+            if str(artifact.relative_to(ROOT)) not in text:
+                fail(f"{path.relative_to(ROOT)} missing {artifact.relative_to(ROOT)}")
+
+
+def main() -> None:
+    profile = load(PROFILE)
+    policy = load(POLICY)
+    tools = load(TOOLS)
+    claims = load(CLAIMS)
+    scoreboard = load(SCOREBOARD)
+    for label, artifact in [("profile", profile), ("policy", policy), ("tools", tools), ("claims", claims), ("scoreboard", scoreboard)]:
+        if artifact.get("supportSafe") is not True:
+            fail(f"{label} must be supportSafe")
+        assert_support_safe(artifact, label)
+    validate_profile(profile)
+    validate_policy(policy)
+    validate_tools(tools)
+    validate_claims(claims)
+    validate_scoreboard(scoreboard)
+    validate_docs()
+    print("weaver-customization-check: ok issues=635,636,637,638 claims=scoped provider-lab customer_ready=false")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Proves Sprint 25 Weaver customization across RuntimeProfile versioning/rollback, admin policy boundaries, tool approval receipts, and scoped claim gating.
- Adds Sprint 25 provider-lab fixtures, scoreboard, closure report, and a release-evidence validator.

## Scope and user impact

- Admin/operator impact: customization evidence now shows allowed personal settings are versioned and rollbackable while forbidden raw config/secret/MCP/plugin/team-wide attempts fail closed with support-safe audit reasons.
- Developer impact: Weaver tool writes now validate a structured ApprovalReceipt before invocation and record receipt audit metadata.
- Release impact: customized-Weaver wording is gated by `weaverCustomizationCheck` and `releaseEvidenceCheck`.

## Spec / acceptance link

- Issue: closes #635, closes #636, closes #637, closes #638
- Repo spec or spec note: `docs/governed-weaver-runtime-security-contract.md`, `specs/0007-governed-weaver-runtime/tasks.md`
- Acceptance scenario / mapping marker when product behavior changed: server contract tests plus `release/provider-lab/weaver-runtime/sprint-25-scoreboard.json`
- Product-core questions intentionally left unresolved: none for Sprint 25; Forgejo/Admin Console setup proof remains Sprint 26/#659.

## Branch, target, and release path

- [x] Branch started from current `origin/main`
- [x] PR targets protected `main`
- [x] No long-lived `dev`/`testing`/`staging` branch involved
- [x] Production release is not implied by this merge

## Screenshots or docs impact

- Adds `docs/evidence/weaver-customization-report.md` and `docs/sprint-25-closure-report.md`.

## Accessibility and localization

- No UI string or screenshot changes.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: Sprint 25 release/evidence fixtures and server contract tests.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented: scoped security and quality gap audits were used before implementation.

## Checks run

- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [x] `make release-notes-check` / `./gradlew releaseEvidenceCheck --console=plain`
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant for Sprint 25 provider-lab evidence; Sprint 26/#659 covers local Forgejo setup proof.

Additional targeted checks:

- [x] `python3 tools/weaver_customization_check.py`
- [x] `cd server && ./gradlew test --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest' --tests 'com.massimotter.weave.backend.weaver.WeaverToolRegistryTest' --console=plain`

## Notes for reviewers

- Claim boundary is deliberately narrow: provider-lab Sprint 25 evidence only, no customer-ready Weaver or production PA availability claim.
