### PR TITLE
feat: define Admin Console CI/CD setup proof

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ registerRootCommandTask('providerLabCheck', ['python3', 'tools/provider_lab_chec
 registerRootCommandTask('chatProviderSwitchCheck', ['python3', 'tools/chat_provider_switch_check.py'], 'Validate Sprint 23 Chat Provider Switch canonical object coverage, LossyFieldReport enforcement, and ProviderRef redaction fixtures.')
 registerRootCommandTask('weaverRuntimeFactoryCheck', ['python3', 'tools/weaver_runtime_factory_check.py'], 'Validate Sprint 24 Weaver Runtime Factory lifecycle, reconciliation, isolation, and claim-gate fixtures.')
 registerRootCommandTask('weaverCustomizationCheck', ['python3', 'tools/weaver_customization_check.py'], 'Validate Sprint 25 Weaver customization profile, policy, tool approval, and claim-gate fixtures.')
+registerRootCommandTask('adminCicdOrchestrationCheck', ['python3', 'tools/admin_cicd_orchestration_check.py'], 'Validate Sprint 26 Admin Console CI/CD setup orchestration contract and local Forgejo proof fixtures.')
 registerRootCommandTask('specContractTest', ['python3', 'tools/spec_contract_check_test.py'], 'Run fixture tests for the repo-local Weave spec contract guard.')
 registerRootCommandTask('androidReleaseIdentityCheck', ['python3', 'tools/android_release_identity_check.py'], 'Validate Android package identity and release-signing fail-safe posture.')
 registerRootCommandTask('adminDependencyPolicyCheck', ['python3', 'tools/admin_console_dependency_policy_check.py'], 'Validate Admin Console dependency pins and lockfile policy.')
@@ -78,7 +79,7 @@ tasks.register('releaseReadinessCheck', Exec) {
     commandLine execCommand(args)
     outputs.upToDateWhen { false }
 }
-registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_claim_matrix_check.py && python3 tools/product_trust_claim_matrix_check.py && python3 tools/product_reality_claim_gate_check.py && python3 tools/provider_lab_check.py && python3 tools/chat_provider_switch_check.py && python3 tools/weaver_runtime_factory_check.py && python3 tools/weaver_customization_check.py && python3 tools/release_trust_claim_control_check.py && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py && python3 tools/release_readiness_check_test.py'], 'Validate release notes structure, README markers, provider reality, product-reality, Sprint 22 provider-lab gate, Sprint 23 chat-switch contract fixtures, Sprint 24 Weaver runtime factory fixtures, product-trust and release-trust claim matrices, labels, generator fixture evidence, Sprint 5 project-readiness closure evidence, Sprint 6 enterprise release gates, and RC readiness fixtures.')
+registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_claim_matrix_check.py && python3 tools/product_trust_claim_matrix_check.py && python3 tools/product_reality_claim_gate_check.py && python3 tools/provider_lab_check.py && python3 tools/chat_provider_switch_check.py && python3 tools/weaver_runtime_factory_check.py && python3 tools/weaver_customization_check.py && python3 tools/admin_cicd_orchestration_check.py && python3 tools/release_trust_claim_control_check.py && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py && python3 tools/release_readiness_check_test.py'], 'Validate release notes structure, README markers, provider reality, product-reality, Sprint 22 provider-lab gate, Sprint 23 chat-switch contract fixtures, Sprint 24 Weaver runtime factory fixtures, product-trust and release-trust claim matrices, labels, generator fixture evidence, Sprint 5 project-readiness closure evidence, Sprint 6 enterprise release gates, and RC readiness fixtures.')
 
 tasks.register('docsCheck') {
     group = 'verification'
@@ -121,6 +122,7 @@ ext.ciEvidenceGates = [
     'productRealityClaimGateCheck',
     'weaverRuntimeFactoryCheck',
     'weaverCustomizationCheck',
+    'adminCicdOrchestrationCheck',
     'androidReleaseIdentityCheck',
     'adminDependencyPolicyCheck',
     'releaseEvidenceCheck',
@@ -235,6 +237,8 @@ List<String> artifactPathsForGate(String gateName) {
             return ['docs/product-reality-foundation.md', 'release/product-reality-gates.json', 'tools/product_reality_claim_gate_check.py']
         case 'weaverCustomizationCheck':
             return ['release/provider-lab/weaver-runtime/sprint-25-scoreboard.json', 'release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json', 'tools/weaver_customization_check.py']
+        case 'adminCicdOrchestrationCheck':
+            return ['specs/admin-ci-cd-orchestration-contract.md', 'release/provider-lab/admin-cicd/local-forgejo-setup-proof.fixture.json', 'tools/admin_cicd_orchestration_check.py']
         case 'releaseEvidenceCheck':
             return ['README.md', 'tools/fixtures/release_notes_unreleased.expected.md']
         case 'projectReadinessEvidenceCheck':

--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -38,6 +38,7 @@ void main() {
         'Identity reconcile and offboarding fail closed before destructive changes',
         'Weaver runtime and tools remain preflight-only',
         'Release promotion requires accessibility and restore evidence',
+        'Admin sees missing Forgejo runner registration before pipeline dispatch',
         'Weave Home starts the daily work loop',
         'A normal member sees a user-ready organization flow',
         'Admin sees provider categories before member use',

--- a/docs/evidence/admin-cicd-setup-proof.md
+++ b/docs/evidence/admin-cicd-setup-proof.md
@@ -1,0 +1,31 @@
+# Admin Console CI/CD setup proof
+
+Status: Sprint 26 / #659 contract and local Forgejo proof seam.
+
+## Scope
+
+This evidence establishes the Admin Console as the canonical setup surface and CI/CD as the execution/validation backend. It is support-safe and contract-first: it validates provider manifests, SecretRef/variable-name display, pipeline run references, status copy, and fail-closed behavior. It does not dispatch a real pipeline while the local Forgejo runner is missing.
+
+## Artifacts
+
+- `specs/admin-ci-cd-orchestration-contract.md` — #659 contract for setup states, `PipelineProviderManifest`, `PipelineRunRef`, SecretRef validation, fail-closed behavior, and the local Forgejo seam.
+- `release/provider-lab/admin-cicd/pipeline-provider-manifest.fixture.json` — GitHub Actions, Azure DevOps, local Forgejo Actions, and Woodpecker manifest coverage.
+- `release/provider-lab/admin-cicd/local-forgejo-setup-proof.fixture.json` — local Forgejo target proof with connection refs, secret/variable names, runner-missing preflight block, and support-safe run-ref shape.
+- `release/provider-lab/admin-cicd/admin-console-copy.fixture.json` — Admin Console missing-name/status/progress/fail-closed copy model.
+- `e2e/features/sprint_26_admin_cicd_setup.feature` — Gherkin mapping for the first setup-flow proof.
+- `docs/evidence/admin-cicd-ui-test-plan.md` — Admin Console UI path coverage plan for provider selection, fallback, missing-secret display, blocked trigger, run status, dry-run, abort, apply, and post-reconcile evidence.
+
+## Local Forgejo status
+
+Support-safe local diagnostic on 2026-06-03 found the Forgejo service and database service present. No act_runner/Woodpecker runner service was present. The setup proof therefore blocks trigger before dispatch with `runner_missing` and shows only the missing runner-registration name/role in Admin Console copy.
+
+## Gates
+
+- `python3 tools/admin_cicd_orchestration_check.py`
+- `./gradlew releaseEvidenceCheck --console=plain`
+- `./gradlew acceptanceContract --console=plain` after the Gherkin scenario mapping is updated.
+- `./gradlew specContract docsCheck --console=plain` for the new contract and evidence docs.
+
+## Claim boundary
+
+This proof may claim that Weave has a support-safe contract and local Forgejo preflight seam for Admin Console-driven CI/CD setup orchestration. It must not claim production cutover, customer-ready migration automation, live Forgejo pipeline dispatch, runner installation, commercial adapter implementation, raw CI log access, raw provider diagnostics, token visibility, or secret-value validation.

--- a/docs/evidence/admin-cicd-ui-test-plan.md
+++ b/docs/evidence/admin-cicd-ui-test-plan.md
@@ -1,0 +1,28 @@
+# Admin CI/CD setup UI test plan
+
+Status: Sprint 26 / #659 support-safe UI coverage plan.
+
+## Required Admin Console paths
+
+| Path | Expected Admin Console result | Safety rule |
+| --- | --- | --- |
+| Provider-domain selection | Admin chooses Weave domains and target provider families in product language. | No provider SDK fields or raw endpoints in member-facing copy. |
+| Existing adapter question | Admin can state whether a current adapter/provider should be reused. | Existing provider details remain support-safe refs. |
+| Self-hosted fallback | When no adapter exists, Admin Console recommends self-hosted options such as Forgejo/Woodpecker-style CI/CD. | Recommendation does not imply runner installation or mutation. |
+| Missing-secret display | Admin sees missing names and roles such as `WEAVE_FORGEJO_TOKEN` or `FORGEJO_ACTIONS_RUNNER_REGISTRATION`. | Values, tokens, raw URLs, raw CI logs, payloads, and tenant URLs stay hidden. |
+| Trigger blocked | If preflight lacks runner readiness, SecretRefs, approval, provider support, or rate-limit capacity, trigger remains unavailable. | Fail closed before dispatch. |
+| Run started | After preflight and approval pass, Admin Console shows a support-safe `PipelineRunRef`. | No raw provider link or log required to continue in Weave. |
+| Dry-run complete | Admin sees mapping/loss report and next actions. | Dry-run is not migration apply or go-live. |
+| Migration aborted | Admin sees cancellation/abort status and evidence refs. | Provider-specific cancellation diagnostics are redacted. |
+| Migration applied | Admin sees apply evidence only when the domain contract permits apply. | Apply still does not equal production go-live. |
+| Post-reconcile evidence | Admin sees post-reconcile readiness, evidence freshness, and blockers. | Go-live approval remains separate. |
+
+## Local Forgejo scenario
+
+Current local Forgejo proof is intentionally blocked before dispatch because runner readiness is missing. The UI test should assert:
+
+- required variables/SecretRefs are named, not valued;
+- `FORGEJO_ACTIONS_RUNNER_REGISTRATION` is displayed as the missing runner-registration name;
+- setup state is `preflight_blocked` with reason `runner_missing`;
+- no pipeline dispatch action is available;
+- raw CI logs, provider payloads, credential-bearing URLs, tenant URLs, token values, secret values, and member content are absent.

--- a/e2e/features/sprint_26_admin_cicd_setup.feature
+++ b/e2e/features/sprint_26_admin_cicd_setup.feature
@@ -1,0 +1,11 @@
+Feature: Sprint 26 Admin Console CI/CD setup orchestration
+  The Admin Console is the canonical setup surface while CI/CD executes and validates setup.
+
+  @sprint26-admin-cicd-setup
+  Scenario: Admin sees missing Forgejo runner registration before pipeline dispatch
+    Given an admin registers the local Forgejo CI/CD provider through support-safe refs
+    And required Forgejo variables and SecretRefs are named without displaying values
+    When setup preflight checks runner readiness before dispatch
+    Then the Admin Console shows the missing name "FORGEJO_ACTIONS_RUNNER_REGISTRATION"
+    And the setup state is blocked with reason "runner_missing"
+    And no pipeline dispatch, secret value, raw CI log, provider payload, credential-bearing URL, tenant URL, or member content is exposed

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -1421,6 +1421,43 @@
           ]
         }
       ]
+    },
+    {
+      "feature": "e2e/features/sprint_26_admin_cicd_setup.feature",
+      "executableTest": "tools/admin_cicd_orchestration_check.py",
+      "evidenceMode": "offline-spec",
+      "tag": "@sprint26-admin-cicd-setup",
+      "scenario": "Admin sees missing Forgejo runner registration before pipeline dispatch",
+      "evidenceMarkers": [
+        "SPRINT26_ADMIN_CICD_SETUP_PROOF"
+      ],
+      "additionalEvidence": [
+        {
+          "path": "specs/admin-ci-cd-orchestration-contract.md",
+          "fragments": [
+            "The Organization/Admin Console is the canonical setup surface",
+            "PipelineProviderManifest v1",
+            "PipelineRunRef v1",
+            "Local Forgejo proof seam"
+          ]
+        },
+        {
+          "path": "release/provider-lab/admin-cicd/local-forgejo-setup-proof.fixture.json",
+          "fragments": [
+            "FORGEJO_ACTIONS_RUNNER_REGISTRATION",
+            "runner_missing",
+            "none-trigger-blocked-before-dispatch"
+          ]
+        },
+        {
+          "path": "release/provider-lab/admin-cicd/admin-console-copy.fixture.json",
+          "fragments": [
+            "Setup is blocked until required CI/CD names exist.",
+            "values stay hidden",
+            "Runner readiness is missing."
+          ]
+        }
+      ]
     }
   ]
 }

--- a/release/provider-lab/admin-cicd/admin-console-copy.fixture.json
+++ b/release/provider-lab/admin-cicd/admin-console-copy.fixture.json
@@ -1,0 +1,61 @@
+{
+  "artifactKind": "weave-admin-cicd-admin-console-copy-v1",
+  "issue": 659,
+  "supportSafe": true,
+  "setupStates": [
+    "provider_discovery",
+    "ci_cd_registration",
+    "domain_selection",
+    "adapter_question",
+    "self_hosted_recommendation",
+    "target_provider_selection",
+    "preflight",
+    "dry_run_mapping",
+    "admin_approval",
+    "trigger_requested",
+    "run_observing",
+    "migration_apply_candidate",
+    "abort_requested",
+    "resume_requested",
+    "post_reconcile_readiness",
+    "evidence_complete",
+    "go_live_approval_required"
+  ],
+  "missingSecretCopy": {
+    "headline": "Setup is blocked until required CI/CD names exist.",
+    "body": "Add the missing repository variables or SecretRefs in your approved CI/CD or secret-manager surface. Weave shows required names and roles only; values stay hidden.",
+    "displayedNames": [
+      "WEAVE_FORGEJO_TOKEN",
+      "WEAVE_FORGEJO_API_URL",
+      "FORGEJO_ACTIONS_RUNNER_REGISTRATION"
+    ],
+    "displayedRoles": ["repository_secret", "repository_variable", "runner_registration"],
+    "forbiddenDisplay": ["secret values", "tokens", "raw CI logs", "provider payloads", "credential-bearing URLs", "tenant URLs", "member content"]
+  },
+  "progressCopy": [
+    {
+      "state": "preflight",
+      "copy": "Weave is checking required CI/CD names, runner readiness, approval gates, and redaction rules before dispatch."
+    },
+    {
+      "state": "trigger_requested",
+      "copy": "Weave has requested the setup pipeline through the registered CI/CD backend. Stay in Admin Console for progress."
+    },
+    {
+      "state": "run_observing",
+      "copy": "Weave is observing the pipeline run through a support-safe run reference. Raw logs and provider payloads stay hidden."
+    },
+    {
+      "state": "evidence_complete",
+      "copy": "Setup evidence is captured. Go-live approval remains separate."
+    }
+  ],
+  "failClosedCopy": [
+    "Pipeline provider is not configured.",
+    "Required SecretRef or variable name is missing.",
+    "Admin approval is missing or expired.",
+    "Runner readiness is missing.",
+    "Provider status is unknown after timeout.",
+    "Rate limit exhausted; retry is blocked until the provider window resets."
+  ]
+}

--- a/release/provider-lab/admin-cicd/local-forgejo-setup-proof.fixture.json
+++ b/release/provider-lab/admin-cicd/local-forgejo-setup-proof.fixture.json
@@ -1,0 +1,87 @@
+{
+  "artifactKind": "weave-admin-cicd-local-forgejo-setup-proof-v1",
+  "issue": 659,
+  "supportSafe": true,
+  "proofTarget": "Massimo local Forgejo",
+  "providerKey": "local-forgejo-actions",
+  "connectionRefs": {
+    "baseUrlVariable": "WEAVE_FORGEJO_BASE_URL",
+    "apiUrlVariable": "WEAVE_FORGEJO_API_URL",
+    "usernameVariable": "WEAVE_FORGEJO_USERNAME",
+    "sshHostVariable": "WEAVE_FORGEJO_SSH_HOST",
+    "sshPortVariable": "WEAVE_FORGEJO_SSH_PORT",
+    "tokenSecret": "WEAVE_FORGEJO_TOKEN"
+  },
+  "localDiagnostic": {
+    "composeRootRef": "homelab-compose-root",
+    "forgejoService": "present",
+    "forgejoDatabaseService": "present",
+    "runnerService": "missing",
+    "diagnosticAt": "2026-06-03T09:49:34Z",
+    "source": "support-safe docker compose service-name check"
+  },
+  "secretValidation": [
+    {
+      "name": "WEAVE_FORGEJO_TOKEN",
+      "role": "repository_secret",
+      "state": "present",
+      "valueDisplayed": false
+    },
+    {
+      "name": "WEAVE_FORGEJO_BASE_URL",
+      "role": "repository_variable",
+      "state": "present",
+      "valueDisplayed": false
+    },
+    {
+      "name": "WEAVE_FORGEJO_API_URL",
+      "role": "repository_variable",
+      "state": "present",
+      "valueDisplayed": false
+    },
+    {
+      "name": "WEAVE_FORGEJO_USERNAME",
+      "role": "repository_variable",
+      "state": "present",
+      "valueDisplayed": false
+    },
+    {
+      "name": "WEAVE_FORGEJO_SSH_HOST",
+      "role": "repository_variable",
+      "state": "present",
+      "valueDisplayed": false
+    },
+    {
+      "name": "WEAVE_FORGEJO_SSH_PORT",
+      "role": "repository_variable",
+      "state": "present",
+      "valueDisplayed": false
+    }
+  ],
+  "adminConsoleStatus": {
+    "state": "preflight_blocked",
+    "reasonCode": "runner_missing",
+    "missingNamesDisplayed": ["FORGEJO_ACTIONS_RUNNER_REGISTRATION"],
+    "copy": "Forgejo is reachable through configured refs, but no supported runner registration is present. Add a Forgejo Actions runner registration through the customer CI/CD secret mechanism, then rerun preflight. Secret values and provider URLs stay hidden."
+  },
+  "pipelineRunRef": {
+    "providerKey": "local-forgejo-actions",
+    "workflowRef": "weave-admin-setup-e2e",
+    "runRef": "none-trigger-blocked-before-dispatch",
+    "status": "blocked",
+    "correlationRef": "forgejo-local-preflight-2026-06-03",
+    "auditRef": "audit://admin-cicd/local-forgejo/preflight-blocked",
+    "evidenceRef": "release/provider-lab/admin-cicd/local-forgejo-setup-proof.fixture.json",
+    "nextActionCode": "register_runner_before_trigger",
+    "supportSafeSummary": "Trigger blocked before dispatch because runner readiness is missing."
+  },
+  "failClosedCases": [
+    "runner_missing",
+    "missing_secret_ref",
+    "raw_secret_value_supplied",
+    "raw_ci_log_supplied",
+    "unknown_status_timeout",
+    "rate_limit_exhausted",
+    "approval_missing"
+  ]
+}

--- a/release/provider-lab/admin-cicd/pipeline-provider-manifest.fixture.json
+++ b/release/provider-lab/admin-cicd/pipeline-provider-manifest.fixture.json
@@ -1,0 +1,154 @@
+{
+  "artifactKind": "weave-admin-cicd-pipeline-provider-manifest-v1",
+  "issue": 659,
+  "supportSafe": true,
+  "canonicalSetupSurface": "Admin Console",
+  "executionBackend": "customer-owned CI/CD",
+  "providers": [
+    {
+      "providerKey": "github-actions",
+      "providerFamily": "github-actions",
+      "displayName": "GitHub Actions",
+      "supportTier": "contract_fixture",
+      "trigger": {
+        "manualDispatch": true,
+        "workflowRefRequired": true,
+        "branchOrRefInput": true,
+        "environmentApproval": true,
+        "dryRunInput": true,
+        "idempotencyKey": true,
+        "triggerAuthRefType": "SecretRef"
+      },
+      "status": {
+        "polling": true,
+        "webhook": true,
+        "terminalStates": ["success", "failed", "cancelled", "timed_out"],
+        "unknownStatusBehavior": "fail_closed_after_timeout",
+        "correlationFields": ["providerKey", "workflowRef", "runRef", "correlationRef"],
+        "rawLogRedactionRequired": true
+      },
+      "approval": {
+        "nativeEnvironmentApproval": true,
+        "adminConsoleApproval": true,
+        "serviceConnectionApproval": false
+      },
+      "operations": {
+        "cancel": true,
+        "retry": true,
+        "rollbackSupport": "domain_contract_required",
+        "rateLimitPolicy": "backoff_and_fail_closed"
+      }
+    },
+    {
+      "providerKey": "azure-devops",
+      "providerFamily": "azure-devops-pipelines",
+      "displayName": "Azure DevOps Pipelines",
+      "supportTier": "contract_fixture",
+      "trigger": {
+        "manualDispatch": true,
+        "workflowRefRequired": true,
+        "branchOrRefInput": true,
+        "environmentApproval": true,
+        "dryRunInput": true,
+        "idempotencyKey": true,
+        "triggerAuthRefType": "SecretRef"
+      },
+      "status": {
+        "polling": true,
+        "webhook": true,
+        "terminalStates": ["succeeded", "failed", "cancelled"],
+        "unknownStatusBehavior": "fail_closed_after_timeout",
+        "correlationFields": ["providerKey", "pipelineRef", "runRef", "correlationRef"],
+        "rawLogRedactionRequired": true
+      },
+      "approval": {
+        "nativeEnvironmentApproval": true,
+        "adminConsoleApproval": true,
+        "serviceConnectionApproval": true
+      },
+      "operations": {
+        "cancel": true,
+        "retry": true,
+        "rollbackSupport": "domain_contract_required",
+        "rateLimitPolicy": "retry_after_or_fail_closed"
+      }
+    },
+    {
+      "providerKey": "local-forgejo-actions",
+      "providerFamily": "forgejo-actions",
+      "displayName": "Forgejo Actions / act_runner",
+      "supportTier": "local_e2e_target",
+      "trigger": {
+        "manualDispatch": true,
+        "workflowRefRequired": true,
+        "branchOrRefInput": true,
+        "environmentApproval": false,
+        "dryRunInput": true,
+        "idempotencyKey": true,
+        "triggerAuthRefType": "SecretRef"
+      },
+      "status": {
+        "polling": true,
+        "webhook": true,
+        "terminalStates": ["success", "failure", "cancelled", "skipped"],
+        "unknownStatusBehavior": "fail_closed_after_timeout",
+        "correlationFields": ["providerKey", "workflowRef", "runRef", "correlationRef"],
+        "rawLogRedactionRequired": true
+      },
+      "approval": {
+        "nativeEnvironmentApproval": false,
+        "adminConsoleApproval": true,
+        "serviceConnectionApproval": false
+      },
+      "operations": {
+        "cancel": true,
+        "retry": true,
+        "rollbackSupport": "domain_contract_required",
+        "rateLimitPolicy": "backoff_and_fail_closed"
+      }
+    },
+    {
+      "providerKey": "woodpecker-ci",
+      "providerFamily": "woodpecker-ci",
+      "displayName": "Woodpecker CI",
+      "supportTier": "self_hosted_contract_fixture",
+      "trigger": {
+        "manualDispatch": true,
+        "workflowRefRequired": true,
+        "branchOrRefInput": true,
+        "environmentApproval": false,
+        "dryRunInput": true,
+        "idempotencyKey": true,
+        "triggerAuthRefType": "SecretRef"
+      },
+      "status": {
+        "polling": true,
+        "webhook": true,
+        "terminalStates": ["success", "failure", "killed", "error"],
+        "unknownStatusBehavior": "fail_closed_after_timeout",
+        "correlationFields": ["providerKey", "pipelineRef", "runRef", "correlationRef"],
+        "rawLogRedactionRequired": true
+      },
+      "approval": {
+        "nativeEnvironmentApproval": false,
+        "adminConsoleApproval": true,
+        "serviceConnectionApproval": false
+      },
+      "operations": {
+        "cancel": true,
+        "retry": true,
+        "rollbackSupport": "domain_contract_required",
+        "rateLimitPolicy": "backoff_and_fail_closed"
+      }
+    }
+  ],
+  "forbiddenFields": [
+    "secretValue",
+    "tokenValue",
+    "rawCiLog",
+    "rawProviderPayload",
+    "credentialBearingUrl",
+    "tenantUrl",
+    "memberContent"
+  ]
+}

--- a/specs/admin-ci-cd-orchestration-contract.md
+++ b/specs/admin-ci-cd-orchestration-contract.md
@@ -1,0 +1,95 @@
+# Admin CI/CD orchestration contract
+
+Status: Sprint 26 / issue #659 contract slice.
+
+## Product rule
+
+The Organization/Admin Console is the canonical setup surface. CI/CD is the customer-owned execution and validation backend. Admins choose domains, providers, and setup intent in Weave product language; Weave maps that intent to a supported pipeline provider contract, validates required variable and SecretRef names, triggers only when authorized, and reflects support-safe progress back in the Admin Console.
+
+This contract does not authorize production cutover, provider mutation in customer infrastructure, commercial adapter implementation, raw provider diagnostics, raw CI logs, raw provider payloads, token display, secret-value display, or credential-bearing links. Migration apply and go-live approval are separate gates with separate evidence.
+
+## Setup state model
+
+Admin Console setup states are stable Weave states, not CI-provider folklore:
+
+1. `provider_discovery` — show supported setup backends and their capability limits.
+2. `ci_cd_registration` — register a CI/CD provider by manifest and support-safe refs.
+3. `domain_selection` — choose Weave domains such as Chat, Files, Boards, Calendar, Identity, Health, and Weaver.
+4. `adapter_question` — ask whether an existing adapter/provider should be reused.
+5. `self_hosted_recommendation` — recommend a self-hosted default when no adapter exists.
+6. `target_provider_selection` — select target providers in product terms.
+7. `preflight` — validate manifest, auth scope, approval requirements, variable names, SecretRef names, runner readiness, and rate limits.
+8. `dry_run_mapping` — produce a support-safe mapping/loss report without mutation.
+9. `admin_approval` — require explicit admin approval before trigger/apply steps.
+10. `trigger_requested` — call the pipeline provider abstraction only after preflight and approval pass.
+11. `run_observing` — correlate to a `PipelineRunRef` and show Weave progress states.
+12. `migration_apply_candidate` — apply is still separate and blocked unless the domain contract permits it.
+13. `abort_requested` — cancel or mark abort when supported.
+14. `resume_requested` — resume from a prior support-safe run ref when supported.
+15. `post_reconcile_readiness` — show reconciliation evidence after the run.
+16. `evidence_complete` — capture release/operator evidence without claiming go-live.
+17. `go_live_approval_required` — production cutover needs a separate explicit approval.
+
+## PipelineProviderManifest v1
+
+Each provider manifest must declare:
+
+- `providerKey`, `providerFamily`, `displayName`, and `supportTier`.
+- Trigger capabilities: manual dispatch, workflow/pipeline refs, branch/ref input, environment approval support, dry-run input support, idempotency key support, and trigger auth ref type.
+- Status capabilities: polling, webhook, terminal states, unknown-status handling, run correlation fields, and raw-log redaction requirement.
+- Approval capabilities: native environment approval, service connection approval, manual Admin Console approval, or unsupported.
+- Cancellation, retry, rollback-support, timeout, and rate-limit behavior.
+- Required variables and SecretRefs by role. The manifest names required names and roles only; it never carries values.
+- Support-safe diagnostic codes. Provider payloads, raw CI logs, bearer diagnostics, credential-bearing links, tenant URLs, secret values, and member content are forbidden.
+
+## SecretRef and variable validation
+
+Validation states:
+
+- `present` — required name exists; value is not displayed.
+- `missing` — required name is absent; Admin Console shows the missing name and where to set it.
+- `wrong_role` — a name exists in the wrong scope or role.
+- `stale` — rotation or freshness evidence is too old.
+- `unverified` — provider cannot prove presence without unsafe access.
+- `blocked_value_supplied` — a secret value, token, bearer diagnostic, raw URL, raw log, or raw payload was supplied to Weave; fail closed.
+
+Admin Console copy must say exactly which names are missing, for example `WEAVE_FORGEJO_TOKEN` or `WEAVE_FORGEJO_API_URL`, and whether the customer may set them as repository variables, repository secrets, environment secrets, external secret-manager refs, or provider-native secret refs. It must not display values.
+
+## PipelineRunRef v1
+
+A run reference contains only:
+
+- `providerKey` and `runRef` as opaque refs.
+- `workflowRef` or `pipelineRef` as a support-safe logical name.
+- `status` from `blocked`, `queued`, `running`, `failed`, `cancelled`, `timed_out`, `rate_limited`, `approval_required`, `dry_run_complete`, `evidence_complete`, or `unknown`.
+- `correlationRef`, `auditRef`, `evidenceRef`, and `updatedAt`.
+- Optional `nextActionCode` and `supportSafeSummary`.
+
+It must not include provider URLs, credential-bearing links, raw logs, raw payloads, tokens, secret values, tenant URLs, or member content.
+
+## Fail-closed rules
+
+The setup abstraction fails closed for:
+
+- unconfigured pipeline provider;
+- missing SecretRef or required variable name;
+- unsupported adapter or unsupported trigger/status feature;
+- failed or missing admin approval;
+- missing runner readiness;
+- unknown status beyond timeout;
+- webhook timeout;
+- rate-limit exhaustion;
+- cancellation unsupported by provider;
+- raw secret/log/payload/value supplied in any Admin Console or support path.
+
+## Local Forgejo proof seam
+
+Massimo's local Forgejo is the Sprint 26 local E2E target. The proof must represent it through support-safe refs only:
+
+- `providerKey=local-forgejo-actions`;
+- `providerFamily=forgejo-actions`;
+- base/API/SSH connection details referenced by variable names, not values;
+- token referenced by `WEAVE_FORGEJO_TOKEN`, never printed;
+- runner readiness as a validation state. If no act_runner/Woodpecker runner is present, trigger is blocked with `runner_missing` before any pipeline dispatch.
+
+The local proof may validate preflight, missing-name display, redaction, trigger-blocked status, run-ref shape, and support-safe evidence. It must not mutate Forgejo data, create runners, rotate unrelated secrets, or claim production setup completion without separate approval and evidence.

--- a/tools/admin_cicd_orchestration_check.py
+++ b/tools/admin_cicd_orchestration_check.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Validate Sprint 26 Admin Console CI/CD setup orchestration fixtures."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_DIR = ROOT / "release" / "provider-lab" / "admin-cicd"
+MANIFEST = ARTIFACT_DIR / "pipeline-provider-manifest.fixture.json"
+FORGEJO = ARTIFACT_DIR / "local-forgejo-setup-proof.fixture.json"
+COPY = ARTIFACT_DIR / "admin-console-copy.fixture.json"
+CONTRACT = ROOT / "specs" / "admin-ci-cd-orchestration-contract.md"
+EVIDENCE = ROOT / "docs" / "evidence" / "admin-cicd-setup-proof.md"
+FEATURE = ROOT / "e2e" / "features" / "sprint_26_admin_cicd_setup.feature"
+UI_PLAN = ROOT / "docs" / "evidence" / "admin-cicd-ui-test-plan.md"
+
+FORBIDDEN_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"bearer\s+[a-z0-9._-]+",
+        r"ghp_[a-z0-9_]+",
+        r"token\s*[:=]\s*[^\s,}\"]+",
+        r"secret(Value)?\s*[:=]\s*[^\s,}\"]+",
+        r"https?://[^\s)\"]+",
+        r"ssh://[^\s)\"]+",
+    ]
+]
+
+FORBIDDEN_FIELD_NAMES = {
+    "secretValue",
+    "tokenValue",
+    "rawCiLog",
+    "rawProviderPayload",
+    "credentialBearingUrl",
+    "tenantUrl",
+    "memberContent",
+}
+
+REQUIRED_STATES = {
+    "provider_discovery",
+    "ci_cd_registration",
+    "domain_selection",
+    "adapter_question",
+    "self_hosted_recommendation",
+    "target_provider_selection",
+    "preflight",
+    "dry_run_mapping",
+    "admin_approval",
+    "trigger_requested",
+    "run_observing",
+    "migration_apply_candidate",
+    "abort_requested",
+    "resume_requested",
+    "post_reconcile_readiness",
+    "evidence_complete",
+    "go_live_approval_required",
+}
+
+
+def fail(message: str) -> None:
+    print(f"admin-cicd-orchestration-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"missing {path.relative_to(ROOT)}")
+    except json.JSONDecodeError as error:
+        fail(f"invalid JSON in {path.relative_to(ROOT)}: {error}")
+    if not isinstance(value, dict):
+        fail(f"{path.relative_to(ROOT)} must contain a JSON object")
+    return value
+
+
+def assert_support_safe(value: Any, label: str, path: tuple[str, ...] = ()) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = (*path, key)
+            if key in FORBIDDEN_FIELD_NAMES and child_path != ("forbiddenFields",):
+                fail(f"{label} contains forbidden field {'.'.join(child_path)}")
+            assert_support_safe(child, label, child_path)
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            assert_support_safe(child, label, (*path, str(index)))
+        return
+    if isinstance(value, str):
+        for pattern in FORBIDDEN_PATTERNS:
+            if pattern.search(value):
+                fail(f"{label} contains forbidden support-unsafe pattern {pattern.pattern!r} at {'.'.join(path)}")
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    if manifest.get("artifactKind") != "weave-admin-cicd-pipeline-provider-manifest-v1":
+        fail("pipeline provider manifest kind mismatch")
+    if manifest.get("canonicalSetupSurface") != "Admin Console":
+        fail("Admin Console must be the canonical setup surface")
+    if set(manifest.get("forbiddenFields", [])) != FORBIDDEN_FIELD_NAMES:
+        fail("manifest forbiddenFields must exactly match the support-safety field denylist")
+    provider_list = manifest.get("providers", [])
+    if not isinstance(provider_list, list):
+        fail("manifest providers must be a list")
+    providers: dict[str, dict[str, Any]] = {}
+    for index, provider in enumerate(provider_list):
+        if not isinstance(provider, dict):
+            fail(f"provider entry {index} must be an object")
+        provider_key = provider.get("providerKey")
+        if not isinstance(provider_key, str) or not provider_key:
+            fail(f"provider entry {index} missing providerKey")
+        if provider_key in providers:
+            fail(f"duplicate providerKey {provider_key}")
+        providers[provider_key] = provider
+    for provider_key in ["github-actions", "azure-devops", "local-forgejo-actions", "woodpecker-ci"]:
+        if provider_key not in providers:
+            fail(f"manifest missing provider {provider_key}")
+    for key, provider in providers.items():
+        for section in ["trigger", "status", "approval", "operations"]:
+            if not isinstance(provider.get(section), dict):
+                fail(f"provider {key} missing {section}")
+        if provider["trigger"].get("manualDispatch") is not True:
+            fail(f"provider {key} must support manual dispatch contract")
+        if provider["trigger"].get("triggerAuthRefType") != "SecretRef":
+            fail(f"provider {key} trigger auth must use SecretRef")
+        if provider["status"].get("rawLogRedactionRequired") is not True:
+            fail(f"provider {key} must require raw log redaction")
+        if provider["status"].get("unknownStatusBehavior") != "fail_closed_after_timeout":
+            fail(f"provider {key} must fail closed on unknown status")
+        if provider["operations"].get("rateLimitPolicy") not in {"backoff_and_fail_closed", "retry_after_or_fail_closed"}:
+            fail(f"provider {key} must declare fail-closed rate-limit policy")
+
+
+def validate_forgejo(proof: dict[str, Any]) -> None:
+    if proof.get("artifactKind") != "weave-admin-cicd-local-forgejo-setup-proof-v1":
+        fail("local Forgejo proof kind mismatch")
+    refs = proof.get("connectionRefs", {})
+    required_refs = {
+        "baseUrlVariable": "WEAVE_FORGEJO_BASE_URL",
+        "apiUrlVariable": "WEAVE_FORGEJO_API_URL",
+        "usernameVariable": "WEAVE_FORGEJO_USERNAME",
+        "sshHostVariable": "WEAVE_FORGEJO_SSH_HOST",
+        "sshPortVariable": "WEAVE_FORGEJO_SSH_PORT",
+        "tokenSecret": "WEAVE_FORGEJO_TOKEN",
+    }
+    if refs != required_refs:
+        fail("local Forgejo connection refs must name variables/secrets exactly and contain no values")
+    diagnostic = proof.get("localDiagnostic", {})
+    if diagnostic.get("forgejoService") != "present" or diagnostic.get("forgejoDatabaseService") != "present":
+        fail("local Forgejo proof must show Forgejo and DB services present")
+    if diagnostic.get("runnerService") != "missing":
+        fail("current local proof must fail closed while runner service is missing")
+    validations = proof.get("secretValidation", [])
+    if any(item.get("valueDisplayed") is not False for item in validations):
+        fail("secret/variable validation must never display values")
+    if proof.get("adminConsoleStatus", {}).get("reasonCode") != "runner_missing":
+        fail("local Forgejo preflight must block on runner_missing")
+    run_ref = proof.get("pipelineRunRef", {})
+    if run_ref.get("status") != "blocked" or run_ref.get("runRef") != "none-trigger-blocked-before-dispatch":
+        fail("local Forgejo run ref must be blocked before dispatch")
+
+
+def validate_copy(copy: dict[str, Any]) -> None:
+    if copy.get("artifactKind") != "weave-admin-cicd-admin-console-copy-v1":
+        fail("Admin Console copy artifact kind mismatch")
+    if set(copy.get("setupStates", [])) != REQUIRED_STATES:
+        fail("Admin Console copy must cover the complete setup state model")
+    missing = copy.get("missingSecretCopy", {})
+    for name in ["WEAVE_FORGEJO_TOKEN", "WEAVE_FORGEJO_API_URL", "FORGEJO_ACTIONS_RUNNER_REGISTRATION"]:
+        if name not in missing.get("displayedNames", []):
+            fail(f"missing-secret copy must display required name {name}")
+    for forbidden in ["secret values", "tokens", "raw CI logs", "provider payloads", "credential-bearing URLs", "tenant URLs", "member content"]:
+        if forbidden not in missing.get("forbiddenDisplay", []):
+            fail(f"copy must forbid displaying {forbidden}")
+    if len(copy.get("progressCopy", [])) < 4 or len(copy.get("failClosedCopy", [])) < 6:
+        fail("copy fixture must cover progress and fail-closed states")
+
+
+def validate_docs() -> None:
+    for path in [CONTRACT, EVIDENCE, FEATURE, UI_PLAN]:
+        if not path.exists():
+            fail(f"missing {path.relative_to(ROOT)}")
+    contract = CONTRACT.read_text(encoding="utf-8")
+    required_fragments = [
+        "The Organization/Admin Console is the canonical setup surface",
+        "PipelineProviderManifest v1",
+        "PipelineRunRef v1",
+        "Local Forgejo proof seam",
+        "fail closed",
+    ]
+    for fragment in required_fragments:
+        if fragment not in contract:
+            fail(f"contract missing fragment {fragment!r}")
+    evidence = EVIDENCE.read_text(encoding="utf-8")
+    for relpath in [MANIFEST, FORGEJO, COPY, CONTRACT, FEATURE, UI_PLAN]:
+        if str(relpath.relative_to(ROOT)) not in evidence:
+            fail(f"evidence report missing {relpath.relative_to(ROOT)}")
+    feature = FEATURE.read_text(encoding="utf-8")
+    if "@sprint26-admin-cicd-setup" not in feature or "runner_missing" not in feature:
+        fail("Gherkin feature must map the Sprint 26 local Forgejo runner-missing proof")
+    ui_plan = UI_PLAN.read_text(encoding="utf-8")
+    for fragment in [
+        "Provider-domain selection",
+        "Self-hosted fallback",
+        "Missing-secret display",
+        "Trigger blocked",
+        "Run started",
+        "Dry-run complete",
+        "Migration aborted",
+        "Migration applied",
+        "Post-reconcile evidence",
+        "FORGEJO_ACTIONS_RUNNER_REGISTRATION",
+    ]:
+        if fragment not in ui_plan:
+            fail(f"UI test plan missing {fragment!r}")
+
+
+def main() -> None:
+    manifest = load(MANIFEST)
+    forgejo = load(FORGEJO)
+    copy = load(COPY)
+    for label, artifact in [("manifest", manifest), ("forgejo", forgejo), ("copy", copy)]:
+        if artifact.get("supportSafe") is not True:
+            fail(f"{label} must be supportSafe")
+        assert_support_safe(artifact, label)
+    validate_manifest(manifest)
+    validate_forgejo(forgejo)
+    validate_copy(copy)
+    validate_docs()
+    print("admin-cicd-orchestration-check: ok issue=659 local_forgejo=preflight_blocked runner_missing")
+    print("SPRINT26_ADMIN_CICD_SETUP_PROOF")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Defines the Sprint 26/#659 Admin Console CI/CD-backed setup orchestration contract.
- Adds provider-manifest, Admin Console copy, and local Forgejo proof fixtures with fail-closed runner-missing behavior.
- Adds a validator and Gherkin mapping so release/acceptance gates prove the contract without dispatching a live pipeline.

## Scope and user impact

- Admins get a product-language setup contract: Admin Console is the primary workflow, CI/CD executes/validates in the background.
- Missing variables/SecretRefs are shown by name and role only; values, raw logs, raw provider payloads, URLs, and tokens stay hidden.
- Local Forgejo is represented as the Sprint 26 E2E proof target, but dispatch is blocked while no runner registration is present.

## Spec / acceptance link

- Issue: advances #659
- Repo spec or spec note: `specs/admin-ci-cd-orchestration-contract.md`
- Acceptance scenario / mapping marker when product behavior changed: `@sprint26-admin-cicd-setup` / `SPRINT26_ADMIN_CICD_SETUP_PROOF`
- Product-core questions intentionally left unresolved: none for the contract slice; live runner installation/dispatch remains blocked until runner evidence exists.

## Branch, target, and release path

- [x] Branch started from current `origin/main`
- [x] PR targets protected `main`
- [x] No long-lived `dev`/`testing`/`staging` branch involved
- [x] Production release is not implied by this merge

## Screenshots or docs impact

- Adds #659 contract/evidence docs and support-safe provider-lab fixtures.

## Accessibility and localization

- No UI implementation strings in this slice; Admin Console copy fixture is English product copy for future UI tests.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: `specs/admin-ci-cd-orchestration-contract.md`
- [x] `./gradlew specContract` run for spec/product-contract changes

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented: local gates and support-safe fixture validator are included; will address review comments if any land.

## Checks run

- [x] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [x] `./gradlew docsCheck --console=plain`
- [x] `./gradlew releaseEvidenceCheck --console=plain`
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): live dispatch skipped; local Forgejo runner is missing, so preflight fails closed before dispatch.

Additional targeted check:

- [x] `python3 tools/admin_cicd_orchestration_check.py`

## Notes for reviewers

- This intentionally does not install or configure an act_runner/Woodpecker runner. The proof names that as missing and blocks trigger before dispatch.
- The fixture names GitHub variables/secrets, but never includes secret values or local provider URL values.
