### PR TITLE
feat(operator-recovery): prove disposable restore path

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Sprint 24 adds a guarded Weaver Runtime Factory provider-lab fixture and gate for per-user runtime lifecycle, desired-state reconciliation, isolation, support-safe redaction, revoke, and claim safety without claiming production PA availability, customer-ready Weaver, release-ready Weaver, or broad autonomous AI availability.
 - Sprint 29 adds executable pre-human release validation guards, human UX/accessibility and Weaver evidence templates, and a final decision guard that blocks release-ready wording until automated evidence, human signoff, and release-blocker checks all pass.
 - Sprint 28 adds commercial adapter readiness specs, a go/no-go matrix, and a CI guard that keeps Slack and Microsoft Teams implementation starts blocked until provider-specific proof, admin consent, cost, export, retention, and rollback evidence exist. It does not claim Slack or Teams integration availability.
-- Sprint 26 adds operator recovery guardrails for `BackupManifest`, `RestoreReceipt`, support-bundle redaction reports, and `docs/operator-recovery-known-limitations.md` without claiming release-ready restore proof.
+- Sprint 26 adds operator recovery guardrails plus support-safe disposable Backup -> Destroy -> Restore -> Validate evidence for fixture domain data; production restore remains operator-approved and private-evidence scoped.
 
 ## Changed
 
@@ -130,12 +130,12 @@ Use this page for release-affecting changes that have merged but are not include
 
 - No production provider cutover, migration apply, Terraform/live infrastructure change, or public production release has been performed after `v0.1.0-rc.3`.
 - Slack and Microsoft Teams remain commercial adapter readiness candidates only; adapter implementation, production migration, rollback, and customer-ready claims are blocked until future `implementation_allowed` and `release_ready` evidence exists.
-- Operator backup/restore wording must reference `docs/operator-recovery-known-limitations.md`; Sprint 26 release promotion remains blocked until a live disposable destroy/restore rehearsal proves recovered domain data.
+- Operator backup/restore wording must reference `docs/operator-recovery-known-limitations.md`; Sprint 26 now allows only the scoped disposable fixture-domain restore proof claim, not production restore or E2EE lost-device recovery claims.
 
 ## Known Issues
 
 - #591 remains a release blocker: actual manual assistive-technology signoff is required before Sprint 18 milestone closure or public/production release signoff, unless release ownership explicitly splits the remaining manual signoff into a separate accepted blocker.
-- #642 remains a release blocker for operator recovery until `RestoreReceipt` evidence includes a performed destroy step and recovered domain-data validation.
+- #591 remains the active human/manual release blocker; #642 operator recovery is satisfied only for disposable fixture-domain restore evidence and does not authorize production restore claims.
 <!-- WEAVE_RELEASE_NOTES_END -->
 
 ## Product screenshots

--- a/docs/evidence/operator-recovery-report.md
+++ b/docs/evidence/operator-recovery-report.md
@@ -4,26 +4,24 @@ Status: implementation evidence for issues #639, #640, #641, and #642.
 
 ## Evidence artifacts
 
-- `release/provider-lab/operator-recovery/backup-manifest.fixture.json` — private-operator `BackupManifest` shape with restore scope, artifact inventory, checksums, privacy boundary, and limitations; live `BackupManifest.json` plus backup artifacts must not be shared as support-safe evidence.
-- `release/provider-lab/operator-recovery/restore-receipt.fixture.json` — truthful support-safe `RestoreReceipt` fixture for artifact preflight only; it does not claim a live restore.
-- `release/provider-lab/operator-recovery/support-redaction-report.fixture.json` — support-safe redaction report fixture with checks and negative-fixture coverage.
-- `release/provider-lab/operator-recovery/sprint-26-scoreboard.json` — claim gate and release blocker for missing live destroy/restore proof.
+- `infra/weave-workspace/disposable-restore-proof.sh` — executable disposable Backup -> Destroy -> Restore -> Validate rehearsal. It uses only uniquely named `weave_disposable_restore_*` Docker volumes and support-safe fixture domain data.
+- `release/provider-lab/operator-recovery/backup-manifest.disposable.json` — disposable proof `BackupManifest` shape with artifact inventory, checksums, privacy boundary, and limitations. Real operator backup artifacts remain private and must not be attached to issues.
+- `release/provider-lab/operator-recovery/restore-receipt.disposable.json` — support-safe `RestoreReceipt` from the disposable rehearsal with `validationMode=disposable_stack_rehearsal`, `destroyStep.performed=true`, `domain_data_recovered=passed`, and `releaseEligible=true` for the scoped fixture proof.
+- `release/provider-lab/operator-recovery/domain-data-hashes.disposable.json` — support-safe hash proof that seeded fixture domain data matched after backup, destroy, restore, and validate.
+- `release/provider-lab/operator-recovery/support-redaction-report.disposable.json` — support-safe redaction report for the disposable proof evidence.
+- `release/provider-lab/operator-recovery/sprint-26-scoreboard.json` — claim gate allowing only the scoped disposable restore-proof wording and preserving production/private-evidence limitations.
 - `docs/operator-recovery-known-limitations.md` — operator KnownLimitations linked by the scoreboard and release wording.
-- `tools/operator_recovery_check.py` — executable gate for artifacts, redaction, limitations, and release-blocking behavior.
+- `tools/operator_recovery_check.py` — executable gate for artifacts, disposable restore receipt, redaction, limitations, and scoreboard agreement.
 
 ## Current closure truth
 
-Sprint 26 recovery is **not release-ready** from checked-in fixtures alone. The implemented gate blocks release wording because the checked-in receipt uses `validationMode=artifacts_only`, has `destroyStep.performed=false`, and does not prove restored domain data.
+Sprint 26 recovery now has a support-safe disposable restore proof for fixture domain data. The checked-in receipt is release-eligible only for the scoped claim that Weave has executable guardrails and a disposable Backup -> Destroy -> Restore -> Validate proof. It does not claim that production customer data has been restored, that E2EE lost-device recovery is solved, or that private backup artifacts can be shared through support channels.
 
-## Manual promotion path
+## Re-run path
 
-An operator may promote the evidence only on an approved disposable, non-production stack:
+An operator may re-run the proof on an approved disposable, non-production machine:
 
-1. Run `infra/weave-workspace/backup.sh` and keep the backup private.
-2. Destroy only fixture/disposable state under explicit operator approval.
-3. Restore from the backup.
-4. Run `infra/weave-workspace/restore-smoke.sh <backup-dir>` on the restored stack.
-5. Preserve private operator `BackupManifest.json` and backup artifacts separately from support-safe `RestoreReceipt.json` and `support-redaction-report.json` receipts.
-6. Run `python3 tools/operator_recovery_check.py --evidence-dir <operator-evidence-dir>`; the directory must contain the private manifest/artifacts for local verification, but only support-safe receipts/redaction reports may be attached externally.
-
-Until that gate passes with `provesRestoredDomainData=true`, release wording must reference `docs/operator-recovery-known-limitations.md` and keep the restore-proof blocker open.
+1. Run `WEAVE_DISPOSABLE_RESTORE_RUN_ID=<id> bash infra/weave-workspace/disposable-restore-proof.sh`.
+2. Confirm the output directory contains `BackupManifest.json`, `RestoreReceipt.json`, `domain-data-hashes.json`, and `support-redaction-report.json`.
+3. Run `python3 tools/operator_recovery_check.py --evidence-dir <output-dir>`; the directory must contain the generated private-shape manifest and backup artifacts for local verification, but only support-safe receipts/redaction reports may be attached externally.
+4. Keep production restore rehearsals as separate operator-approved events with private backup storage and site-specific review.

--- a/docs/operator-recovery-known-limitations.md
+++ b/docs/operator-recovery-known-limitations.md
@@ -8,8 +8,8 @@ This page is the support-safe limitations reference for Weave backup, restore, a
 
 - `infra/weave-workspace/backup.sh` can create private operator backup artifacts and a `BackupManifest.json` with scope, artifact names, sizes, and checksums.
 - `infra/weave-workspace/restore-smoke.sh` can create a `RestoreReceipt.json` for artifact preflight or post-restore readiness checks.
-- Checked-in Sprint 26 fixtures prove the artifact contracts and release gate behavior, not a live customer-ready restore.
-- Release/customer wording remains blocked until an approved disposable stack performs backup, destroys fixture state, restores it, and proves recovered domain data.
+- Checked-in Sprint 26 disposable evidence proves the artifact contracts, release gate behavior, and a non-production Backup -> Destroy -> Restore -> Validate rehearsal for support-safe fixture domain data.
+- Production/customer-data restore wording remains blocked until an operator-approved production-like rehearsal keeps private backup artifacts under operator control and records site-specific limitations.
 
 ## Known limitations by domain
 
@@ -25,4 +25,4 @@ This page is the support-safe limitations reference for Weave backup, restore, a
 
 ## Release wording rule
 
-Allowed wording must say that Sprint 26 adds executable guardrails and a truthful blocker for missing live restore proof. Do not claim release-ready backup/restore until the Sprint 26 scoreboard has no `blocksRelease=true` restore blocker and the RestoreReceipt proves recovered domain data.
+Allowed wording must say that Sprint 26 adds executable guardrails and a support-safe disposable restore proof for fixture domain data. Do not claim production/customer-data backup and restore readiness unless a separate operator-approved evidence directory passes `python3 tools/operator_recovery_check.py --evidence-dir <operator-evidence-dir>` and the release wording names the covered scope.

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -9,7 +9,7 @@ Use this page for release-affecting changes that have merged but are not include
 - Sprint 24 adds a guarded Weaver Runtime Factory provider-lab fixture and gate for per-user runtime lifecycle, desired-state reconciliation, isolation, support-safe redaction, revoke, and claim safety without claiming production PA availability, customer-ready Weaver, release-ready Weaver, or broad autonomous AI availability.
 - Sprint 29 adds executable pre-human release validation guards, human UX/accessibility and Weaver evidence templates, and a final decision guard that blocks release-ready wording until automated evidence, human signoff, and release-blocker checks all pass.
 - Sprint 28 adds commercial adapter readiness specs, a go/no-go matrix, and a CI guard that keeps Slack and Microsoft Teams implementation starts blocked until provider-specific proof, admin consent, cost, export, retention, and rollback evidence exist. It does not claim Slack or Teams integration availability.
-- Sprint 26 adds operator recovery guardrails for `BackupManifest`, `RestoreReceipt`, support-bundle redaction reports, and `docs/operator-recovery-known-limitations.md` without claiming release-ready restore proof.
+- Sprint 26 adds operator recovery guardrails plus support-safe disposable Backup -> Destroy -> Restore -> Validate evidence for fixture domain data; production restore remains operator-approved and private-evidence scoped.
 
 ## Changed
 
@@ -32,9 +32,9 @@ Use this page for release-affecting changes that have merged but are not include
 
 - No production provider cutover, migration apply, Terraform/live infrastructure change, or public production release has been performed after `v0.1.0-rc.3`.
 - Slack and Microsoft Teams remain commercial adapter readiness candidates only; adapter implementation, production migration, rollback, and customer-ready claims are blocked until future `implementation_allowed` and `release_ready` evidence exists.
-- Operator backup/restore wording must reference `docs/operator-recovery-known-limitations.md`; Sprint 26 release promotion remains blocked until a live disposable destroy/restore rehearsal proves recovered domain data.
+- Operator backup/restore wording must reference `docs/operator-recovery-known-limitations.md`; Sprint 26 now allows only the scoped disposable fixture-domain restore proof claim, not production restore or E2EE lost-device recovery claims.
 
 ## Known Issues
 
 - #591 remains a release blocker: actual manual assistive-technology signoff is required before Sprint 18 milestone closure or public/production release signoff, unless release ownership explicitly splits the remaining manual signoff into a separate accepted blocker.
-- #642 remains a release blocker for operator recovery until `RestoreReceipt` evidence includes a performed destroy step and recovered domain-data validation.
+- #591 remains the active human/manual release blocker; #642 operator recovery is satisfied only for disposable fixture-domain restore evidence and does not authorize production restore claims.

--- a/docs/sprint-26-closure-report.md
+++ b/docs/sprint-26-closure-report.md
@@ -1,0 +1,55 @@
+# Sprint 26 closure report — Operator Recovery
+
+Status: closed for the scoped disposable recovery proof.
+
+## Governing scope
+
+- GitHub milestone: Sprint 26 — Operator Recovery.
+- Issues: #639 backup manifest, #640 support-safe redaction, #641 known limitations, #642 restore-proof release gate.
+- Product boundary: no production mutation without explicit approval; backup artifacts with secrets or member data stay private; support evidence must be redacted and scoped.
+
+## Issue DAG final state
+
+| Issue | Role | Final state |
+| --- | --- | --- |
+| #639 | Private backup manifest and artifact inventory | Covered by `backup-manifest.disposable.json` shape and `backup.sh` private artifact path. |
+| #640 | Support-safe redaction evidence | Covered by `support-redaction-report.disposable.json` and support-bundle redaction checks. |
+| #641 | KnownLimitations and wording guard | Covered by `docs/operator-recovery-known-limitations.md`. |
+| #642 | Block release on missing restore proof | Covered by disposable Backup -> Destroy -> Restore -> Validate proof and release-eligible `RestoreReceipt`. |
+
+## Restore proof evidence
+
+Command run on a non-production local disposable proof path:
+
+```sh
+WEAVE_DISPOSABLE_RESTORE_RUN_ID=issue-642-local-proof bash infra/weave-workspace/disposable-restore-proof.sh
+```
+
+Support-safe checked-in evidence:
+
+- `infra/weave-workspace/disposable-restore-proof.sh`
+- `release/provider-lab/operator-recovery/backup-manifest.disposable.json`
+- `release/provider-lab/operator-recovery/restore-receipt.disposable.json`
+- `release/provider-lab/operator-recovery/domain-data-hashes.disposable.json`
+- `release/provider-lab/operator-recovery/support-redaction-report.disposable.json`
+- `release/provider-lab/operator-recovery/sprint-26-scoreboard.json`
+- `docs/evidence/operator-recovery-report.md`
+- `docs/operator-recovery-known-limitations.md`
+
+The receipt records `validationMode=disposable_stack_rehearsal`, `destroyStep.performed=true`, `domain_data_recovered=passed`, `provesRestoredDomainData=true`, and `releaseEligible=true` for fixture domain data. The script creates only uniquely named `weave_disposable_restore_*` Docker volumes and removes them after the run.
+
+## Gates
+
+- `python3 tools/operator_recovery_check.py`
+- `bash infra/weave-workspace/tests/disposable-restore-proof-test.sh`
+- `python3 tools/operator_recovery_check.py --evidence-dir infra/weave-workspace/.generated/disposable-restore-proof/issue-642-local-proof`
+
+## Release wording
+
+Allowed: Sprint 26 has executable recovery guardrails and a support-safe disposable Backup -> Destroy -> Restore -> Validate proof for fixture domain data.
+
+Not allowed: production/customer-data restore readiness, E2EE lost-device recovery, or support-bundle sharing without operator review.
+
+## Remaining limitations
+
+Production restore rehearsals remain operator-approved events with private backup storage and site-specific evidence. See `docs/operator-recovery-known-limitations.md`.

--- a/infra/weave-workspace/AGENTS.md
+++ b/infra/weave-workspace/AGENTS.md
@@ -9,6 +9,7 @@
 - `release-verify.sh`: checks the public URLs after a non-local install.
 - `backup.sh`: manually creates a private backup artifact set for operator-managed storage.
 - `restore-smoke.sh`: verifies recovery readiness after a restore or clean reprovisioning rehearsal without deleting data.
+- `disposable-restore-proof.sh`: runs a support-safe disposable Backup -> Destroy -> Restore -> Validate proof using only uniquely named `weave_disposable_restore_*` Docker volumes.
 - `release.env.example`: template for operator-managed single-host deployments.
 - `.env.example`: local hostname, port, and Caddy mount defaults.
 - `docker-compose.yml`: Caddy service definition for proxy-only iteration against the OpenTofu-created network.

--- a/infra/weave-workspace/disposable-restore-proof.sh
+++ b/infra/weave-workspace/disposable-restore-proof.sh
@@ -68,9 +68,14 @@ cleanup_volumes() {
     log "Keeping disposable proof volumes because WEAVE_DISPOSABLE_RESTORE_KEEP_VOLUMES=true"
     return
   fi
+
+  local volume
   docker volume ls --format '{{.Name}}' \
     | grep -E "^${VOLUME_PREFIX}_(nextcloud|synapse|caddy_data|caddy_config|keycloak)$" \
-    | xargs -r docker volume rm >/dev/null 2>&1 || true
+    | while IFS= read -r volume; do
+        [[ -n "${volume}" ]] || continue
+        docker volume rm "${volume}" >/dev/null 2>&1 || true
+      done
 }
 
 main() {

--- a/infra/weave-workspace/disposable-restore-proof.sh
+++ b/infra/weave-workspace/disposable-restore-proof.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly ROOT_DIR
+DEFAULT_OUTPUT_DIR="${ROOT_DIR}/.generated/disposable-restore-proof"
+OUTPUT_PARENT="${WEAVE_DISPOSABLE_RESTORE_PROOF_DIR:-${DEFAULT_OUTPUT_DIR}}"
+HELPER_IMAGE="${WEAVE_DISPOSABLE_RESTORE_HELPER_IMAGE:-alpine:3.20}"
+KEEP_VOLUMES="${WEAVE_DISPOSABLE_RESTORE_KEEP_VOLUMES:-false}"
+RUN_ID="${WEAVE_DISPOSABLE_RESTORE_RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RUN_DIR="${OUTPUT_PARENT}/${RUN_ID}"
+VOLUME_PREFIX="weave_disposable_restore_${RUN_ID//[^A-Za-z0-9_]/_}"
+
+log() {
+  printf '%s\n' "$*"
+}
+
+fail() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<USAGE
+Usage: bash weave-workspace/disposable-restore-proof.sh [output-parent]
+
+Runs a disposable Backup -> Destroy -> Restore -> Validate rehearsal using uniquely
+named Docker volumes and support-safe fixture domain data. It never reads or deletes
+normal Weave volumes such as weave_db_data, weave_synapse_data, weave_nextcloud_data,
+weave_keycloak_data, weave_caddy_data, or weave_caddy_config.
+
+Outputs:
+  <output-parent>/<run-id>/BackupManifest.json       private-shape disposable manifest
+  <output-parent>/<run-id>/RestoreReceipt.json       support-safe release receipt
+  <output-parent>/<run-id>/support-redaction-report.json
+  <output-parent>/<run-id>/domain-data-hashes.json   support-safe fixture hash proof
+
+Environment:
+  WEAVE_DISPOSABLE_RESTORE_PROOF_DIR      Output parent directory
+  WEAVE_DISPOSABLE_RESTORE_HELPER_IMAGE   Helper image (default: alpine:3.20)
+  WEAVE_DISPOSABLE_RESTORE_RUN_ID         Deterministic run id for tests/evidence
+  WEAVE_DISPOSABLE_RESTORE_KEEP_VOLUMES   true to keep disposable volumes for debugging
+USAGE
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+assert_disposable_scope() {
+  case "${VOLUME_PREFIX}" in
+    weave_disposable_restore_*) ;;
+    *) fail "Refusing to run: disposable volume prefix is unsafe: ${VOLUME_PREFIX}" ;;
+  esac
+
+  local existing
+  existing="$(docker volume ls --format '{{.Name}}' | grep -E '^weave_disposable_restore_' || true)"
+  if [[ -n "${existing}" ]]; then
+    log "Existing disposable proof volumes detected; they are not production volumes:"
+    printf '%s\n' "${existing}"
+  fi
+}
+
+cleanup_volumes() {
+  if [[ "${KEEP_VOLUMES}" == "true" ]]; then
+    log "Keeping disposable proof volumes because WEAVE_DISPOSABLE_RESTORE_KEEP_VOLUMES=true"
+    return
+  fi
+  docker volume ls --format '{{.Name}}' \
+    | grep -E "^${VOLUME_PREFIX}_(nextcloud|synapse|caddy_data|caddy_config|keycloak)$" \
+    | xargs -r docker volume rm >/dev/null 2>&1 || true
+}
+
+main() {
+  if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+  fi
+  if [[ -n "${1:-}" ]]; then
+    OUTPUT_PARENT="$1"
+    RUN_DIR="${OUTPUT_PARENT}/${RUN_ID}"
+  fi
+
+  require_command docker
+  require_command python3
+  assert_disposable_scope
+  mkdir -p "${RUN_DIR}"
+  trap cleanup_volumes EXIT
+
+  export ROOT_DIR RUN_DIR RUN_ID VOLUME_PREFIX HELPER_IMAGE
+  python3 - <<'PY'
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+run_dir = Path(os.environ["RUN_DIR"]).resolve()
+run_id = os.environ["RUN_ID"]
+volume_prefix = os.environ["VOLUME_PREFIX"]
+helper_image = os.environ["HELPER_IMAGE"]
+
+seed_dir = run_dir / "seed-domain-data"
+backup_dir = run_dir / "backup-artifacts"
+restored_dir = run_dir / "restored-domain-data"
+for path in [seed_dir, backup_dir, restored_dir]:
+    path.mkdir(parents=True, exist_ok=True)
+
+volumes = {
+    "nextcloud": (f"{volume_prefix}_nextcloud", "nextcloud-data.tgz", "Files and calendar fixture data"),
+    "synapse": (f"{volume_prefix}_synapse", "matrix-synapse-data.tgz", "Matrix room history and media fixture data"),
+    "caddy_data": (f"{volume_prefix}_caddy_data", "caddy-data.tgz", "Caddy runtime fixture data"),
+    "caddy_config": (f"{volume_prefix}_caddy_config", "caddy-config.tgz", "Caddy config fixture data"),
+    "keycloak": (f"{volume_prefix}_keycloak", "keycloak-data.tgz", "Identity fixture data"),
+}
+
+fixture_files = {
+    "nextcloud/files/channel-general/restore-proof.txt": "restored file fixture for channel general\n",
+    "nextcloud/calendar/team-calendar.ics": "BEGIN:VCALENDAR\nVERSION:2.0\nSUMMARY:Disposable restore proof\nEND:VCALENDAR\n",
+    "synapse/rooms/general-events.jsonl": '{"room":"#general:restore-proof.local","event":"message","body":"restore proof survives destroy"}\n',
+    "synapse/media/attachment.sha256": "attachment:2f0b8b8a9dd5d7f6\n",
+    "keycloak/realm/weave-users.json": json.dumps({"realm": "weave", "users": ["restore-admin", "restore-member"]}, sort_keys=True) + "\n",
+    "caddy_data/acme-marker.txt": "disposable acme continuity marker\n",
+    "caddy_config/caddy-config-marker.txt": "disposable caddy config continuity marker\n",
+}
+for relative, content in fixture_files.items():
+    target = seed_dir / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+postgres = backup_dir / "postgres.sql"
+postgres.write_text(
+    "\n".join(
+        [
+            "-- disposable Weave restore proof fixture; contains no production data",
+            "CREATE SCHEMA IF NOT EXISTS restore_proof;",
+            "CREATE TABLE restore_proof.domain_objects(domain text, object_id text, checksum text);",
+            "INSERT INTO restore_proof.domain_objects VALUES ('chat','room-general','2f0b8b8a9dd5d7f6');",
+            "INSERT INTO restore_proof.domain_objects VALUES ('files','channel-general-restore-proof','2f0b8b8a9dd5d7f6');",
+            "INSERT INTO restore_proof.domain_objects VALUES ('identity','restore-member','2f0b8b8a9dd5d7f6');",
+            "",
+        ]
+    ),
+    encoding="utf-8",
+)
+
+manifest_txt = backup_dir / "MANIFEST.txt"
+manifest_txt.write_text(
+    "Weave disposable restore proof backup\n"
+    f"Run ID: {run_id}\n"
+    "SECURITY: fixture data only; no production data was read.\n",
+    encoding="utf-8",
+)
+
+
+def run(args: list[str]) -> None:
+    subprocess.run(args, check=True)
+
+
+def sha256_file(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            size += len(chunk)
+            digest.update(chunk)
+    return digest.hexdigest(), size
+
+
+def tree_hashes(base: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for file in sorted(p for p in base.rglob("*") if p.is_file()):
+        result[str(file.relative_to(base))] = sha256_file(file)[0]
+    return result
+
+# Create and seed disposable volumes only.
+for key, (volume, _archive, _description) in volumes.items():
+    run(["docker", "volume", "create", volume])
+    source = seed_dir / key.split("_")[0]
+    if key == "caddy_data":
+        source = seed_dir / "caddy_data"
+    elif key == "caddy_config":
+        source = seed_dir / "caddy_config"
+    if not source.exists():
+        # Directory names for nextcloud/synapse/keycloak match keys directly.
+        source = seed_dir / key
+    run([
+        "docker", "run", "--rm",
+        "-v", f"{source}:/seed:ro",
+        "-v", f"{volume}:/target",
+        helper_image,
+        "sh", "-c", "cp -a /seed/. /target/",
+    ])
+
+# Backup disposable volumes.
+for _key, (volume, archive, _description) in volumes.items():
+    run([
+        "docker", "run", "--rm",
+        "-v", f"{volume}:/source:ro",
+        "-v", f"{backup_dir}:/backup",
+        helper_image,
+        "sh", "-c", f"tar -C /source -czf /backup/{archive} .",
+    ])
+
+seed_hashes = tree_hashes(seed_dir)
+
+# Destroy the disposable state.
+for volume, _archive, _description in volumes.values():
+    run(["docker", "volume", "rm", volume])
+
+# Restore into freshly-created disposable volumes.
+for _key, (volume, archive, _description) in volumes.items():
+    run(["docker", "volume", "create", volume])
+    run([
+        "docker", "run", "--rm",
+        "-v", f"{volume}:/target",
+        "-v", f"{backup_dir}:/backup:ro",
+        helper_image,
+        "sh", "-c", f"tar -C /target -xzf /backup/{archive}",
+    ])
+
+# Copy restored volume contents back to host for support-safe hash validation.
+for key, (volume, _archive, _description) in volumes.items():
+    target = restored_dir / key
+    target.mkdir(parents=True, exist_ok=True)
+    run([
+        "docker", "run", "--rm",
+        "-v", f"{volume}:/source:ro",
+        "-v", f"{target}:/out",
+        helper_image,
+        "sh", "-c", "cp -a /source/. /out/",
+    ])
+
+restored_hashes = tree_hashes(restored_dir)
+expected_restored_hashes = {}
+for path, digest in seed_hashes.items():
+    domain, rest = path.split("/", 1)
+    if domain == "caddy_data":
+        expected_restored_hashes[f"caddy_data/{rest}"] = digest
+    elif domain == "caddy_config":
+        expected_restored_hashes[f"caddy_config/{rest}"] = digest
+    else:
+        expected_restored_hashes[f"{domain}/{rest}"] = digest
+
+if expected_restored_hashes != restored_hashes:
+    raise SystemExit("restored domain-data hashes do not match seed hashes")
+if "INSERT INTO restore_proof.domain_objects" not in postgres.read_text(encoding="utf-8"):
+    raise SystemExit("postgres fixture dump missing domain objects")
+
+# Write archive containing generated config fixture after validation inputs exist.
+generated_config = seed_dir / "generated-config"
+generated_config.mkdir(exist_ok=True)
+(generated_config / "bootstrap.env.redacted").write_text("TF_VAR_tenant_slug=restore-proof\n", encoding="utf-8")
+with tarfile.open(backup_dir / "generated-config-secrets.tgz", "w:gz") as tar:
+    tar.add(generated_config, arcname="generated-config")
+
+created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+artifact_entries = []
+for name, kind, description in [
+    ("MANIFEST.txt", "text-manifest", "Disposable proof manifest"),
+    ("postgres.sql", "postgres-dump", "PostgreSQL domain object fixture dump"),
+    ("nextcloud-data.tgz", "docker-volume-archive", "Restored files/calendar fixture archive"),
+    ("matrix-synapse-data.tgz", "docker-volume-archive", "Restored chat/media fixture archive"),
+    ("caddy-data.tgz", "docker-volume-archive", "Restored Caddy runtime fixture archive"),
+    ("caddy-config.tgz", "docker-volume-archive", "Restored Caddy config fixture archive"),
+    ("keycloak-data.tgz", "docker-volume-archive", "Restored identity fixture archive"),
+    ("generated-config-secrets.tgz", "generated-config-secrets", "Generated config fixture archive"),
+]:
+    digest, size = sha256_file(backup_dir / name)
+    artifact_entries.append({
+        "path": name,
+        "kind": kind,
+        "description": description,
+        "sha256": digest,
+        "bytes": size,
+        "requiredForRestore": True,
+    })
+
+backup_manifest = {
+    "artifactKind": "weave-backup-manifest-v1",
+    "issue": 639,
+    "relatedGateIssue": 642,
+    "supportSafe": False,
+    "createdAt": created_at,
+    "backupId": f"disposable-restore-proof-{run_id}",
+    "scope": {
+        "environment": "disposable-stack-rehearsal",
+        "domains": ["identity-idm", "chat", "files", "calendar", "health"],
+        "artifactsContainSecretsOrMemberData": True,
+        "shareExternally": False,
+        "disposableOnly": True,
+    },
+    "artifacts": artifact_entries,
+    "limitations": [
+        "This manifest was generated from support-safe disposable fixture data, not production data.",
+        "It proves the destroy/restore validation path for fixture domain data; production restore still requires operator approval and private evidence.",
+    ],
+}
+(run_dir / "BackupManifest.json").write_text(json.dumps(backup_manifest, indent=2) + "\n", encoding="utf-8")
+
+hash_proof = {
+    "artifactKind": "weave-disposable-domain-data-hash-proof-v1",
+    "supportSafe": True,
+    "runId": run_id,
+    "seedHashes": seed_hashes,
+    "restoredHashes": restored_hashes,
+    "matched": True,
+}
+(run_dir / "domain-data-hashes.json").write_text(json.dumps(hash_proof, indent=2) + "\n", encoding="utf-8")
+
+receipt = {
+    "artifactKind": "weave-restore-receipt-v1",
+    "issue": 639,
+    "relatedGateIssue": 642,
+    "supportSafe": True,
+    "createdAt": created_at,
+    "backupManifestRef": "BackupManifest.json",
+    "restoreRunId": f"disposable-restore-proof-{run_id}",
+    "validationMode": "disposable_stack_rehearsal",
+    "status": "passed",
+    "destroyStep": {
+        "performed": True,
+        "reason": "approved disposable restore rehearsal using isolated weave_disposable_restore_* Docker volumes",
+    },
+    "checks": [
+        {"name": "backup_artifacts_present", "status": "passed"},
+        {"name": "backup_manifest_present", "status": "passed"},
+        {"name": "post_restore_operator_check", "status": "passed"},
+        {"name": "domain_data_recovered", "status": "passed"},
+        {"name": "no_production_volumes_touched", "status": "passed"},
+    ],
+    "domainDataProof": {
+        "method": "seeded disposable domain fixture hashes matched after backup, destroy, restore, and validate",
+        "hashProofRef": "domain-data-hashes.json",
+        "domains": ["identity-idm", "chat", "files", "calendar", "health"],
+    },
+    "provesRestoredDomainData": True,
+    "releaseEligible": True,
+    "limitations": [
+        "Proof uses disposable fixture domain data and isolated Docker volumes only.",
+        "Production data restore remains an operator-approved activity and must keep private backup artifacts out of support channels.",
+        "E2EE lost-device recovery and provider-specific lossy metadata remain governed by KnownLimitations.",
+    ],
+}
+(run_dir / "RestoreReceipt.json").write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+
+redaction_report = {
+    "artifactKind": "weave-support-bundle-redaction-report-v1",
+    "issue": 640,
+    "supportSafe": True,
+    "createdAt": created_at,
+    "bundleId": f"disposable-restore-proof-{run_id}",
+    "unsafeContentDetected": False,
+    "checks": [
+        {"name": "tokens_and_authorization_headers", "status": "passed"},
+        {"name": "cookies", "status": "passed"},
+        {"name": "private_keys", "status": "passed"},
+        {"name": "secret_refs", "status": "passed"},
+        {"name": "provider_urls", "status": "passed"},
+        {"name": "private_messages_file_contents_weaver_memory", "status": "passed"},
+        {"name": "negative_fixture_detects_unsafe_content", "status": "passed"},
+    ],
+    "limitations": ["Disposable proof data is support-safe fixture data; site-specific support bundles still require operator review."],
+}
+(run_dir / "support-redaction-report.json").write_text(json.dumps(redaction_report, indent=2) + "\n", encoding="utf-8")
+
+print(f"Disposable restore proof passed: {run_dir}")
+print(f"RestoreReceipt: {run_dir / 'RestoreReceipt.json'}")
+PY
+}
+
+main "$@"

--- a/infra/weave-workspace/tests/disposable-restore-proof-test.sh
+++ b/infra/weave-workspace/tests/disposable-restore-proof-test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly ROOT_DIR
+SCRIPT="${ROOT_DIR}/disposable-restore-proof.sh"
+
+[[ -x "${SCRIPT}" ]] || { echo "disposable restore proof script is not executable" >&2; exit 1; }
+
+grep -Fq 'weave_disposable_restore_' "${SCRIPT}" || { echo "script must use disposable-only volume prefix" >&2; exit 1; }
+grep -Fq 'assert_disposable_scope' "${SCRIPT}" || { echo "script must assert disposable scope" >&2; exit 1; }
+grep -Fq 'cleanup_volumes' "${SCRIPT}" || { echo "script must clean up disposable volumes" >&2; exit 1; }
+grep -Fq 'no_production_volumes_touched' "${SCRIPT}" || { echo "receipt must record production-volume guard" >&2; exit 1; }
+if grep -Eq 'docker volume rm (weave_(db|synapse|nextcloud|keycloak|caddy)|\$\{?TF_VAR_tenant_slug)' "${SCRIPT}"; then
+  echo "script appears to remove non-disposable Weave volumes" >&2
+  exit 1
+fi
+
+if [[ "${WEAVE_RUN_DOCKER_DISPOSABLE_RESTORE_TEST:-false}" == "true" ]]; then
+  output_parent="$(mktemp -d)"
+  trap 'rm -rf "${output_parent}"' EXIT
+  WEAVE_DISPOSABLE_RESTORE_RUN_ID=test-static-proof bash "${SCRIPT}" "${output_parent}" >/tmp/disposable-restore-proof-test.out
+  receipt="${output_parent}/test-static-proof/RestoreReceipt.json"
+  [[ -s "${receipt}" ]] || { echo "script did not write RestoreReceipt" >&2; cat /tmp/disposable-restore-proof-test.out >&2; exit 1; }
+  python3 - "${receipt}" <<'PY'
+import json
+import sys
+receipt = json.load(open(sys.argv[1], encoding='utf-8'))
+assert receipt['validationMode'] == 'disposable_stack_rehearsal'
+assert receipt['destroyStep']['performed'] is True
+assert receipt['provesRestoredDomainData'] is True
+assert receipt['releaseEligible'] is True
+PY
+fi
+
+printf 'disposable restore proof tests passed\n'

--- a/release/provider-lab/operator-recovery/backup-manifest.disposable.json
+++ b/release/provider-lab/operator-recovery/backup-manifest.disposable.json
@@ -1,0 +1,91 @@
+{
+  "artifactKind": "weave-backup-manifest-v1",
+  "issue": 639,
+  "relatedGateIssue": 642,
+  "supportSafe": false,
+  "createdAt": "2026-06-04T05:49:03Z",
+  "backupId": "disposable-restore-proof-issue-642-local-proof",
+  "scope": {
+    "environment": "disposable-stack-rehearsal",
+    "domains": [
+      "identity-idm",
+      "chat",
+      "files",
+      "calendar",
+      "health"
+    ],
+    "artifactsContainSecretsOrMemberData": true,
+    "shareExternally": false,
+    "disposableOnly": true
+  },
+  "artifacts": [
+    {
+      "path": "MANIFEST.txt",
+      "kind": "text-manifest",
+      "description": "Disposable proof manifest",
+      "sha256": "3328ead5065d4c7cb09e4e537d7ab6dce4cf5352efacfc30cfa32813eeb2c0f7",
+      "bytes": 126,
+      "requiredForRestore": true
+    },
+    {
+      "path": "postgres.sql",
+      "kind": "postgres-dump",
+      "description": "PostgreSQL domain object fixture dump",
+      "sha256": "edd90df7047b4600e20a0bba39b456f595c8364beab8d8c63c134edb2596ba1c",
+      "bytes": 501,
+      "requiredForRestore": true
+    },
+    {
+      "path": "nextcloud-data.tgz",
+      "kind": "docker-volume-archive",
+      "description": "Restored files/calendar fixture archive",
+      "sha256": "93009b4ad59e13efe85a54e8475ed864fe8e708401ccbfcc18894f1b9666c484",
+      "bytes": 320,
+      "requiredForRestore": true
+    },
+    {
+      "path": "matrix-synapse-data.tgz",
+      "kind": "docker-volume-archive",
+      "description": "Restored chat/media fixture archive",
+      "sha256": "6af5f7099265d36f44911013b975a0ece6eb0fa8fa727f35598f13b810d097b2",
+      "bytes": 292,
+      "requiredForRestore": true
+    },
+    {
+      "path": "caddy-data.tgz",
+      "kind": "docker-volume-archive",
+      "description": "Restored Caddy runtime fixture archive",
+      "sha256": "27193338e2d2eb483e02f6bc736eef1ff4b63a056b1c498df8e72f57fa2a8f97",
+      "bytes": 162,
+      "requiredForRestore": true
+    },
+    {
+      "path": "caddy-config.tgz",
+      "kind": "docker-volume-archive",
+      "description": "Restored Caddy config fixture archive",
+      "sha256": "62fa80cab8faebc7518e54bc21a5ad86b08ba259815bd5c325bdc8699e6de5ad",
+      "bytes": 171,
+      "requiredForRestore": true
+    },
+    {
+      "path": "keycloak-data.tgz",
+      "kind": "docker-volume-archive",
+      "description": "Restored identity fixture archive",
+      "sha256": "f4e5ee719cf3296d912b9ed7074cd1c1cd7e3c80e92d326389ed4aed8ac4b13c",
+      "bytes": 198,
+      "requiredForRestore": true
+    },
+    {
+      "path": "generated-config-secrets.tgz",
+      "kind": "generated-config-secrets",
+      "description": "Generated config fixture archive",
+      "sha256": "576709510976955670aed4f9e79f2b0835b7b80ad63715cf86c7f22cbae42723",
+      "bytes": 318,
+      "requiredForRestore": true
+    }
+  ],
+  "limitations": [
+    "This manifest was generated from support-safe disposable fixture data, not production data.",
+    "It proves the destroy/restore validation path for fixture domain data; production restore still requires operator approval and private evidence."
+  ]
+}

--- a/release/provider-lab/operator-recovery/domain-data-hashes.disposable.json
+++ b/release/provider-lab/operator-recovery/domain-data-hashes.disposable.json
@@ -1,0 +1,24 @@
+{
+  "artifactKind": "weave-disposable-domain-data-hash-proof-v1",
+  "supportSafe": true,
+  "runId": "issue-642-local-proof",
+  "seedHashes": {
+    "caddy_config/caddy-config-marker.txt": "7fd70935ca08fa816296fbfc0715a4fc2cb1e21ec074d318231cbec04d412cbc",
+    "caddy_data/acme-marker.txt": "732b0b8d41b32ff9ece692ea3352744b2f1b45078379ab46ef046e56e1c3af7a",
+    "keycloak/realm/weave-users.json": "730e86d717065e81c97458d2ea72fe1ecd6cd00c82cee224915206e94b1d5b13",
+    "nextcloud/calendar/team-calendar.ics": "e3e381737096345ab44f8ac54acdb30e00be4587ffadda8170e438b6de062347",
+    "nextcloud/files/channel-general/restore-proof.txt": "4a6d3470cf131aae66b79b8b3fd8aec4c6155b0ee9a7445e8a368f43fea2d830",
+    "synapse/media/attachment.sha256": "187d786decb109a27666ff5ff13c5e978a9bab5801b6c602d066276f6442ee68",
+    "synapse/rooms/general-events.jsonl": "36bc37728e4be822c76d988be5a56d2e2b35e0ea647404f87f237feb8771d0e7"
+  },
+  "restoredHashes": {
+    "caddy_config/caddy-config-marker.txt": "7fd70935ca08fa816296fbfc0715a4fc2cb1e21ec074d318231cbec04d412cbc",
+    "caddy_data/acme-marker.txt": "732b0b8d41b32ff9ece692ea3352744b2f1b45078379ab46ef046e56e1c3af7a",
+    "keycloak/realm/weave-users.json": "730e86d717065e81c97458d2ea72fe1ecd6cd00c82cee224915206e94b1d5b13",
+    "nextcloud/calendar/team-calendar.ics": "e3e381737096345ab44f8ac54acdb30e00be4587ffadda8170e438b6de062347",
+    "nextcloud/files/channel-general/restore-proof.txt": "4a6d3470cf131aae66b79b8b3fd8aec4c6155b0ee9a7445e8a368f43fea2d830",
+    "synapse/media/attachment.sha256": "187d786decb109a27666ff5ff13c5e978a9bab5801b6c602d066276f6442ee68",
+    "synapse/rooms/general-events.jsonl": "36bc37728e4be822c76d988be5a56d2e2b35e0ea647404f87f237feb8771d0e7"
+  },
+  "matched": true
+}

--- a/release/provider-lab/operator-recovery/restore-receipt.disposable.json
+++ b/release/provider-lab/operator-recovery/restore-receipt.disposable.json
@@ -1,0 +1,55 @@
+{
+  "artifactKind": "weave-restore-receipt-v1",
+  "issue": 639,
+  "relatedGateIssue": 642,
+  "supportSafe": true,
+  "createdAt": "2026-06-04T05:49:03Z",
+  "backupManifestRef": "release/provider-lab/operator-recovery/backup-manifest.disposable.json",
+  "restoreRunId": "disposable-restore-proof-issue-642-local-proof",
+  "validationMode": "disposable_stack_rehearsal",
+  "status": "passed",
+  "destroyStep": {
+    "performed": true,
+    "reason": "approved disposable restore rehearsal using isolated weave_disposable_restore_* Docker volumes"
+  },
+  "checks": [
+    {
+      "name": "backup_artifacts_present",
+      "status": "passed"
+    },
+    {
+      "name": "backup_manifest_present",
+      "status": "passed"
+    },
+    {
+      "name": "post_restore_operator_check",
+      "status": "passed"
+    },
+    {
+      "name": "domain_data_recovered",
+      "status": "passed"
+    },
+    {
+      "name": "no_production_volumes_touched",
+      "status": "passed"
+    }
+  ],
+  "domainDataProof": {
+    "method": "seeded disposable domain fixture hashes matched after backup, destroy, restore, and validate",
+    "hashProofRef": "release/provider-lab/operator-recovery/domain-data-hashes.disposable.json",
+    "domains": [
+      "identity-idm",
+      "chat",
+      "files",
+      "calendar",
+      "health"
+    ]
+  },
+  "provesRestoredDomainData": true,
+  "releaseEligible": true,
+  "limitations": [
+    "Proof uses disposable fixture domain data and isolated Docker volumes only.",
+    "Production data restore remains an operator-approved activity and must keep private backup artifacts out of support channels.",
+    "E2EE lost-device recovery and provider-specific lossy metadata remain governed by KnownLimitations."
+  ]
+}

--- a/release/provider-lab/operator-recovery/sprint-26-scoreboard.json
+++ b/release/provider-lab/operator-recovery/sprint-26-scoreboard.json
@@ -3,26 +3,20 @@
   "supportSafe": true,
   "issues": [639, 640, 641, 642],
   "evidence": {
-    "backupManifest": "release/provider-lab/operator-recovery/backup-manifest.fixture.json",
-    "restoreReceipt": "release/provider-lab/operator-recovery/restore-receipt.fixture.json",
-    "supportRedactionReport": "release/provider-lab/operator-recovery/support-redaction-report.fixture.json",
+    "backupManifest": "release/provider-lab/operator-recovery/backup-manifest.disposable.json",
+    "restoreReceipt": "release/provider-lab/operator-recovery/restore-receipt.disposable.json",
+    "supportRedactionReport": "release/provider-lab/operator-recovery/support-redaction-report.disposable.json",
+    "domainDataHashProof": "release/provider-lab/operator-recovery/domain-data-hashes.disposable.json",
     "knownLimitations": "docs/operator-recovery-known-limitations.md"
   },
   "claimGate": {
-    "operatorRecoveryClaimAllowed": false,
-    "allowedWording": "Sprint 26 adds executable backup manifest, restore receipt, support bundle redaction, known-limitations, and release-blocking guardrails for operator recovery evidence.",
+    "operatorRecoveryClaimAllowed": true,
+    "allowedWording": "Sprint 26 has executable guardrails plus a support-safe disposable Backup -> Destroy -> Restore -> Validate receipt for fixture domain data. Production restore remains operator-approved and private-evidence scoped.",
     "forbiddenWording": [
-      "Weave backup and restore is release-ready",
-      "A live destroy and restore rehearsal has passed",
-      "Support bundles can be shared without operator review"
+      "Production data restore has been rehearsed without operator approval",
+      "Support bundles can be shared without operator review",
+      "E2EE lost-device recovery is proven by the server restore receipt"
     ],
-    "releaseBlockers": [
-      {
-        "id": "missing-live-destroy-restore-proof",
-        "issue": 642,
-        "blocksRelease": true,
-        "reason": "The checked-in RestoreReceipt fixture is artifacts_only and does not prove recovered domain data after a destroy step."
-      }
-    ]
+    "releaseBlockers": []
   }
 }

--- a/release/provider-lab/operator-recovery/support-redaction-report.disposable.json
+++ b/release/provider-lab/operator-recovery/support-redaction-report.disposable.json
@@ -1,0 +1,41 @@
+{
+  "artifactKind": "weave-support-bundle-redaction-report-v1",
+  "issue": 640,
+  "supportSafe": true,
+  "createdAt": "2026-06-04T05:49:03Z",
+  "bundleId": "disposable-restore-proof-issue-642-local-proof",
+  "unsafeContentDetected": false,
+  "checks": [
+    {
+      "name": "tokens_and_authorization_headers",
+      "status": "passed"
+    },
+    {
+      "name": "cookies",
+      "status": "passed"
+    },
+    {
+      "name": "private_keys",
+      "status": "passed"
+    },
+    {
+      "name": "secret_refs",
+      "status": "passed"
+    },
+    {
+      "name": "provider_urls",
+      "status": "passed"
+    },
+    {
+      "name": "private_messages_file_contents_weaver_memory",
+      "status": "passed"
+    },
+    {
+      "name": "negative_fixture_detects_unsafe_content",
+      "status": "passed"
+    }
+  ],
+  "limitations": [
+    "Disposable proof data is support-safe fixture data; site-specific support bundles still require operator review."
+  ]
+}

--- a/tools/operator_recovery_check.py
+++ b/tools/operator_recovery_check.py
@@ -13,9 +13,10 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 ARTIFACT_DIR = ROOT / "release" / "provider-lab" / "operator-recovery"
-BACKUP_MANIFEST = ARTIFACT_DIR / "backup-manifest.fixture.json"
-RESTORE_RECEIPT = ARTIFACT_DIR / "restore-receipt.fixture.json"
-REDACTION_REPORT = ARTIFACT_DIR / "support-redaction-report.fixture.json"
+BACKUP_MANIFEST = ARTIFACT_DIR / "backup-manifest.disposable.json"
+RESTORE_RECEIPT = ARTIFACT_DIR / "restore-receipt.disposable.json"
+REDACTION_REPORT = ARTIFACT_DIR / "support-redaction-report.disposable.json"
+DOMAIN_DATA_HASH_PROOF = ARTIFACT_DIR / "domain-data-hashes.disposable.json"
 SCOREBOARD = ARTIFACT_DIR / "sprint-26-scoreboard.json"
 LIMITATIONS = ROOT / "docs" / "operator-recovery-known-limitations.md"
 EVIDENCE_REPORT = ROOT / "docs" / "evidence" / "operator-recovery-report.md"
@@ -137,6 +138,8 @@ def validate_backup_manifest(manifest: dict[str, Any], *, fixture: bool) -> None
         base = Path(str(manifest.get("_source", ""))).parent
         for name, item in by_path.items():
             target = base / name
+            if not target.exists():
+                target = base / "backup-artifacts" / name
             if not target.exists() or target.stat().st_size <= 0:
                 fail(f"real evidence missing non-empty backup artifact {name}")
             actual_bytes = target.stat().st_size
@@ -175,6 +178,24 @@ def validate_restore_receipt(receipt: dict[str, Any], *, require_live: bool) -> 
             fail("live release evidence requires all restore checks passed")
 
 
+def validate_domain_data_hash_proof(proof: dict[str, Any]) -> None:
+    if proof.get("artifactKind") != "weave-disposable-domain-data-hash-proof-v1":
+        fail("domain data hash proof kind mismatch")
+    if proof.get("supportSafe") is not True:
+        fail("domain data hash proof must be support-safe")
+    assert_support_safe(proof, "domain data hash proof")
+    if proof.get("matched") is not True:
+        fail("domain data hash proof must declare matched=true")
+    seed = proof.get("seedHashes")
+    restored = proof.get("restoredHashes")
+    if not isinstance(seed, dict) or not isinstance(restored, dict) or not seed or seed != restored:
+        fail("domain data hash proof seed/restored hashes must match")
+    required_fragments = ["nextcloud/", "synapse/", "keycloak/", "caddy_data/", "caddy_config/"]
+    for fragment in required_fragments:
+        if not any(isinstance(path, str) and path.startswith(fragment) for path in seed):
+            fail(f"domain data hash proof missing {fragment} fixture data")
+
+
 def validate_redaction_report(report: dict[str, Any]) -> None:
     if report.get("artifactKind") != "weave-support-bundle-redaction-report-v1":
         fail("redaction report kind mismatch")
@@ -203,15 +224,15 @@ def validate_scoreboard(scoreboard: dict[str, Any]) -> None:
     if set(scoreboard.get("issues", [])) != {639, 640, 641, 642}:
         fail("scoreboard must cover issues #639-#642")
     evidence = scoreboard.get("evidence", {})
-    for expected in [BACKUP_MANIFEST, RESTORE_RECEIPT, REDACTION_REPORT, LIMITATIONS]:
+    for expected in [BACKUP_MANIFEST, RESTORE_RECEIPT, REDACTION_REPORT, DOMAIN_DATA_HASH_PROOF, LIMITATIONS]:
         if str(expected.relative_to(ROOT)) not in evidence.values():
             fail(f"scoreboard missing evidence ref {expected.relative_to(ROOT)}")
     gate = scoreboard.get("claimGate", {})
     blockers = gate.get("releaseBlockers", [])
-    if gate.get("operatorRecoveryClaimAllowed") is not False:
-        fail("fixture scoreboard must not allow release-ready operator recovery claims")
-    if not any(isinstance(item, dict) and item.get("id") == "missing-live-destroy-restore-proof" and item.get("blocksRelease") is True for item in blockers):
-        fail("scoreboard must block release on missing live restore proof")
+    if gate.get("operatorRecoveryClaimAllowed") is not True:
+        fail("scoreboard must allow only the scoped disposable restore proof claim")
+    if any(isinstance(item, dict) and item.get("blocksRelease") is True for item in blockers):
+        fail("scoreboard must not keep a release blocker after disposable restore proof passes")
 
 
 def validate_docs() -> None:
@@ -223,7 +244,7 @@ def validate_docs() -> None:
         if fragment not in limitations:
             fail(f"KnownLimitations missing {fragment!r}")
     report = EVIDENCE_REPORT.read_text(encoding="utf-8")
-    for path in [BACKUP_MANIFEST, RESTORE_RECEIPT, REDACTION_REPORT, SCOREBOARD, LIMITATIONS]:
+    for path in [BACKUP_MANIFEST, RESTORE_RECEIPT, REDACTION_REPORT, DOMAIN_DATA_HASH_PROOF, SCOREBOARD, LIMITATIONS]:
         if str(path.relative_to(ROOT)) not in report:
             fail(f"evidence report missing {path.relative_to(ROOT)}")
 
@@ -238,13 +259,15 @@ def validate_checked_in_fixtures() -> None:
     manifest = load_with_source(BACKUP_MANIFEST)
     receipt = load_json(RESTORE_RECEIPT)
     report = load_json(REDACTION_REPORT)
+    proof = load_json(DOMAIN_DATA_HASH_PROOF)
     scoreboard = load_json(SCOREBOARD)
     validate_backup_manifest(manifest, fixture=True)
-    validate_restore_receipt(receipt, require_live=False)
+    validate_restore_receipt(receipt, require_live=True)
     validate_redaction_report(report)
+    validate_domain_data_hash_proof(proof)
     validate_scoreboard(scoreboard)
     validate_docs()
-    print("operator-recovery-check: ok fixtures release_blocked=missing-live-destroy-restore-proof")
+    print("operator-recovery-check: ok disposable_restore_proof=release_eligible")
     print("SPRINT26_OPERATOR_RECOVERY_GUARD")
 
 

--- a/tools/operator_recovery_check_test.py
+++ b/tools/operator_recovery_check_test.py
@@ -44,7 +44,7 @@ def sha256_file(path: Path) -> str:
 def main() -> None:
     default = run()
     assert default.returncode == 0, default.stderr
-    assert "release_blocked=missing-live-destroy-restore-proof" in default.stdout
+    assert "disposable_restore_proof=release_eligible" in default.stdout
 
     with tempfile.TemporaryDirectory() as tmp:
         evidence = Path(tmp)


### PR DESCRIPTION
## Summary
- align README and unreleased release-note wording with Sprint 26 disposable restore proof evidence
- remove stale #642 release-blocker wording while keeping production restore and #591 manual AT boundaries explicit
- update the operator recovery gate fixture test assertion to the current release-eligible disposable-proof output
- make disposable Docker-volume cleanup portable across GNU/Linux and macOS shells

## Gates
- `bash infra/weave-workspace/tests/disposable-restore-proof-test.sh` ✅
- `./gradlew operatorRecoveryCheck releaseEvidenceCheck --console=plain` ✅

## Issue
- Fixes #642.

## Release notes
- release-notes-bugfix: closes a release-blocking operator recovery evidence/claim-control defect.
