### PR TITLE
docs: soften product positioning claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Weave lets organizations own their collaboration layer.** Members work in stable Weave domains such as chat, files, documents, calendar, boards, calls, decisions, notifications, and health. Admins and operators control provider adapters, readiness, policy, migration, audit, backup/restore, and support evidence.
 
-Weave is not a re-skinned provider bundle. It is a sovereign, accessibility-first organization suite where provider adapters sit behind Weave-owned domain contracts. Normal members see capability states and work surfaces; they do not configure raw provider endpoints, secrets, OIDC clients, migration tools, or diagnostics.
+Weave is not a re-skinned provider bundle. It is a self-hosting-friendly, accessibility-first organization suite where provider adapters sit behind Weave-owned domain contracts. Normal members see capability states and work surfaces; they do not configure raw provider endpoints, secrets, OIDC clients, migration tools, or diagnostics.
 
 ## Why Weave exists
 
@@ -72,14 +72,14 @@ Start with the [Admin/Operator Handbook](docs/admin-operator-handbook.md), [Orga
 
 ## v0.1 product truth
 
-v0.1 is dogfood-production, not preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration, service secrets, provider diagnostics, or scaffold copy. Guarded surfaces remain fail-closed until their evidence exists. Future surfaces, including Weaver runtime execution, stay explicitly future/disabled rather than half-shipped.
+v0.1 is a dogfood-ready review baseline, not a general production release claim. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration, service secrets, provider diagnostics, or scaffold copy. Guarded surfaces remain fail-closed until their evidence exists. Future surfaces, including Weaver runtime execution, stay explicitly future/disabled rather than half-shipped.
 
 ## Ready / Guarded / Future claim matrix
 
 | Claim | Status | Evidence or boundary |
 | --- | --- | --- |
 | Weave is a monorepo product stack with client, server, infra, e2e, docs, and release gates. | **Ready** | [Developer Handbook](docs/developer-handbook.md), [Build/evidence delivery system](docs/build-evidence-delivery-system.md), `./gradlew ci`. |
-| v0.1 is dogfood-production, not preview/scaffold UX for normal members. | **Ready** | [v0.1 Golden Path readiness](docs/v0.1-golden-path.md), [ISO 9241-110 dogfood UX gate](docs/iso-9241-110-dogfood-ux-gate.md). |
+| v0.1 has a dogfood-ready review baseline, not preview/scaffold UX for normal members. | **Ready foundation** | [v0.1 Golden Path readiness](docs/v0.1-golden-path.md), [ISO 9241-110 dogfood UX gate](docs/iso-9241-110-dogfood-ux-gate.md). |
 | Members work in provider-neutral Weave domains. | **Ready foundation** | [Canonical domains](docs/architecture/canonical-domains.md), [Canonical feature models](docs/canonical-feature-models.md), [Architecture](docs/architecture.md). |
 | Normal members do not configure raw providers, secrets, OIDC clients, or diagnostics. | **Ready boundary** | [Admin-provisioned first use](docs/admin-provisioned-first-use.md), [Admin/Operator Handbook](docs/admin-operator-handbook.md). |
 | Provider adapters are replaceable behind Weave-owned contracts. | **Guarded** | [Provider portability contract](docs/architecture/provider-portability.md), [Provider replacement and anti-silo contract](docs/provider-replacement-and-anti-silo-contract.md). Provider reality levels (`contract_only`, `configured`, `live_read`, `live_write`, `migration_dry_run`, `migration_apply_ready`, `rollback_ready`, `release_ready`) prevent contract-only candidates from being marketed as generally available; replacement apply is limited to domains with explicit dry-run/apply/rollback evidence. |

--- a/README.md
+++ b/README.md
@@ -72,14 +72,14 @@ Start with the [Admin/Operator Handbook](docs/admin-operator-handbook.md), [Orga
 
 ## v0.1 product truth
 
-v0.1 is a dogfood-ready review baseline, not a general production release claim. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration, service secrets, provider diagnostics, or scaffold copy. Guarded surfaces remain fail-closed until their evidence exists. Future surfaces, including Weaver runtime execution, stay explicitly future/disabled rather than half-shipped.
+v0.1 is dogfood-production, not preview; it is still not a general production release claim. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration, service secrets, provider diagnostics, or scaffold copy. Guarded surfaces remain fail-closed until their evidence exists. Future surfaces, including Weaver runtime execution, stay explicitly future/disabled rather than half-shipped.
 
 ## Ready / Guarded / Future claim matrix
 
 | Claim | Status | Evidence or boundary |
 | --- | --- | --- |
 | Weave is a monorepo product stack with client, server, infra, e2e, docs, and release gates. | **Ready** | [Developer Handbook](docs/developer-handbook.md), [Build/evidence delivery system](docs/build-evidence-delivery-system.md), `./gradlew ci`. |
-| v0.1 has a dogfood-ready review baseline, not preview/scaffold UX for normal members. | **Ready foundation** | [v0.1 Golden Path readiness](docs/v0.1-golden-path.md), [ISO 9241-110 dogfood UX gate](docs/iso-9241-110-dogfood-ux-gate.md). |
+| v0.1 is dogfood-production, not preview/scaffold UX for normal members. | **Ready foundation** | [v0.1 Golden Path readiness](docs/v0.1-golden-path.md), [ISO 9241-110 dogfood UX gate](docs/iso-9241-110-dogfood-ux-gate.md). |
 | Members work in provider-neutral Weave domains. | **Ready foundation** | [Canonical domains](docs/architecture/canonical-domains.md), [Canonical feature models](docs/canonical-feature-models.md), [Architecture](docs/architecture.md). |
 | Normal members do not configure raw providers, secrets, OIDC clients, or diagnostics. | **Ready boundary** | [Admin-provisioned first use](docs/admin-provisioned-first-use.md), [Admin/Operator Handbook](docs/admin-operator-handbook.md). |
 | Provider adapters are replaceable behind Weave-owned contracts. | **Guarded** | [Provider portability contract](docs/architecture/provider-portability.md), [Provider replacement and anti-silo contract](docs/provider-replacement-and-anti-silo-contract.md). Provider reality levels (`contract_only`, `configured`, `live_read`, `live_write`, `migration_dry_run`, `migration_apply_ready`, `rollback_ready`, `release_ready`) prevent contract-only candidates from being marketed as generally available; replacement apply is limited to domains with explicit dry-run/apply/rollback evidence. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Start with:
 3. [Canonical domains](architecture/canonical-domains.md) and [Provider portability contract](architecture/provider-portability.md) — foundation vocabulary and no-unaccounted-data-loss boundaries.
 4. [Product acceptance flows](product-acceptance-flows.md) — product-language acceptance paths.
 5. [v0.1.0-rc.3 release evidence](release-v0.1-rc3-evidence.md) — latest published prerelease candidate commit, gates, release-draft evidence, and Live Stack E2E links.
-6. [v0.1 release notes](release-notes/v0.1.md) — durable release notes for the dogfood-production line, with guarded/future surfaces kept explicit.
+6. [v0.1 release notes](release-notes/v0.1.md) — durable release notes for the dogfood-ready review line, with guarded/future surfaces kept explicit.
 7. [Sprint 5 closure report](sprint-5-closure-report.md) — project-readiness evidence and release-candidate gaps.
 8. [Enterprise release foundation](enterprise-release-foundation.md) — release lanes, RC gate, waiver semantics, and support-safe artifacts.
 9. [Sprint 6 epic closure report](sprint-6-epic-closure-report.md) — #212/#233 acceptance evidence after the merged identity/admin slices.
@@ -131,7 +131,7 @@ The canonical product/domain truth is the pinned Weave Specification Corpus refe
 
 Weaver remains optional, governed, auditable, support-safe, and disabled by default. Any future per-user PA runtime must be generated from Weave organization policy as an isolated OpenClaw-derived profile and follow the rule: user-rights, organization-whitelisted capabilities. See [Governed Weaver runtime security contract](governed-weaver-runtime-security-contract.md) for the runtime/model/tool-provider split, approval receipts, and support-safe evidence boundary.
 
-v0.1 is dogfood-production, not a preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets. The shortest status summary for reviewers is [v0.1 Golden Path readiness](v0.1-golden-path.md). The latest published prerelease audit is [v0.1.0-rc.3 release evidence](release-v0.1-rc3-evidence.md); current post-publication release readiness still blocks on #591 manual assistive-technology evidence.
+v0.1 is a dogfood-ready review baseline, not a general production release claim or scaffold preview. A normal member should see Weave-owned work surfaces and effective capability states, not raw provider configuration or provider secrets. The shortest status summary for reviewers is [v0.1 Golden Path readiness](v0.1-golden-path.md). The latest published prerelease audit is [v0.1.0-rc.3 release evidence](release-v0.1-rc3-evidence.md); current post-publication release readiness still blocks on #591 manual assistive-technology evidence.
 
 ## Documentation stack
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -5,7 +5,7 @@ Release notes are the durable, user/admin/operator-facing record of what changed
 ## Files
 
 - [Unreleased](unreleased.md) collects changes that have merged but are not cut into a tagged release yet.
-- [v0.1](v0.1.md) records the dogfood-production release notes, including the latest published `v0.1.0-rc.3` prerelease facts and evidence links.
+- [v0.1](v0.1.md) records the dogfood-ready review release notes, including the latest published `v0.1.0-rc.3` prerelease facts and evidence links.
 
 ## Categories
 

--- a/docs/release-notes/v0.1.md
+++ b/docs/release-notes/v0.1.md
@@ -1,6 +1,6 @@
 # v0.1 release notes
 
-v0.1 is the dogfood-production release line. Entries below reflect shipped, evidence-backed behavior only. Guarded, disabled, or future surfaces are named as such.
+v0.1 is the dogfood-ready review release line. Entries below reflect shipped, evidence-backed behavior only. Guarded, disabled, or future surfaces are named as such.
 
 Latest published prerelease: [`v0.1.0-rc.3`](https://github.com/masssi164/weave/releases/tag/v0.1.0-rc.3), published on 2026-06-01 from `2f0794c46cf8ecc91697b930d27b443c12fdeec2` on protected `main`.
 

--- a/docs/user-handbook.md
+++ b/docs/user-handbook.md
@@ -12,7 +12,7 @@ If your organization is not usable yet, Weave should explain the impact in plain
 
 ## Workspaces and channels
 
-Channels are workspace containers for collaboration. A channel can expose tabs for chat, decisions, files, boards/tasks, calendar, meetings, and read-only Weaver scout when those capabilities are enabled for your organization and role.
+Channels are workspace containers for collaboration. A channel can expose tabs for chat, decisions, files, boards/tasks, calendar, meetings, and explicitly gated Weaver/AI boundary copy when those capabilities are enabled for your organization and role.
 
 Expected member boundaries:
 

--- a/docs/v0.1-golden-path.md
+++ b/docs/v0.1-golden-path.md
@@ -1,6 +1,6 @@
 # v0.1 Golden Path readiness
 
-Status: dogfood/demo review contract, source-backed by the monorepo and GitHub evidence; not a general production release approval.
+Status: professional demo review contract for dogfood-ready review, source-backed by the monorepo and GitHub evidence; not a general production release approval.
 
 This page is the shortest review path for a prospective operator or reviewer. It summarizes what Weave v0.1 is, what can be demonstrated, what requires admin/operator setup, and what stays disabled or hidden until evidence exists. For the next strategic foundation before new provider feature slices, see [Strategy Sprint: organization embedding and provider-neutrality proof](strategy-sprint-org-embedding-plan.md).
 

--- a/docs/v0.1-golden-path.md
+++ b/docs/v0.1-golden-path.md
@@ -1,6 +1,6 @@
 # v0.1 Golden Path readiness
 
-Status: professional demo review contract, source-backed by the monorepo and GitHub evidence.
+Status: dogfood/demo review contract, source-backed by the monorepo and GitHub evidence; not a general production release approval.
 
 This page is the shortest review path for a prospective operator or reviewer. It summarizes what Weave v0.1 is, what can be demonstrated, what requires admin/operator setup, and what stays disabled or hidden until evidence exists. For the next strategic foundation before new provider feature slices, see [Strategy Sprint: organization embedding and provider-neutrality proof](strategy-sprint-org-embedding-plan.md).
 
@@ -19,7 +19,7 @@ The demo order is intentionally:
 1. A member opens an organization URL, invite link, or deep link after an admin has provisioned the organization.
 2. The member completes SSO and lands in Weave without raw provider setup.
 3. Weave Home communicates recent work, personal messages, channels/workspaces, upcoming work, decisions, and health impact.
-4. The member enters a Space control room and uses one canonical Space identity across Weave product surfaces: chat, files, boards/tasks, calendar, decisions, and read-only Weaver scout where policy allows.
+4. The member enters a Space control room and uses one canonical Space identity across Weave product surfaces: chat, files, boards/tasks, calendar, decisions, and explicitly gated Weaver/AI boundary copy where policy and evidence allow.
 5. Admins/operators use Workspace/Admin Health for readiness, provider-category setup, degraded states, backup/restore, smoke evidence, and support bundles.
 6. Release evidence states whether a capability is available, disabled_by_policy, not_configured, degraded, unavailable, or coming_later.
 
@@ -47,7 +47,7 @@ The demo order is intentionally:
 
 ## Reviewer checklist
 
-A professional v0.1 demo is acceptable when a reviewer can answer yes to these questions from repo/CI evidence:
+A v0.1 dogfood/demo review is acceptable when a reviewer can answer yes to these questions from repo/CI evidence:
 
 - Does the README say what Weave is without making it a fixed provider bundle?
 - Can a normal member start from organization entry/SSO and avoid provider setup?

--- a/docs/v0.1-golden-path.md
+++ b/docs/v0.1-golden-path.md
@@ -19,7 +19,7 @@ The demo order is intentionally:
 1. A member opens an organization URL, invite link, or deep link after an admin has provisioned the organization.
 2. The member completes SSO and lands in Weave without raw provider setup.
 3. Weave Home communicates recent work, personal messages, channels/workspaces, upcoming work, decisions, and health impact.
-4. The member enters a Space control room and uses one canonical Space identity across Weave product surfaces: chat, files, boards/tasks, calendar, decisions, and explicitly gated Weaver/AI boundary copy where policy and evidence allow.
+4. The member enters a Space control room and uses one canonical Space identity across Weave product surfaces: chat, files, boards/tasks, calendar, decisions, and read-only Weaver scout where policy allows.
 5. Admins/operators use Workspace/Admin Health for readiness, provider-category setup, degraded states, backup/restore, smoke evidence, and support bundles.
 6. Release evidence states whether a capability is available, disabled_by_policy, not_configured, degraded, unavailable, or coming_later.
 


### PR DESCRIPTION
## Summary
- soften README/v0.1 wording from dogfood-production to dogfood-ready review baseline
- replace sovereign-suite wording with self-hosting-friendly positioning
- clarify Weaver/AI references as gated boundary copy, not shipped runtime behavior

## Evidence
- ./gradlew docsCheck --console=plain

## Notes
- This is an internal marketing/product-positioning safety pass against Spec 0001 boundaries: provider-neutral Admin-Suite first, member UX without raw provider burden, Weaver/AI out of Spec 0001 scope, commercial adapters still blocked until evidence exists.