### PR TITLE
ci: add local Forgejo dispatch preflight workflow

### DIFF
--- a/.forgejo/workflows/weave-admin-setup-e2e.yml
+++ b/.forgejo/workflows/weave-admin-setup-e2e.yml
@@ -1,0 +1,34 @@
+name: Weave Admin Setup E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      evidence_mode:
+        description: "support-safe evidence mode; smoke does not claim #665 live-stack E2E"
+        required: false
+        default: "smoke"
+
+jobs:
+  support-safe-preflight:
+    name: Support-safe Forgejo dispatch preflight
+    runs-on:
+      - ubuntu-latest
+      - docker
+    timeout-minutes: 20
+    steps:
+      - name: Check out weave
+        uses: actions/checkout@v4
+      - name: Validate support-safe local Forgejo contracts
+        run: |
+          set -euo pipefail
+          python3 tools/local_forgejo_runner_readiness_check.py
+          python3 tools/local_forgejo_pipeline_provider_check.py
+          python3 tools/local_domain_adapter_plan_check.py
+          python3 tools/local_forgejo_e2e_handoff_check.py
+      - name: Emit claim boundary
+        run: |
+          set -euo pipefail
+          echo "pipeline_terminal_success=false"
+          echo "stack_readiness_passed=false"
+          echo "weave_e2e_passed=false"
+          echo "claim_boundary=dispatch_preflight_only_not_665_closure"


### PR DESCRIPTION
## Summary

- Add a local Forgejo `weave-admin-setup-e2e` workflow target.
- Keep the workflow explicitly support-safe: it validates runner/provider/domain/#665 handoff contracts and emits a non-claiming boundary.
- Do **not** claim #665 live-stack success: local Forgejo currently has a Docker/Linux runner, while the existing GitHub live-stack E2E workflow is macOS/ARM64-specific.

## Related issues

- #665 remains open until a real local Forgejo workflow reaches terminal success, deployed-stack readiness passes, and Weave E2E passes.
- Supports the #681 customer-simple bootstrap flow by creating an actual dispatch target instead of a phantom workflow.

## Checks run

- [x] `python3 tools/local_forgejo_runner_readiness_check.py`
- [x] `python3 tools/local_forgejo_pipeline_provider_check.py`
- [x] `python3 tools/local_domain_adapter_plan_check.py`
- [x] `python3 tools/local_forgejo_e2e_handoff_check.py`
- [x] `git diff --check`

## Release notes label

- [x] `release-notes-skip`
