### PR TITLE
feat: add physical iPhone LAN dogfood handoff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ registerRootCommandTask('weaveControlModesCheck', ['python3', 'tools/weave_contr
 registerRootCommandTask('sprint29HumanValidationCheck', ['python3', 'tools/sprint29_human_validation_check.py'], 'Validate Sprint 29 human-in-the-loop release validation artifacts, manual templates, and no-fake-signoff guard posture.')
 registerRootCommandTask('commercialAdapterReadinessCheck', ['python3', 'tools/commercial_adapter_readiness_check.py'], 'Validate Sprint 28 commercial adapter readiness specs, go/no-go matrix, and implementation-start guard.')
 registerRootCommandTask('sprint30HotPhaseCheck', ['python3', 'tools/sprint30_hot_phase_check.py'], 'Validate Sprint 30 hot-phase slogan, unified setup, member onboarding, support-safe evidence, and Weaver governance guardrails.')
+registerRootCommandTask('sprint31LanDogfoodCheck', ['python3', 'tools/sprint31_lan_dogfood_check.py'], 'Validate Sprint 31 physical iPhone LAN dogfood command, handoff, client boundary, and support-safe evidence.')
 registerRootCommandTask('localDomainAdapterPlanCheck', ['python3', 'tools/local_domain_adapter_plan_check.py'], 'Validate Sprint 27 local domain-adapter deployable plan fixtures and acceptance mapping.')
 registerRootCommandTask('localForgejoPipelineProviderCheck', ['python3', 'tools/local_forgejo_pipeline_provider_check.py'], 'Validate Sprint 27 local Forgejo PipelineProvider fixtures and acceptance mapping.')
 registerRootCommandTask('crossDomainProviderProofCheck', ['python3', 'tools/cross_domain_provider_proof_check.py'], 'Validate Sprint 27 Calendar, Files, Identity provider-boundary fixtures, scoreboard, claim gate, and acceptance mapping.')
@@ -91,7 +92,7 @@ tasks.register('releaseReadinessCheck', Exec) {
     commandLine execCommand(args)
     outputs.upToDateWhen { false }
 }
-registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_claim_matrix_check.py && python3 tools/product_trust_claim_matrix_check.py && python3 tools/product_reality_claim_gate_check.py && python3 tools/provider_lab_check.py && python3 tools/chat_provider_switch_check.py && python3 tools/weaver_runtime_factory_check.py && python3 tools/weaver_customization_check.py && python3 tools/admin_cicd_orchestration_check.py && python3 tools/operator_recovery_check.py && python3 tools/operator_recovery_check_test.py && python3 tools/local_cicd_bootstrapper_check.py && python3 tools/local_forgejo_runner_readiness_check.py && python3 tools/local_forgejo_e2e_handoff_check.py && python3 tools/weave_control_modes_check.py && python3 tools/local_domain_adapter_plan_check.py && python3 tools/local_forgejo_pipeline_provider_check.py && python3 tools/cross_domain_provider_proof_check.py && python3 tools/commercial_adapter_readiness_check.py && python3 tools/sprint30_hot_phase_check.py && python3 tools/sprint29_human_validation_check.py && python3 tools/release_trust_claim_control_check.py && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py && python3 tools/release_readiness_check_test.py'], 'Validate release notes, README markers, provider reality, Sprint 26/27/28/29 evidence gates, claim matrices, labels, generator fixtures, project readiness, enterprise release gates, and RC readiness fixtures.')
+registerRootCommandTask('releaseEvidenceCheck', ['bash', '-lc', 'PYTHON=python3; [ -x build/docs-venv/bin/python ] && PYTHON=build/docs-venv/bin/python; "$PYTHON" tools/docs_check.py --release-notes-only && python3 tools/readme_release_notes.py --check && python3 tools/release_claim_matrix_check.py && python3 tools/product_trust_claim_matrix_check.py && python3 tools/product_reality_claim_gate_check.py && python3 tools/provider_lab_check.py && python3 tools/chat_provider_switch_check.py && python3 tools/weaver_runtime_factory_check.py && python3 tools/weaver_customization_check.py && python3 tools/admin_cicd_orchestration_check.py && python3 tools/operator_recovery_check.py && python3 tools/operator_recovery_check_test.py && python3 tools/local_cicd_bootstrapper_check.py && python3 tools/local_forgejo_runner_readiness_check.py && python3 tools/local_forgejo_e2e_handoff_check.py && python3 tools/weave_control_modes_check.py && python3 tools/local_domain_adapter_plan_check.py && python3 tools/local_forgejo_pipeline_provider_check.py && python3 tools/cross_domain_provider_proof_check.py && python3 tools/commercial_adapter_readiness_check.py && python3 tools/sprint30_hot_phase_check.py && python3 tools/sprint31_lan_dogfood_check.py && python3 tools/sprint29_human_validation_check.py && python3 tools/release_trust_claim_control_check.py && python3 tools/release_notes_label_check_test.py && python3 tools/release_notes_generate.py --input tools/fixtures/release_notes_prs.json --output tools/fixtures/release_notes_unreleased.expected.md --check && python3 tools/project_readiness_evidence_check.py && python3 tools/release_gate_check.py && python3 tools/release_readiness_check_test.py'], 'Validate release notes, README markers, provider reality, Sprint 26/27/28/29 evidence gates, claim matrices, labels, generator fixtures, project readiness, enterprise release gates, and RC readiness fixtures.')
 
 tasks.register('docsCheck') {
     group = 'verification'
@@ -142,12 +143,14 @@ ext.ciEvidenceGates = [
     'sprint29HumanValidationCheck',
     'commercialAdapterReadinessCheck',
     'sprint30HotPhaseCheck',
+    'sprint31LanDogfoodCheck',
     'localDomainAdapterPlanCheck',
     'localForgejoPipelineProviderCheck',
     'crossDomainProviderProofCheck',
     'androidReleaseIdentityCheck',
     'adminDependencyPolicyCheck',
     'releaseEvidenceCheck',
+    'sprint31LanDogfoodCheck',
     'projectReadinessEvidenceCheck',
     'enterpriseReleaseGateCheck'
 ]
@@ -263,6 +266,8 @@ List<String> artifactPathsForGate(String gateName) {
             return ['specs/admin-ci-cd-orchestration-contract.md', 'release/provider-lab/admin-cicd/local-forgejo-setup-proof.fixture.json', 'tools/admin_cicd_orchestration_check.py']
         case 'releaseEvidenceCheck':
             return ['README.md', 'tools/fixtures/release_notes_unreleased.expected.md', 'release/sprint-29-human-validation']
+        case 'sprint31LanDogfoodCheck':
+            return ['tools/weavectl', 'tools/sprint31_lan_dogfood_check.py', 'release/sprint-31-physical-iphone-lan-dogfood', 'docs/sprint-31-iphone-lan-dogfood-runbook.md']
         case 'sprint29HumanValidationCheck':
             return ['release/sprint-29-human-validation', 'docs/evidence/sprint-29-human-validation', 'tools/sprint29_human_validation_check.py', 'tools/sprint29_release_decision_guard.py']
         case 'projectReadinessEvidenceCheck':

--- a/client/android/app/src/main/AndroidManifest.xml
+++ b/client/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="weave"
         android:name="${applicationName}"
@@ -22,6 +23,12 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+            <intent-filter android:label="weave_member_handoff">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="weave" android:pathPrefix="/join" />
             </intent-filter>
         </activity>
         <activity

--- a/client/ios/Runner/Info.plist
+++ b/client/ios/Runner/Info.plist
@@ -32,6 +32,16 @@
 				<string>com.massimotter.weave</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>Weave member handoff</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>weave</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
@@ -43,7 +53,7 @@
 		<dict/>
 	</dict>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string></string>
+	<string>Weave connects to your workspace services on the same local network for local dogfood setup.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/client/lib/core/router/app_router.dart
+++ b/client/lib/core/router/app_router.dart
@@ -11,6 +11,7 @@ import 'package:weave/features/chat/presentation/chat_screen.dart';
 import 'package:weave/features/files/presentation/files_screen.dart';
 import 'package:weave/features/help/presentation/help_screen.dart';
 import 'package:weave/features/onboarding/presentation/first_run_screen.dart';
+import 'package:weave/features/onboarding/presentation/member_handoff_screen.dart';
 import 'package:weave/features/onboarding/presentation/providers/first_run_status_provider.dart';
 import 'package:weave/features/onboarding/presentation/setup_flow.dart';
 import 'package:weave/features/onboarding/presentation/welcome_screen.dart';
@@ -36,6 +37,7 @@ GoRouter appRouter(Ref ref) {
           state.matchedLocation == AppRoutes.welcome ||
           state.matchedLocation == AppRoutes.setup;
       final onSignIn = state.matchedLocation == AppRoutes.signIn;
+      final onJoin = state.matchedLocation == AppRoutes.join;
       final onFirstRun = state.matchedLocation == AppRoutes.firstRun;
       final onHiddenReleaseOneRoute =
           state.matchedLocation == AppRoutes.calendar ||
@@ -50,7 +52,7 @@ GoRouter appRouter(Ref ref) {
         case BootstrapPhase.error:
           return null;
         case BootstrapPhase.needsSetup:
-          return onOnboarding ? null : AppRoutes.welcome;
+          return (onOnboarding || onJoin) ? null : AppRoutes.welcome;
         case BootstrapPhase.needsSignIn:
           return onSignIn ? null : AppRoutes.signIn;
         case BootstrapPhase.ready:
@@ -86,6 +88,10 @@ GoRouter appRouter(Ref ref) {
       GoRoute(
         path: AppRoutes.signIn,
         builder: (context, state) => const SignInScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.join,
+        builder: (context, state) => MemberHandoffScreen(uri: state.uri),
       ),
       GoRoute(
         path: AppRoutes.firstRun,

--- a/client/lib/core/router/app_router.g.dart
+++ b/client/lib/core/router/app_router.g.dart
@@ -55,4 +55,4 @@ final class AppRouterProvider
   }
 }
 
-String _$appRouterHash() => r'4333ef38cd75f4a03b36ce9566d7f1b036d815c5';
+String _$appRouterHash() => r'5bd1cfe68017cb755cc391053fcb333928ff2740';

--- a/client/lib/core/router/app_routes.dart
+++ b/client/lib/core/router/app_routes.dart
@@ -5,6 +5,7 @@ abstract final class AppRoutes {
   static const welcome = '/welcome';
   static const setup = '/setup';
   static const signIn = '/sign-in';
+  static const join = '/join';
   static const firstRun = '/first-run';
   static const chat = '/chat';
   static const chatRoomRelative = 'rooms/:roomId';

--- a/client/lib/features/auth/presentation/sign_in_screen.dart
+++ b/client/lib/features/auth/presentation/sign_in_screen.dart
@@ -105,21 +105,7 @@ class SignInScreen extends ConsumerWidget {
                                 ),
                                 const SizedBox(height: 12),
                                 const Text(
-                                  'Identity provider is selected by the Weave Admin Console; this client uses the organization sign-in endpoint.',
-                                ),
-                                const SizedBox(height: 8),
-                                Text(
-                                  l10n.signInConfigurationIssuer(
-                                    configuration.oidcIssuerUrl.toString(),
-                                  ),
-                                ),
-                                const SizedBox(height: 8),
-                                Text(
-                                  l10n.signInConfigurationClientId(
-                                    configuration
-                                        .oidcClientRegistration
-                                        .clientId,
-                                  ),
+                                  'Your Weave invite selected the workspace sign-in endpoint. Continue with SSO; if this does not work, ask an admin/operator to refresh the invite and mention WEAVE-SSO-NOT-COMPLETE.',
                                 ),
                               ],
                             ),

--- a/client/lib/features/onboarding/domain/entities/member_handoff.dart
+++ b/client/lib/features/onboarding/domain/entities/member_handoff.dart
@@ -1,0 +1,167 @@
+import 'package:weave/core/failures/app_failure.dart';
+
+class MemberHandoff {
+  const MemberHandoff({
+    required this.handoffRef,
+    required this.profile,
+    required this.runId,
+    required this.organizationSlug,
+    required this.workspaceSlug,
+    required this.appBaseUrl,
+  });
+
+  final String handoffRef;
+  final String profile;
+  final String runId;
+  final String organizationSlug;
+  final String workspaceSlug;
+  final Uri appBaseUrl;
+
+  Uri get issuerUrl => _withoutQuery('/auth/realms/weave');
+
+  Uri get backendApiBaseUrl => _withoutQuery('/api');
+
+  Uri get providerNeutralServiceUrl => _withoutQuery('/');
+
+  Uri _withoutQuery(String path) => Uri(
+    scheme: appBaseUrl.scheme,
+    host: appBaseUrl.host,
+    port: appBaseUrl.hasPort ? appBaseUrl.port : null,
+    path: path,
+  );
+}
+
+class MemberHandoffParser {
+  const MemberHandoffParser();
+
+  MemberHandoff parse(Uri uri) {
+    final query = uri.queryParameters;
+    final handoffRef = _requiredSafeRef(query, 'handoff_ref');
+    final profile = _requiredSafeSlug(
+      query,
+      'profile',
+      fallback: 'local-lan-dogfood',
+    );
+    final runId = _requiredSafeSlug(query, 'run_id', fallback: 'unknown-run');
+    final org = _requiredSafeSlug(query, 'org');
+    final workspace = _requiredSafeSlug(query, 'workspace');
+    _rejectCredentialBearingQuery(query);
+
+    final appBaseUrl = _baseUrlFrom(uri);
+    _validatePhoneReachable(appBaseUrl);
+
+    return MemberHandoff(
+      handoffRef: handoffRef,
+      profile: profile,
+      runId: runId,
+      organizationSlug: org,
+      workspaceSlug: workspace,
+      appBaseUrl: appBaseUrl,
+    );
+  }
+
+  Uri _baseUrlFrom(Uri uri) {
+    if (uri.scheme == 'weave') {
+      final raw = uri.queryParameters['app_base_url'];
+      if (raw == null || raw.trim().isEmpty) {
+        throw const AppFailure.validation(
+          'WEAVE-HANDOFF-MISSING-BASE: Ask an admin/operator to refresh the invite.',
+        );
+      }
+      return Uri.parse(raw);
+    }
+    return Uri(
+      scheme: uri.scheme,
+      host: uri.host,
+      port: uri.hasPort ? uri.port : null,
+      path: '/',
+    );
+  }
+
+  String _requiredSafeRef(Map<String, String> query, String key) {
+    final value = query[key]?.trim();
+    if (value == null ||
+        value.isEmpty ||
+        !RegExp(r'^[A-Za-z0-9._:-]{6,96}$').hasMatch(value)) {
+      throw const AppFailure.validation(
+        'WEAVE-HANDOFF-INVALID: The invite is not a valid Weave handoff.',
+      );
+    }
+    return value;
+  }
+
+  String _requiredSafeSlug(
+    Map<String, String> query,
+    String key, {
+    String? fallback,
+  }) {
+    final value = query[key]?.trim() ?? fallback;
+    if (value == null ||
+        value.isEmpty ||
+        !RegExp(r'^[A-Za-z0-9][A-Za-z0-9_-]{1,63}$').hasMatch(value)) {
+      throw const AppFailure.validation(
+        'WEAVE-HANDOFF-INVALID: The invite is missing safe organization context.',
+      );
+    }
+    return value;
+  }
+
+  void _rejectCredentialBearingQuery(Map<String, String> query) {
+    const forbidden = {
+      'token',
+      'access_token',
+      'refresh_token',
+      'id_token',
+      'client_secret',
+      'password',
+      'matrix_url',
+      'nextcloud_url',
+      'provider_url',
+      'secret_ref',
+      'credential_url',
+    };
+    for (final key in query.keys) {
+      if (forbidden.contains(key.toLowerCase())) {
+        throw const AppFailure.validation(
+          'WEAVE-HANDOFF-SECRET-BLOCKED: Ask an admin/operator for a support-safe invite.',
+        );
+      }
+    }
+  }
+
+  void _validatePhoneReachable(Uri uri) {
+    final host = uri.host.toLowerCase();
+    if (host.isEmpty ||
+        host == 'localhost' ||
+        host == 'host.docker.internal' ||
+        host == 'docker.for.mac.localhost' ||
+        host.endsWith('.local')) {
+      throw const AppFailure.validation(
+        'WEAVE-LAN-UNREACHABLE: The invite does not point to a phone-reachable LAN address.',
+      );
+    }
+    final parts = host.split('.');
+    if (parts.length == 4 &&
+        parts.every((part) => int.tryParse(part) != null)) {
+      final octets = parts.map(int.parse).toList(growable: false);
+      final loopback = octets.first == 127;
+      final unspecified = octets.every((octet) => octet == 0);
+      final privateLan =
+          octets.first == 10 ||
+          (octets.first == 172 && octets[1] >= 16 && octets[1] <= 31) ||
+          (octets.first == 192 && octets[1] == 168);
+      if (loopback || unspecified || !privateLan) {
+        throw const AppFailure.validation(
+          'WEAVE-LAN-UNREACHABLE: The invite does not point to a phone-reachable LAN address.',
+        );
+      }
+    } else if (!host.endsWith('.lan') &&
+        !host.endsWith('.home') &&
+        !host.endsWith('.home.internal') &&
+        !host.endsWith('.internal')) {
+      throw const AppFailure.validation(
+        'WEAVE-LAN-UNREACHABLE: The invite does not point to a phone-reachable LAN address.',
+      );
+    }
+  }
+}

--- a/client/lib/features/onboarding/domain/use_cases/consume_member_handoff.dart
+++ b/client/lib/features/onboarding/domain/use_cases/consume_member_handoff.dart
@@ -1,0 +1,33 @@
+import 'package:weave/features/onboarding/domain/entities/member_handoff.dart';
+import 'package:weave/features/server_config/domain/entities/oidc_client_registration.dart';
+import 'package:weave/features/server_config/domain/entities/oidc_provider_type.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/entities/service_endpoints.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+
+class ConsumeMemberHandoff {
+  const ConsumeMemberHandoff({
+    required ServerConfigurationRepository repository,
+  }) : _repository = repository;
+
+  final ServerConfigurationRepository _repository;
+
+  Future<MemberHandoff> call(Uri uri) async {
+    final handoff = const MemberHandoffParser().parse(uri);
+    await _repository.saveConfiguration(
+      ServerConfiguration(
+        providerType: OidcProviderType.keycloak,
+        oidcIssuerUrl: handoff.issuerUrl,
+        oidcClientRegistration: const OidcClientRegistration.manual(
+          clientId: 'weave-mobile',
+        ),
+        serviceEndpoints: ServiceEndpoints(
+          matrixHomeserverUrl: handoff.providerNeutralServiceUrl,
+          nextcloudBaseUrl: handoff.providerNeutralServiceUrl,
+          backendApiBaseUrl: handoff.backendApiBaseUrl,
+        ),
+      ),
+    );
+    return handoff;
+  }
+}

--- a/client/lib/features/onboarding/presentation/member_handoff_screen.dart
+++ b/client/lib/features/onboarding/presentation/member_handoff_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:weave/core/bootstrap/presentation/providers/app_bootstrap_provider.dart';
+import 'package:weave/core/router/app_routes.dart';
+import 'package:weave/core/widgets/error_state.dart';
+import 'package:weave/core/widgets/loading_state.dart';
+import 'package:weave/features/onboarding/domain/use_cases/consume_member_handoff.dart';
+import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+
+final consumeMemberHandoffProvider = Provider<ConsumeMemberHandoff>((ref) {
+  return ConsumeMemberHandoff(
+    repository: ref.watch(serverConfigurationRepositoryProvider),
+  );
+});
+
+class MemberHandoffScreen extends ConsumerStatefulWidget {
+  const MemberHandoffScreen({super.key, required this.uri});
+
+  final Uri uri;
+
+  @override
+  ConsumerState<MemberHandoffScreen> createState() =>
+      _MemberHandoffScreenState();
+}
+
+class _MemberHandoffScreenState extends ConsumerState<MemberHandoffScreen> {
+  Object? _failure;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(_consume);
+  }
+
+  Future<void> _consume() async {
+    try {
+      await ref.read(consumeMemberHandoffProvider).call(widget.uri);
+      ref.invalidate(appBootstrapProvider);
+      if (mounted) {
+        context.go(AppRoutes.signIn);
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(() => _failure = error);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final failure = _failure;
+    if (failure != null) {
+      return Scaffold(
+        body: SafeArea(
+          child: Center(
+            child: ErrorState(
+              message: 'We could not open this Weave invite',
+              guidance: '$failure',
+              retryLabel: 'Try again',
+              onRetry: () {
+                setState(() => _failure = null);
+                _consume();
+              },
+            ),
+          ),
+        ),
+      );
+    }
+    return const Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: LoadingState(
+            message: 'Opening Weave invite',
+            hint: 'We are preparing sign-in for this workspace.',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/client/test/features/onboarding/member_handoff_test.dart
+++ b/client/test/features/onboarding/member_handoff_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/onboarding/domain/entities/member_handoff.dart';
+
+void main() {
+  group('MemberHandoffParser', () {
+    test('accepts support-safe LAN handoff for local dogfood', () {
+      final handoff = const MemberHandoffParser().parse(
+        Uri.parse(
+          'http://192.168.42.10:8080/join?handoff_ref=handoff-abc123&org=massimo-dogfood&workspace=home&run_id=s31-check',
+        ),
+      );
+
+      expect(handoff.profile, 'local-lan-dogfood');
+      expect(handoff.appBaseUrl.toString(), 'http://192.168.42.10:8080/');
+      expect(
+        handoff.issuerUrl.toString(),
+        'http://192.168.42.10:8080/auth/realms/weave',
+      );
+      expect(
+        handoff.backendApiBaseUrl.toString(),
+        'http://192.168.42.10:8080/api',
+      );
+    });
+
+    test('rejects loopback and Mac-only handoff targets', () {
+      for (final host in ['localhost', '127.0.0.1', '0.0.0.0', 'weave.local']) {
+        expect(
+          () => const MemberHandoffParser().parse(
+            Uri.parse(
+              'http://$host:8080/join?handoff_ref=handoff-abc123&org=massimo-dogfood&workspace=home',
+            ),
+          ),
+          throwsA(isA<AppFailure>()),
+        );
+      }
+    });
+
+    test('rejects credential-bearing handoff query data', () {
+      expect(
+        () => const MemberHandoffParser().parse(
+          Uri.parse(
+            'http://192.168.42.10:8080/join?handoff_ref=handoff-abc123&org=massimo-dogfood&workspace=home&access_token=secret',
+          ),
+        ),
+        throwsA(isA<AppFailure>()),
+      );
+    });
+  });
+}

--- a/docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md
+++ b/docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md
@@ -1,0 +1,31 @@
+# Sprint 31 physical iPhone LAN dogfood checklist
+
+Use this checklist after `weavectl profile apply` emits the run id. Do not paste screenshots or logs that contain tokens, credential URLs, provider payloads, Matrix homeserver internals, member private content, or raw downstream errors.
+
+## Operator preflight
+
+- Run id:
+- Command: `tools/weavectl profile apply --profile local-lan-dogfood --lan-host <Mac LAN IP> --emit-handoff --emit-evidence --preflight-mode tcp`
+- Evidence directory:
+- Handoff artifact:
+- Readiness artifact:
+- LAN assumption: iPhone and Mac are on the same LAN, with client isolation disabled.
+- Preflight result: pass / fail with stable code only.
+
+## Tester script for Massimo
+
+1. Install or open the Weave app on the physical iPhone.
+2. Scan the QR or open the handoff link from the emitted handoff artifact.
+3. Confirm the handoff opens Weave sign-in without asking for OIDC issuer, OIDC client ID, Matrix URL, Nextcloud URL, provider hostname, TLS certificate, provider diagnostics, SecretRef, or credential URL.
+4. Complete SSO.
+5. Confirm Weave workspace/home appears.
+6. If it fails, record only the stable next-action code, for example `WEAVE-LAN-UNREACHABLE`, `WEAVE-HANDOFF-INVALID`, or `WEAVE-SSO-NOT-COMPLETE`.
+
+## Result
+
+- Device: physical iPhone, model/iOS version optional.
+- Handoff type: QR / link / deep link / organization URL.
+- SSO result: pass / fail.
+- Workspace/home result: pass / fail.
+- Accessibility note: QR/link prompt was readable by screen reader and did not rely on color alone.
+- Redaction confirmation: no secrets, tokens, credential-bearing URLs, raw provider payloads, raw provider diagnostics, homeserver internals, or member content captured.

--- a/docs/sprint-31-closure-report.md
+++ b/docs/sprint-31-closure-report.md
@@ -1,0 +1,57 @@
+# Sprint 31 closure report — Physical iPhone LAN Dogfood
+
+Sprint 31 implements the executable local LAN dogfood path for Massimo's physical iPhone. Remote GitHub issue and CI state remain the closure source of truth.
+
+## Governing scope
+
+- Milestone: `Sprint 31 — Physical iPhone LAN Dogfood`.
+- Issues: #697, #698, #699, #700, #701.
+- Prior contract: `release/sprint-30-hot-phase/profile-driven-setup.fixture.json`.
+- Runbook: `docs/sprint-31-iphone-lan-dogfood-runbook.md`.
+- Physical-device checklist: `docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md`.
+
+## Issue DAG final state
+
+1. #697 and #698: one profile-driven command prepares readiness, validates LAN endpoint shape/TCP reachability, emits support-safe handoff/evidence under one run id.
+2. #699: client `/join` handoff path consumes the generated LAN handoff and routes to existing SSO without normal-member provider setup fields.
+3. #700: Sprint 31 guard and checklist prove loopback/Mac-only rejection, redaction, and physical iPhone evidence capture.
+4. #701: runbook and closure report publish exact command, expected tester result, and remaining physical-device action.
+
+## Exact command for Massimo
+
+```sh
+WEAVE_LAN_HOST=<Mac LAN IP> tools/weavectl profile apply \
+  --profile local-lan-dogfood \
+  --lan-host "$WEAVE_LAN_HOST" \
+  --emit-handoff \
+  --emit-evidence \
+  --preflight-mode tcp
+```
+
+Expected output: `run_id=...`, `readiness=.../readiness.json`, `handoff=.../handoff.json`, `evidence=.../evidence.json`, the `weave:/join?...` deep link, the LAN URL/QR payload, and the screen-reader-friendly tester prompt.
+
+## What Massimo should see
+
+Massimo opens the QR/link from `handoff.json` on the physical iPhone, completes SSO, and lands in Weave workspace/home. The app must not ask for OIDC issuer, OIDC client ID, Matrix URL, Nextcloud URL, provider hostname, TLS certificate, provider diagnostics, SecretRef, or credential URL.
+
+## Remaining physical-device step
+
+The repository can prepare and validate the LAN handoff, but final success requires Massimo's real iPhone on the same LAN. Smallest remaining action: run the command with the actual Mac LAN IP while the stack is listening, open the emitted handoff on the iPhone, complete SSO, and fill the checklist result.
+
+## Evidence and gates
+
+- `python3 tools/sprint31_lan_dogfood_check.py`
+- `./gradlew sprint31LanDogfoodCheck`
+- `./gradlew acceptanceContract`
+- `./gradlew clientCi`
+- `./gradlew docsCheck`
+- `./gradlew releaseEvidenceCheck`
+
+Local evidence before PR:
+
+- `python3 tools/sprint31_lan_dogfood_check.py`: pass.
+- `./gradlew sprint31LanDogfoodCheck acceptanceContract docsCheck releaseEvidenceCheck`: pass.
+- `cd client && flutter analyze --fatal-infos`: pass.
+- `cd client && flutter test test/features/onboarding/member_handoff_test.dart test/features/auth/sign_in_screen_test.dart test/architecture/member_client_provider_boundary_contract_test.dart`: pass.
+
+CI/main evidence is to be updated after the PR merges.

--- a/docs/sprint-31-closure-report.md
+++ b/docs/sprint-31-closure-report.md
@@ -50,8 +50,17 @@ The repository can prepare and validate the LAN handoff, but final success requi
 Local evidence before PR:
 
 - `python3 tools/sprint31_lan_dogfood_check.py`: pass.
+- `tools/weavectl profile apply --profile local-lan-dogfood --lan-host 192.168.42.10 --emit-handoff --emit-evidence --preflight-mode validate-only --run-id s31-smoke --output-dir /tmp/weave-s31-smoke`: pass.
 - `./gradlew sprint31LanDogfoodCheck acceptanceContract docsCheck releaseEvidenceCheck`: pass.
 - `cd client && flutter analyze --fatal-infos`: pass.
 - `cd client && flutter test test/features/onboarding/member_handoff_test.dart test/features/auth/sign_in_screen_test.dart test/architecture/member_client_provider_boundary_contract_test.dart`: pass.
+- `./gradlew clientCi`: pass.
 
-CI/main evidence is to be updated after the PR merges.
+GitHub evidence before merge:
+
+- PR: #702 `feat: add physical iPhone LAN dogfood handoff`.
+- Release notes label: `release-notes-feature`.
+- Copilot review request fallback: `copilot` and `github-copilot` were not resolvable as review users by GitHub GraphQL, so merge readiness relies on local gates plus GitHub CI.
+- PR CI run `27007385556`: `Release Notes Label Check` pass; `Gradle CI` pass.
+
+Main evidence is to be verified after the PR merges.

--- a/docs/sprint-31-iphone-lan-dogfood-runbook.md
+++ b/docs/sprint-31-iphone-lan-dogfood-runbook.md
@@ -1,0 +1,39 @@
+# Sprint 31 runbook — Physical iPhone LAN dogfood
+
+Sprint 31 prepares Massimo's first real iPhone test on the same LAN as the Mac. It does not require public DNS or trusted internet TLS for this local dogfood profile.
+
+## Operator command
+
+From the repo root, after starting the local stack on a phone-reachable Mac LAN address:
+
+```sh
+WEAVE_LAN_HOST=<Mac LAN IP> tools/weavectl profile apply \
+  --profile local-lan-dogfood \
+  --lan-host "$WEAVE_LAN_HOST" \
+  --emit-handoff \
+  --emit-evidence \
+  --preflight-mode tcp
+```
+
+For dry validation before the stack is listening, use `--preflight-mode validate-only`. The command writes one run id under `build/evidence/local-lan-dogfood/<run-id>/` with `readiness.json`, `handoff.json`, and `evidence.json`.
+
+The command rejects `localhost`, `127.0.0.1`, `0.0.0.0`, container-only names, and Mac-only `.local` assumptions before handoff output. Handoff evidence stores refs and endpoint classes, not raw secrets or provider diagnostics. The handoff includes both a LAN URL/QR payload and a separate `weave:/join?...` deep link; the mobile manifests register that member handoff scheme separately from the OIDC callback scheme.
+
+## What Massimo should see
+
+Give Massimo the QR/link from `handoff.json` and say:
+
+> Open this Weave invite on the iPhone while it is on the same LAN as the Mac. It starts sign-in and then opens the Weave workspace home.
+
+Expected tester path:
+
+1. Install or open Weave on the physical iPhone.
+2. Tap or scan the invite/QR/handoff.
+3. Continue with SSO.
+4. Land in Weave workspace/home.
+
+The member path must not ask for OIDC issuer, OIDC client ID, Matrix URL, Nextcloud URL, provider hostname, TLS certificate, provider diagnostics, SecretRef, or credential URL.
+
+## Physical evidence
+
+Use `docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md`. If the only remaining step is Massimo's real iPhone, record that as the smallest remaining action: run the command with the real LAN IP, open the handoff on the iPhone, complete SSO, and mark workspace/home result.

--- a/release/sprint-31-physical-iphone-lan-dogfood/example-evidence.json
+++ b/release/sprint-31-physical-iphone-lan-dogfood/example-evidence.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "sprint31.physical-iphone-lan-dogfood.evidence.v1",
+  "runId": "s31-example",
+  "profile": "local-lan-dogfood",
+  "operatorCommand": "weavectl profile apply --profile local-lan-dogfood --lan-host <LAN-IP> --emit-handoff --emit-evidence --preflight-mode tcp",
+  "artifacts": {
+    "readiness": "build/evidence/local-lan-dogfood/s31-example/readiness.json",
+    "handoff": "build/evidence/local-lan-dogfood/s31-example/handoff.json"
+  },
+  "refs": {
+    "handoffRef": "handoff-example",
+    "readinessRef": "readiness-example",
+    "auditRef": "audit-example"
+  },
+  "redactedEndpointClass": "rfc1918-lan-ip",
+  "supportSafe": true,
+  "claimBoundary": "prepared physical iPhone LAN dogfood handoff; final physical-device success requires Massimo's iPhone execution"
+}

--- a/release/sprint-31-physical-iphone-lan-dogfood/local-lan-dogfood.profile.json
+++ b/release/sprint-31-physical-iphone-lan-dogfood/local-lan-dogfood.profile.json
@@ -1,0 +1,33 @@
+{
+  "schemaVersion": "sprint31.local-lan-dogfood.profile.v1",
+  "profile": "local-lan-dogfood",
+  "entrypoint": "weavectl profile apply",
+  "singlePipeline": true,
+  "profileVariablesOnly": true,
+  "defaultCommand": "tools/weavectl profile apply --profile local-lan-dogfood --lan-host $WEAVE_LAN_HOST --emit-handoff --emit-evidence --preflight-mode tcp",
+  "memberPhoneAllowed": true,
+  "publicDnsRequired": false,
+  "trustedInternetTlsRequired": false,
+  "rejects": [
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "host.docker.internal",
+    "docker.for.mac.localhost",
+    "Mac-only .local names",
+    "credential-bearing URLs",
+    "raw provider diagnostics"
+  ],
+  "memberPath": ["open handoff", "SSO", "Weave workspace home"],
+  "forbiddenMemberInputs": [
+    "OIDC issuer",
+    "OIDC client ID",
+    "Matrix URL",
+    "Nextcloud URL",
+    "provider hostname",
+    "TLS certificate",
+    "provider diagnostic",
+    "SecretRef",
+    "credential URL"
+  ]
+}

--- a/tools/sprint31_lan_dogfood_check.py
+++ b/tools/sprint31_lan_dogfood_check.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Validate Sprint 31 physical iPhone LAN dogfood artifacts and guards."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FORBIDDEN_TEXT = [
+    "access_token=",
+    "refresh_token=",
+    "id_token=",
+    "client_secret=",
+    "password=",
+    "secretref://",
+    "raw provider payload",
+    "raw provider diagnostics",
+    "homeserver internals",
+]
+FORBIDDEN_MEMBER_INPUTS = [
+    "OIDC issuer",
+    "OIDC client ID",
+    "Matrix URL",
+    "Nextcloud URL",
+    "provider hostname",
+    "TLS certificate",
+    "provider diagnostic",
+    "SecretRef",
+    "credential URL",
+]
+
+
+def fail(message: str) -> None:
+    print(f"sprint31-lan-dogfood-check: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read(rel: str) -> str:
+    path = ROOT / rel
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        fail(f"missing required file: {rel}")
+
+
+def run(args: list[str], expect_success: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(args, cwd=ROOT, text=True, capture_output=True, check=False)
+    if expect_success and result.returncode != 0:
+        fail(f"command failed: {' '.join(args)}\n{result.stdout}\n{result.stderr}")
+    if not expect_success and result.returncode == 0:
+        fail(f"command unexpectedly succeeded: {' '.join(args)}")
+    return result
+
+
+def assert_no_forbidden(rel: str) -> None:
+    text = read(rel).lower()
+    for fragment in FORBIDDEN_TEXT:
+        if fragment.lower() in text and rel.endswith(".json"):
+            fail(f"forbidden support detail in {rel}: {fragment}")
+
+
+def main() -> None:
+    profile = json.loads(read("release/sprint-31-physical-iphone-lan-dogfood/local-lan-dogfood.profile.json"))
+    if profile.get("entrypoint") != "weavectl profile apply" or not profile.get("singlePipeline"):
+        fail("Sprint 31 profile must use the unified weavectl profile apply pipeline")
+    if profile.get("publicDnsRequired") or profile.get("trustedInternetTlsRequired"):
+        fail("local-lan-dogfood must not require public DNS or trusted internet TLS")
+    for item in FORBIDDEN_MEMBER_INPUTS:
+        if item not in profile.get("forbiddenMemberInputs", []):
+            fail(f"profile must forbid member input: {item}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        result = run([
+            "python3",
+            "tools/weavectl",
+            "profile",
+            "apply",
+            "--profile",
+            "local-lan-dogfood",
+            "--lan-host",
+            "192.168.42.10",
+            "--emit-handoff",
+            "--emit-evidence",
+            "--preflight-mode",
+            "validate-only",
+            "--run-id",
+            "s31-check",
+            "--output-dir",
+            tmp,
+        ])
+        if "tester_next_action=" not in result.stdout:
+            fail("weavectl output must include tester next action")
+        base = Path(tmp) / "s31-check"
+        readiness = json.loads((base / "readiness.json").read_text(encoding="utf-8"))
+        handoff = json.loads((base / "handoff.json").read_text(encoding="utf-8"))
+        evidence = json.loads((base / "evidence.json").read_text(encoding="utf-8"))
+        if readiness.get("phoneReachability", {}).get("hostClass") != "rfc1918-lan-ip":
+            fail("readiness must classify RFC1918 LAN IP")
+        if handoff.get("memberPath") != ["open handoff", "SSO", "Weave workspace home"]:
+            fail("handoff must preserve normal member path")
+        tester_visible = handoff.get("testerVisible", {})
+        if not tester_visible.get("screenReaderPrompt"):
+            fail("handoff must include screen-reader-friendly prompt")
+        if not str(tester_visible.get("deepLink", "")).startswith("weave:/join?"):
+            fail("handoff must include the separate Weave member handoff deep link scheme")
+        for item in FORBIDDEN_MEMBER_INPUTS:
+            if item not in handoff.get("forbiddenMemberInputs", []):
+                fail(f"handoff must forbid member input: {item}")
+        if evidence.get("supportSafe") is not True:
+            fail("evidence must be marked support-safe")
+        for artifact in [base / "readiness.json", base / "handoff.json", base / "evidence.json"]:
+            text = artifact.read_text(encoding="utf-8").lower()
+            for fragment in ["access_token", "client_secret", "secretref://", "credential_url"]:
+                if fragment in text:
+                    fail(f"credential-bearing fragment in generated artifact: {artifact}")
+
+    for bad_host in ["localhost", "127.0.0.1", "0.0.0.0", "host.docker.internal", "weave.local"]:
+        run([
+            "python3",
+            "tools/weavectl",
+            "profile",
+            "apply",
+            "--profile",
+            "local-lan-dogfood",
+            "--lan-host",
+            bad_host,
+            "--emit-handoff",
+        ], expect_success=False)
+
+    client_join = read("client/lib/features/onboarding/domain/entities/member_handoff.dart")
+    for phrase in ["WEAVE-LAN-UNREACHABLE", "WEAVE-HANDOFF-SECRET-BLOCKED", "handoff_ref", "app_base_url"]:
+        if phrase not in client_join:
+            fail(f"client handoff parser missing {phrase}")
+    sign_in = read("client/lib/features/auth/presentation/sign_in_screen.dart")
+    for leaked in ["signInConfigurationIssuer", "signInConfigurationClientId"]:
+        if leaked in sign_in:
+            fail(f"sign-in screen must not display provider setup detail: {leaked}")
+    ios_plist = read("client/ios/Runner/Info.plist")
+    if "<string>weave</string>" not in ios_plist or "same local network" not in ios_plist:
+        fail("iOS must register the separate Weave handoff scheme and explain LAN usage")
+    android_manifest = read("client/android/app/src/main/AndroidManifest.xml")
+    if "weave_member_handoff" not in android_manifest or "android:scheme=\"weave\"" not in android_manifest:
+        fail("Android must register a separate Weave member handoff scheme on MainActivity")
+
+    for rel in [
+        "docs/sprint-31-iphone-lan-dogfood-runbook.md",
+        "docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md",
+        "docs/sprint-31-closure-report.md",
+    ]:
+        text = read(rel)
+        for phrase in ["physical iPhone", "SSO", "workspace/home"]:
+            if phrase not in text:
+                fail(f"{rel} missing {phrase}")
+        assert_no_forbidden(rel)
+
+    print("sprint31-lan-dogfood-check: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/weavectl
+++ b/tools/weavectl
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Minimal Weave Control CLI for profile-driven local dogfood handoff evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import socket
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlencode
+
+FORBIDDEN_EVIDENCE_FRAGMENTS = [
+    "access_token=",
+    "refresh_token=",
+    "id_token=",
+    "client_secret=",
+    "password=",
+    "secretref://",
+    "matrix.",
+    "/_matrix/",
+    "homeserver",
+    "nextcloud.",
+    "raw provider",
+]
+
+PROFILE_CONTRACT = {
+    "dev": {"reachabilityMode": "developer-local", "memberPhoneAllowed": False},
+    "local-lan-dogfood": {"reachabilityMode": "lan", "memberPhoneAllowed": True},
+    "public-dogfood": {"reachabilityMode": "public-domain", "memberPhoneAllowed": True},
+    "production": {"reachabilityMode": "production-domain", "memberPhoneAllowed": True},
+}
+
+
+def fail(message: str, code: int = 2) -> None:
+    print(f"weavectl: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="weavectl")
+    sub = parser.add_subparsers(dest="command", required=True)
+    profile = sub.add_parser("profile")
+    profile_sub = profile.add_subparsers(dest="profile_command", required=True)
+    apply = profile_sub.add_parser("apply")
+    apply.add_argument("--profile", required=True, choices=sorted(PROFILE_CONTRACT))
+    apply.add_argument("--lan-host")
+    apply.add_argument("--public-host")
+    apply.add_argument("--app-port", type=int, default=8080)
+    apply.add_argument("--api-port", type=int, default=8081)
+    apply.add_argument("--scheme", choices=["http", "https"], default="http")
+    apply.add_argument("--organization-slug", default="massimo-dogfood")
+    apply.add_argument("--workspace-slug", default="home")
+    apply.add_argument("--invite-channel", choices=["qr", "link", "deep-link", "org-url"], default="qr")
+    apply.add_argument("--emit-handoff", action="store_true")
+    apply.add_argument("--emit-evidence", action="store_true")
+    apply.add_argument("--evidence")
+    apply.add_argument("--output-dir", default="build/evidence/local-lan-dogfood")
+    apply.add_argument("--run-id")
+    apply.add_argument("--preflight-mode", choices=["validate-only", "tcp"], default="validate-only")
+    apply.add_argument("--timeout-seconds", type=float, default=1.5)
+    return parser.parse_args(argv)
+
+
+def now_run_id() -> str:
+    return "s31-" + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def normalize_host(raw: str | None, profile: str) -> str:
+    if profile == "local-lan-dogfood":
+        raw = raw or os.environ.get("WEAVE_LAN_HOST")
+        if not raw:
+            fail("--lan-host or WEAVE_LAN_HOST is required for local-lan-dogfood")
+    elif profile == "public-dogfood":
+        raw = raw or os.environ.get("WEAVE_PUBLIC_HOST")
+        if not raw:
+            fail("--public-host or WEAVE_PUBLIC_HOST is required for public-dogfood")
+    elif profile == "production":
+        raw = raw or os.environ.get("WEAVE_PUBLIC_HOST")
+        if not raw:
+            fail("--public-host or WEAVE_PUBLIC_HOST is required for production")
+    else:
+        raw = raw or "127.0.0.1"
+    host = raw.strip().strip("/")
+    if "://" in host:
+        fail("host input must be a host or IP only, not a URL")
+    return host
+
+
+def classify_host(host: str) -> str:
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        lowered = host.lower()
+        if lowered in {"localhost", "host.docker.internal", "docker.for.mac.localhost"}:
+            return "forbidden-container-or-localhost"
+        if lowered.endswith(".local"):
+            return "forbidden-mac-only-mdns"
+        if re.fullmatch(r"[a-z0-9-]+", lowered):
+            return "forbidden-container-only-name"
+        if lowered.endswith((".lan", ".home", ".home.internal", ".internal")):
+            return "lan-dns"
+        return "dns"
+    if ip.is_loopback or ip.is_unspecified:
+        return "forbidden-loopback"
+    if ip.version == 4 and ip.is_private:
+        return "rfc1918-lan-ip"
+    if ip.version == 6 and (ip.is_private or ip.is_link_local):
+        return "lan-ipv6"
+    return "public-ip"
+
+
+def validate_phone_host(host: str, profile: str) -> str:
+    host_class = classify_host(host)
+    if profile == "local-lan-dogfood":
+        if host_class.startswith("forbidden"):
+            fail(f"phone handoff blocked: {host} is {host_class}")
+        if host_class not in {"rfc1918-lan-ip", "lan-ipv6", "lan-dns"}:
+            fail(f"phone handoff blocked: {host} is not a LAN-reachable endpoint shape")
+    elif profile in {"public-dogfood", "production"} and host_class.startswith("forbidden"):
+        fail(f"member handoff blocked: {host} is {host_class}")
+    return host_class
+
+
+def tcp_probe(host: str, port: int, timeout: float) -> dict[str, object]:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return {"port": port, "reachable": True, "summary": "tcp-connect-ok"}
+    except OSError:
+        return {"port": port, "reachable": False, "summary": "S31-LAN-PREFLIGHT-TCP-UNREACHABLE"}
+
+
+def support_safe_ref(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()[:12]
+    return f"{prefix}-{digest}"
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    lowered = text.lower()
+    for fragment in FORBIDDEN_EVIDENCE_FRAGMENTS:
+        if fragment in lowered:
+            fail(f"support-safe redaction blocked artifact {path}: forbidden fragment {fragment}")
+    path.write_text(text, encoding="utf-8")
+
+
+def apply_profile(args: argparse.Namespace) -> int:
+    host = normalize_host(args.lan_host or args.public_host, args.profile)
+    host_class = validate_phone_host(host, args.profile)
+    run_id = args.run_id or now_run_id()
+    app_base_url = f"{args.scheme}://{host}:{args.app_port}"
+    api_base_url = f"{args.scheme}://{host}:{args.api_port}"
+    handoff_ref = support_safe_ref("handoff", run_id, args.profile, app_base_url)
+    readiness_ref = support_safe_ref("readiness", run_id, args.profile, api_base_url)
+    audit_ref = support_safe_ref("audit", run_id, handoff_ref, readiness_ref)
+
+    probes: list[dict[str, object]] = []
+    if args.preflight_mode == "tcp":
+        probes = [tcp_probe(host, args.app_port, args.timeout_seconds), tcp_probe(host, args.api_port, args.timeout_seconds)]
+        if not all(probe["reachable"] for probe in probes):
+            fail("LAN TCP preflight failed; start the stack or choose the phone-reachable LAN host before emitting handoff")
+    else:
+        probes = [
+            {"port": args.app_port, "reachable": "shape-validated", "summary": "S31-LAN-PREFLIGHT-SHAPE-OK"},
+            {"port": args.api_port, "reachable": "shape-validated", "summary": "S31-LAN-PREFLIGHT-SHAPE-OK"},
+        ]
+
+    handoff_query = urlencode({"handoff_ref": handoff_ref, "org": args.organization_slug, "workspace": args.workspace_slug, "run_id": run_id})
+    tester_url = f"{app_base_url}/join?{handoff_query}"
+    deep_link_query = urlencode({"handoff_ref": handoff_ref, "org": args.organization_slug, "workspace": args.workspace_slug, "run_id": run_id, "app_base_url": app_base_url})
+    deep_link = f"weave:/join?{deep_link_query}"
+    output_dir = Path(args.output_dir) / run_id
+    readiness_path = output_dir / "readiness.json"
+    handoff_path = output_dir / "handoff.json"
+    evidence_path = Path(args.evidence) if args.evidence else output_dir / "evidence.json"
+
+    readiness = {
+        "schemaVersion": "sprint31.local-lan-dogfood.readiness.v1",
+        "runId": run_id,
+        "profile": args.profile,
+        "reachabilityMode": PROFILE_CONTRACT[args.profile]["reachabilityMode"],
+        "phoneReachability": {"hostClass": host_class, "preflightMode": args.preflight_mode, "probes": probes},
+        "nextTesterAction": "Install or open Weave on the iPhone, scan the QR or open the handoff link, complete SSO, and confirm the workspace home appears.",
+        "supportSafe": True,
+    }
+    handoff = {
+        "schemaVersion": "sprint31.local-lan-dogfood.handoff.v1",
+        "runId": run_id,
+        "profile": args.profile,
+        "handoffType": args.invite_channel,
+        "handoffRef": handoff_ref,
+        "testerVisible": {
+            "url": tester_url,
+            "deepLink": deep_link,
+            "qrPayload": tester_url,
+            "screenReaderPrompt": "Open this Weave invite on the iPhone. It starts sign-in and then opens the Weave workspace home.",
+        },
+        "memberPath": ["open handoff", "SSO", "Weave workspace home"],
+        "forbiddenMemberInputs": ["OIDC issuer", "OIDC client ID", "Matrix URL", "Nextcloud URL", "provider hostname", "TLS certificate", "provider diagnostic", "SecretRef", "credential URL"],
+        "supportSafe": True,
+    }
+    evidence = {
+        "schemaVersion": "sprint31.physical-iphone-lan-dogfood.evidence.v1",
+        "runId": run_id,
+        "profile": args.profile,
+        "operatorCommand": "weavectl profile apply --profile local-lan-dogfood --lan-host <LAN-IP> --emit-handoff --emit-evidence --preflight-mode tcp",
+        "artifacts": {"readiness": str(readiness_path), "handoff": str(handoff_path)},
+        "refs": {"handoffRef": handoff_ref, "readinessRef": readiness_ref, "auditRef": audit_ref},
+        "redactedEndpointClass": host_class,
+        "supportSafe": True,
+        "claimBoundary": "prepared physical iPhone LAN dogfood handoff; final physical-device success requires Massimo's iPhone execution",
+    }
+
+    write_json(readiness_path, readiness)
+    if args.emit_handoff:
+        write_json(handoff_path, handoff)
+    if args.emit_evidence or args.evidence:
+        write_json(evidence_path, evidence)
+
+    print(f"run_id={run_id}")
+    print(f"readiness={readiness_path}")
+    if args.emit_handoff:
+        print(f"handoff={handoff_path}")
+        print(f"tester_next_action={handoff['testerVisible']['screenReaderPrompt']}")
+    if args.emit_evidence or args.evidence:
+        print(f"evidence={evidence_path}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.command == "profile" and args.profile_command == "apply":
+        return apply_profile(args)
+    fail("unsupported command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- add `tools/weavectl profile apply --profile local-lan-dogfood` with LAN endpoint validation, support-safe handoff/evidence output, and loopback/Mac-only endpoint rejection
- add `/join` member handoff parsing/consumption so iPhone onboarding can continue through SSO without provider setup screens
- register a separate mobile handoff deep-link scheme and publish Sprint 31 runbook, checklist, profile fixture, evidence fixture, and closure report

## Issues
Closes #697
Closes #698
Closes #699
Closes #700
Closes #701

## Evidence
- `python3 tools/sprint31_lan_dogfood_check.py`
- `tools/weavectl profile apply --profile local-lan-dogfood --lan-host 192.168.42.10 --emit-handoff --emit-evidence --preflight-mode validate-only --run-id s31-smoke --output-dir /tmp/weave-s31-smoke`
- `./gradlew sprint31LanDogfoodCheck acceptanceContract docsCheck releaseEvidenceCheck`
- `cd client && flutter analyze --fatal-infos`
- `cd client && flutter test test/features/onboarding/member_handoff_test.dart test/features/auth/sign_in_screen_test.dart test/architecture/member_client_provider_boundary_contract_test.dart`
- `./gradlew clientCi`

## Physical iPhone note
The executable command prepares and validates the LAN handoff. The only remaining non-automated evidence is Massimo opening/scanning the generated handoff on the physical iPhone on the same LAN and recording the checklist outcome in `docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md`.
