### PR TITLE
fix: harden weavectl bootstrap executor boundary

### DIFF
--- a/tools/bootstrap_foundation_check.py
+++ b/tools/bootstrap_foundation_check.py
@@ -268,6 +268,14 @@ def assert_bootstrap_runtime() -> None:
         "--plan", str(forged_path), "--execute", "--approval-ref", "APPROVAL-123",
     ], "--execute is not allowed")
 
+    unsafe_plan_input = dict(plan)
+    unsafe_plan_input["forbiddenClaims"] = [*plan.get("forbiddenClaims", []), "access_token=SHOULD_BE_REJECTED"]
+    unsafe_plan_input_path = write_case_plan("unsafe-plan-input", unsafe_plan_input)
+    run_command_expect_failure([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
+        "--plan", str(unsafe_plan_input_path),
+    ], "support-safe redaction blocked artifact")
+
     unsafe_receipt_plan = dict(plan)
     unsafe_receipt_plan["providerStack"] = dict(plan["providerStack"], ref="access_token=unsafe")
     unsafe_receipt_path = write_case_plan("unsafe-receipt", unsafe_receipt_plan)

--- a/tools/bootstrap_foundation_check.py
+++ b/tools/bootstrap_foundation_check.py
@@ -246,6 +246,14 @@ def assert_bootstrap_runtime() -> None:
         "--plan", str(plan_path.relative_to(ROOT)), "--execute", "--approval-ref", "https://example.invalid/ticket",
     ], "--approval-ref must be a support-safe ticket id")
 
+    forged_ref_plan = dict(plan)
+    forged_ref_plan["planRef"] = "bootstrap-plan-forged"
+    forged_ref_path = write_case_plan("forged-plan-ref", forged_ref_plan)
+    run_command_expect_failure([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
+        "--plan", str(forged_ref_path),
+    ], "planRef does not match plan content")
+
     forged_output = run_command([
         "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "plan",
         "--profile", "external-providers", "--target", "forgejo-actions",

--- a/tools/bootstrap_foundation_check.py
+++ b/tools/bootstrap_foundation_check.py
@@ -245,7 +245,7 @@ def assert_bootstrap_runtime() -> None:
     ], "--execute is not allowed")
 
     unsafe_receipt_plan = dict(plan)
-    unsafe_receipt_plan["providerStack"] = dict(plan["providerStack"], ref="https://unsafe.example/provider")
+    unsafe_receipt_plan["providerStack"] = dict(plan["providerStack"], ref="access_token=unsafe")
     unsafe_receipt_path = write_case_plan("unsafe-receipt", unsafe_receipt_plan)
     run_command_expect_failure([
         "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",

--- a/tools/bootstrap_foundation_check.py
+++ b/tools/bootstrap_foundation_check.py
@@ -114,6 +114,26 @@ def run_command(args: list[str]) -> str:
     return completed.stdout
 
 
+def run_command_expect_failure(args: list[str], expected_fragment: str) -> None:
+    try:
+        completed = subprocess.run(args, cwd=ROOT, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=20)
+    except subprocess.TimeoutExpired:
+        fail(f"command timed out {' '.join(args)}")
+    output = f"{completed.stdout}\n{completed.stderr}"
+    if completed.returncode == 0:
+        fail(f"command unexpectedly succeeded {' '.join(args)}")
+    if expected_fragment not in output:
+        fail(f"command failure for {' '.join(args)} did not include {expected_fragment!r}: {output.strip()}")
+
+
+def write_case_plan(case_name: str, payload: dict[str, Any]) -> Path:
+    case_dir = BOOTSTRAP_RUNTIME_EVIDENCE / "negative-cases" / case_name
+    case_dir.mkdir(parents=True, exist_ok=True)
+    path = case_dir / "plan.json"
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
 def extract_output_ref(output: str, key: str) -> str:
     prefix = f"{key}="
     for line in output.splitlines():
@@ -193,7 +213,44 @@ def assert_bootstrap_runtime() -> None:
         fail("weavectl bootstrap apply must be dry-run/non-dispatch by default")
     if receipt.get("terminalBooleans", {}).get("client_bootstrap_handoff_ready") is not False:
         fail("bootstrap apply receipt must not claim client handoff readiness from dry-run")
+    if receipt.get("approvalRef") is not None or receipt.get("approvalRefHash") is not None:
+        fail("dry-run receipt must not persist an approval ref")
     assert_support_safe(receipt, "weavectl bootstrap apply receipt")
+
+    malicious_executor = dict(plan)
+    malicious_executor["mutationBoundary"] = dict(plan["mutationBoundary"], executor="/usr/bin/true")
+    malicious_executor_path = write_case_plan("malicious-executor", malicious_executor)
+    run_command_expect_failure([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
+        "--plan", str(malicious_executor_path), "--execute", "--approval-ref", "APPROVAL-123",
+    ], "bootstrap executor must be the allowlisted repo-relative path")
+
+    run_command_expect_failure([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
+        "--plan", str(plan_path.relative_to(ROOT)), "--execute", "--approval-ref", "https://example.invalid/ticket",
+    ], "--approval-ref must be a support-safe ticket id")
+
+    forged_output = run_command([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "plan",
+        "--profile", "external-providers", "--target", "forgejo-actions",
+        "--run-id", "foundation-check-forged", "--output-dir", "build/evidence/bootstrap-foundation",
+    ])
+    forged_plan_path = ROOT / extract_output_ref(forged_output, "plan")
+    forged_plan = load(forged_plan_path)
+    forged_plan["mutationBoundary"] = dict(forged_plan["mutationBoundary"], executeSupportedNow=True, executor="infra/weave-workspace/install.sh")
+    forged_path = write_case_plan("forged-execute-supported", forged_plan)
+    run_command_expect_failure([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
+        "--plan", str(forged_path), "--execute", "--approval-ref", "APPROVAL-123",
+    ], "--execute is not allowed")
+
+    unsafe_receipt_plan = dict(plan)
+    unsafe_receipt_plan["providerStack"] = dict(plan["providerStack"], ref="https://unsafe.example/provider")
+    unsafe_receipt_path = write_case_plan("unsafe-receipt", unsafe_receipt_plan)
+    run_command_expect_failure([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
+        "--plan", str(unsafe_receipt_path),
+    ], "support-safe redaction blocked artifact")
 
 
 def main() -> int:

--- a/tools/bootstrap_foundation_check.py
+++ b/tools/bootstrap_foundation_check.py
@@ -225,6 +225,22 @@ def assert_bootstrap_runtime() -> None:
         "--plan", str(malicious_executor_path), "--execute", "--approval-ref", "APPROVAL-123",
     ], "bootstrap executor must be the allowlisted repo-relative path")
 
+    traversal_executor = dict(plan)
+    traversal_executor["mutationBoundary"] = dict(plan["mutationBoundary"], executor="../../usr/bin/true")
+    traversal_executor_path = write_case_plan("traversal-executor", traversal_executor)
+    run_command_expect_failure([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
+        "--plan", str(traversal_executor_path), "--execute", "--approval-ref", "APPROVAL-123",
+    ], "bootstrap executor must be the allowlisted repo-relative path")
+
+    nonallowlisted_executor = dict(plan)
+    nonallowlisted_executor["mutationBoundary"] = dict(plan["mutationBoundary"], executor="tools/weavectl")
+    nonallowlisted_executor_path = write_case_plan("nonallowlisted-executor", nonallowlisted_executor)
+    run_command_expect_failure([
+        "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
+        "--plan", str(nonallowlisted_executor_path), "--execute", "--approval-ref", "APPROVAL-123",
+    ], "bootstrap executor is not allowlisted for this profile/target")
+
     run_command_expect_failure([
         "python3", str(WEAVECTL.relative_to(ROOT)), "bootstrap", "apply",
         "--plan", str(plan_path.relative_to(ROOT)), "--execute", "--approval-ref", "https://example.invalid/ticket",

--- a/tools/weavectl
+++ b/tools/weavectl
@@ -32,6 +32,21 @@ FORBIDDEN_EVIDENCE_FRAGMENTS = [
     "raw provider",
 ]
 
+FORBIDDEN_EVIDENCE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in [
+        r"bearer\s+[a-z0-9._-]+",
+        r"gh[pousr]_[a-z0-9_]{12,}",
+        r"(token|secret|password|private[_-]?key)\s*[:=]\s*[^\s,}\"]+",
+        r"https?://[^\s)\"]+",
+        r"ssh://[^\s)\"]+",
+        r"-----begin\s+(rsa|dsa|ec|openssh|private)\s+private\s+key-----",
+    ]
+]
+
+APPROVAL_REF_RE = re.compile(r"^(APPROVAL|CHANGE|TICKET|ISSUE|GH|JIRA|OPS|SEC)-[A-Za-z0-9][A-Za-z0-9._:-]{2,63}$")
+ALLOWED_LOCAL_EXECUTOR = Path("infra/weave-workspace/install.sh")
+
 PROFILE_CONTRACT = {
     "dev": {"reachabilityMode": "developer-local", "memberPhoneAllowed": False},
     "local-lan-dogfood": {"reachabilityMode": "lan", "memberPhoneAllowed": True},
@@ -144,7 +159,55 @@ def write_json(path: Path, payload: dict[str, object]) -> None:
     for fragment in FORBIDDEN_EVIDENCE_FRAGMENTS:
         if fragment in lowered:
             fail(f"support-safe redaction blocked artifact {path}: forbidden fragment {fragment}")
+    for pattern in FORBIDDEN_EVIDENCE_PATTERNS:
+        if pattern.search(text):
+            fail(f"support-safe redaction blocked artifact {path}: forbidden pattern {pattern.pattern}")
     path.write_text(text, encoding="utf-8")
+
+
+def validate_approval_ref(raw: str | None) -> str:
+    if raw is None or not APPROVAL_REF_RE.fullmatch(raw):
+        fail("--approval-ref must be a support-safe ticket id like APPROVAL-123, OPS-2026-001, or GH-703")
+    return raw
+
+
+def validate_plan_integrity(plan: dict[str, object], plan_path: Path) -> None:
+    if plan.get("artifactKind") != "bootstrap-plan":
+        fail("bootstrap plan missing artifactKind=bootstrap-plan")
+    run_id = str(plan.get("runId") or "")
+    profile = str(plan.get("profile") or "")
+    target = str(plan.get("targetProviderLane") or "")
+    setup_mode = str(plan.get("setupMode") or "")
+    if profile not in BOOTSTRAP_PROFILES:
+        fail(f"bootstrap plan has unknown profile: {profile}")
+    if target not in BOOTSTRAP_TARGETS:
+        fail(f"bootstrap plan has unknown target provider lane: {target}")
+    expected_ref = support_safe_ref("bootstrap-plan", run_id, profile, target, setup_mode)
+    if plan.get("planRef") != expected_ref:
+        fail(f"bootstrap plan provenance check failed for {plan_path}: planRef does not match plan content")
+
+
+def expected_executor_for_plan(plan: dict[str, object]) -> Path:
+    profile = str(plan.get("profile") or "")
+    target = str(plan.get("targetProviderLane") or "")
+    if target not in {"local-shell", "local-docker"} or profile not in LOCAL_EXECUTE_PROFILES:
+        fail(f"--execute is not allowed for profile={profile} target={target}")
+    mutation = plan.get("mutationBoundary", {})
+    if not isinstance(mutation, dict):
+        fail("bootstrap plan missing mutation boundary")
+    claimed = str(mutation.get("executor") or "")
+    claimed_path = Path(claimed)
+    if claimed_path.is_absolute() or ".." in claimed_path.parts:
+        fail("bootstrap executor must be the allowlisted repo-relative path")
+    if claimed_path != ALLOWED_LOCAL_EXECUTOR:
+        fail("bootstrap executor is not allowlisted for this profile/target")
+    executor = (ROOT / ALLOWED_LOCAL_EXECUTOR).resolve()
+    root = ROOT.resolve()
+    if root not in executor.parents:
+        fail("bootstrap executor resolved outside the repository")
+    if not executor.exists():
+        fail(f"executor does not exist: {ALLOWED_LOCAL_EXECUTOR}")
+    return executor
 
 
 def read_json(path: Path) -> dict[str, object]:
@@ -288,24 +351,22 @@ def apply_bootstrap(args: argparse.Namespace) -> int:
         fail("unsupported bootstrap plan schema")
     if plan.get("supportSafe") is not True:
         fail("bootstrap plan must be supportSafe=true")
+    validate_plan_integrity(plan, plan_path)
     mutation = plan.get("mutationBoundary", {})
     if not isinstance(mutation, dict):
         fail("bootstrap plan missing mutation boundary")
-    if args.execute and not args.approval_ref:
-        fail("--execute requires --approval-ref")
+    approval_ref = validate_approval_ref(args.approval_ref) if args.execute else None
     if args.execute and mutation.get("executeSupportedNow") is not True:
         fail(f"--execute is not implemented for target {plan.get('targetProviderLane')}")
 
     run_id = str(plan.get("runId"))
-    apply_ref = support_safe_ref("bootstrap-apply", run_id, str(plan.get("planRef")), str(args.approval_ref or "dry-run"))
+    apply_ref = support_safe_ref("bootstrap-apply", run_id, str(plan.get("planRef")), str(approval_ref or "dry-run"))
     receipt_path = plan_path.parent / "apply-receipt.json"
     mode = "execute" if args.execute else "dry_run_validate_only"
     command_result: str | None = None
 
     if args.execute:
-        executor = ROOT / str(mutation.get("executor"))
-        if not executor.exists():
-            fail(f"executor does not exist: {executor.relative_to(ROOT)}")
+        executor = expected_executor_for_plan(plan)
         completed = subprocess.run([str(executor)], cwd=str(executor.parent), check=False)
         command_result = "success" if completed.returncode == 0 else f"failed_exit_{completed.returncode}"
         if completed.returncode != 0:
@@ -318,7 +379,8 @@ def apply_bootstrap(args: argparse.Namespace) -> int:
         "planRef": plan.get("planRef"),
         "applyRef": apply_ref,
         "mode": mode,
-        "approvalRef": args.approval_ref,
+        "approvalRef": "redacted" if approval_ref else None,
+        "approvalRefHash": support_safe_ref("approval-ref", approval_ref) if approval_ref else None,
         "supportSafe": True,
         "targetProviderLane": plan.get("targetProviderLane"),
         "profile": plan.get("profile"),

--- a/tools/weavectl
+++ b/tools/weavectl
@@ -150,16 +150,30 @@ def support_safe_ref(prefix: str, *parts: str) -> str:
     return f"{prefix}-{digest}"
 
 
+def assert_support_safe_payload(value: object, label: str, path: tuple[str, ...] = ()) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            assert_support_safe_payload(child, label, (*path, str(key)))
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            assert_support_safe_payload(child, label, (*path, str(index)))
+        return
+    if isinstance(value, str):
+        lowered = value.lower()
+        location = ".".join(path) or "<root>"
+        for fragment in FORBIDDEN_EVIDENCE_FRAGMENTS:
+            if fragment in lowered:
+                fail(f"support-safe redaction blocked artifact {label}: forbidden fragment {fragment} at {location}")
+        for pattern in FORBIDDEN_EVIDENCE_PATTERNS:
+            if pattern.search(value):
+                fail(f"support-safe redaction blocked artifact {label}: forbidden pattern {pattern.pattern} at {location}")
+
+
 def write_json(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    assert_support_safe_payload(payload, str(path))
     text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
-    lowered = text.lower()
-    for fragment in FORBIDDEN_EVIDENCE_FRAGMENTS:
-        if fragment in lowered:
-            fail(f"support-safe redaction blocked artifact {path}: forbidden fragment {fragment}")
-    for pattern in FORBIDDEN_EVIDENCE_PATTERNS:
-        if pattern.search(text):
-            fail(f"support-safe redaction blocked artifact {path}: forbidden pattern {pattern.pattern}")
     path.write_text(text, encoding="utf-8")
 
 
@@ -349,6 +363,7 @@ def apply_bootstrap(args: argparse.Namespace) -> int:
         fail("unsupported bootstrap plan schema")
     if plan.get("supportSafe") is not True:
         fail("bootstrap plan must be supportSafe=true")
+    assert_support_safe_payload(plan, str(plan_path))
     validate_plan_integrity(plan, plan_path)
     mutation = plan.get("mutationBoundary", {})
     if not isinstance(mutation, dict):

--- a/tools/weavectl
+++ b/tools/weavectl
@@ -38,8 +38,6 @@ FORBIDDEN_EVIDENCE_PATTERNS = [
         r"bearer\s+[a-z0-9._-]+",
         r"gh[pousr]_[a-z0-9_]{12,}",
         r"(token|secret|password|private[_-]?key)\s*[:=]\s*[^\s,}\"]+",
-        r"https?://[^\s)\"]+",
-        r"ssh://[^\s)\"]+",
         r"-----begin\s+(rsa|dsa|ec|openssh|private)\s+private\s+key-----",
     ]
 ]


### PR DESCRIPTION
## Summary
- harden `tools/weavectl bootstrap apply` so execute mode validates plan provenance and only allows the repo-owned bootstrap executor
- redact/hash approval references in apply receipts and reuse forbidden-pattern checks for runtime artifacts
- add non-mutating negative tests for malicious executor paths, forged execute support, unsafe approval refs, and unsafe artifact writes
- extend executor negative tests to cover all three rejection branches: absolute path, relative `..` traversal, and non-allowlisted relative path

## Scope and user impact

-

## Spec / acceptance link

- Issue:
- Repo spec or spec note:
- Acceptance scenario / mapping marker when product behavior changed:
- Product-core questions intentionally left unresolved: none / listed below

## Branch, target, and release path

- [ ] Branch started from current `origin/main`
- [ ] PR targets protected `main`
- [ ] No long-lived `dev`/`testing`/`staging` branch involved
- [ ] Production release is not implied by this merge

## Screenshots or docs impact

-

## Accessibility and localization

-

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [ ] Contract/spec change documented:
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [ ] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented

## Checks run

- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason):

## Notes for reviewers

- `./gradlew bootstrapFoundationCheck --console=plain` ✅
- `python3 -m py_compile tools/weavectl tools/bootstrap_foundation_check.py` ✅
- `python3 tools/bootstrap_foundation_check.py` ✅ (6 negative cases)
- `./gradlew weaveControlModesCheck --console=plain` ✅
- No live Docker/Terraform/Synapse mutation was performed.
- `docsCheck` could not run in the hotfix worktree because the selected local Python/Xcode interpreter has no `mkdocs` module; GitHub CI should provide the canonical check.
- Release promotion remains separately blocked by #591 manual Assistive-Technology signoff/waiver.