### PR TITLE
fix: avoid release readiness ciSummary property collision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,9 @@ tasks.register('releaseReadinessCheck', Exec) {
     group = 'verification'
     description = 'Validate local release-candidate readiness evidence without publishing a release. Override with -PcandidateVersion, -PcandidateTag, -PcandidateCommit, -PciSummary, -PliveEvidenceDir, -PliveManifest, -PblockersJson, -Pwaiver, and -Pjson=true.'
     workingDir projectDir
-    def candidateVersion = (findProperty('candidateVersion') ?: '0.1.0-rc.1').toString()
-    def candidateTag = (findProperty('candidateTag') ?: "v${candidateVersion.startsWith('v') ? candidateVersion.substring(1) : candidateVersion}").toString()
+    def candidateVersion = providers.gradleProperty('candidateVersion').orElse('0.1.0-rc.1').get().toString()
+    def defaultCandidateTag = "v${candidateVersion.startsWith('v') ? candidateVersion.substring(1) : candidateVersion}"
+    def candidateTag = providers.gradleProperty('candidateTag').orElse(defaultCandidateTag).get().toString()
     def args = ['python3', 'tools/release_readiness_check.py', '--candidate-version', candidateVersion, '--candidate-tag', candidateTag]
     [
         candidateCommit: '--candidate-commit',
@@ -82,12 +83,13 @@ tasks.register('releaseReadinessCheck', Exec) {
         blockersJson: '--blockers-json',
         waiver: '--waiver'
     ].each { propertyName, flag ->
-        if (findProperty(propertyName) != null) {
+        def propertyValue = providers.gradleProperty(propertyName.toString()).orNull
+        if (propertyValue != null) {
             args.add(flag)
-            args.add(findProperty(propertyName).toString())
+            args.add(propertyValue.toString())
         }
     }
-    if ((findProperty('json') ?: 'false').toString().toBoolean()) {
+    if (providers.gradleProperty('json').orElse('false').get().toString().toBoolean()) {
         args.add('--json')
     }
     commandLine execCommand(args)

--- a/tools/release_readiness_check.py
+++ b/tools/release_readiness_check.py
@@ -323,7 +323,7 @@ def extract_open_blockers(data: Any) -> list[dict[str, Any]]:
     for item in candidates:
         if not isinstance(item, dict):
             continue
-        state = str(item.get("state", "open"))
+        state = str(item.get("state", "open")).lower()
         labels = item.get("labels", [])
         label_names: set[str] = set()
         for label in labels:

--- a/tools/release_readiness_check_test.py
+++ b/tools/release_readiness_check_test.py
@@ -106,6 +106,18 @@ class ReleaseReadinessCheckTest(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("#360", self.check_by_id(self.json_result(completed), "release-blockers")["summary"])
 
+    def test_uppercase_open_release_blocker_blocks(self) -> None:
+        blockers = {
+            "schemaVersion": 1,
+            "issues": [
+                {"number": 591, "title": "Manual AT signoff", "state": "OPEN", "labels": [{"name": "release-blocker"}]}
+            ],
+        }
+        (self.root / "release-blockers.json").write_text(json.dumps(blockers), encoding="utf-8")
+        completed = self.run_check()
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("#591", self.check_by_id(self.json_result(completed), "release-blockers")["summary"])
+
     def test_missing_e2e_can_be_waived_with_explicit_marker(self) -> None:
         manifest = self.root / "weave-live-stack-acceptance-evidence" / "release-evidence-manifest.json"
         manifest.unlink()


### PR DESCRIPTION
## Summary

Fixes the Gradle `releaseReadinessCheck` task so optional CLI overrides are read only from explicit `-P...` Gradle properties. The previous `findProperty('ciSummary')` lookup collided with the existing `ciSummary` task name, causing the default release readiness command to pass a bogus `--ci-summary` value and report the authoritative CI summary as missing.

## Why

During the heartbeat release scan, `./gradlew ci --no-daemon` produced `build/evidence/ci-summary.json` for commit `aa14667b3add`, but `./gradlew releaseReadinessCheck --no-daemon` still failed the `ci-summary` check. Running the check directly proved the Python checker was fine; the Gradle wrapper task was shadowing the `ciSummary` option with the task object.

## Testing

- `./gradlew releaseReadinessFixtureTest --no-daemon`
- `./gradlew releaseReadinessCheck -Pjson=true --no-daemon` now passes `ci-summary` by default and remains blocked only on the expected release evidence gates: missing credentialed Live Stack manifest and missing release-blocker evidence.

Refs #710.
