### PR TITLE
test: add governed Weaver foundation evidence

### DIFF
--- a/docs/evidence/weaver-customization-report.md
+++ b/docs/evidence/weaver-customization-report.md
@@ -4,7 +4,7 @@ Status: Sprint 25 provider-lab evidence, support-safe.
 
 ## Scope
 
-This report covers Sprint 25 issues #635, #636, #637, and #638. It proves a bounded customization slice only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts, rollback restores a previous profile hash, and customized-Weaver claims are gated by matching scoreboard evidence.
+This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 governed-foundation issue #711. It proves bounded Weaver governance only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts, rollback restores a previous profile hash, and governed-Weaver claims are gated by matching evidence.
 
 ## Evidence artifacts
 
@@ -13,6 +13,7 @@ This report covers Sprint 25 issues #635, #636, #637, and #638. It proves a boun
 - `release/provider-lab/weaver-runtime/tool-approval-gate-proof.fixture.json` — #637 read/write/approval/revocation/expiry/consent grant proof.
 - `release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json` — #638 accepted scoped claim and rejected overclaim set.
 - `release/provider-lab/weaver-runtime/sprint-25-scoreboard.json` — #635-#638 green scoreboard with no release blockers.
+- `release/provider-lab/weaver-runtime/sprint-32-governed-foundation.fixture.json` — #711 disabled-by-default policy evaluation, read-only first tool registry, ApprovalReceipt-gated write/external-send cases, and one-way RuntimeProfile/OpenClaw projection proof.
 
 ## Executable gates
 
@@ -21,4 +22,4 @@ This report covers Sprint 25 issues #635, #636, #637, and #638. It proves a boun
 
 ## Claim boundary
 
-This evidence does not claim customer-ready Weaver, production PA availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, raw memory export, raw secrets, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab Sprint 25 artifacts.
+This evidence does not claim customer-ready Weaver, production PA availability, broad member availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, marketplace MCPs, raw memory export, raw secrets, autonomous routine writes, external-send without ApprovalReceipt, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab and governed-foundation artifacts.

--- a/release/provider-lab/weaver-runtime/sprint-32-governed-foundation.fixture.json
+++ b/release/provider-lab/weaver-runtime/sprint-32-governed-foundation.fixture.json
@@ -1,0 +1,153 @@
+{
+  "artifactKind": "weave-weaver-runtime-sprint-32-governed-foundation-proof",
+  "supportSafe": true,
+  "githubIssue": 711,
+  "scope": "governed Weaver foundation; disabled by default; policy-generated RuntimeProfile/OpenClaw projection; read-only first tool registry; ApprovalReceipt required for writes/external-send",
+  "defaultPosture": {
+    "weaverCategoryDefault": "disabled",
+    "normalMemberRawOpenClawEditing": "hidden_or_rbac_stripped",
+    "rawConfigExported": false,
+    "rawToolChannelMcpSecretSettingsEditableByMember": false,
+    "runtimeGeneratorDefault": "disabled"
+  },
+  "policyEvaluationCases": [
+    {
+      "id": "default-disabled",
+      "organizationCategoryEnabled": false,
+      "userGrant": "weaver.enabled",
+      "runtimeGeneratorEnabled": true,
+      "memberOptIn": true,
+      "decision": "deny",
+      "reason": "organization_category_disabled"
+    },
+    {
+      "id": "missing-user-flag",
+      "organizationCategoryEnabled": true,
+      "userGrant": null,
+      "runtimeGeneratorEnabled": true,
+      "memberOptIn": true,
+      "decision": "deny",
+      "reason": "missing_weaver_enabled_grant"
+    },
+    {
+      "id": "missing-generator",
+      "organizationCategoryEnabled": true,
+      "userGrant": "weaver.enabled",
+      "runtimeGeneratorEnabled": false,
+      "memberOptIn": true,
+      "decision": "deny",
+      "reason": "runtime_generator_disabled"
+    },
+    {
+      "id": "missing-opt-in",
+      "organizationCategoryEnabled": true,
+      "userGrant": "weaver.enabled",
+      "runtimeGeneratorEnabled": true,
+      "memberOptIn": false,
+      "decision": "deny",
+      "reason": "member_opt_in_required"
+    },
+    {
+      "id": "all-enablement-conditions-present",
+      "organizationCategoryEnabled": true,
+      "userGrant": "weaver.enabled",
+      "runtimeGeneratorEnabled": true,
+      "memberOptIn": true,
+      "decision": "permit",
+      "reason": "all_enablement_conditions_satisfied"
+    }
+  ],
+  "grantIntersectionCases": [
+    {
+      "id": "overbroad-grant-reduced",
+      "organizationAllowlist": ["calendar.search_events", "files.search"],
+      "userRights": ["calendar.search_events", "files.search", "boards.comment"],
+      "effectiveGrants": ["calendar.search_events", "files.search"],
+      "blockedGrants": ["boards.comment"],
+      "decision": "permit_intersection_only"
+    },
+    {
+      "id": "no-intersection-denied",
+      "organizationAllowlist": ["calendar.search_events"],
+      "userRights": ["boards.search_tasks"],
+      "effectiveGrants": [],
+      "blockedGrants": ["boards.search_tasks"],
+      "decision": "deny_no_effective_grants"
+    }
+  ],
+  "toolRegistryV1": {
+    "allowedReadOnlyTools": [
+      "calendar.search_events",
+      "boards.search_tasks",
+      "files.search",
+      "chat.search_messages"
+    ],
+    "writeOrExternalSendTools": [
+      "boards.comment",
+      "notifications.create_action_request"
+    ],
+    "cases": [
+      {
+        "id": "calendar-search-allowed",
+        "tool": "calendar.search_events",
+        "requestedMode": "read",
+        "approvalReceiptRequired": false,
+        "decision": "allow"
+      },
+      {
+        "id": "boards-comment-without-approval",
+        "tool": "boards.comment",
+        "requestedMode": "write",
+        "approvalReceiptRequired": true,
+        "approvalReceiptPresent": false,
+        "decision": "deny_approval_required"
+      },
+      {
+        "id": "external-send-with-approval",
+        "tool": "notifications.create_action_request",
+        "requestedMode": "external_send",
+        "approvalReceiptRequired": true,
+        "approvalReceiptPresent": true,
+        "decision": "allow_with_audit"
+      },
+      {
+        "id": "unknown-tool-fails-closed",
+        "tool": "mcp.marketplace.install",
+        "requestedMode": "write",
+        "approvalReceiptRequired": true,
+        "approvalReceiptPresent": false,
+        "decision": "deny_unknown_tool"
+      }
+    ]
+  },
+  "runtimeProfileProjection": {
+    "sourceOfTruth": "Weave policy and user rights",
+    "projectionDirection": "one_way_to_openclaw_runtime_profile",
+    "normalMemberCanEditRawOpenClaw": false,
+    "rawConfigHidden": true,
+    "includesCredentialRefsOnly": true,
+    "containsProviderSecrets": false,
+    "containsRawToolOutput": false,
+    "profileHashPresent": true,
+    "auditPolicyRequiredFields": [
+      "runtimeProfileHash",
+      "userRef",
+      "tool",
+      "domain",
+      "providerRef",
+      "credentialRef",
+      "policyDecision",
+      "approvalReceiptRef"
+    ]
+  },
+  "claimGate": {
+    "acceptedClaim": "Sprint 32 adds support-safe governed Weaver foundation evidence: disabled-by-default policy evaluation, read-only first tool registry, ApprovalReceipt-gated writes/external-send, and one-way RuntimeProfile/OpenClaw projection generated from Weave policy.",
+    "rejectedClaims": [
+      "Weaver is broadly available to all members.",
+      "Weaver can execute arbitrary tools or marketplace MCPs.",
+      "Normal members can edit raw OpenClaw config, channels, MCP, secrets, or tool allowlists.",
+      "Weaver can perform routine writes or external sends without ApprovalReceipt.",
+      "This evidence closes manual AT or public release blocker #591."
+    ]
+  }
+}

--- a/tools/weaver_customization_check.py
+++ b/tools/weaver_customization_check.py
@@ -147,6 +147,23 @@ def validate_claims(artifact: dict[str, Any]) -> None:
             fail(f"claim boundary missing {phrase}")
 
 
+def load_case_map(cases: Any, *, label: str) -> dict[str, dict[str, Any]]:
+    if not isinstance(cases, list):
+        fail(f"{label} must be a list")
+
+    case_map: dict[str, dict[str, Any]] = {}
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            fail(f"{label}[{index}] must be an object")
+        case_id = case.get("id")
+        if not isinstance(case_id, str):
+            fail(f"{label}[{index}].id must be a string")
+        if case_id in case_map:
+            fail(f"{label} contains duplicate id {case_id!r}")
+        case_map[case_id] = case
+    return case_map
+
+
 def validate_sprint32_governed_foundation(artifact: dict[str, Any]) -> None:
     if artifact.get("artifactKind") != "weave-weaver-runtime-sprint-32-governed-foundation-proof":
         fail("Sprint 32 governed foundation artifact kind mismatch")
@@ -156,7 +173,7 @@ def validate_sprint32_governed_foundation(artifact: dict[str, Any]) -> None:
     if default_posture.get("rawToolChannelMcpSecretSettingsEditableByMember") is not False:
         fail("normal members must not edit raw OpenClaw tool/channel/MCP/secret settings")
 
-    policy_cases = {case.get("id"): case for case in artifact.get("policyEvaluationCases", []) if isinstance(case, dict)}
+    policy_cases = load_case_map(artifact.get("policyEvaluationCases", []), label="policyEvaluationCases")
     if set(policy_cases) != set(REQUIRED_SPRINT32_POLICY_CASES):
         fail(f"Sprint 32 policy case mismatch: {sorted(policy_cases)}")
     for case_id, decision in REQUIRED_SPRINT32_POLICY_CASES.items():

--- a/tools/weaver_customization_check.py
+++ b/tools/weaver_customization_check.py
@@ -16,6 +16,7 @@ POLICY = ARTIFACT_DIR / "policy-boundary-proof.fixture.json"
 TOOLS = ARTIFACT_DIR / "tool-approval-gate-proof.fixture.json"
 CLAIMS = ARTIFACT_DIR / "sprint-25-claim-gate.fixture.json"
 SCOREBOARD = ARTIFACT_DIR / "sprint-25-scoreboard.json"
+SPRINT32_GOVERNED = ARTIFACT_DIR / "sprint-32-governed-foundation.fixture.json"
 EVIDENCE = ROOT / "docs" / "evidence" / "weaver-customization-report.md"
 CLOSURE = ROOT / "docs" / "sprint-25-closure-report.md"
 
@@ -32,6 +33,20 @@ SECRET_PATTERNS = [
         r"https?://[^\s)\"]*@",
     ]
 ]
+
+REQUIRED_SPRINT32_POLICY_CASES = {
+    "default-disabled": "deny",
+    "missing-user-flag": "deny",
+    "missing-generator": "deny",
+    "missing-opt-in": "deny",
+    "all-enablement-conditions-present": "permit",
+}
+REQUIRED_SPRINT32_READONLY_TOOLS = {
+    "calendar.search_events",
+    "boards.search_tasks",
+    "files.search",
+    "chat.search_messages",
+}
 
 
 def fail(message: str) -> None:
@@ -132,6 +147,68 @@ def validate_claims(artifact: dict[str, Any]) -> None:
             fail(f"claim boundary missing {phrase}")
 
 
+def validate_sprint32_governed_foundation(artifact: dict[str, Any]) -> None:
+    if artifact.get("artifactKind") != "weave-weaver-runtime-sprint-32-governed-foundation-proof":
+        fail("Sprint 32 governed foundation artifact kind mismatch")
+    default_posture = artifact.get("defaultPosture", {})
+    if default_posture.get("weaverCategoryDefault") != "disabled" or default_posture.get("runtimeGeneratorDefault") != "disabled":
+        fail("Sprint 32 governed foundation must keep Weaver disabled by default")
+    if default_posture.get("rawToolChannelMcpSecretSettingsEditableByMember") is not False:
+        fail("normal members must not edit raw OpenClaw tool/channel/MCP/secret settings")
+
+    policy_cases = {case.get("id"): case for case in artifact.get("policyEvaluationCases", []) if isinstance(case, dict)}
+    if set(policy_cases) != set(REQUIRED_SPRINT32_POLICY_CASES):
+        fail(f"Sprint 32 policy case mismatch: {sorted(policy_cases)}")
+    for case_id, decision in REQUIRED_SPRINT32_POLICY_CASES.items():
+        if policy_cases[case_id].get("decision") != decision or not policy_cases[case_id].get("reason"):
+            fail(f"Sprint 32 policy case {case_id} must decide {decision} with a reason")
+
+    for case in artifact.get("grantIntersectionCases", []):
+        effective = set(case.get("effectiveGrants", []))
+        allowlist = set(case.get("organizationAllowlist", []))
+        rights = set(case.get("userRights", []))
+        if effective != allowlist.intersection(rights):
+            fail(f"Sprint 32 grant intersection case {case.get('id')} has wrong effective grants")
+        if not set(case.get("blockedGrants", [])).isdisjoint(effective):
+            fail(f"Sprint 32 grant intersection case {case.get('id')} blocks an effective grant")
+
+    registry = artifact.get("toolRegistryV1", {})
+    if set(registry.get("allowedReadOnlyTools", [])) != REQUIRED_SPRINT32_READONLY_TOOLS:
+        fail("Sprint 32 read-only tool registry must contain the exact initial tool set")
+    tool_cases = {case.get("id"): case for case in registry.get("cases", []) if isinstance(case, dict)}
+    required_decisions = {
+        "calendar-search-allowed": "allow",
+        "boards-comment-without-approval": "deny_approval_required",
+        "external-send-with-approval": "allow_with_audit",
+        "unknown-tool-fails-closed": "deny_unknown_tool",
+    }
+    for case_id, decision in required_decisions.items():
+        if tool_cases.get(case_id, {}).get("decision") != decision:
+            fail(f"Sprint 32 tool registry case {case_id} must decide {decision}")
+    if tool_cases["boards-comment-without-approval"].get("approvalReceiptPresent") is not False:
+        fail("write without ApprovalReceipt must be denied")
+
+    projection = artifact.get("runtimeProfileProjection", {})
+    if projection.get("sourceOfTruth") != "Weave policy and user rights" or projection.get("projectionDirection") != "one_way_to_openclaw_runtime_profile":
+        fail("RuntimeProfile/OpenClaw projection must be generated one-way from Weave policy")
+    for key in ["normalMemberCanEditRawOpenClaw", "containsProviderSecrets", "containsRawToolOutput"]:
+        if projection.get(key) is not False:
+            fail(f"Sprint 32 projection must set {key}=false")
+    required_audit = {"runtimeProfileHash", "userRef", "tool", "domain", "providerRef", "credentialRef", "policyDecision", "approvalReceiptRef"}
+    if set(projection.get("auditPolicyRequiredFields", [])) != required_audit:
+        fail("Sprint 32 audit policy required fields mismatch")
+
+    claims = artifact.get("claimGate", {})
+    accepted = str(claims.get("acceptedClaim", ""))
+    for phrase in ["disabled-by-default", "read-only first tool registry", "ApprovalReceipt-gated", "Weave policy"]:
+        if phrase not in accepted:
+            fail(f"Sprint 32 accepted claim missing {phrase}")
+    rejected = "\n".join(claims.get("rejectedClaims", []))
+    for phrase in ["broadly available", "marketplace MCPs", "raw OpenClaw config", "without ApprovalReceipt", "#591"]:
+        if phrase.lower() not in rejected.lower():
+            fail(f"Sprint 32 rejected claims missing {phrase}")
+
+
 def validate_scoreboard(scoreboard: dict[str, Any]) -> None:
     if scoreboard.get("artifactKind") != "weave-weaver-runtime-sprint-25-scoreboard":
         fail("scoreboard artifact kind mismatch")
@@ -159,6 +236,9 @@ def validate_docs() -> None:
         for artifact in [PROFILE, POLICY, TOOLS, CLAIMS, SCOREBOARD]:
             if str(artifact.relative_to(ROOT)) not in text:
                 fail(f"{path.relative_to(ROOT)} missing {artifact.relative_to(ROOT)}")
+    evidence_text = EVIDENCE.read_text(encoding="utf-8")
+    if "#711" not in evidence_text or str(SPRINT32_GOVERNED.relative_to(ROOT)) not in evidence_text:
+        fail("Weaver customization evidence report missing Sprint 32 #711 governed foundation artifact")
 
 
 def main() -> None:
@@ -167,7 +247,8 @@ def main() -> None:
     tools = load(TOOLS)
     claims = load(CLAIMS)
     scoreboard = load(SCOREBOARD)
-    for label, artifact in [("profile", profile), ("policy", policy), ("tools", tools), ("claims", claims), ("scoreboard", scoreboard)]:
+    sprint32_governed = load(SPRINT32_GOVERNED)
+    for label, artifact in [("profile", profile), ("policy", policy), ("tools", tools), ("claims", claims), ("scoreboard", scoreboard), ("sprint32_governed", sprint32_governed)]:
         if artifact.get("supportSafe") is not True:
             fail(f"{label} must be supportSafe")
         assert_support_safe(artifact, label)
@@ -176,8 +257,9 @@ def main() -> None:
     validate_tools(tools)
     validate_claims(claims)
     validate_scoreboard(scoreboard)
+    validate_sprint32_governed_foundation(sprint32_governed)
     validate_docs()
-    print("weaver-customization-check: ok issues=635,636,637,638 claims=scoped provider-lab customer_ready=false")
+    print("weaver-customization-check: ok issues=635,636,637,638,711 claims=scoped governed-foundation customer_ready=false")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add support-safe Sprint 32 governed Weaver foundation evidence for #711.
- Extend the Weaver customization gate to validate disabled-by-default policy evaluation, grant intersection, read-only first tool registry, ApprovalReceipt-gated write/external-send cases, and one-way RuntimeProfile/OpenClaw projection.
- Update the evidence report with explicit no-broad-availability/no-raw-OpenClaw/no-marketplace/no-autonomous-write claim boundaries.

## Scope and user impact

- Organizations get verifiable governed-Weaver posture without enabling broad personal-assistant availability.
- Normal members remain blocked from raw OpenClaw config/channel/MCP/secret/tool settings.
- Weaver is treated as an agent inside Weave; this PR does not add deployment architecture or live runtime mutation.

## Spec / acceptance link

- Issue: Addresses #711.
- Repo spec or spec note: `specs/0007-governed-weaver-runtime/spec.md`, `docs/evidence/weaver-customization-report.md`.
- Acceptance scenario / mapping marker when product behavior changed: `@weave-v01-governed-weaver-runtime-policy`, `@weave-v01-governed-weaver-tool-registry` evidence paths extended through `tools/weaver_customization_check.py`.
- Product-core questions intentionally left unresolved: none.

## Branch, target, and release path

- [x] Branch started from current `origin/main`
- [x] PR targets protected `main`
- [x] No long-lived `dev`/`testing`/`staging` branch involved
- [x] Production release is not implied by this merge

## Screenshots or docs impact

- Evidence documentation updated only.
- No screenshots changed.

## Accessibility and localization

- No UI or localization surfaces changed.
- Manual AT/public-release blocker #591 remains open and is explicitly not closed by this evidence.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: governed Weaver evidence fixture and gate extension.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Review readiness

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented

## Checks run

- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): skipped; no live infra/provider/prod mutation authorized.

Additional focused checks run:

- [x] `python3 tools/weaver_customization_check.py`
- [x] `./gradlew weaverRuntimeFactoryCheck weaverCustomizationCheck`
- [x] `python3 tools/docs_check.py`
- [x] `./gradlew releaseEvidenceCheck`

## Notes for reviewers

- This PR intentionally keeps Weaver disabled by default and does not expose exec, marketplace MCPs, raw OpenClaw config, raw secrets, broad PA availability, or autonomous writes.
