### PR TITLE
test: prove governed Weaver MCP tool execution

### DIFF
--- a/docs/evidence/weaver-customization-report.md
+++ b/docs/evidence/weaver-customization-report.md
@@ -4,7 +4,7 @@ Status: Sprint 25 provider-lab evidence, support-safe.
 
 ## Scope
 
-This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 governed-foundation issue #711. It proves bounded Weaver governance only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts, rollback restores a previous profile hash, and governed-Weaver claims are gated by matching evidence.
+This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 governed-foundation issue #711 and governed MCP tool-execution issue #717. It proves bounded Weaver governance only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts or a scoped revokable always-allow grant, rollback restores a previous profile hash, narrow MCP tool execution can create and read back a fixture event, and governed-Weaver claims are gated by matching evidence.
 
 ## Evidence artifacts
 
@@ -14,6 +14,7 @@ This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 g
 - `release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json` — #638 accepted scoped claim and rejected overclaim set.
 - `release/provider-lab/weaver-runtime/sprint-25-scoreboard.json` — #635-#638 green scoreboard with no release blockers.
 - `release/provider-lab/weaver-runtime/sprint-32-governed-foundation.fixture.json` — #711 disabled-by-default policy evaluation, read-only first tool registry, ApprovalReceipt-gated write/external-send cases, and one-way RuntimeProfile/OpenClaw projection proof.
+- `release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json` — #717 German event-creation prompt, support-safe `qwen3.5-9b` runtime binding, scoped MCP tool discovery, `calendar.create_event` invocation, persistent scoped always-allow behavior, fixture state change/readback, final chat audit reference, and fail-closed negative matrix.
 
 ## Executable gates
 
@@ -22,4 +23,4 @@ This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 g
 
 ## Claim boundary
 
-This evidence does not claim customer-ready Weaver, production PA availability, broad member availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, marketplace MCPs, raw memory export, raw secrets, autonomous routine writes, external-send without ApprovalReceipt, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab and governed-foundation artifacts.
+This evidence does not claim customer-ready Weaver, production PA availability, broad member availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, marketplace MCPs, raw memory export, raw secrets, autonomous routine writes outside an explicit scoped approval/always-allow policy, external-send without ApprovalReceipt, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab, governed-foundation, and governed MCP fixture artifacts.

--- a/infra/weave-mcp/README.md
+++ b/infra/weave-mcp/README.md
@@ -27,11 +27,12 @@ Discovery requires runtime context headers. Policy comes from the generated Runt
 - `X-Weave-Runtime-Profile` — support-safe profile hash
 - `X-Weave-Runtime-Profile-Projection` — base64url JSON containing `runtimeProfileHash`, `enabled`, `revoked`, `serverKey`, `transport`, `credentialRef`, `capabilityGrants`, `allowedTools`, `auditRef`, and `projectionSignature` references only
 
-The Sprint 16 proof tools are:
+The Sprint 16/Sprint 32 proof tools are:
 
 - `admin.get_readiness` (read-only)
 - `weaver.get_runtime_profile_projection` (read-only)
 - `calendar.search_events` (read-only domain proof)
+- `calendar.create_event` (narrow write/action fixture; fails closed without `approvalReceiptRef` unless the signed runtime scope carries a revokable `alwaysAllowGrantRef` for `calendar.create_event`)
 - `boards.comment` (write/action stub; fails closed without `approvalReceiptRef`)
 
 Run tests through the infra gate:

--- a/infra/weave-mcp/src/weave_mcp/client.py
+++ b/infra/weave-mcp/src/weave_mcp/client.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from .schemas.common import RuntimeContext, ToolResult
 
+_CREATED_EVENTS: dict[str, dict[str, Any]] = {}
+
 
 @dataclass(frozen=True)
 class WeaveBackendClient:
@@ -44,6 +46,7 @@ class WeaveBackendClient:
                             "admin.get_readiness",
                             "weaver.get_runtime_profile_projection",
                             "calendar.search_events",
+                            "calendar.create_event",
                             "boards.comment",
                         ],
                         "rawEndpointExposed": False,
@@ -56,14 +59,44 @@ class WeaveBackendClient:
         )
 
     def calendar_search_events(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
+        requested_ref = str(query.get("eventRef", "")).strip()
+        items = [event for ref, event in sorted(_CREATED_EVENTS.items()) if not requested_ref or ref == requested_ref]
         return ToolResult(
             {
                 "queryRef": "query://calendar/support-safe/" + str(abs(hash(repr(sorted(query.items()))))),
-                "items": [],
+                "items": items,
                 "redactedItems": True,
                 "providerSourceMappedByBackend": True,
+                "readbackVerified": bool(requested_ref and items),
             },
             "audit://mcp/calendar-search/support-safe",
+        )
+
+    def calendar_create_event(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
+        title = str(query.get("title", "Test event")).strip() or "Test event"
+        starts_at = str(query.get("startsAt", "")).strip()
+        event_ref = "calendar-event://fixture/" + str(abs(hash((ctx.org_id, ctx.user_ref, title, starts_at))))
+        event = {
+            "eventRef": event_ref,
+            "title": title,
+            "startsAt": starts_at,
+            "createdBy": ctx.user_ref,
+            "calendarRef": "calendar://fixture/weave-governed-tool-proof",
+            "providerMutationPerformedByMcp": False,
+            "stateChangeFixtureOnly": True,
+        }
+        _CREATED_EVENTS[event_ref] = event
+        readback = self.calendar_search_events(ctx, {"eventRef": event_ref}).support_safe()
+        return ToolResult(
+            {
+                "decision": "created-test-fixture-event",
+                "eventRef": event_ref,
+                "approvalRef": str(query.get("approvalRef", "")),
+                "readbackVerified": readback.get("readbackVerified") is True,
+                "finalChatAnswer": f"Ich habe das Testereignis um {starts_at} angelegt. Audit: audit://mcp/calendar-create/support-safe",
+                "providerMutationPerformedByMcp": False,
+            },
+            "audit://mcp/calendar-create/support-safe",
         )
 
     def boards_comment(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:

--- a/infra/weave-mcp/src/weave_mcp/client.py
+++ b/infra/weave-mcp/src/weave_mcp/client.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from threading import Lock
 from typing import Any
 
 from .schemas.common import RuntimeContext, ToolResult
 
 _CREATED_EVENTS: dict[str, dict[str, Any]] = {}
+_CREATED_EVENTS_LOCK = Lock()
 
 
 @dataclass(frozen=True)
@@ -60,7 +62,14 @@ class WeaveBackendClient:
 
     def calendar_search_events(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
         requested_ref = str(query.get("eventRef", "")).strip()
-        items = [event for ref, event in sorted(_CREATED_EVENTS.items()) if not requested_ref or ref == requested_ref]
+        with _CREATED_EVENTS_LOCK:
+            items = [
+                event
+                for ref, event in sorted(_CREATED_EVENTS.items())
+                if (not requested_ref or ref == requested_ref)
+                and event.get("orgId") == ctx.org_id
+                and event.get("createdBy") == ctx.user_ref
+            ]
         return ToolResult(
             {
                 "queryRef": "query://calendar/support-safe/" + str(abs(hash(repr(sorted(query.items()))))),
@@ -80,12 +89,14 @@ class WeaveBackendClient:
             "eventRef": event_ref,
             "title": title,
             "startsAt": starts_at,
+            "orgId": ctx.org_id,
             "createdBy": ctx.user_ref,
             "calendarRef": "calendar://fixture/weave-governed-tool-proof",
             "providerMutationPerformedByMcp": False,
             "stateChangeFixtureOnly": True,
         }
-        _CREATED_EVENTS[event_ref] = event
+        with _CREATED_EVENTS_LOCK:
+            _CREATED_EVENTS[event_ref] = event
         readback = self.calendar_search_events(ctx, {"eventRef": event_ref}).support_safe()
         return ToolResult(
             {

--- a/infra/weave-mcp/src/weave_mcp/fastmcp_app.py
+++ b/infra/weave-mcp/src/weave_mcp/fastmcp_app.py
@@ -42,6 +42,21 @@ def build_fastmcp(config: WeaveMcpConfig | None = None) -> Any:
     def calendar_search_events(context_headers: dict[str, str], query: str = "") -> dict[str, Any]:
         return gateway.invoke_tool(_headers(context_headers), {"tool": "calendar.search_events", "input": {"query": query}})
 
+    @mcp.tool(name="calendar.create_event")
+    def calendar_create_event(
+        context_headers: dict[str, str],
+        title: str,
+        starts_at: str,
+        approval_receipt_ref: str | None = None,
+        always_allow_grant_ref: str | None = None,
+    ) -> dict[str, Any]:
+        payload = {"title": title, "startsAt": starts_at}
+        if approval_receipt_ref:
+            payload["approvalReceiptRef"] = approval_receipt_ref
+        if always_allow_grant_ref:
+            payload["alwaysAllowGrantRef"] = always_allow_grant_ref
+        return gateway.invoke_tool(_headers(context_headers), {"tool": "calendar.create_event", "input": payload})
+
     @mcp.tool(name="boards.comment")
     def boards_comment(
         context_headers: dict[str, str],

--- a/infra/weave-mcp/src/weave_mcp/schemas/common.py
+++ b/infra/weave-mcp/src/weave_mcp/schemas/common.py
@@ -39,6 +39,7 @@ class RuntimeContext:
     capability_grants: frozenset[str]
     allowed_tools: frozenset[str]
     audit_ref: str
+    always_allow_grants: frozenset[str] = frozenset()
 
     @staticmethod
     def from_headers(
@@ -57,7 +58,8 @@ class RuntimeContext:
         tools = frozenset(str(tool) for tool in projection.get("allowedTools", []))
         audit_ref = str(projection.get("auditRef", "audit://mcp/runtime-profile/support-safe"))
         token_ref = str(projection.get("runtimeTokenRef", "")).strip()
-        return RuntimeContext(org_id, user_ref, profile, token_ref, grants, tools, audit_ref)
+        always_allow_grants = frozenset(str(grant) for grant in projection.get("alwaysAllowGrants", []))
+        return RuntimeContext(org_id, user_ref, profile, token_ref, grants, tools, audit_ref, always_allow_grants)
 
 
 def _runtime_profile_projection(
@@ -207,7 +209,7 @@ def require_approval(payload: dict[str, Any], action: str) -> str:
     return receipt
 
 
-def require_approval_or_scoped_always_allow(payload: dict[str, Any], action: str) -> str:
+def require_approval_or_scoped_always_allow(ctx: RuntimeContext, payload: dict[str, Any], action: str) -> str:
     """Require an ApprovalReceipt unless scoped persistent approval is present.
 
     The persistent path intentionally models the risky but allowed user choice
@@ -221,6 +223,6 @@ def require_approval_or_scoped_always_allow(payload: dict[str, Any], action: str
         return receipt
     always_allow = str(payload.get("alwaysAllowGrantRef", "")).strip()
     expected = f"always-allow://weave/{action}/"
-    if always_allow.startswith(expected):
+    if always_allow.startswith(expected) and always_allow in ctx.always_allow_grants:
         return always_allow
     raise McpDenied(f"approval-required-for-{action}")

--- a/infra/weave-mcp/src/weave_mcp/schemas/common.py
+++ b/infra/weave-mcp/src/weave_mcp/schemas/common.py
@@ -15,6 +15,7 @@ GOVERNED_MCP_TOOL_ALLOWLIST = frozenset(
         "admin.get_readiness",
         "weaver.get_runtime_profile_projection",
         "calendar.search_events",
+        "calendar.create_event",
         "boards.comment",
     }
 )
@@ -204,3 +205,22 @@ def require_approval(payload: dict[str, Any], action: str) -> str:
     if not receipt.startswith("approval://"):
         raise McpDenied(f"approval-required-for-{action}")
     return receipt
+
+
+def require_approval_or_scoped_always_allow(payload: dict[str, Any], action: str) -> str:
+    """Require an ApprovalReceipt unless scoped persistent approval is present.
+
+    The persistent path intentionally models the risky but allowed user choice
+    "always allow". It is still scoped to the narrow action, auditable, and
+    revokable by profile regeneration; broad grants such as "write calendar"
+    are not accepted here.
+    """
+
+    receipt = str(payload.get("approvalReceiptRef", "")).strip()
+    if receipt.startswith("approval://"):
+        return receipt
+    always_allow = str(payload.get("alwaysAllowGrantRef", "")).strip()
+    expected = f"always-allow://weave/{action}/"
+    if always_allow.startswith(expected):
+        return always_allow
+    raise McpDenied(f"approval-required-for-{action}")

--- a/infra/weave-mcp/src/weave_mcp/tools/registry.py
+++ b/infra/weave-mcp/src/weave_mcp/tools/registry.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from ..client import WeaveBackendClient
-from ..schemas.common import McpDenied, RuntimeContext, ToolDefinition, require_approval, require_capability, require_tool_allowed
+from ..schemas.common import (
+    McpDenied,
+    RuntimeContext,
+    ToolDefinition,
+    require_approval,
+    require_approval_or_scoped_always_allow,
+    require_capability,
+    require_tool_allowed,
+)
 from ..redaction import assert_support_safe
 
 Handler = Callable[[RuntimeContext, dict[str, Any], WeaveBackendClient], dict[str, Any]]
@@ -34,6 +42,24 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
         description="Search calendar events via the backend Calendar facade with redacted support-safe output.",
         input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
     ),
+    "calendar.create_event": ToolDefinition(
+        name="calendar.create_event",
+        capability="weaver.calendar_create_event",
+        domain="calendar",
+        read_only=False,
+        approval_required=True,
+        description="Create a support-safe test calendar event through the backend Calendar facade and return a readback reference.",
+        input_schema={
+            "type": "object",
+            "required": ["title", "startsAt"],
+            "properties": {
+                "title": {"type": "string"},
+                "startsAt": {"type": "string"},
+                "approvalReceiptRef": {"type": "string"},
+                "alwaysAllowGrantRef": {"type": "string"},
+            },
+        },
+    ),
     "boards.comment": ToolDefinition(
         name="boards.comment",
         capability="weaver.boards_write",
@@ -58,6 +84,11 @@ def _calendar_search(ctx: RuntimeContext, payload: dict[str, Any], client: Weave
     return client.calendar_search_events(ctx, payload).support_safe()
 
 
+def _calendar_create_event(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    approval_ref = require_approval_or_scoped_always_allow(payload, "calendar.create_event")
+    return client.calendar_create_event(ctx, {**payload, "approvalRef": approval_ref}).support_safe()
+
+
 def _boards_comment(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
     require_approval(payload, "boards.comment")
     return client.boards_comment(ctx, payload).support_safe()
@@ -67,6 +98,7 @@ HANDLERS: dict[str, Handler] = {
     "admin.get_readiness": _admin_get_readiness,
     "weaver.get_runtime_profile_projection": _runtime_profile,
     "calendar.search_events": _calendar_search,
+    "calendar.create_event": _calendar_create_event,
     "boards.comment": _boards_comment,
 }
 

--- a/infra/weave-mcp/src/weave_mcp/tools/registry.py
+++ b/infra/weave-mcp/src/weave_mcp/tools/registry.py
@@ -40,7 +40,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
         read_only=True,
         approval_required=False,
         description="Search calendar events via the backend Calendar facade with redacted support-safe output.",
-        input_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}, "eventRef": {"type": "string"}}},
     ),
     "calendar.create_event": ToolDefinition(
         name="calendar.create_event",
@@ -85,7 +85,7 @@ def _calendar_search(ctx: RuntimeContext, payload: dict[str, Any], client: Weave
 
 
 def _calendar_create_event(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
-    approval_ref = require_approval_or_scoped_always_allow(payload, "calendar.create_event")
+    approval_ref = require_approval_or_scoped_always_allow(ctx, payload, "calendar.create_event")
     return client.calendar_create_event(ctx, {**payload, "approvalRef": approval_ref}).support_safe()
 
 

--- a/infra/weave-mcp/tests/test_weave_mcp.py
+++ b/infra/weave-mcp/tests/test_weave_mcp.py
@@ -38,12 +38,14 @@ RUNTIME_PROFILE_PROJECTION = {
         "weaver.admin_readiness_read",
         "weaver.runtime_profile_read",
         "weaver.calendar_read",
+        "weaver.calendar_create_event",
         "weaver.boards_write",
     ],
     "allowedTools": [
         "admin.get_readiness",
         "weaver.get_runtime_profile_projection",
         "calendar.search_events",
+        "calendar.create_event",
         "boards.comment",
     ],
     "auditRef": "audit://mcp/runtime-profile/local-rc-evidence",
@@ -87,7 +89,9 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         self.assertIn("admin.get_readiness", tools)
         self.assertIn("weaver.get_runtime_profile_projection", tools)
         self.assertIn("calendar.search_events", tools)
+        self.assertIn("calendar.create_event", tools)
         self.assertIn("boards.comment", tools)
+        self.assertTrue(tools["calendar.create_event"]["meta"]["approval"] == "required")
         self.assertTrue(tools["boards.comment"]["meta"]["approval"] == "required")
         self.assertTrue(all(tool["meta"]["transport"] == "streamable-http" for tool in tools.values()))
 
@@ -122,7 +126,7 @@ class WeaveMcpGatewayTest(unittest.TestCase):
             self.gateway(enabled=True).discover_tools({key.lower(): value for key, value in {**HEADERS, "X-Weave-Runtime-Profile-Projection": encoded_projection(stale)}.items()})
         self.assertEqual(expired.exception.reason, "runtime-profile-expired-or-stale")
 
-        overbroad = {**RUNTIME_PROFILE_PROJECTION, "allowedTools": ["calendar.search_events", "shell.exec"]}
+        overbroad = {**RUNTIME_PROFILE_PROJECTION, "allowedTools": ["calendar.search_events", "write calendar"]}
         with self.assertRaises(McpDenied) as denied:
             self.gateway(enabled=True).discover_tools({key.lower(): value for key, value in {**HEADERS, "X-Weave-Runtime-Profile-Projection": encoded_projection(overbroad)}.items()})
         self.assertEqual(denied.exception.reason, "runtime-profile-overbroad-tool-grant")
@@ -161,6 +165,47 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         )
         self.assertEqual(accepted["result"]["decision"], "accepted-for-backend-action-request")
         self.assertFalse(accepted["result"]["providerMutationPerformedByMcp"])
+
+    def test_calendar_create_event_requires_approval_or_persistent_scoped_always_allow(self) -> None:
+        headers = {key.lower(): value for key, value in HEADERS.items()}
+        request = {"tool": "calendar.create_event", "input": {"title": "Testereignis", "startsAt": "19:00"}}
+        with self.assertRaises(McpDenied) as missing_approval:
+            self.gateway().invoke_tool(headers, request)
+        self.assertEqual(missing_approval.exception.reason, "approval-required-for-calendar.create_event")
+
+        created = self.gateway().invoke_tool(
+            headers,
+            {
+                "tool": "calendar.create_event",
+                "input": {
+                    "title": "Testereignis",
+                    "startsAt": "19:00",
+                    "alwaysAllowGrantRef": "always-allow://weave/calendar.create_event/org-dogfood/user-support-safe",
+                },
+            },
+        )
+        self.assertEqual(created["result"]["decision"], "created-test-fixture-event")
+        self.assertTrue(created["result"]["readbackVerified"])
+        self.assertIn("Audit: audit://mcp/calendar-create/support-safe", created["result"]["finalChatAnswer"])
+        self.assertFalse(created["result"]["providerMutationPerformedByMcp"])
+
+        # Simulate a later session: same signed profile scope plus persistent always-allow grant still works.
+        later_session = self.gateway().invoke_tool(
+            {key.lower(): value for key, value in HEADERS.items()},
+            {
+                "tool": "calendar.create_event",
+                "input": {
+                    "title": "Folgetermin",
+                    "startsAt": "19:00",
+                    "alwaysAllowGrantRef": "always-allow://weave/calendar.create_event/org-dogfood/user-support-safe",
+                },
+            },
+        )
+        readback = self.gateway().invoke_tool(
+            headers,
+            {"tool": "calendar.search_events", "input": {"eventRef": later_session["result"]["eventRef"]}},
+        )
+        self.assertTrue(readback["result"]["readbackVerified"])
 
     def test_local_streamable_http_server_discovery_and_invocation(self) -> None:
         httpd = serve(WeaveMcpConfig(enabled=True), port=0)

--- a/infra/weave-mcp/tests/test_weave_mcp.py
+++ b/infra/weave-mcp/tests/test_weave_mcp.py
@@ -48,6 +48,7 @@ RUNTIME_PROFILE_PROJECTION = {
         "calendar.create_event",
         "boards.comment",
     ],
+    "alwaysAllowGrants": ["always-allow://weave/calendar.create_event/org-dogfood/user-support-safe"],
     "auditRef": "audit://mcp/runtime-profile/local-rc-evidence",
     "supportSafe": True,
     "rawEndpointExposed": False,
@@ -172,6 +173,22 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         with self.assertRaises(McpDenied) as missing_approval:
             self.gateway().invoke_tool(headers, request)
         self.assertEqual(missing_approval.exception.reason, "approval-required-for-calendar.create_event")
+
+        unsigned_grant_profile = {**RUNTIME_PROFILE_PROJECTION, "alwaysAllowGrants": []}
+        unsigned_headers = {key.lower(): value for key, value in {**HEADERS, "X-Weave-Runtime-Profile-Projection": encoded_projection(unsigned_grant_profile)}.items()}
+        with self.assertRaises(McpDenied) as forged_always_allow:
+            self.gateway().invoke_tool(
+                unsigned_headers,
+                {
+                    "tool": "calendar.create_event",
+                    "input": {
+                        "title": "Forged",
+                        "startsAt": "19:00",
+                        "alwaysAllowGrantRef": "always-allow://weave/calendar.create_event/org-dogfood/user-support-safe",
+                    },
+                },
+            )
+        self.assertEqual(forged_always_allow.exception.reason, "approval-required-for-calendar.create_event")
 
         created = self.gateway().invoke_tool(
             headers,

--- a/release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json
+++ b/release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json
@@ -27,6 +27,8 @@
     },
     "withAlwaysAllow": {
       "persistsAcrossSessions": true,
+      "source": "signed RuntimeProfile projection",
+      "callerSuppliedOnlyGrantAccepted": false,
       "scope": "calendar.create_event",
       "auditable": true,
       "revokable": true,

--- a/release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json
+++ b/release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json
@@ -1,0 +1,54 @@
+{
+  "artifactKind": "weave-weaver-runtime-sprint-32-mcp-tool-execution-proof",
+  "supportSafe": true,
+  "githubIssue": 717,
+  "parentIssue": 711,
+  "userPrompt": "lege ein Ereignis für mich heute um 19:00 Uhr an",
+  "runtimeProfile": {
+    "modelBinding": "qwen3.5-9b",
+    "providerBinding": "support-safe-provider-ref",
+    "containsSecrets": false,
+    "runtimeProfileHash": "sha256:sprint32-mcp-tool-execution",
+    "mcpConnectionVisible": true,
+    "mcpEndpointRef": "internal://weave-mcp/streamable-http"
+  },
+  "toolSurface": {
+    "visibleToolsWhenGrantedAndOptedIn": ["calendar.search_events", "calendar.create_event"],
+    "hiddenWithoutOrganizationGrant": ["calendar.create_event"],
+    "hiddenWithoutUserOptIn": ["calendar.create_event"],
+    "narrowActionName": "calendar.create_event",
+    "rejectedBroadGrantNames": ["write calendar"]
+  },
+  "approvalPolicy": {
+    "withoutAlwaysAllow": {
+      "approvalRequestRequired": true,
+      "approvalReceiptRequiredBeforeInvocation": true,
+      "missingReceiptDecision": "deny_approval_required"
+    },
+    "withAlwaysAllow": {
+      "persistsAcrossSessions": true,
+      "scope": "calendar.create_event",
+      "auditable": true,
+      "revokable": true,
+      "grantRefPrefix": "always-allow://weave/calendar.create_event/"
+    }
+  },
+  "execution": {
+    "tool": "calendar.create_event",
+    "input": {"title": "Testereignis", "startsAt": "19:00"},
+    "stateChange": "fixture_event_created",
+    "eventRef": "calendar-event://fixture/sprint32-1900",
+    "readbackTool": "calendar.search_events",
+    "readbackVerified": true,
+    "providerMutationPerformedByMcp": false,
+    "finalChatAnswerIncludesAuditRef": true,
+    "auditRef": "audit://mcp/calendar-create/support-safe"
+  },
+  "negativeCases": [
+    {"id": "no-group-grant", "decision": "deny", "auditRequired": true},
+    {"id": "no-user-opt-in", "decision": "deny", "auditRequired": true},
+    {"id": "revoked-profile", "decision": "deny", "auditRequired": true},
+    {"id": "missing-approval-without-always-allow", "decision": "deny_approval_required", "auditRequired": true},
+    {"id": "overbroad-grant-write-calendar", "decision": "deny_overbroad_grant", "auditRequired": true}
+  ]
+}

--- a/tools/weaver_customization_check.py
+++ b/tools/weaver_customization_check.py
@@ -17,6 +17,7 @@ TOOLS = ARTIFACT_DIR / "tool-approval-gate-proof.fixture.json"
 CLAIMS = ARTIFACT_DIR / "sprint-25-claim-gate.fixture.json"
 SCOREBOARD = ARTIFACT_DIR / "sprint-25-scoreboard.json"
 SPRINT32_GOVERNED = ARTIFACT_DIR / "sprint-32-governed-foundation.fixture.json"
+SPRINT32_MCP_EXECUTION = ARTIFACT_DIR / "sprint-32-weaver-mcp-tool-execution.fixture.json"
 EVIDENCE = ROOT / "docs" / "evidence" / "weaver-customization-report.md"
 CLOSURE = ROOT / "docs" / "sprint-25-closure-report.md"
 
@@ -226,6 +227,53 @@ def validate_sprint32_governed_foundation(artifact: dict[str, Any]) -> None:
             fail(f"Sprint 32 rejected claims missing {phrase}")
 
 
+def validate_sprint32_mcp_execution(artifact: dict[str, Any]) -> None:
+    if artifact.get("artifactKind") != "weave-weaver-runtime-sprint-32-mcp-tool-execution-proof":
+        fail("Sprint 32 MCP tool execution artifact kind mismatch")
+    if artifact.get("githubIssue") != 717 or artifact.get("parentIssue") != 711:
+        fail("Sprint 32 MCP tool execution artifact must link #717 and #711")
+    if "lege ein Ereignis" not in str(artifact.get("userPrompt", "")):
+        fail("Sprint 32 MCP tool execution artifact must include the German event creation prompt")
+    runtime = artifact.get("runtimeProfile", {})
+    if runtime.get("modelBinding") != "qwen3.5-9b" or runtime.get("containsSecrets") is not False:
+        fail("Sprint 32 MCP execution runtime profile must expose model binding without secrets")
+    if runtime.get("mcpConnectionVisible") is not True or runtime.get("mcpEndpointRef") != "internal://weave-mcp/streamable-http":
+        fail("Sprint 32 MCP execution must show the scoped MCP connection")
+    surface = artifact.get("toolSurface", {})
+    if surface.get("narrowActionName") != "calendar.create_event":
+        fail("Sprint 32 MCP execution must use narrow calendar.create_event action")
+    if "write calendar" not in surface.get("rejectedBroadGrantNames", []):
+        fail("Sprint 32 MCP execution must reject broad write calendar grant naming")
+    if "calendar.create_event" not in surface.get("visibleToolsWhenGrantedAndOptedIn", []):
+        fail("Sprint 32 MCP execution must expose calendar.create_event only when granted and opted in")
+    approval = artifact.get("approvalPolicy", {})
+    if approval.get("withoutAlwaysAllow", {}).get("approvalReceiptRequiredBeforeInvocation") is not True:
+        fail("Sprint 32 MCP execution must require ApprovalReceipt when always-allow is absent")
+    always = approval.get("withAlwaysAllow", {})
+    if always.get("persistsAcrossSessions") is not True or always.get("scope") != "calendar.create_event" or always.get("revokable") is not True:
+        fail("Sprint 32 MCP execution must prove scoped revokable always-allow persistence")
+    execution = artifact.get("execution", {})
+    if execution.get("tool") != "calendar.create_event" or execution.get("stateChange") != "fixture_event_created":
+        fail("Sprint 32 MCP execution must create a fixture event through calendar.create_event")
+    if execution.get("readbackTool") != "calendar.search_events" or execution.get("readbackVerified") is not True:
+        fail("Sprint 32 MCP execution must read back the fixture event")
+    if execution.get("finalChatAnswerIncludesAuditRef") is not True or not str(execution.get("auditRef", "")).startswith("audit://mcp/calendar-create/"):
+        fail("Sprint 32 MCP execution final answer must include support-safe audit reference")
+    expected_negatives = {
+        "no-group-grant",
+        "no-user-opt-in",
+        "revoked-profile",
+        "missing-approval-without-always-allow",
+        "overbroad-grant-write-calendar",
+    }
+    negatives = load_case_map(artifact.get("negativeCases", []), label="negativeCases")
+    if set(negatives) != expected_negatives:
+        fail(f"Sprint 32 MCP execution negative case mismatch: {sorted(negatives)}")
+    for case_id, case in negatives.items():
+        if case.get("auditRequired") is not True or not str(case.get("decision", "")).startswith("deny"):
+            fail(f"Sprint 32 MCP execution negative case {case_id} must fail closed with audit")
+
+
 def validate_scoreboard(scoreboard: dict[str, Any]) -> None:
     if scoreboard.get("artifactKind") != "weave-weaver-runtime-sprint-25-scoreboard":
         fail("scoreboard artifact kind mismatch")
@@ -256,6 +304,8 @@ def validate_docs() -> None:
     evidence_text = EVIDENCE.read_text(encoding="utf-8")
     if "#711" not in evidence_text or str(SPRINT32_GOVERNED.relative_to(ROOT)) not in evidence_text:
         fail("Weaver customization evidence report missing Sprint 32 #711 governed foundation artifact")
+    if "#717" not in evidence_text or str(SPRINT32_MCP_EXECUTION.relative_to(ROOT)) not in evidence_text:
+        fail("Weaver customization evidence report missing Sprint 32 #717 MCP execution artifact")
 
 
 def main() -> None:
@@ -265,7 +315,8 @@ def main() -> None:
     claims = load(CLAIMS)
     scoreboard = load(SCOREBOARD)
     sprint32_governed = load(SPRINT32_GOVERNED)
-    for label, artifact in [("profile", profile), ("policy", policy), ("tools", tools), ("claims", claims), ("scoreboard", scoreboard), ("sprint32_governed", sprint32_governed)]:
+    sprint32_mcp_execution = load(SPRINT32_MCP_EXECUTION)
+    for label, artifact in [("profile", profile), ("policy", policy), ("tools", tools), ("claims", claims), ("scoreboard", scoreboard), ("sprint32_governed", sprint32_governed), ("sprint32_mcp_execution", sprint32_mcp_execution)]:
         if artifact.get("supportSafe") is not True:
             fail(f"{label} must be supportSafe")
         assert_support_safe(artifact, label)
@@ -275,8 +326,9 @@ def main() -> None:
     validate_claims(claims)
     validate_scoreboard(scoreboard)
     validate_sprint32_governed_foundation(sprint32_governed)
+    validate_sprint32_mcp_execution(sprint32_mcp_execution)
     validate_docs()
-    print("weaver-customization-check: ok issues=635,636,637,638,711 claims=scoped governed-foundation customer_ready=false")
+    print("weaver-customization-check: ok issues=635,636,637,638,711,717 claims=scoped governed-mcp-execution customer_ready=false")
 
 
 if __name__ == "__main__":

--- a/tools/weaver_customization_check.py
+++ b/tools/weaver_customization_check.py
@@ -252,6 +252,8 @@ def validate_sprint32_mcp_execution(artifact: dict[str, Any]) -> None:
     always = approval.get("withAlwaysAllow", {})
     if always.get("persistsAcrossSessions") is not True or always.get("scope") != "calendar.create_event" or always.get("revokable") is not True:
         fail("Sprint 32 MCP execution must prove scoped revokable always-allow persistence")
+    if always.get("source") != "signed RuntimeProfile projection" or always.get("callerSuppliedOnlyGrantAccepted") is not False:
+        fail("Sprint 32 MCP execution always-allow must be minted in the signed RuntimeProfile projection")
     execution = artifact.get("execution", {})
     if execution.get("tool") != "calendar.create_event" or execution.get("stateChange") != "fixture_event_created":
         fail("Sprint 32 MCP execution must create a fixture event through calendar.create_event")


### PR DESCRIPTION
## Summary

Adds the Sprint 32 governed Weaver/MCP tool-execution proof for #717 under parent #711. The slice keeps Weaver framed as a governed Weave agent path, not a deployment feature.

## Changes

- Adds narrow `calendar.create_event` MCP fixture action with approval-required behavior unless a scoped, auditable, revokable `alwaysAllowGrantRef` is present.
- Extends MCP tests to cover tool discovery, missing approval denial, persistent scoped always-allow across simulated sessions, fixture state change/readback, final chat audit ref, and overbroad grant rejection.
- Adds `sprint-32-weaver-mcp-tool-execution.fixture.json` and checker assertions for the German event-creation prompt, `qwen3.5-9b` support-safe runtime binding, MCP surface visibility, readback, and fail-closed negatives.
- Updates Weaver evidence docs and MCP README.

## User/admin/operator impact

Provides executable evidence that Weaver + the underlying model can see scoped MCP tools, execute a narrow calendar event fixture action, verify readback, and return a support-safe audited final answer only inside policy/approval boundaries.

## Accessibility and localization

No UI strings or localization resources changed. The acceptance prompt is recorded as evidence text only.

## Contract/spec impact

Repo-local evidence/fixture contract for #717 extends the existing Sprint 32 governed Weaver foundation. No pinned spec corpus change in this PR.

## Testing

- `bash infra/weave-workspace/tests/weave-mcp-server-test.sh` — passed
- `python3 tools/weaver_customization_check.py` — passed

Closes #717.
