### PR TITLE
docs: mark Weaver MCP proof as fixture-only

### DIFF
--- a/docs/evidence/weaver-customization-report.md
+++ b/docs/evidence/weaver-customization-report.md
@@ -1,10 +1,10 @@
 # Weaver customization evidence report
 
-Status: Sprint 25 provider-lab evidence, support-safe.
+Status: Sprint 25/32 provider-lab fixture evidence, support-safe. Not isolated live E2E evidence.
 
 ## Scope
 
-This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 governed-foundation issue #711 and governed MCP tool-execution issue #717. It proves bounded Weaver governance only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts or a scoped revokable always-allow grant, rollback restores a previous profile hash, narrow MCP tool execution can create and read back a fixture event, and governed-Weaver claims are gated by matching evidence.
+This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 governed-foundation issue #711 and governed MCP tool-execution issue #717. It proves bounded Weaver governance only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts or a scoped revokable always-allow grant, rollback restores a previous profile hash, narrow MCP fixture execution can create and read back an in-memory fixture event, and governed-Weaver fixture claims are gated by matching evidence. It does not prove Keycloak group-derived `weaver.enabled` or live/isolated provider calendar mutation; see #719.
 
 ## Evidence artifacts
 
@@ -14,7 +14,11 @@ This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 g
 - `release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json` — #638 accepted scoped claim and rejected overclaim set.
 - `release/provider-lab/weaver-runtime/sprint-25-scoreboard.json` — #635-#638 green scoreboard with no release blockers.
 - `release/provider-lab/weaver-runtime/sprint-32-governed-foundation.fixture.json` — #711 disabled-by-default policy evaluation, read-only first tool registry, ApprovalReceipt-gated write/external-send cases, and one-way RuntimeProfile/OpenClaw projection proof.
-- `release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json` — #717 German event-creation prompt, support-safe `qwen3.5-9b` runtime binding, scoped MCP tool discovery, `calendar.create_event` invocation, persistent scoped always-allow behavior, fixture state change/readback, final chat audit reference, and fail-closed negative matrix.
+- `release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json` — #717 German event-creation prompt, support-safe `qwen3.5-9b` runtime binding, scoped MCP tool discovery, `calendar.create_event` fixture invocation, persistent scoped always-allow behavior in a synthetic signed runtime projection, in-memory fixture state change/readback, final chat audit reference, and fail-closed negative matrix. This is not a Keycloak-token or isolated provider E2E receipt; see #719.
+
+## Evidence boundary
+
+#718/#717 evidence is fixture/contract evidence only. It does not establish that a real Keycloak `weaver-group` exists, that a token minted for that group grants `weaver.enabled`, or that the German prompt creates an event in an isolated live calendar/provider. That missing proof is tracked by #719 and must block future Weaver/MCP live-proof claims.
 
 ## Executable gates
 
@@ -23,4 +27,4 @@ This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 g
 
 ## Claim boundary
 
-This evidence does not claim customer-ready Weaver, production PA availability, broad member availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, marketplace MCPs, raw memory export, raw secrets, autonomous routine writes outside an explicit scoped approval/always-allow policy, external-send without ApprovalReceipt, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab, governed-foundation, and governed MCP fixture artifacts.
+This evidence does not claim customer-ready Weaver, production PA availability, broad member availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, marketplace MCPs, raw memory export, raw secrets, autonomous routine writes outside an explicit scoped approval/always-allow policy, external-send without ApprovalReceipt, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab, governed-foundation, and governed MCP fixture artifacts. Do not cite this report as isolated E2E proof for Keycloak group policy or live calendar event creation.

--- a/release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json
+++ b/release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json
@@ -1,5 +1,7 @@
 {
   "artifactKind": "weave-weaver-runtime-sprint-32-mcp-tool-execution-proof",
+  "evidenceBoundary": "fixture-only; not Keycloak token E2E and not live provider calendar mutation",
+  "gapIssue": 719,
   "supportSafe": true,
   "githubIssue": 717,
   "parentIssue": 711,
@@ -43,6 +45,7 @@
     "readbackTool": "calendar.search_events",
     "readbackVerified": true,
     "providerMutationPerformedByMcp": false,
+    "stateStore": "in-memory fixture",
     "finalChatAnswerIncludesAuditRef": true,
     "auditRef": "audit://mcp/calendar-create/support-safe"
   },

--- a/tools/weaver_customization_check.py
+++ b/tools/weaver_customization_check.py
@@ -232,6 +232,8 @@ def validate_sprint32_mcp_execution(artifact: dict[str, Any]) -> None:
         fail("Sprint 32 MCP tool execution artifact kind mismatch")
     if artifact.get("githubIssue") != 717 or artifact.get("parentIssue") != 711:
         fail("Sprint 32 MCP tool execution artifact must link #717 and #711")
+    if artifact.get("gapIssue") != 719 or "fixture-only" not in str(artifact.get("evidenceBoundary", "")):
+        fail("Sprint 32 MCP execution must declare fixture-only boundary and #719 E2E gap")
     if "lege ein Ereignis" not in str(artifact.get("userPrompt", "")):
         fail("Sprint 32 MCP tool execution artifact must include the German event creation prompt")
     runtime = artifact.get("runtimeProfile", {})
@@ -257,6 +259,8 @@ def validate_sprint32_mcp_execution(artifact: dict[str, Any]) -> None:
     execution = artifact.get("execution", {})
     if execution.get("tool") != "calendar.create_event" or execution.get("stateChange") != "fixture_event_created":
         fail("Sprint 32 MCP execution must create a fixture event through calendar.create_event")
+    if execution.get("stateStore") != "in-memory fixture" or execution.get("providerMutationPerformedByMcp") is not False:
+        fail("Sprint 32 MCP execution must remain clearly labelled as in-memory fixture state, not provider mutation")
     if execution.get("readbackTool") != "calendar.search_events" or execution.get("readbackVerified") is not True:
         fail("Sprint 32 MCP execution must read back the fixture event")
     if execution.get("finalChatAnswerIncludesAuditRef") is not True or not str(execution.get("auditRef", "")).startswith("audit://mcp/calendar-create/"):
@@ -330,7 +334,7 @@ def main() -> None:
     validate_sprint32_governed_foundation(sprint32_governed)
     validate_sprint32_mcp_execution(sprint32_mcp_execution)
     validate_docs()
-    print("weaver-customization-check: ok issues=635,636,637,638,711,717 claims=scoped governed-mcp-execution customer_ready=false")
+    print("weaver-customization-check: ok issues=635,636,637,638,711,717 gap=719 claims=scoped governed-mcp-fixture-only customer_ready=false isolated_e2e=false")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Corrects the evidence boundary after Massimo's quality concern: #718/#717 is fixture/contract evidence only, not isolated Keycloak-token/live-provider E2E proof.

## Changes

- Marks the Weaver customization report as provider-lab fixture evidence, not isolated live E2E evidence.
- Adds #719 as the explicit gap issue for Keycloak `weaver-group` / `weaver.enabled` token derivation and governed MCP event creation E2E proof.
- Adds fixture-only boundary metadata to the #717 artifact.
- Tightens `tools/weaver_customization_check.py` so the evidence output advertises `isolated_e2e=false` and rejects missing #719/boundary metadata.

## Testing

- `python3 tools/weaver_customization_check.py` — passed

Refs #719.
