### PR TITLE
chore: add quality reset review gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,10 @@ body:
   - type: markdown
     attributes:
       value: |
+        Quality Reset: pure bugfixes may use pragmatic reproduction/acceptance notes, but any changed observable product behavior or claim still needs spec traceability, mapped Gherkin acceptance, evidence mode/reality level, and a relevant Fachveto.
+  - type: markdown
+    attributes:
+      value: |
         Use this for behavior that is broken now. If the problem is cleanup after the rebuild, use **Technical debt** instead.
   - type: textarea
     id: what-happened
@@ -58,6 +62,18 @@ body:
       placeholder: "Command/run/artifact URL, sanitized logs, screenshot alt text, etc."
     validations:
       required: true
+
+  - type: textarea
+    id: behavior-change-traceability
+    attributes:
+      label: Behavior-change traceability, evidence mode, and Fachveto
+      description: Required if the fix changes observable product behavior or product/release claims; otherwise state "No observable behavior or claim change".
+      value: |
+        Behavior/claim change: none / describe
+        Spec link: N/A or specs/...
+        Mapped Gherkin scenario: N/A or e2e/features/... + e2e/scenario_mappings.json
+        Evidence mode / reality level: N/A or offline-spec/live-runtime + realityLevel
+        Fachveto owner/path: N/A or named owner/path
   - type: textarea
     id: impact
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,6 +7,8 @@ body:
     attributes:
       value: |
         Use this for new or changed product behavior. Keep Weave domain-first: client/member UX should see Weave concepts, not raw provider administration.
+
+        Quality Reset: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance contracts before implementation/merge. Do not invent product meaning in this issue; link the spec work or mark it as required first.
   - type: textarea
     id: goal
     attributes:
@@ -38,10 +40,12 @@ body:
   - type: textarea
     id: spec-link
     attributes:
-      label: Repo-local spec or acceptance note
-      description: Link `specs/NNNN-slug/spec.md` when available. If not yet available, state whether this should create one or why a lightweight acceptance note is enough.
+      label: Repo-local spec / Spec Kit link
+      description: Link `specs/NNNN-slug/spec.md`, plan, tasks, or traceability entry. Product behavior changes must create/update this before implementation unless this is a pure bugfix with pragmatic acceptance notes.
       value: |
         Spec: TBD
+        Plan/tasks: TBD
+        Traceability: TBD
         Spec needed before implementation: yes/no
     validations:
       required: true
@@ -60,11 +64,14 @@ body:
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance criteria / evidence gate
-      description: How do we know this is done? Name tests, docs, scenarios, screenshots, CI, or support-safe evidence.
+      label: Mapped Gherkin / evidence gate
+      description: Name the Gherkin feature/scenario, scenario mapping, and evidence gate. Use canonical `evidenceMode` (`offline-spec` or `live-runtime`) and `realityLevel` when applicable; only `release_ready` may support customer-ready wording.
       value: |
+        Gherkin scenario and mapping:
         -
-        -
+
+        Evidence mode / reality level: offline-spec or live-runtime; contract_only/configured/live_read/live_write/migration_dry_run/migration_apply_ready/rollback_ready/release_ready when applicable
+        Required gates:
         -
     validations:
       required: true
@@ -81,6 +88,23 @@ body:
     attributes:
       label: Accessibility and localization considerations
       description: Keyboard, screen reader, semantics, visible focus, text scaling, localization, non-color-only states.
+
+  - type: textarea
+    id: risk-veto
+    attributes:
+      label: Risk, privacy, accessibility, and Fachveto
+      description: Name the relevant review/veto owner for product/spec, architecture, security/privacy, accessibility, provider, release, or evidence risk. Small pure bugfixes may state a lightweight veto path.
+      value: |
+        Risk/privacy/a11y impact:
+        -
+
+        Fachveto owner/path:
+        -
+
+        Support-safe evidence constraints:
+        - no secrets, raw tokens, raw provider payloads, raw endpoints, openclaw.json, or SecretRef/CredentialRef values
+    validations:
+      required: true
   - type: textarea
     id: monorepo-impact
     attributes:

--- a/.github/ISSUE_TEMPLATE/technical_debt.yml
+++ b/.github/ISSUE_TEMPLATE/technical_debt.yml
@@ -6,6 +6,10 @@ body:
   - type: markdown
     attributes:
       value: |
+        Quality Reset: technical debt work must not change observable product behavior or claims without repo-local spec traceability, mapped Gherkin acceptance, evidence mode/reality level, and Fachveto gates.
+  - type: markdown
+    attributes:
+      value: |
         Use this for cleanup after the rebuild: stale branches/worktrees, duplicated specs, unfinished migrations, brittle tests, old provider assumptions, missing docs links, or architecture drift.
   - type: textarea
     id: debt
@@ -47,6 +51,18 @@ body:
       description: What should be true when this debt is resolved?
     validations:
       required: true
+
+  - type: textarea
+    id: behavior-change-traceability
+    attributes:
+      label: Behavior-change traceability, evidence mode, and Fachveto
+      description: Required if the cleanup changes observable product behavior or product/release claims; otherwise state "No observable behavior or claim change".
+      value: |
+        Behavior/claim change: none / describe
+        Spec link: N/A or specs/...
+        Mapped Gherkin scenario: N/A or e2e/features/... + e2e/scenario_mappings.json
+        Evidence mode / reality level: N/A or offline-spec/live-runtime + realityLevel
+        Fachveto owner/path: N/A or named owner/path
   - type: textarea
     id: cleanup-plan
     attributes:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,26 @@
+# Weave Copilot review instructions
+
+Weave is a regulated-quality monorepo. Review for evidence, traceability, and claim hygiene before style.
+
+## Quality Reset review rules
+
+- Product/domain claims are frozen unless the PR links repo-local specs plus mapped Gherkin acceptance contracts.
+- Do not accept fixture/contract evidence as isolated E2E evidence. Require the PR to use canonical evidence terms from `docs/acceptance-contracts.md` (`offline-spec` vs `live-runtime`) and `docs/product-reality-foundation.md` (`realityLevel`).
+- Weaver/Governed PA is a first-class Weave product component, but Weaver/security/product claims require specs, mapped Gherkin acceptance, evidence, and a relevant Fachveto.
+- Do not allow issues/PR bodies or docs to invent product meaning outside specs. Ask for a spec update instead.
+- For approval semantics, distinguish OpenClaw exec approval states from product user permissions; never treat `allow always` as blanket product permission.
+
+## What to flag
+
+- Missing spec link for changed product behavior.
+- Missing mapped Gherkin scenario for user/admin/operator-observable behavior.
+- Missing evidence gate, CI command, or support-safe artifact.
+- Misleading release/customer-ready/product claims.
+- Secrets, bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values in logs/docs/evidence.
+- Accessibility, localization, privacy, audit, supportability, deployability, or provider-portability gaps.
+- Missing exactly-one release-notes label plan.
+- Missing Fachveto owner for product/security/privacy/a11y/provider/release changes.
+
+## Review style
+
+Prefer actionable blocking comments with file/line and the missing gate. Keep suggestions concise. If evidence is fixture/contract-only, require `offline-spec` / `contract_only` wording and reject isolated E2E, live-runtime, release-ready, or customer-ready claims.

--- a/.github/instructions/weave-quality.instructions.md
+++ b/.github/instructions/weave-quality.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "**"
+---
+
+# Weave quality gate instructions
+
+When reviewing or editing Weave changes:
+
+- Follow strict GitHub Spec Kit flow for product/domain changes: specify -> plan -> tasks -> implement.
+- Require repo-local spec references and mapped Gherkin acceptance contracts before product claims merge.
+- Use canonical evidence vocabulary: `evidenceMode` is `offline-spec` or `live-runtime`; provider/domain `realityLevel` follows `docs/product-reality-foundation.md`.
+- Treat `offline-spec` / `contract_only` fixture evidence as insufficient for live-runtime, release-ready, or customer-ready claims.
+- Require a named Fachveto owner for product/spec, architecture, security/privacy, accessibility, provider, release, or evidence risk.
+- Use GitHub Copilot review first while available; if unavailable or insufficient, require a matching subagent reviewer with equivalent or stronger capability.
+- Keep Massimo's OpenClaw agent hierarchy and personal runtime configuration out of product repo files.
+- Never include secrets, raw tokens, raw provider payloads, personal OpenClaw config, or unsafe diagnostics in checked-in evidence.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,13 @@
 ## Spec / acceptance link
 
 - Issue:
-- Repo spec or spec note:
-- Acceptance scenario / mapping marker when product behavior changed:
+- Repo spec / Spec Kit package:
+- Plan/tasks/traceability:
+- Mapped Gherkin feature/scenario when product behavior changed:
+- Evidence mode / reality level: `offline-spec` or `live-runtime`; `contract_only` / `configured` / `live_read` / `live_write` / `migration_dry_run` / `migration_apply_ready` / `rollback_ready` / `release_ready` when applicable
 - Product-core questions intentionally left unresolved: none / listed below
+
+Quality Reset rule: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance before merge. `offline-spec` / `contract_only` fixture evidence must not be described as `live-runtime`, isolated E2E, `release_ready`, or customer-ready evidence.
 
 ## Branch, target lane, and release path
 
@@ -49,9 +53,11 @@ Choose exactly one before review/merge; CI fails otherwise.
 
 -
 
-## Accessibility and localization
+## Risk, privacy, accessibility, and localization
 
--
+- Security/privacy impact:
+- Accessibility/localization impact:
+- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.
 
 ## Contract impact
 
@@ -59,17 +65,21 @@ Choose exactly one before review/merge; CI fails otherwise.
 - [ ] Contract/spec change documented:
 - [ ] `./gradlew specContract` run for spec/product-contract changes
 
-## Review readiness
+## Review readiness and Fachveto
 
 - [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
 - [ ] Copilot findings addressed or fallback human/agent review evidence documented
+- [ ] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
+- Fachveto owner/path:
+- If Copilot is unavailable/insufficient, matching reviewer used:
 
 ## Checks run
 
 - [ ] `git diff --check`
-- [ ] `./gradlew specCorpusConformance`
+- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
 - [ ] `./gradlew specContract`
 - [ ] `./gradlew acceptanceContract`
+- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
 - [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
 - [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
 - [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
@@ -86,4 +96,6 @@ Choose exactly one before review/merge; CI fails otherwise.
 
 ## Notes for reviewers
 
--
+- Review for claim hygiene first: spec/Gherkin/evidenceMode/realityLevel must match the PR wording.
+- Approval semantics must distinguish OpenClaw exec approval states from product user permissions; never treat `allow always` as blanket product permission.
+- Keep Massimo's OpenClaw agent hierarchy, allowlists, model routing, personal operator paths, and runtime configuration out of product repo files.


### PR DESCRIPTION
## Summary

Implements the first Quality Reset guidance slice for Weave review and merge hygiene. This PR adds Copilot/reviewer instructions and tightens issue/PR templates so product claims require spec, Gherkin/acceptance, evidence classification, risk/privacy/a11y review, Fachveto ownership, and release-notes label discipline.

Quality Reset policy basis:

- Product/domain SSOT is moving repo-internal via strict GitHub Spec Kit flow: specify → plan → tasks → implement.
- Product behavior and product claims are frozen unless linked specs plus Gherkin/acceptance examples exist.
- Fixture/contract evidence must not be described as isolated E2E or customer-ready evidence.
- Weaver/Governed PA is a product component, but Weaver/security/product claims require specs, Gherkin/acceptance, evidence, and relevant Fachveto.
- GitHub Copilot review should run first while available; otherwise use a matching subagent reviewer with equivalent or stronger risk coverage.
- OpenClaw exec approval states must not be equated with blanket product user permissions.

## Scope

- Adds `.github/copilot-instructions.md`.
- Adds `.github/instructions/weave-quality.instructions.md`.
- Tightens feature, bug, and technical-debt issue templates.
- Tightens PR template for evidence class, Fachveto, review fallback, and quality gates.

No product semantics, implementation behavior, live infra, or secrets changed.

## Testing / gates

- `git diff --check` — passed
- YAML parse for issue templates via Ruby `YAML.load_file` — passed
- `./gradlew docsCheck` — blocked locally because the local Python environment is missing `mkdocs` (`No module named mkdocs`)

## Review / veto

- Release notes label: `release-notes-skip`
- Review requested: GitHub Copilot first
- Fachveto needed before merge: Product/Spec + QA/Evidence + Integration Review lightweight reset-guidance veto
