### PR TITLE
ci: accept configured weave.test DNS in live E2E

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -130,7 +130,7 @@ jobs:
           hosts=(weave.test api.weave.test auth.weave.test files.weave.test matrix.weave.test)
           missing=()
           for host in "${hosts[@]}"; do
-            if ! dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1'; then
+            if ! dscacheutil -q host -a name "$host" | grep -q 'ip_address:'; then
               missing+=("$host")
             fi
           done
@@ -141,14 +141,16 @@ jobs:
               printf '%s\n' "$line" | sudo tee -a /etc/hosts >/dev/null
               sudo dscacheutil -flushcache || true
             else
-              echo "::error::Runner cannot resolve required Weave hostnames and passwordless sudo is unavailable. Add this /etc/hosts line before rerunning: $line" >&2
+              echo "::error::Runner cannot resolve required Weave hostnames and passwordless sudo is unavailable. Configure weave.test DNS for this runner or add this fallback /etc/hosts line before rerunning: $line" >&2
               exit 1
             fi
           fi
 
           for host in "${hosts[@]}"; do
-            dscacheutil -q host -a name "$host" | grep -q 'ip_address: 127.0.0.1' || {
-              echo "::error::Runner still cannot resolve $host to 127.0.0.1" >&2
+            resolved="$(dscacheutil -q host -a name "$host" || true)"
+            printf '%s\n' "$resolved"
+            printf '%s\n' "$resolved" | grep -q 'ip_address:' || {
+              echo "::error::Runner still cannot resolve $host" >&2
               exit 1
             }
           done


### PR DESCRIPTION
## Summary\n- treat configured weave.test DNS as valid for the self-hosted live runner\n- keep /etc/hosts loopback as fallback only when hostnames are missing\n- avoid failing when weave.test resolves to the runner LAN address\n\n## Gates\n- git diff --check\n- actionlint .github/workflows/live-stack-e2e.yml (if installed)\n- ./gradlew specCorpusConformance specContract acceptanceContract --console=plain\n\n## Live E2E context\nRun 27420284084 failed before stack bootstrap because the runner resolved weave.test via configured DNS rather than 127.0.0.1.