### PR TITLE
docs: reset DevOps lane flow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,12 +13,37 @@
 - Acceptance scenario / mapping marker when product behavior changed:
 - Product-core questions intentionally left unresolved: none / listed below
 
-## Branch, target, and release path
+## Branch, target lane, and release path
 
-- [ ] Branch started from current `origin/main`
-- [ ] PR targets protected `main`
-- [ ] No long-lived `dev`/`testing`/`staging` branch involved
+- Target lane: dev / future/* / rc/* / main exception
+- [ ] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
+- [ ] Linked issue(s) or explicit spec/evidence note are listed above
+- [ ] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
 - [ ] Production release is not implied by this merge
+
+## Spec impact
+
+Choose one and explain when needed.
+
+- [ ] none
+- [ ] implements locked spec
+- [ ] updates spec (linked corpus/spec task required):
+- [ ] changes evidence only
+
+## Release note
+
+Use exactly one form.
+
+- Release note:
+- Release note: none — reason:
+
+## Release notes label
+
+Choose exactly one before review/merge; CI fails otherwise.
+
+- [ ] `release-notes-feature`
+- [ ] `release-notes-bugfix`
+- [ ] `release-notes-skip`
 
 ## Screenshots or docs impact
 
@@ -34,14 +59,6 @@
 - [ ] Contract/spec change documented:
 - [ ] `./gradlew specContract` run for spec/product-contract changes
 
-## Release notes label
-
-Choose exactly one before review/merge; CI fails otherwise.
-
-- [ ] `release-notes-feature`
-- [ ] `release-notes-bugfix`
-- [ ] `release-notes-skip`
-
 ## Review readiness
 
 - [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
@@ -49,11 +66,14 @@ Choose exactly one before review/merge; CI fails otherwise.
 
 ## Checks run
 
+- [ ] `git diff --check`
+- [ ] `./gradlew specCorpusConformance`
 - [ ] `./gradlew specContract`
 - [ ] `./gradlew acceptanceContract`
 - [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
 - [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
 - [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
+- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
 - [ ] `flutter pub get`
 - [ ] `flutter gen-l10n`
 - [ ] `dart run build_runner build --delete-conflicting-outputs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ v0.1 is dogfood-production, not preview. No scaffold, roadmap, or coming-soon UX
 Before coding, opening PRs, merging, or declaring work complete, read and follow:
 
 - `docs/developer-handbook.md` for coding conventions, Gradle gates, generated code, accessibility/i18n, and evidence expectations.
-- `docs/gitflow-pr-workflow.md` for protected `main`, short-lived branches, PR readiness, merge rules, and release-notes labels.
+- `docs/gitflow-pr-workflow.md` for lane-based DevOps flow, protected `main`/`dev`, PR readiness, merge rules, and release-notes labels.
 - `docs/weave-operating-model.md` for delivery lifecycle and governance.
 - `specs/weave-specs.lock.json`, the pinned spec corpus files, `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and transitional repo-local `specs/` for conformance context.
 - Domain docs near the changed area (`client/`, `server/`, `infra/`, `e2e/`, `docs/`).

--- a/README.md
+++ b/README.md
@@ -293,4 +293,4 @@ export PATH="$JAVA_HOME/bin:$PATH"
 - Keep Weaver governed, optional, and disabled by default until its gates exist.
 - Prefer accessible headings, concise bullets, descriptive links, and alt text over dense copy.
 - Do not expose provider secrets or service tokens to Flutter, support bundles, app config, logs, screenshots, or docs.
-- Follow [Developer Handbook](docs/developer-handbook.md) and [Trunk-based PR and release workflow](docs/gitflow-pr-workflow.md) before opening, reviewing, or merging PRs.
+- Follow [Developer Handbook](docs/developer-handbook.md) and [Lane-based PR and release workflow](docs/gitflow-pr-workflow.md) before opening, reviewing, or merging PRs.

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -101,15 +101,15 @@ make offline-contract-test
 - Run `dart run build_runner build --delete-conflicting-outputs` after model/provider/codegen changes.
 - Keep user-facing strings localizable; do not add hard-coded English text in widgets when the surrounding feature already uses l10n.
 
-## Trunk-based PR and release workflow
+## Lane-based PR and release workflow
 
-Use protected `main` plus short-lived PR branches; do not introduce long-lived `dev`, `develop`, `testing`, `staging`, or `release/*` branches as the primary flow. Keep changes issue/spec-driven and request Copilot review on every review-ready PR. Every PR must deliberately choose exactly one release-notes label before review/merge:
+Use the lane-based DevOps flow: protected `main` for stable release truth, protected `dev` for integration, `future/*` for larger not-yet-release-ready lines, `rc/*` for release candidates and Live Stack E2E evidence, and `hotfix/*` for emergency stable-line fixes. See [Weave DevOps branching model](devops/branching-model.md), [release flow](devops/release-flow.md), [release notes policy](devops/release-notes.md), and [spec governance](devops/spec-governance.md). Every PR must deliberately choose exactly one release-notes label before review/merge:
 
 - `release-notes-feature`
 - `release-notes-bugfix`
 - `release-notes-skip`
 
-Release notes are generated from merged PR labels, not manually reconstructed later. The CI `Release Notes Label Check` runs on every pull-request update and fails PRs with zero or multiple release-notes labels; label-only changes run that lightweight check without re-running the full Gradle CI job. See [Weave operating model](weave-operating-model.md) for the delivery contract and [Trunk-based PR and release workflow](gitflow-pr-workflow.md) for label semantics and merge rules.
+Release notes are generated from merged PR labels, not manually reconstructed later. The CI `Release Notes Label Check` runs on every pull-request update and fails PRs with zero or multiple release-notes labels; label-only changes run that lightweight check without re-running the full Gradle CI job. See [Weave operating model](weave-operating-model.md) for the delivery contract and [Lane-based PR and release workflow](gitflow-pr-workflow.md) for label semantics and merge rules.
 
 ## Spec-driven sprint contract
 

--- a/docs/devops/branching-model.md
+++ b/docs/devops/branching-model.md
@@ -1,0 +1,59 @@
+# Weave DevOps branching model
+
+Weave uses a lane-based flow. The goal is a stable basis where the pinned specification corpus, implementation work, release candidates, and release truth are visible without turning daily work into heavy classic GitFlow.
+
+## Lanes
+
+- `main` is protected stable and release truth.
+  - It must contain release-ready code and release evidence only.
+  - Normal product work does not target `main` directly.
+  - PRs to `main` are limited to promoted `rc/*` branches or documented emergency `hotfix/*` exceptions.
+  - Release tags are generated from `main`.
+- `dev` is the protected integration lane.
+  - Issue branches, bugfix branches, documentation branches, and spec-integration branches normally target `dev`.
+  - `dev` is allowed to be ahead of the current release, but it must stay buildable and evidence-backed.
+  - CI/spec gates run here before release-candidate cutting.
+- `future/*` lanes hold larger product lines that are not release-ready yet.
+  - They must keep spec reconciliation explicit.
+  - They periodically PR back into `dev` in reviewable slices.
+  - They are not a shortcut around release notes, linked issues, or acceptance evidence.
+- `rc/<version>` lanes are release-candidate and E2E lanes.
+  - Cut them from `dev` when the candidate scope is ready.
+  - Only stabilization fixes, release evidence, and release-note corrections belong here.
+  - Full Live Stack E2E and release-evidence gates run here before promotion.
+  - A green and reviewed `rc/*` branch promotes to `main` by PR.
+- `hotfix/*` lanes are emergency exceptions.
+  - Cut them from `main` for urgent release-truth fixes.
+  - PR them to `main`, then backport or merge the fix into `dev` so the lanes do not diverge silently.
+
+## Issue branch naming
+
+Use short-lived branches that show intent and owner area:
+
+- `fix/<issue>-short-name`
+- `feat/<issue>-short-name`
+- `docs/<issue-or-topic>`
+- `spec/<issue-or-topic>`
+- `hotfix/<issue>-short-name`
+
+## Required PR declarations
+
+Every PR declares:
+
+- target lane: `dev`, `future/*`, `rc/*`, or a `main` exception;
+- linked issue or explicit spec/evidence note;
+- release note text, or `Release note: none` with a reason;
+- spec impact: none, updates spec, implements locked spec, or changes evidence only;
+- gates run and evidence locations.
+
+## Protection intent
+
+Branch protection should make the lane names meaningful:
+
+- protect `main`, `dev`, and active `rc/*` branches;
+- require reviews and green required checks before merge;
+- require linear or squash history according to the repository merge policy;
+- prevent direct pushes except for documented administrator recovery;
+- keep release publication behind explicit approval.
+
+This document records intended governance only. It does not mutate GitHub branch protection.

--- a/docs/devops/release-flow.md
+++ b/docs/devops/release-flow.md
@@ -1,0 +1,41 @@
+# Weave release flow
+
+This release flow keeps `main` stable while still giving Weave a practical integration lane for issues, specification work, and release-candidate evidence.
+
+## Normal issue flow
+
+- Recover truth from the pinned spec corpus in `specs/weave-specs.lock.json` and the linked issue.
+- Create a short-lived issue branch from current `dev`.
+- Implement the smallest reviewable slice.
+- Update acceptance evidence, docs, and release-note text in the same PR when behavior or operations change.
+- Open the PR to `dev` with the PR template filled.
+- Run the smallest meaningful local gate and let CI validate the lane.
+
+## Spec integration flow
+
+- Treat the pinned Weave Specification Corpus as fachliche product/domain truth.
+- Use this repo for implementation evidence, generated/transitional projections, and conformance checks.
+- If implementation reality and corpus truth disagree, choose one explicit path:
+  - open or link a spec-change task in the corpus; or
+  - open or link a conformance-fix task in this repo.
+- Do not let implementation state silently redefine product or domain meaning.
+
+## Release-candidate flow
+
+- Cut `rc/<version>` from `dev` only after the candidate scope is coherent.
+- Freeze scope on `rc/<version>` to stabilization, evidence, release-note fixes, and release blockers.
+- Run release evidence gates, including Live Stack E2E when relevant for the release.
+- Record candidate evidence in the release evidence docs or artifacts.
+- Promote `rc/<version>` to `main` by PR only when gates and reviews are green or an accepted release-gate exception is documented.
+- Tag releases from `main` after promotion.
+
+## Hotfix flow
+
+- Cut `hotfix/*` from `main` only for urgent stable-line fixes.
+- Keep the hotfix narrow and evidence-backed.
+- PR to `main` with the `main` exception explained in the PR body.
+- Immediately backport or merge the accepted fix into `dev` and any affected active `rc/*` lane.
+
+## No release-ready claim by default
+
+A green PR or local gate is not a release-ready claim. Release readiness requires the relevant `rc/*` evidence, release notes, protected checks, and closure of named release blockers.

--- a/docs/devops/release-notes.md
+++ b/docs/devops/release-notes.md
@@ -1,0 +1,46 @@
+# Release notes policy
+
+Every issue and PR must make its release-note impact explicit. This keeps generated release notes traceable and prevents silent product, operator, or support changes.
+
+## PR body requirement
+
+Each PR includes one of these forms:
+
+- `Release note: <short user/admin/operator/developer-facing note>`
+- `Release note: none — <reason>`
+
+Valid `none` reasons include:
+
+- test-only maintenance with no behavior or support impact;
+- internal refactor with no user, admin, operator, developer, or release-process effect;
+- duplicate note already covered by a linked PR;
+- evidence-only update with no change to shipped behavior.
+
+Do not use `none` for docs, release-process, admin/operator behavior, infrastructure behavior, accessibility, localization, or supportability changes that a reader of release notes should know about.
+
+## Label requirement
+
+Each PR still carries exactly one release-notes label:
+
+- `release-notes-feature`
+- `release-notes-bugfix`
+- `release-notes-skip`
+
+The label controls generated release-note grouping. The PR-body release-note line records the human-readable note or the skip reason.
+
+## Issue requirement
+
+Issues should include a release-note expectation when acceptance is defined:
+
+- expected release-note wording for user/admin/operator-facing changes;
+- `Release note: none` with a reason for work that should not appear in notes;
+- any linked spec or evidence artifact that constrains the wording.
+
+## Release-candidate check
+
+Before promoting an `rc/*` lane to `main`, verify that included PRs have:
+
+- exactly one release-notes label;
+- a release-note line or explicit none reason;
+- no unresolved release-note TODOs;
+- generated draft notes that match the release scope.

--- a/docs/devops/spec-governance.md
+++ b/docs/devops/spec-governance.md
@@ -1,0 +1,35 @@
+# Specification governance in the DevOps flow
+
+The DevOps lanes exist to protect the specification boundary, not to replace it.
+
+## Truth boundary
+
+- Canonical fachliche product/domain truth is the pinned Weave Specification Corpus in `specs/weave-specs.lock.json`.
+- This repository is implementation and evidence truth: code, tests, CI, release evidence, issues, PRs, and generated or transitional spec projections.
+- Repo-local `specs/` content can prove or project conformance, but it must not silently redefine the pinned corpus.
+
+## Required spec impact declaration
+
+Every PR declares one spec impact:
+
+- `none` — no product/domain contract changed;
+- `implements locked spec` — implementation or evidence now conforms to the pinned corpus;
+- `updates spec` — a linked corpus change is required or already accepted;
+- `changes evidence only` — evidence, gates, fixtures, or reports changed without changing product/domain meaning.
+
+## Lane-specific spec rules
+
+- `dev` receives normal spec integration and conformance-fix work.
+- `future/*` may explore larger product lines, but each merge toward `dev` must reconcile with the pinned corpus or link the required corpus change.
+- `rc/*` should not introduce new product/domain meaning. If a release candidate exposes a spec gap, either fix conformance, defer the scope, or record a release-gate exception.
+- `main` must only receive spec-consistent, release-ready truth or a documented emergency hotfix.
+
+## Conflict handling
+
+When implementation and corpus disagree:
+
+- do not normalize the mismatch away in docs;
+- name the mismatch in the linked issue or PR;
+- choose conformance fix or spec-change path;
+- run `./gradlew specCorpusConformance` and `./gradlew specContract` when feasible;
+- record any skipped gate with the reason and next safe action.

--- a/docs/gitflow-pr-workflow.md
+++ b/docs/gitflow-pr-workflow.md
@@ -1,23 +1,25 @@
-# Trunk-based PR and release workflow
+# Lane-based PR and release workflow
 
-Weave uses protected `main` plus short-lived PR branches. Do not add long-lived `dev`, `develop`, `testing`, `staging`, or `release/*` branches as the primary flow. Keep changes spec-driven: intent -> issue/spec note -> acceptance/evidence -> implementation -> review. For the full delivery contract, see [Weave operating model](weave-operating-model.md).
+Weave uses clear DevOps lanes instead of heavy classic GitFlow: `main` for stable release truth, `dev` for integration, `future/*` for larger not-yet-release-ready lines, `rc/*` for release candidates and Live Stack E2E evidence, and `hotfix/*` for urgent stable-line fixes. Keep changes spec-driven: intent -> issue/spec note -> acceptance/evidence -> implementation -> review. For the full delivery contract, see [Weave operating model](weave-operating-model.md) and the DevOps docs under `docs/devops/`.
 
 ## Branch and PR rules
 
-1. Start from current `origin/main`; `main` is the only long-lived integration branch.
+1. Start from the correct current lane: normally `origin/dev`, `future/*` for large future lines, `rc/*` for candidate stabilization, or `origin/main` only for emergency hotfixes.
 2. Create a focused branch named for the scope, for example `docs/mkdocs-handbook-foundation`, `feat/admin-policy-profiles`, or `fix/chat-empty-state`.
 3. Keep unrelated local files and assistant workspace files out of commits.
 4. Open a PR early enough for CI and review, but mark it draft if it is not review-ready.
 5. Before requesting review, run the smallest meaningful local gate and record it in the PR body.
-6. Request GitHub Copilot review on every review-ready PR.
-7. Do not merge until protected checks are green, conversations are resolved, and the release-notes label gate passes.
+6. Declare target lane, linked issue, release-note line or none reason, spec impact, and gates run.
+7. Request GitHub Copilot review on every review-ready PR.
+8. Do not merge until protected checks are green, conversations are resolved, and the release-notes label gate passes.
 
 
 ## Dev, testing, staging, and production
 
-- Local development and temporary previews use a developer machine or disposable worktree, not a durable `dev` branch.
+- `dev` is a branch lane for integration; it is not a deployed environment.
+- Local development and temporary previews still use developer machines or disposable worktrees.
 - Testing/staging is represented by GitHub Environments or workflow targets, especially for release-candidate and Live Stack E2E evidence.
-- Release candidates are tags on `main` such as `vX.Y.Z-rc.N`.
+- Release candidates use `rc/<version>` branches cut from `dev`; release tags are generated from `main` after promotion.
 - Production releases use final SemVer tags such as `vX.Y.Z` plus explicit production approval.
 - A merge to `main` makes Weave release-capable; it is not an automatic production deploy.
 
@@ -41,7 +43,7 @@ Before review-ready:
 
 - Link the issue or spec note that explains intent and acceptance criteria.
 - Choose exactly one release-notes label.
-- Fill the PR template, including user/admin/operator impact and checks run.
+- Fill the PR template, including target lane, release-note line or none reason, spec impact, user/admin/operator impact, and checks run.
 - Note contract/spec changes or explicitly mark that there are none.
 - For UI-facing changes, include accessibility and localization impact.
 - For docs/release process changes, run `make docs-check`; use `make release-notes-check` alone only for release-note page or label-policy edits that do not need a site build.
@@ -57,7 +59,7 @@ The docs gate also checks that release-note pages and diagram navigation remain 
 
 A PR is merge-ready only when:
 
-- it has exactly one release-notes label;
+- it declares target lane, spec impact, release-note line or none reason, and exactly one release-notes label;
 - Copilot review was requested for the review-ready PR;
 - required CI is green or an explicit accepted exception is documented;
 - acceptance/evidence changes are mapped where product behavior changed;

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ Start with:
 Start with:
 
 1. [Developer Handbook](developer-handbook.md) — local prerequisites, Java 21+ requirement, Gradle gates, client/server/admin/infra workflows, and evidence expectations.
-2. [Trunk-based PR and release workflow](gitflow-pr-workflow.md) — branch, review, label, release-note, and merge rules.
+2. [Lane-based PR and release workflow](gitflow-pr-workflow.md) — branch, review, label, release-note, and merge rules.
 3. [Spec-driven development for Weave](spec-driven-development.md) — pinned spec corpus, conformance lifecycle, evidence gates, and agent orchestration.
 4. [AI-assisted delivery orchestration](agent-team-orchestration.md) — repo-safe roles, handoff briefs, runtime-boundary guardrails, and optimization loop.
 5. [Canonical domains](architecture/canonical-domains.md) — product-owned domain registry for identity, people, spaces, chat, files, documents, calendar, boards, calls, decisions, notifications, health, and Weaver.
@@ -102,7 +102,7 @@ Canonical handbooks:
 - [User Handbook](user-handbook.md)
 - [Admin/Operator Handbook](admin-operator-handbook.md)
 - [Developer Handbook](developer-handbook.md)
-- [GitFlow/PR workflow](gitflow-pr-workflow.md)
+- [Lane-based PR workflow](gitflow-pr-workflow.md)
 
 Release and evidence docs:
 

--- a/docs/weave-operating-model.md
+++ b/docs/weave-operating-model.md
@@ -13,10 +13,12 @@ This page is the compact working contract for Weave delivery. It keeps sprint, r
 
 ## Branch and release model
 
-- `main` is the only long-lived integration branch and must remain release-capable.
-- Work uses short-lived feature, fix, docs, or CI branches from current `origin/main`.
-- Do not introduce long-lived `dev`, `develop`, `testing`, `staging`, or `release/*` branches as the primary flow.
-- Every PR targets `main`, stays focused, and carries exactly one release-notes label:
+- `main` is protected stable and release truth; only promoted `rc/*` branches or documented emergency `hotfix/*` exceptions target it.
+- `dev` is the protected integration lane for normal issue, bugfix, documentation, and spec-integration PRs.
+- `future/*` lanes hold larger not-yet-release-ready product lines and periodically reconcile back to `dev`.
+- `rc/<version>` lanes are cut from `dev` for release-candidate stabilization, full Live Stack E2E, and release evidence before promotion to `main`.
+- `hotfix/*` lanes are cut from `main` for urgent stable-line fixes and must be backported or merged into `dev`.
+- Every PR declares its target lane, linked issue, release-note text or explicit none reason, spec impact, gates run, and exactly one release-notes label:
   - `release-notes-feature`
   - `release-notes-bugfix`
   - `release-notes-skip`
@@ -26,7 +28,7 @@ This page is the compact working contract for Weave delivery. It keeps sprint, r
 
 ## Environments
 
-- `local/dev` is a developer machine, temporary preview, or disposable worktree; it is not a durable branch.
+- Local developer machines and disposable worktrees remain temporary environments. The durable `dev` branch is an integration lane, not a deployed environment.
 - `testing`/`staging` is a GitHub Environment or workflow target for release-candidate verification and Live Stack E2E evidence.
 - `production` is a GitHub Environment guarded by manual approval and release evidence.
 - Live Stack E2E is release evidence, not a replacement for local or PR-safe gates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,11 @@ nav:
       - Weave operating model: weave-operating-model.md
       - Spec-driven development: spec-driven-development.md
       - AI-assisted delivery orchestration: agent-team-orchestration.md
-      - Trunk-based PR and release workflow: gitflow-pr-workflow.md
+      - Lane-based PR and release workflow: gitflow-pr-workflow.md
+      - DevOps branching model: devops/branching-model.md
+      - DevOps release flow: devops/release-flow.md
+      - DevOps release notes policy: devops/release-notes.md
+      - DevOps spec governance: devops/spec-governance.md
       - Architecture: architecture.md
       - Canonical feature models: canonical-feature-models.md
       - Accessible workflow context contract: workflow-context-contract.md

--- a/tools/pr_body_check.py
+++ b/tools/pr_body_check.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Validate minimal Weave PR body governance fields."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+RELEASE_NOTE_RE = re.compile(r"(?im)^\s*-?\s*Release note:\s*(?!\s*$).+")
+TARGET_LANE_RE = re.compile(r"(?im)^\s*-?\s*Target lane:\s*(dev|future/\*|future/[^\s]+|rc/\*|rc/[^\s]+|main exception)\b")
+SPEC_IMPACT_RE = re.compile(r"(?im)^\s*- \[[xX]\]\s*(none|implements locked spec|updates spec|changes evidence only)\b")
+ISSUE_RE = re.compile(r"(?im)^\s*-?\s*(Issue|Linked issue\(s\)):\s*(?!\s*$).+")
+GATES_RE = re.compile(r"(?im)^## Checks run\b")
+
+
+def validate(text: str) -> list[str]:
+    errors: list[str] = []
+    if not TARGET_LANE_RE.search(text):
+        errors.append("missing target lane declaration: dev, future/*, rc/*, or main exception")
+    if not ISSUE_RE.search(text):
+        errors.append("missing linked issue or explicit spec/evidence note")
+    if not RELEASE_NOTE_RE.search(text):
+        errors.append("missing release note line or 'Release note: none — reason'")
+    if not SPEC_IMPACT_RE.search(text):
+        errors.append("missing checked spec impact option")
+    if not GATES_RE.search(text):
+        errors.append("missing Checks run section")
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: tools/pr_body_check.py <pr-body.md>", file=sys.stderr)
+        return 2
+    text = Path(argv[1]).read_text(encoding="utf-8")
+    errors = validate(text)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("PR body check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary

- Reset the documented Weave DevOps model to clear lanes: `main`, `dev`, `future/*`, `rc/*`, and `hotfix/*`.
- Add DevOps docs for branching, release flow, release-note policy, and spec governance.
- Update the PR template and add a lightweight PR-body validation script for lane/release-note/spec-impact declarations.

## Scope and user impact

- Developer/operator documentation and PR governance only.
- No runtime product behavior changes.

## Spec / acceptance link

- Issue: explicit operator decision from Massimo; no GitHub issue was provided for this governance reset.
- Repo spec or spec note: `specs/weave-specs.lock.json` pins the corpus at `6a6550dfef13f5582d1d3f1cdd5443564e246c1c`; this PR documents repo-side implementation/evidence governance and does not redefine corpus truth.
- Acceptance scenario / mapping marker when product behavior changed: none; docs/process-only change.
- Product-core questions intentionally left unresolved: none.

## Branch, target lane, and release path

- Target lane: main exception
- [x] Branch started from the correct lane (`main` for this one-time bootstrap governance reset requested from current `origin/main`).
- [x] Linked issue(s) or explicit spec/evidence note are listed above.
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception; this PR is a documented bootstrap exception to establish the new lane policy before `dev`/`rc` protections are in place.
- [x] Production release is not implied by this merge.

## Spec impact

Choose one and explain when needed.

- [ ] none
- [ ] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [x] changes evidence only

## Release note

Use exactly one form.

- Release note: Documented the Weave DevOps lane reset and PR governance requirements for release notes, spec impact, and target lanes.
- Release note: none — reason:

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- Adds `docs/devops/` pages and updates developer/operating model docs plus MkDocs navigation.

## Accessibility and localization

- Docs use headings and bullets instead of dense tables in the new DevOps pages.
- No localization changes.

## Contract impact

- [x] No public API/auth/topology/spec contract change
- [ ] Contract/spec change documented:
- [x] `./gradlew specContract` run for spec/product-contract changes

## Review readiness

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented (pending review)

## Checks run

- [x] `git diff --check`
- [x] `./gradlew specCorpusConformance`
- [x] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [x] `./gradlew docsCheck`
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [x] `python3 tools/pr_body_check.py /tmp/pr-body-fixture.md`
- [x] negative fixture returns expected errors for `python3 tools/pr_body_check.py /tmp/pr-body-bad.md`
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not required for docs-only governance reset. Run 27423203205 completed successfully while this PR was open: https://github.com/masssi164/weave/actions/runs/27423203205

## Notes for reviewers

- This PR intentionally documents desired branch protections/workflows but does not mutate GitHub branch protection.
- Existing release blockers (#719, #710, #591) and open PRs (#720, #721) remain; this PR does not claim release readiness.
