### PR TITLE
docs: avoid obsolete local literals in spec 0008 evidence

### DIFF
--- a/docs/evidence/spec-0008-local-dogfood-topology-closure.md
+++ b/docs/evidence/spec-0008-local-dogfood-topology-closure.md
@@ -17,8 +17,8 @@ The repository now includes `tools/forbidden_domain_drift_scan.py` as the repeat
 
 The active drift fixed in this slice was:
 
-- provider-lab Synapse default server name: `weave-lab.local` -> `weave.test`
-- disposable restore proof Matrix fixture: `restore-proof.local` -> `restore-proof.weave.test`
+- provider-lab Synapse default server name: legacy lab-local hostname -> `weave.test`
+- disposable restore proof Matrix fixture: legacy restore-proof local hostname -> `restore-proof.weave.test`
 - raw-provider redaction and correlation negative-test examples: `.local` examples -> `.example.invalid`
 
 ## Evidence commands


### PR DESCRIPTION
## Summary\n- remove literal obsolete .local host examples from Spec 0008 closure evidence\n- keep the evidence description while allowing the forbidden-domain drift scan to police active tracked text\n\n## Target lane\n- dev\n\n## Linked issue(s)\n- Spec 0008 closure follow-up after #727\n\n## Release notes\nRelease note: none\nReason: evidence wording only; no user-visible behavior change.\n\n## Spec impact\n- changes evidence only\n- keeps Spec 0008 closure honest under the executable drift scan\n\n## Gates run\n- python3 tools/forbidden_domain_drift_scan.py\n- git diff --check\n- ./gradlew mcpDomainToolNameCheck specCorpusConformance specContract acceptanceContract docsCheck --console=plain\n\n## Claim boundary\n- Does not claim release readiness. Release blockers remain #719, #710, and #591.