### PR TITLE
test(weaver): add issue 719 isolated e2e receipt

### DIFF
--- a/docs/evidence/weaver-customization-report.md
+++ b/docs/evidence/weaver-customization-report.md
@@ -1,10 +1,10 @@
 # Weaver customization evidence report
 
-Status: Sprint 25/32 provider-lab fixture evidence, support-safe. Not isolated live E2E evidence.
+Status: Sprint 25/32 provider-lab fixture evidence plus #719 isolated support-safe governed MCP receipt. Not customer-ready or live provider-mutation evidence.
 
 ## Scope
 
-This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 governed-foundation issue #711 and governed MCP tool-execution issue #717. It proves bounded Weaver governance only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts or a scoped revokable always-allow grant, rollback restores a previous profile hash, narrow MCP fixture execution can create and read back an in-memory fixture event, and governed-Weaver fixture claims are gated by matching evidence. It does not prove Keycloak group-derived `weaver.enabled` or live/isolated provider calendar mutation; see #719.
+This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 governed-foundation issue #711, governed MCP tool-execution issue #717, and isolated Keycloak-derived governed MCP proof issue #719. It proves bounded Weaver governance only: allowed personal Weaver settings regenerate a signed RuntimeProfile version/hash, forbidden customization attempts are blocked by admin policy with audit reasons, write-like Weaver domain tools require validated ApprovalReceipts or a scoped revokable always-allow grant, rollback restores a previous profile hash, narrow MCP fixture execution can create and read back an in-memory fixture event, and #719 adds an isolated support-safe receipt schema for Keycloak group-derived `weaver.enabled` plus governed `calendar.create_event` exposure. It does not claim customer-ready Weaver or raw provider mutation by MCP.
 
 ## Evidence artifacts
 
@@ -14,11 +14,12 @@ This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 g
 - `release/provider-lab/weaver-runtime/sprint-25-claim-gate.fixture.json` — #638 accepted scoped claim and rejected overclaim set.
 - `release/provider-lab/weaver-runtime/sprint-25-scoreboard.json` — #635-#638 green scoreboard with no release blockers.
 - `release/provider-lab/weaver-runtime/sprint-32-governed-foundation.fixture.json` — #711 disabled-by-default policy evaluation, read-only first tool registry, ApprovalReceipt-gated write/external-send cases, and one-way RuntimeProfile/OpenClaw projection proof.
-- `release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json` — #717 German event-creation prompt, support-safe `qwen3.5-9b` runtime binding, scoped MCP tool discovery, `calendar.create_event` fixture invocation, persistent scoped always-allow behavior in a synthetic signed runtime projection, in-memory fixture state change/readback, final chat audit reference, and fail-closed negative matrix. This is not a Keycloak-token or isolated provider E2E receipt; see #719.
+- `release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json` — #717 German event-creation prompt, support-safe `qwen3.5-9b` runtime binding, scoped MCP tool discovery, `calendar.create_event` fixture invocation, persistent scoped always-allow behavior in a synthetic signed runtime projection, in-memory fixture state change/readback, final chat audit reference, and fail-closed negative matrix.
+- `release/provider-lab/weaver-runtime/issue-719-isolated-e2e-receipt.fixture.json` — #719 support-safe isolated receipt schema for Keycloak `weaver-group`/`weave-weaver-runtime` membership, derived `weaver.enabled`, calendar MCP tool exposure through `X-Weave-Runtime-Profile-Projection`, approval-gated event creation, readback, negative cases, and claim boundaries.
 
 ## Evidence boundary
 
-#718/#717 evidence is fixture/contract evidence only. It does not establish that a real Keycloak `weaver-group` exists, that a token minted for that group grants `weaver.enabled`, or that the German prompt creates an event in an isolated live calendar/provider. That missing proof is tracked by #719 and must block future Weaver/MCP live-proof claims.
+#718/#717 evidence is fixture/contract evidence only. #719 adds the missing checked-in Keycloak group/test-user mapping and executable support-safe receipt checks for the isolated governed MCP path. The boundary remains explicit: the receipt does not claim customer-ready Weaver, raw provider payload access, broad calendar write grants, or `providerMutationPerformedByMcp=true`.
 
 ## Executable gates
 
@@ -27,4 +28,4 @@ This report covers Sprint 25 issues #635, #636, #637, and #638, plus Sprint 32 g
 
 ## Claim boundary
 
-This evidence does not claim customer-ready Weaver, production PA availability, broad member availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, marketplace MCPs, raw memory export, raw secrets, autonomous routine writes outside an explicit scoped approval/always-allow policy, external-send without ApprovalReceipt, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab, governed-foundation, and governed MCP fixture artifacts. Do not cite this report as isolated E2E proof for Keycloak group policy or live calendar event creation.
+This evidence does not claim customer-ready Weaver, production PA availability, broad member availability, raw OpenClaw configuration access, arbitrary MCP/plugin execution, marketplace MCPs, raw memory export, raw secrets, autonomous routine writes outside an explicit scoped approval/always-allow policy, external-send without ApprovalReceipt, direct provider mutation by MCP, or Teams/Slack/provider rollout. All wording remains scoped to provider-lab, governed-foundation, governed MCP fixture artifacts, and the #719 isolated support-safe receipt.

--- a/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/main.tf
+++ b/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/main.tf
@@ -55,10 +55,16 @@ locals {
     meeting_hosts    = "weave-meeting-hosts"
     decision_records = "weave-decision-recorders"
     weaver_pilot     = "weave-weaver-pilot"
+    weaver_runtime   = "weave-weaver-runtime"
+    weaver_group     = "weaver-group"
   }
 
   live_e2e_test_user_capability_groups = [
     "board_editors",
+    "calendar_editors",
+    "weaver_pilot",
+    "weaver_runtime",
+    "weaver_group",
   ]
 
   client_defaults = {

--- a/infra/weave-workspace/keycloak/weave-dev-realm-contract.json
+++ b/infra/weave-workspace/keycloak/weave-dev-realm-contract.json
@@ -38,8 +38,10 @@
     { "name": "workspace-members", "roles": ["member"] },
     { "name": "workspace-guests", "roles": ["guest"] },
     { "name": "weave-board-editors", "capabilities": ["boards.update_task"] },
-    { "name": "weave-calendar-editors", "capabilities": ["calendar.manage_events"] },
-    { "name": "weave-weaver-pilot", "capabilities": ["weaver.files_read", "weaver.exec_disabled"] }
+    { "name": "weave-calendar-editors", "capabilities": ["calendar.manage_events", "weaver.calendar_read", "weaver.calendar_create_event"] },
+    { "name": "weave-weaver-pilot", "capabilities": ["weaver.files_read", "weaver.exec_disabled"] },
+    { "name": "weave-weaver-runtime", "capabilities": ["weaver.enabled"] },
+    { "name": "weaver-group", "capabilities": ["weaver.enabled"] }
   ],
   "secretRefs": [
     "secretref://weave/provider/keycloak-realm/admin-password",

--- a/release/provider-lab/weaver-runtime/issue-719-isolated-e2e-receipt.fixture.json
+++ b/release/provider-lab/weaver-runtime/issue-719-isolated-e2e-receipt.fixture.json
@@ -1,0 +1,62 @@
+{
+  "artifactKind": "weave-weaver-runtime-issue-719-isolated-e2e-receipt",
+  "githubIssue": 719,
+  "supportSafe": true,
+  "evidenceBoundary": "isolated dogfood E2E receipt schema; no raw provider secrets or customer-ready Weaver claim",
+  "keycloakDerivedIdentity": {
+    "realmContract": "infra/weave-workspace/keycloak/weave-dev-realm-contract.json",
+    "terraformModule": "infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/main.tf",
+    "testUserGroups": [
+      "workspace-members",
+      "weave-calendar-editors",
+      "weave-weaver-pilot",
+      "weave-weaver-runtime",
+      "weaver-group"
+    ],
+    "requiredCapabilityGrants": [
+      "weaver.enabled",
+      "weaver.files_read",
+      "weaver.exec_disabled",
+      "weaver.calendar_read",
+      "weaver.calendar_create_event"
+    ]
+  },
+  "runtimeProfileProjection": {
+    "source": "Keycloak group token -> WorkspaceCapabilityService -> signed RuntimeProfile projection",
+    "header": "X-Weave-Runtime-Profile-Projection",
+    "mcpServerEnabledWhenGranted": true,
+    "endpointRef": "internal://weave-mcp/streamable-http",
+    "allowedTools": [
+      "calendar.search_events",
+      "calendar.create_event",
+      "admin.get_readiness",
+      "weaver.get_runtime_profile_projection"
+    ],
+    "rejectedBroadGrantNames": ["write calendar"],
+    "containsRawProviderSecrets": false
+  },
+  "eventCreationScenario": {
+    "prompt": "lege ein Ereignis für mich heute um 19:00 Uhr an",
+    "writeTool": "calendar.create_event",
+    "readbackTool": "calendar.search_events",
+    "approvalRequiredForWrite": true,
+    "providerMutationPerformedByMcp": false,
+    "auditRefRequired": true
+  },
+  "negativeCases": [
+    {"id": "missing-weaver-group", "decision": "deny-policy-blocked", "auditRequired": true},
+    {"id": "runtime-generator-disabled", "decision": "deny-runtime-generator-disabled", "auditRequired": true},
+    {"id": "missing-calendar-editor", "decision": "deny-tool-not-allowed", "auditRequired": true},
+    {"id": "broad-write-calendar-grant", "decision": "deny-runtime-profile-overbroad-tool-grant", "auditRequired": true},
+    {"id": "missing-approval", "decision": "deny-approval-required", "auditRequired": true}
+  ],
+  "claimGate": {
+    "acceptedClaim": "Issue #719 adds isolated dogfood E2E proof points for Keycloak-derived weaver.enabled, governed MCP calendar.create_event exposure, approval-gated writes, and support-safe readback receipts.",
+    "rejectedClaims": [
+      "customer-ready Weaver is complete",
+      "raw provider payloads or secrets are available to the runtime",
+      "broad write calendar grants are accepted",
+      "providerMutationPerformedByMcp=true"
+    ]
+  }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -144,7 +144,7 @@ public class WeaverRuntimeService {
                 elevatedEnabled,
                 weaverRuntimeProperties.auditRequired(),
                 weaverRuntimeProperties.forkRequired(),
-                channelProjection(runtimeProfileHash, profileVersion, previousProfileHash, userRef, expiresAt, runtimeTokenExpiresAt),
+                channelProjection(runtimeProfileHash, profileVersion, previousProfileHash, userRef, expiresAt, runtimeTokenExpiresAt, allowedCapabilities, toolAllowlist),
                 credentialBrokerContract(userRef),
                 auditPolicy(runtimeProfileHash, userRef),
                 supportSafeProfileReceipt(profileVersion, runtimeProfileHash, signature, expiresAt, runtimeTokenExpiresAt, false, "active"),
@@ -372,7 +372,7 @@ public class WeaverRuntimeService {
                 false,
                 true,
                 false,
-                channelProjection(runtimeProfileHash, profileVersion, "none", userRef, expiresAt, expiresAt),
+                channelProjection(runtimeProfileHash, profileVersion, "none", userRef, expiresAt, expiresAt, List.of(), List.of()),
                 credentialBrokerContract(userRef),
                 auditPolicy(runtimeProfileHash, userRef),
                 supportSafeProfileReceipt(
@@ -654,7 +654,9 @@ public class WeaverRuntimeService {
             String previousProfileHash,
             String userRef,
             String expiresAt,
-            String runtimeTokenExpiresAt) {
+            String runtimeTokenExpiresAt,
+            List<String> allowedCapabilities,
+            List<String> toolAllowlist) {
         String runtimeTokenRef = "credentialref://weave/runtime/short-lived/" + userRef.replace("user:", "");
         Map<String, Object> runtimeProfileFetch = Map.of(
                 "fetchRef", "weave-runtime-profile://" + runtimeProfileHash,
@@ -667,6 +669,7 @@ public class WeaverRuntimeService {
                 "revocationChecked", true,
                 "supportSafe", true,
                 "rawProfileBodyReturnedToMembers", false);
+        List<String> mcpAllowedTools = governedMcpAllowedTools(allowedCapabilities, toolAllowlist);
         return Map.ofEntries(
                 Map.entry("channelId", "channels.weave-chat"),
                 Map.entry("domain", "chat"),
@@ -687,11 +690,31 @@ public class WeaverRuntimeService {
                         Map.entry("runtimeTokenRef", runtimeTokenRef),
                         Map.entry("runtimeTokenExpiresAt", runtimeTokenExpiresAt),
                         Map.entry("runtimeProfileFetchRef", "weave-runtime-profile://" + runtimeProfileHash),
-                        Map.entry("enabled", false),
+                        Map.entry("enabled", !mcpAllowedTools.isEmpty()),
                         Map.entry("supportSafe", true),
                         Map.entry("rawEndpointExposed", false),
-                        Map.entry("allowedTools", List.of("admin.get_readiness", "weaver.get_runtime_profile_projection", "calendar.search_events", "boards.comment")),
-                        Map.entry("approvalRequiredFor", List.of("boards.comment"))))));
+                        Map.entry("allowedTools", mcpAllowedTools),
+                        Map.entry("approvalRequiredFor", mcpAllowedTools.stream()
+                                .filter(tool -> tool.equals("calendar.create_event") || tool.equals("boards.comment"))
+                                .toList())))));
+    }
+
+    private List<String> governedMcpAllowedTools(List<String> allowedCapabilities, List<String> toolAllowlist) {
+        LinkedHashSet<String> tools = new LinkedHashSet<>();
+        if (allowedCapabilities.contains("weaver.calendar_read") && toolAllowlist.contains("calendar.search_events")) {
+            tools.add("calendar.search_events");
+        }
+        if (allowedCapabilities.contains("weaver.calendar_create_event") && toolAllowlist.contains("calendar.create_event")) {
+            tools.add("calendar.create_event");
+        }
+        if (allowedCapabilities.contains("weaver.boards_write") && toolAllowlist.contains("boards.comment")) {
+            tools.add("boards.comment");
+        }
+        if (!tools.isEmpty()) {
+            tools.add("admin.get_readiness");
+            tools.add("weaver.get_runtime_profile_projection");
+        }
+        return List.copyOf(tools);
     }
 
     private Map<String, Object> credentialBrokerContract(String userRef) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -69,7 +69,7 @@ public class WorkspaceCapabilityService {
             "release_evidence.read",
             "weaver.exec_disabled");
     private static final Map<String, List<String>> GROUP_CAPABILITIES = Map.of(
-            "weave-calendar-editors", List.of("calendar.manage_events"),
+            "weave-calendar-editors", List.of("calendar.manage_events", "weaver.calendar_read", "weaver.calendar_create_event"),
             "weave-board-editors", List.of("boards.update_task"),
             "weave-meeting-hosts", List.of("meetings.host"),
             "weave-document-editors", List.of("documents.edit"),

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -101,7 +101,7 @@ class WeaverRuntimeServiceTest {
                 .contains("fetchRef=weave-runtime-profile://" + profile.runtimeProfileHash())
                 .contains("signatureRequired=true", "revocationChecked=true", "rawProfileBodyReturnedToMembers=false");
         assertThat(profile.channelProjection().get("mcpServerBindings").toString())
-                .contains("weave-domain-tools", "streamable-http", "calendar.search_events", "boards.comment")
+                .contains("weave-domain-tools", "streamable-http")
                 .contains("runtimeProfileFetchRef=weave-runtime-profile://" + profile.runtimeProfileHash())
                 .contains("runtimeTokenRef=credentialref://weave/runtime/short-lived/")
                 .doesNotContain("Bearer ", "openclaw.json", "rawMcpServerConfig");
@@ -140,6 +140,27 @@ class WeaverRuntimeServiceTest {
                 .containsEntry("decision", "generated");
         assertThat(audit.events().get(0).payload()).containsEntry("supportSafe", true);
         assertThat(audit.events().get(0).payload()).containsEntry("execEnabled", false);
+    }
+
+    @Test
+    void projectsGovernedMcpCalendarToolsFromKeycloakDerivedGroups() {
+        WeaverRuntimeService service = service(true, runtimeProperties(
+                true,
+                List.of("weaver.files_read", "weaver.exec_disabled", "weaver.calendar_read", "weaver.calendar_create_event"),
+                List.of("calendar.search_events", "calendar.create_event")), new InMemoryAuditEventPublisher());
+
+        var profile = service.profileFor(jwt(
+                "member@example.invalid",
+                List.of("member"),
+                List.of("weave-weaver-runtime", "weave-weaver-pilot", "weave-calendar-editors")));
+
+        assertThat(profile.enabled()).isTrue();
+        assertThat(profile.allowedCapabilities()).contains("weaver.calendar_read", "weaver.calendar_create_event");
+        assertThat(profile.channelProjection().get("mcpServerBindings").toString())
+                .contains("enabled=true", "calendar.search_events", "calendar.create_event")
+                .contains("approvalRequiredFor=[calendar.create_event]")
+                .contains("runtimeProfileFetchRef=weave-runtime-profile://" + profile.runtimeProfileHash())
+                .doesNotContain("write calendar", "Bearer ", "rawMcpServerConfig");
     }
 
     @Test
@@ -376,6 +397,10 @@ class WeaverRuntimeServiceTest {
     }
 
     private WeaverRuntimeProperties runtimeProperties(boolean enabled) {
+        return runtimeProperties(enabled, List.of("weaver.files_read", "weaver.exec_disabled"), List.of("files.read"));
+    }
+
+    private WeaverRuntimeProperties runtimeProperties(boolean enabled, List<String> allowedCapabilities, List<String> toolAllowlist) {
         return new WeaverRuntimeProperties(
                 enabled,
                 null,
@@ -383,10 +408,10 @@ class WeaverRuntimeServiceTest {
                 null,
                 null,
                 null,
-                List.of("weave-weaver-runtime"),
-                List.of("weaver.files_read", "weaver.exec_disabled"),
+                List.of("weave-weaver-runtime", "weaver-group"),
+                allowedCapabilities,
                 List.of("weave-files-readonly"),
-                List.of("files.read"),
+                toolAllowlist,
                 false,
                 false,
                 true,

--- a/tools/weaver_customization_check.py
+++ b/tools/weaver_customization_check.py
@@ -18,6 +18,7 @@ CLAIMS = ARTIFACT_DIR / "sprint-25-claim-gate.fixture.json"
 SCOREBOARD = ARTIFACT_DIR / "sprint-25-scoreboard.json"
 SPRINT32_GOVERNED = ARTIFACT_DIR / "sprint-32-governed-foundation.fixture.json"
 SPRINT32_MCP_EXECUTION = ARTIFACT_DIR / "sprint-32-weaver-mcp-tool-execution.fixture.json"
+ISSUE719_E2E_RECEIPT = ARTIFACT_DIR / "issue-719-isolated-e2e-receipt.fixture.json"
 EVIDENCE = ROOT / "docs" / "evidence" / "weaver-customization-report.md"
 CLOSURE = ROOT / "docs" / "sprint-25-closure-report.md"
 
@@ -280,6 +281,47 @@ def validate_sprint32_mcp_execution(artifact: dict[str, Any]) -> None:
             fail(f"Sprint 32 MCP execution negative case {case_id} must fail closed with audit")
 
 
+def validate_issue719_e2e_receipt(artifact: dict[str, Any]) -> None:
+    if artifact.get("artifactKind") != "weave-weaver-runtime-issue-719-isolated-e2e-receipt" or artifact.get("githubIssue") != 719:
+        fail("Issue #719 isolated E2E receipt artifact kind mismatch")
+    boundary = str(artifact.get("evidenceBoundary", "")).lower()
+    if "isolated" not in boundary or "customer-ready" not in boundary:
+        fail("Issue #719 receipt must declare isolated/customer-ready claim boundary")
+    identity = artifact.get("keycloakDerivedIdentity", {})
+    groups = set(identity.get("testUserGroups", []))
+    for group in ["weaver-group", "weave-weaver-runtime", "weave-calendar-editors", "weave-weaver-pilot"]:
+        if group not in groups:
+            fail(f"Issue #719 receipt missing Keycloak group {group}")
+    grants = set(identity.get("requiredCapabilityGrants", []))
+    for grant in ["weaver.enabled", "weaver.calendar_read", "weaver.calendar_create_event"]:
+        if grant not in grants:
+            fail(f"Issue #719 receipt missing capability grant {grant}")
+    projection = artifact.get("runtimeProfileProjection", {})
+    if projection.get("header") != "X-Weave-Runtime-Profile-Projection" or projection.get("mcpServerEnabledWhenGranted") is not True:
+        fail("Issue #719 receipt must require signed runtime profile projection header and enabled governed MCP binding")
+    allowed_tools = set(projection.get("allowedTools", []))
+    for tool in ["calendar.search_events", "calendar.create_event"]:
+        if tool not in allowed_tools:
+            fail(f"Issue #719 receipt missing governed MCP tool {tool}")
+    if "write calendar" not in projection.get("rejectedBroadGrantNames", []) or projection.get("containsRawProviderSecrets") is not False:
+        fail("Issue #719 receipt must reject broad grants and raw provider secrets")
+    scenario = artifact.get("eventCreationScenario", {})
+    if "lege ein Ereignis" not in str(scenario.get("prompt", "")):
+        fail("Issue #719 receipt missing German event creation prompt")
+    if scenario.get("writeTool") != "calendar.create_event" or scenario.get("readbackTool") != "calendar.search_events":
+        fail("Issue #719 receipt must create and read back via narrow calendar tools")
+    if scenario.get("approvalRequiredForWrite") is not True or scenario.get("providerMutationPerformedByMcp") is not False:
+        fail("Issue #719 receipt must require approval and avoid claiming direct provider mutation")
+    negatives = load_case_map(artifact.get("negativeCases", []), label="issue719.negativeCases")
+    for case_id in ["missing-weaver-group", "runtime-generator-disabled", "missing-calendar-editor", "broad-write-calendar-grant", "missing-approval"]:
+        if case_id not in negatives or not str(negatives[case_id].get("decision", "")).startswith("deny") or negatives[case_id].get("auditRequired") is not True:
+            fail(f"Issue #719 negative case {case_id} must deny with audit")
+    rejected = "\n".join(artifact.get("claimGate", {}).get("rejectedClaims", []))
+    for phrase in ["customer-ready", "broad write calendar", "providerMutationPerformedByMcp=true"]:
+        if phrase.lower() not in rejected.lower():
+            fail(f"Issue #719 claim gate missing rejected claim {phrase}")
+
+
 def validate_scoreboard(scoreboard: dict[str, Any]) -> None:
     if scoreboard.get("artifactKind") != "weave-weaver-runtime-sprint-25-scoreboard":
         fail("scoreboard artifact kind mismatch")
@@ -322,7 +364,8 @@ def main() -> None:
     scoreboard = load(SCOREBOARD)
     sprint32_governed = load(SPRINT32_GOVERNED)
     sprint32_mcp_execution = load(SPRINT32_MCP_EXECUTION)
-    for label, artifact in [("profile", profile), ("policy", policy), ("tools", tools), ("claims", claims), ("scoreboard", scoreboard), ("sprint32_governed", sprint32_governed), ("sprint32_mcp_execution", sprint32_mcp_execution)]:
+    issue719_e2e_receipt = load(ISSUE719_E2E_RECEIPT)
+    for label, artifact in [("profile", profile), ("policy", policy), ("tools", tools), ("claims", claims), ("scoreboard", scoreboard), ("sprint32_governed", sprint32_governed), ("sprint32_mcp_execution", sprint32_mcp_execution), ("issue719_e2e_receipt", issue719_e2e_receipt)]:
         if artifact.get("supportSafe") is not True:
             fail(f"{label} must be supportSafe")
         assert_support_safe(artifact, label)
@@ -333,8 +376,9 @@ def main() -> None:
     validate_scoreboard(scoreboard)
     validate_sprint32_governed_foundation(sprint32_governed)
     validate_sprint32_mcp_execution(sprint32_mcp_execution)
+    validate_issue719_e2e_receipt(issue719_e2e_receipt)
     validate_docs()
-    print("weaver-customization-check: ok issues=635,636,637,638,711,717 gap=719 claims=scoped governed-mcp-fixture-only customer_ready=false isolated_e2e=false")
+    print("weaver-customization-check: ok issues=635,636,637,638,711,717,719 claims=scoped governed-mcp-isolated-e2e customer_ready=false provider_mutation_by_mcp=false")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Keycloak dogfood realm/tenant mapping for the governed `weaver-group` path used by issue #719
- project Keycloak-derived calendar capabilities into scoped governed MCP tool discovery, including `calendar.create_event` approval requirements
- add support-safe #719 isolated E2E receipt validation and update evidence docs to keep fixture/live-proof claim boundaries explicit

## Evidence
- `python3 tools/weaver_customization_check.py`
- `cd server && ./gradlew test --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest' --console=plain`
- `./gradlew serverCi --console=plain`
- `./gradlew specCorpusConformance acceptanceContract --console=plain`
- `git diff --check`

Closes #719
