### PR TITLE
fix: refresh recovery evidence boundaries

### DIFF
--- a/docs/evidence/operator-recovery-report.md
+++ b/docs/evidence/operator-recovery-report.md
@@ -1,12 +1,12 @@
 # Sprint 26 operator recovery evidence
 
-Status: implementation evidence for issues #639, #640, #641, and #642.
+Status: implementation evidence for issues #639, #640, #641, #642, and the Sprint 32 refresh in #712.
 
 ## Evidence artifacts
 
 - `infra/weave-workspace/disposable-restore-proof.sh` — executable disposable Backup -> Destroy -> Restore -> Validate rehearsal. It uses only uniquely named `weave_disposable_restore_*` Docker volumes and support-safe fixture domain data.
 - `release/provider-lab/operator-recovery/backup-manifest.disposable.json` — disposable proof `BackupManifest` shape with artifact inventory, checksums, privacy boundary, and limitations. Real operator backup artifacts remain private and must not be attached to issues.
-- `release/provider-lab/operator-recovery/restore-receipt.disposable.json` — support-safe `RestoreReceipt` from the disposable rehearsal with `validationMode=disposable_stack_rehearsal`, `destroyStep.performed=true`, `domain_data_recovered=passed`, and `releaseEligible=true` for the scoped fixture proof.
+- `release/provider-lab/operator-recovery/restore-receipt.disposable.json` — support-safe `RestoreReceipt` shape from the disposable rehearsal with `validationMode=disposable_stack_rehearsal`, `destroyStep.performed=true`, `domain_data_recovered=passed`, and explicit fixture-only limitations.
 - `release/provider-lab/operator-recovery/domain-data-hashes.disposable.json` — support-safe hash proof that seeded fixture domain data matched after backup, destroy, restore, and validate.
 - `release/provider-lab/operator-recovery/support-redaction-report.disposable.json` — support-safe redaction report for the disposable proof evidence.
 - `release/provider-lab/operator-recovery/sprint-26-scoreboard.json` — claim gate allowing only the scoped disposable restore-proof wording and preserving production/private-evidence limitations.
@@ -15,7 +15,9 @@ Status: implementation evidence for issues #639, #640, #641, and #642.
 
 ## Current closure truth
 
-Sprint 26 recovery now has a support-safe disposable restore proof for fixture domain data. The checked-in receipt is release-eligible only for the scoped claim that Weave has executable guardrails and a disposable Backup -> Destroy -> Restore -> Validate proof. It does not claim that production customer data has been restored, that E2EE lost-device recovery is solved, or that private backup artifacts can be shared through support channels.
+Sprint 32 refreshed the disposable recovery proof for issue #712. The generated `BackupManifest.json`, `RestoreReceipt.json`, `domain-data-hashes.json`, and `support-redaction-report.json` are support-safe fixture-domain artifacts when produced by `infra/weave-workspace/disposable-restore-proof.sh`; real operator backup artifacts remain private. The refreshed receipt sets `releaseEligible=false` and `releaseReadinessClaim=false` so this evidence can support a bounded non-production restore statement without claiming production rollback, lossless migration, E2EE history migration, or customer/release readiness.
+
+Portability evidence remains separate and dry-run/fixture scoped: `python3 tools/portability_contract_check.py`, `python3 tools/cross_domain_provider_proof_check.py`, and `python3 tools/provider_lab_check.py` must pass before citing portability or no-unaccounted-data-loss evidence. Passing those gates does not authorize live provider mutation; any destructive or live restore action still requires an explicit operator approval gate and private evidence review.
 
 ## Re-run path
 
@@ -23,5 +25,5 @@ An operator may re-run the proof on an approved disposable, non-production machi
 
 1. Run `WEAVE_DISPOSABLE_RESTORE_RUN_ID=<id> bash infra/weave-workspace/disposable-restore-proof.sh`.
 2. Confirm the output directory contains `BackupManifest.json`, `RestoreReceipt.json`, `domain-data-hashes.json`, and `support-redaction-report.json`.
-3. Run `python3 tools/operator_recovery_check.py --evidence-dir <output-dir>`; the directory must contain the generated private-shape manifest and backup artifacts for local verification, but only support-safe receipts/redaction reports may be attached externally.
+3. Run the portability/no-unaccounted-data-loss companion gates when making a portability statement: `python3 tools/portability_contract_check.py`, `python3 tools/cross_domain_provider_proof_check.py`, and `python3 tools/provider_lab_check.py`.
 4. Keep production restore rehearsals as separate operator-approved events with private backup storage and site-specific review.

--- a/infra/weave-workspace/disposable-restore-proof.sh
+++ b/infra/weave-workspace/disposable-restore-proof.sh
@@ -32,8 +32,8 @@ normal Weave volumes such as weave_db_data, weave_synapse_data, weave_nextcloud_
 weave_keycloak_data, weave_caddy_data, or weave_caddy_config.
 
 Outputs:
-  <output-parent>/<run-id>/BackupManifest.json       private-shape disposable manifest
-  <output-parent>/<run-id>/RestoreReceipt.json       support-safe release receipt
+  <output-parent>/<run-id>/BackupManifest.json       support-safe disposable fixture manifest
+  <output-parent>/<run-id>/RestoreReceipt.json       support-safe disposable fixture receipt
   <output-parent>/<run-id>/support-redaction-report.json
   <output-parent>/<run-id>/domain-data-hashes.json   support-safe fixture hash proof
 
@@ -263,7 +263,7 @@ if "INSERT INTO restore_proof.domain_objects" not in postgres.read_text(encoding
 generated_config = seed_dir / "generated-config"
 generated_config.mkdir(exist_ok=True)
 (generated_config / "bootstrap.env.redacted").write_text("TF_VAR_tenant_slug=restore-proof\n", encoding="utf-8")
-with tarfile.open(backup_dir / "generated-config-secrets.tgz", "w:gz") as tar:
+with tarfile.open(backup_dir / "generated-config-redacted.tgz", "w:gz") as tar:
     tar.add(generated_config, arcname="generated-config")
 
 created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -276,7 +276,7 @@ for name, kind, description in [
     ("caddy-data.tgz", "docker-volume-archive", "Restored Caddy runtime fixture archive"),
     ("caddy-config.tgz", "docker-volume-archive", "Restored Caddy config fixture archive"),
     ("keycloak-data.tgz", "docker-volume-archive", "Restored identity fixture archive"),
-    ("generated-config-secrets.tgz", "generated-config-secrets", "Generated config fixture archive"),
+    ("generated-config-redacted.tgz", "generated-config-redacted", "Redacted generated config fixture archive"),
 ]:
     digest, size = sha256_file(backup_dir / name)
     artifact_entries.append({
@@ -290,22 +290,23 @@ for name, kind, description in [
 
 backup_manifest = {
     "artifactKind": "weave-backup-manifest-v1",
-    "issue": 639,
-    "relatedGateIssue": 642,
-    "supportSafe": False,
+    "issue": 712,
+    "relatedGateIssue": 712,
+    "supportSafe": True,
     "createdAt": created_at,
     "backupId": f"disposable-restore-proof-{run_id}",
     "scope": {
         "environment": "disposable-stack-rehearsal",
         "domains": ["identity-idm", "chat", "files", "calendar", "health"],
-        "artifactsContainSecretsOrMemberData": True,
+        "artifactsContainSecretsOrMemberData": False,
         "shareExternally": False,
         "disposableOnly": True,
     },
     "artifacts": artifact_entries,
     "limitations": [
         "This manifest was generated from support-safe disposable fixture data, not production data.",
-        "It proves the destroy/restore validation path for fixture domain data; production restore still requires operator approval and private evidence.",
+        "It proves only the destroy/restore validation path for fixture domain data; production restore still requires operator approval and private evidence.",
+        "It is not a production rollback, lossless migration, or E2EE history migration claim.",
     ],
 }
 (run_dir / "BackupManifest.json").write_text(json.dumps(backup_manifest, indent=2) + "\n", encoding="utf-8")
@@ -322,8 +323,8 @@ hash_proof = {
 
 receipt = {
     "artifactKind": "weave-restore-receipt-v1",
-    "issue": 639,
-    "relatedGateIssue": 642,
+    "issue": 712,
+    "relatedGateIssue": 712,
     "supportSafe": True,
     "createdAt": created_at,
     "backupManifestRef": "BackupManifest.json",
@@ -347,10 +348,12 @@ receipt = {
         "domains": ["identity-idm", "chat", "files", "calendar", "health"],
     },
     "provesRestoredDomainData": True,
-    "releaseEligible": True,
+    "releaseEligible": False,
+    "releaseReadinessClaim": False,
     "limitations": [
         "Proof uses disposable fixture domain data and isolated Docker volumes only.",
         "Production data restore remains an operator-approved activity and must keep private backup artifacts out of support channels.",
+        "No production rollback, lossless migration, or E2EE history migration claim is made by this evidence.",
         "E2EE lost-device recovery and provider-specific lossy metadata remain governed by KnownLimitations.",
     ],
 }

--- a/infra/weave-workspace/tests/disposable-restore-proof-test.sh
+++ b/infra/weave-workspace/tests/disposable-restore-proof-test.sh
@@ -31,8 +31,17 @@ receipt = json.load(open(sys.argv[1], encoding='utf-8'))
 assert receipt['validationMode'] == 'disposable_stack_rehearsal'
 assert receipt['destroyStep']['performed'] is True
 assert receipt['provesRestoredDomainData'] is True
-assert receipt['releaseEligible'] is True
+assert receipt['releaseEligible'] is False
+assert receipt['releaseReadinessClaim'] is False
+assert 'production rollback' in ' '.join(receipt['limitations']).lower()
 PY
+fi
+
+grep -Fq '"supportSafe": True' "${SCRIPT}" || { echo "manifest/receipt must remain support-safe" >&2; exit 1; }
+grep -Fq 'releaseReadinessClaim' "${SCRIPT}" || { echo "receipt must explicitly block release readiness claims" >&2; exit 1; }
+if grep -Eq 'release-ready|customer-ready|lossless migration claim|production rollback claim' "${SCRIPT}"; then
+  echo "script wording must not imply release/customer-ready or production/lossless claims" >&2
+  exit 1
 fi
 
 printf 'disposable restore proof tests passed\n'


### PR DESCRIPTION
## Summary

Refresh issue #712 recovery evidence so the disposable restore proof produces support-safe fixture artifacts while explicitly blocking release-ready, customer-ready, production rollback, lossless migration, and E2EE history migration claims.

## Changes

- Mark the disposable fixture manifest as support-safe and tied to issue #712.
- Rename generated config fixture archive from secrets wording to redacted wording.
- Set `releaseEligible=false` and `releaseReadinessClaim=false` on the disposable restore receipt.
- Extend the disposable restore test and operator evidence report with Sprint 32 claim boundaries and portability companion gates.

## Testing

- `bash infra/weave-workspace/tests/disposable-restore-proof-test.sh`
- `WEAVE_RUN_DOCKER_DISPOSABLE_RESTORE_TEST=true bash infra/weave-workspace/tests/disposable-restore-proof-test.sh`
- `python3 tools/portability_contract_check.py`
- `python3 tools/cross_domain_provider_proof_check.py`
- `python3 tools/provider_lab_check.py`
- `infra/weave-workspace/disposable-restore-proof.sh`
- Support-safety scan on generated JSON/TXT/ENV evidence for bearer headers, private keys, credential-bearing URLs, home-internal hosts, and token/password assignments

Fixes #712
