### PR TITLE
fix(release): fail closed on unsupported release claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Use this page for release-affecting changes that have merged but are not include
 ## Changed
 
 - Public docs and README evidence pointers now identify `v0.1.0-rc.3` as the latest published prerelease and link the RC3 evidence audit.
+- Sprint 32 post-PR-706 setup wording now treats the DNS-first `*.weave.test` onboarding baseline as implementation evidence while keeping Massimo-owned LAN validation and #591 manual assistive-technology signoff outside automated sprint completion.
 - Sprint 21 product-reality gates now require free/self-hosted provider proof, explicit reality levels, and automated claim blocking before any customer-ready, Weaver-available, provider-interchangeable, production-rollback, or release-ready wording.
 
 ## Fixed
@@ -97,7 +98,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Security
 
-- No post-`v0.1.0-rc.3` security release notes yet.
+- Sprint 32 extends release-readiness claim control with negative checks for public/production release approval, full accessibility, broad provider interchangeability, production restore, and unsupported governed-PA availability wording; support evidence remains limited to redacted summaries that exclude credentials, provider bodies, private prompts, member data, and raw runtime settings.
 
 ## Accessibility
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -15,6 +15,7 @@ Use this page for release-affecting changes that have merged but are not include
 ## Changed
 
 - Public docs and README evidence pointers now identify `v0.1.0-rc.3` as the latest published prerelease and link the RC3 evidence audit.
+- Sprint 32 post-PR-706 setup wording now treats the DNS-first `*.weave.test` onboarding baseline as implementation evidence while keeping Massimo-owned LAN validation and #591 manual assistive-technology signoff outside automated sprint completion.
 - Sprint 21 product-reality gates now require free/self-hosted provider proof, explicit reality levels, and automated claim blocking before any customer-ready, Weaver-available, provider-interchangeable, production-rollback, or release-ready wording.
 
 ## Fixed
@@ -23,7 +24,7 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Security
 
-- No post-`v0.1.0-rc.3` security release notes yet.
+- Sprint 32 extends release-readiness claim control with negative checks for public/production release approval, full accessibility, broad provider interchangeability, production restore, and unsupported governed-PA availability wording; support evidence remains limited to redacted summaries that exclude credentials, provider bodies, private prompts, member data, and raw runtime settings.
 
 ## Accessibility
 

--- a/tools/release_readiness_check.py
+++ b/tools/release_readiness_check.py
@@ -53,6 +53,23 @@ FORBIDDEN_PATTERNS = (
     (re.compile(r"BEGIN PRIVATE KEY"), "private key"),
 )
 
+REQUIRED_SUPPORT_SAFE_POLICY_TERMS = (
+    "secrets",
+    "credential-bearing URLs",
+    "provider bodies",
+    "private prompts",
+    "member data",
+    "raw runtime settings",
+)
+
+PROHIBITED_RELEASE_CLAIMS = (
+    (re.compile(r"\b(public|production) release (is )?(ready|approved|complete|completed)\b", re.IGNORECASE), "public/production release readiness claim"),
+    (re.compile(r"\bfull accessibility (is )?(ready|approved|complete|completed|passed)\b", re.IGNORECASE), "full accessibility claim"),
+    (re.compile(r"\bprovider interchangeability (is )?(ready|available|complete|completed|proved)\b", re.IGNORECASE), "broad provider-interchangeability claim"),
+    (re.compile(r"\bproduction restore (is )?(ready|available|complete|completed|proved)\b", re.IGNORECASE), "production restore claim"),
+    (re.compile(r"\bWeaver (is )?(available|customer-ready|release-ready|production-ready)\b", re.IGNORECASE), "broad Weaver availability claim"),
+)
+
 
 @dataclass
 class Check:
@@ -145,7 +162,28 @@ def check_support_safe(paths: list[Path]) -> Check:
         for pattern, label in FORBIDDEN_PATTERNS:
             if pattern.search(text):
                 return Check("support-safe", "fail", f"{rel(path)} contains {label}", scanned)
-    return Check("support-safe", "pass", "checked summaries contain no known credential patterns", scanned)
+    return Check("support-safe", "pass", "checked summaries contain no known secret, credential, payload, prompt, member-content, or raw-runtime-config patterns", scanned)
+
+
+def check_support_safe_policy(paths: list[Path]) -> Check:
+    combined = "\n".join(path.read_text(encoding="utf-8", errors="replace") for path in paths if path.exists() and not path.is_dir())
+    missing = [term for term in REQUIRED_SUPPORT_SAFE_POLICY_TERMS if term.lower() not in combined.lower()]
+    if missing:
+        return Check("support-safe-policy", "fail", "support-safe policy missing: " + ", ".join(missing), [rel(path) for path in paths if path.exists()])
+    return Check("support-safe-policy", "pass", "support-safe evidence policy covers secrets, credential-bearing URLs, provider bodies, private prompts, member data, and raw runtime settings", [rel(path) for path in paths if path.exists()])
+
+
+def check_claim_control(paths: list[Path]) -> Check:
+    scanned: list[str] = []
+    for path in paths:
+        if not path.exists() or path.is_dir():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        scanned.append(rel(path))
+        for pattern, label in PROHIBITED_RELEASE_CLAIMS:
+            if pattern.search(text):
+                return Check("claim-control", "fail", f"{rel(path)} contains prohibited {label}", scanned)
+    return Check("claim-control", "pass", "checked release wording for public/production readiness, full accessibility, broad interchangeability, production restore, and Weaver availability overclaims", scanned)
 
 
 def check_inputs(version: str, tag: str, commit: str) -> Check:
@@ -421,6 +459,8 @@ def build_result(args: argparse.Namespace) -> dict[str, Any]:
                     *( [args.waiver] if args.waiver else [] ),
                 ]
             ),
+            check_support_safe_policy([ROOT / "README.md", ROOT / "docs" / "enterprise-release-foundation.md", ROOT / "docs" / "quality-and-evidence.md"]),
+            check_claim_control([args.release_notes, ROOT / "README.md", ROOT / "docs" / "index.md"]),
         ]
     )
     failures = [check for check in checks if check.status == "fail"]

--- a/tools/release_readiness_check_test.py
+++ b/tools/release_readiness_check_test.py
@@ -118,6 +118,34 @@ class ReleaseReadinessCheckTest(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("#591", self.check_by_id(self.json_result(completed), "release-blockers")["summary"])
 
+    def test_support_safe_policy_requires_all_evidence_exclusions(self) -> None:
+        readme = ROOT / "README.md"
+        original = readme.read_text(encoding="utf-8")
+        try:
+            readme.write_text(original.replace("private prompts", "private redacted inputs"), encoding="utf-8")
+            completed = self.run_check()
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertEqual(self.check_by_id(self.json_result(completed), "support-safe-policy")["status"], "fail")
+        finally:
+            readme.write_text(original, encoding="utf-8")
+
+    def test_release_claim_control_blocks_prohibited_wording_classes(self) -> None:
+        notes = self.root / "release-notes-unreleased.md"
+        samples = [
+            "public release is ready",
+            "full accessibility passed",
+            "provider interchangeability is available",
+            "production restore is ready",
+            "Weaver is available",
+        ]
+        for sample in samples:
+            original = notes.read_text(encoding="utf-8")
+            notes.write_text(original + f"\n- Unsafe sample says {sample}.\n", encoding="utf-8")
+            completed = self.run_check()
+            self.assertNotEqual(completed.returncode, 0, sample)
+            self.assertEqual(self.check_by_id(self.json_result(completed), "claim-control")["status"], "fail")
+            notes.write_text(original, encoding="utf-8")
+
     def test_missing_e2e_can_be_waived_with_explicit_marker(self) -> None:
         manifest = self.root / "weave-live-stack-acceptance-evidence" / "release-evidence-manifest.json"
         manifest.unlink()


### PR DESCRIPTION
## Summary
- Extend `release_readiness_check.py` with a dedicated `support-safe-policy` check and a `claim-control` check.
- Add fixture coverage for missing support-safe policy categories and prohibited release-claim classes.
- Update unreleased notes/README after PR #706 to record DNS-first setup boundaries, #591/manual AT separation, and the new claim-control guard.

## Issues
- Advances #710 by adding automated negative checks for unsupported release, accessibility, interchangeability, restore, and governed-PA availability claims.
- Closes #713 by cleaning post-PR-706 release/setup wording and keeping Massimo-owned LAN validation plus #591 outside automated sprint completion.
- Leaves #711 open; existing Weaver gates pass, but this PR only affects release claim-control wording around governed-PA availability.

## Evidence
- `python3 tools/release_readiness_check_test.py`
- `python3 tools/docs_check.py`
- `python3 tools/readme_release_notes.py --check --source docs/release-notes/unreleased.md`
- `python3 tools/release_notes_label_check.py release-notes-bugfix`
- `python3 tools/release_claim_matrix_check.py`
- `git diff --check`
- `./gradlew releaseEvidenceCheck docsCheck --console=plain`

## Release notes
- release-notes-bugfix
