### PR TITLE
feat: add sovereign Weaver MCP foundation

### DIFF
--- a/admin-console/src/api.ts
+++ b/admin-console/src/api.ts
@@ -223,8 +223,13 @@ export interface SuiteDomainReadiness {
   capabilityStates: string[];
   supportSafeErrors: string[];
   portabilityNotes: string[];
+  jurisdictionExposureNotes: string[];
   auditRefs: string[];
   nextAction: string;
+  exposureDescriptor: string;
+  portabilityContractRef: string;
+  auditRequirement: string;
+  weaverMode: string;
   backendOwnedFacade: boolean;
   providerMappingOwnedByServer: boolean;
   rawProviderConfigExposedToMembers: boolean;
@@ -582,8 +587,13 @@ interface ServerSuiteDomainReadiness {
   capabilityStates?: string[];
   supportSafeErrors?: string[];
   portabilityNotes?: string[];
+  jurisdictionExposureNotes?: string[];
   auditRefs?: string[];
   nextAction?: string;
+  exposureDescriptor?: string;
+  portabilityContractRef?: string;
+  auditRequirement?: string;
+  weaverMode?: string;
   backendOwnedFacade?: boolean;
   providerMappingOwnedByServer?: boolean;
   rawProviderConfigExposedToMembers?: boolean;
@@ -1002,10 +1012,23 @@ function normalizeSuiteDomainReadiness(
       "support-safe-errors-required",
     ],
     portabilityNotes: domain.portabilityNotes ?? [],
+    jurisdictionExposureNotes: domain.jurisdictionExposureNotes ?? [
+      "provider/jurisdiction exposure visible to admins only",
+    ],
     auditRefs: domain.auditRefs ?? [],
     nextAction:
       domain.nextAction ??
       "Resolve backend readiness evidence before member go-live.",
+    exposureDescriptor:
+      domain.exposureDescriptor ??
+      "provider and jurisdiction exposure visible; raw diagnostics redacted",
+    portabilityContractRef:
+      domain.portabilityContractRef ??
+      "export/import/lossy/conflict/rollback reports required",
+    auditRequirement:
+      domain.auditRequirement ??
+      "support-safe audit required for readiness and Weaver decisions",
+    weaverMode: domain.weaverMode ?? "model_first_read_only_governed",
     backendOwnedFacade: domain.backendOwnedFacade ?? true,
     providerMappingOwnedByServer: domain.providerMappingOwnedByServer ?? true,
     rawProviderConfigExposedToMembers:
@@ -1577,7 +1600,12 @@ const sampleSuiteDomainReadiness: SuiteDomainReadiness[] = [
       "Export manifests required before provider replacement",
       "Credential-bearing editor URLs remain blocked from support views",
     ],
+    jurisdictionExposureNotes: ["selected adapters may carry provider and subprocessor jurisdiction exposure"],
     auditRefs: ["receipt://suite/files-docs/readiness"],
+    exposureDescriptor: "provider and jurisdiction exposure visible; raw diagnostics redacted",
+    portabilityContractRef: "export/import/lossy/conflict/rollback reports required",
+    auditRequirement: "support-safe audit required for readiness and Weaver decisions",
+    weaverMode: "model_first_read_only_governed",
     nextAction:
       "Confirm checksum, permission, and editor-launch evidence before member writes.",
     backendOwnedFacade: true,
@@ -1602,7 +1630,12 @@ const sampleSuiteDomainReadiness: SuiteDomainReadiness[] = [
     portabilityNotes: [
       "Lossy mapping and conflict reports are required before provider-write apply",
     ],
+    jurisdictionExposureNotes: ["selected adapters may carry provider and subprocessor jurisdiction exposure"],
     auditRefs: ["receipt://suite/boards-tasks/readiness"],
+    exposureDescriptor: "provider and jurisdiction exposure visible; raw diagnostics redacted",
+    portabilityContractRef: "export/import/lossy/conflict/rollback reports required",
+    auditRequirement: "support-safe audit required for readiness and Weaver decisions",
+    weaverMode: "model_first_read_only_governed",
     nextAction:
       "Verify keyboard task flows, conflict states, and audit events before writes.",
     backendOwnedFacade: true,
@@ -1627,7 +1660,12 @@ const sampleSuiteDomainReadiness: SuiteDomainReadiness[] = [
     portabilityNotes: [
       "Private calendar ingestion and credential profile downloads are out of scope",
     ],
+    jurisdictionExposureNotes: ["selected adapters may carry provider and subprocessor jurisdiction exposure"],
     auditRefs: ["receipt://suite/calendar-meetings/readiness"],
+    exposureDescriptor: "provider and jurisdiction exposure visible; raw diagnostics redacted",
+    portabilityContractRef: "export/import/lossy/conflict/rollback reports required",
+    auditRequirement: "support-safe audit required for readiness and Weaver decisions",
+    weaverMode: "model_first_read_only_governed",
     nextAction:
       "Confirm workspace/team/channel event readiness and private-calendar blockers.",
     backendOwnedFacade: true,

--- a/docs/sovereign-domain-mcp-weaver-foundation.md
+++ b/docs/sovereign-domain-mcp-weaver-foundation.md
@@ -1,0 +1,19 @@
+# Sovereign domain, MCP, and Weaver foundation
+
+This foundation keeps Weave's domain contracts product-owned and provider-neutral. It is precise claim-control evidence, not a public readiness claim.
+
+## Wave 1 governed facades
+
+Wave 1 represents these read-only/model-first tools in the Weaver registry: `model.chat`, `identity.read`, `registry.tools.read`, `audit.query`, `files.read`, `calendar.read`, `contacts.read`, `chat.read`, `tasks.read`, and `search.query`.
+
+Unknown tools, provider-raw tools, overbroad grants, revoked/unsigned/mismatched runtime profiles, expired runtime tokens, and write-like tools without a valid `ApprovalReceipt` fail closed before provider access.
+
+## Control Room posture
+
+Admin Control Room suite-domain readiness rows expose support-safe posture only: adapter posture, provider/jurisdiction exposure descriptor, portability contract reference, audit requirement, and Weaver mode. Member surfaces must receive member-safe states and never raw provider config, credential values, raw diagnostics, secrets, or raw runtime internals.
+
+## Claim boundaries
+
+Allowed wording: Weave makes provider and jurisdiction exposure visible, reduces dependency on single-vendor stacks, and preserves portability evidence through export/import/lossy/conflict/rollback reports.
+
+Forbidden wording: Cloud-Act-proof, fully sovereign, legally sovereign, compliance certified, public/customer-ready, full accessibility, broad Weaver availability, or autonomous PA availability. Public/final/full accessibility claims remain blocked by #591 until manual assistive-technology evidence is complete.

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/SuiteDomainReadinessResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/SuiteDomainReadinessResponse.java
@@ -17,8 +17,13 @@ public record SuiteDomainReadinessResponse(
         List<String> capabilityStates,
         List<String> supportSafeErrors,
         List<String> portabilityNotes,
+        List<String> jurisdictionExposureNotes,
         List<String> auditRefs,
         String nextAction,
+        String exposureDescriptor,
+        String portabilityContractRef,
+        String auditRequirement,
+        String weaverMode,
         boolean backendOwnedFacade,
         boolean providerMappingOwnedByServer,
         boolean rawProviderConfigExposedToMembers,
@@ -29,6 +34,7 @@ public record SuiteDomainReadinessResponse(
         capabilityStates = capabilityStates == null ? List.of() : List.copyOf(capabilityStates);
         supportSafeErrors = supportSafeErrors == null ? List.of() : List.copyOf(supportSafeErrors);
         portabilityNotes = portabilityNotes == null ? List.of() : List.copyOf(portabilityNotes);
+        jurisdictionExposureNotes = jurisdictionExposureNotes == null ? List.of() : List.copyOf(jurisdictionExposureNotes);
         auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
         evidence = evidence == null ? Map.of() : Map.copyOf(evidence);
     }

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -1533,8 +1533,13 @@ public class AdminControlPlaneService {
                 Stream.concat(definition.readCapabilities().stream(), definition.writeCapabilities().stream()).toList(),
                 List.of("support-safe-error-codes-only", "raw-provider-bodies-redacted", "credential-bearing-urls-blocked"),
                 portabilityNotes,
+                List.of("provider jurisdiction is visible as procurement-risk metadata", "do not claim Cloud-Act-proof or legally sovereign posture"),
                 List.of("audit://suite/" + definition.domain() + "/readiness"),
                 nextAction,
+                "provider and jurisdiction exposure visible; raw diagnostics redacted",
+                "export/import/lossy/conflict/rollback reports required before provider replacement",
+                "support-safe audit event required for readiness, policy, export, import, and Weaver access decisions",
+                "model_first_read_only_governed",
                 true,
                 true,
                 false,
@@ -1542,7 +1547,9 @@ public class AdminControlPlaneService {
                         "providerCategoryCount", definition.providerCategoryKeys().size(),
                         "supportSafe", true,
                         "rawProviderConfigReturned", false,
-                        "memberProviderSetupControlsReturned", false));
+                        "memberProviderSetupControlsReturned", false,
+                        "exposureDescriptor", "provider and jurisdiction exposure visible; raw diagnostics redacted",
+                        "weaverMode", "model_first_read_only_governed"));
     }
 
     private String aggregateDomainReadiness(List<String> states) {

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -204,6 +204,16 @@ public class WeaverToolRegistry {
 
     private Map<String, WeaverDomainToolDefinition> initialDefinitions() {
         Map<String, WeaverDomainToolDefinition> registry = new LinkedHashMap<>();
+        add(registry, tool("model.chat", "weaver", WeaverToolMode.READ, "weaver.model_chat", WeaverApprovalRequirement.NONE));
+        add(registry, tool("identity.read", "identity", WeaverToolMode.READ, "weaver.identity_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("registry.tools.read", "weaver", WeaverToolMode.READ, "weaver.registry_tools_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("audit.query", "health", WeaverToolMode.READ, "weaver.audit_query", WeaverApprovalRequirement.NONE));
+        add(registry, tool("files.read", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("calendar.read", "calendar-events", WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("contacts.read", "people", WeaverToolMode.READ, "weaver.contacts_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("chat.read", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("tasks.read", "boards-tasks", WeaverToolMode.READ, "weaver.tasks_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("search.query", "weave-search", WeaverToolMode.READ, "weaver.search_query", WeaverApprovalRequirement.NONE));
         add(registry, tool("calendar.search_events", "calendar-events", WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("boards.search_tasks", "boards-tasks", WeaverToolMode.READ, "weaver.boards_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("files.search", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -19,10 +19,10 @@ class WeaverToolRegistryTest {
         var tools = registry.discover(List.of("weaver.files_read", "weaver.boards_write"));
 
         assertThat(tools).extracting(WeaverDomainToolDefinition::name)
-                .containsExactly("files.search", "boards.comment");
+                .containsExactly("files.read", "files.search", "boards.comment");
         assertThat(tools).extracting(WeaverDomainToolDefinition::version).containsOnly("v1");
         assertThat(tools).extracting(WeaverDomainToolDefinition::requiredCapability)
-                .containsExactly("weaver.files_read", "weaver.boards_write");
+                .containsExactly("weaver.files_read", "weaver.files_read", "weaver.boards_write");
         assertThat(tools).allSatisfy(tool -> {
             assertThat(tool.name()).contains(".");
             assertThat(tool.inputSchema()).containsEntry("additionalProperties", false);
@@ -175,6 +175,59 @@ class WeaverToolRegistryTest {
         assertThat(result.status()).isEqualTo("scoped_grant_missing");
         assertThat(result.redactedResult()).containsEntry("auditRef", "audit://weaver-tool/boards.comment/scoped_grant_missing");
         assertThat(audit.events().get(0).payload()).containsEntry("decision", "scoped_grant_missing");
+    }
+
+    @Test
+    void exposesWaveOneReadOnlyMcpFacadeToolsAndFailsClosedForUnknownTools() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverToolRegistry registry = new WeaverToolRegistry(audit);
+
+        var tools = registry.discover(List.of(
+                "weaver.model_chat",
+                "weaver.identity_read",
+                "weaver.registry_tools_read",
+                "weaver.audit_query",
+                "weaver.files_read",
+                "weaver.calendar_read",
+                "weaver.contacts_read",
+                "weaver.chat_read",
+                "weaver.tasks_read",
+                "weaver.search_query"));
+
+        assertThat(tools).extracting(WeaverDomainToolDefinition::name).contains(
+                "model.chat",
+                "identity.read",
+                "registry.tools.read",
+                "audit.query",
+                "files.read",
+                "calendar.read",
+                "contacts.read",
+                "chat.read",
+                "tasks.read",
+                "search.query");
+        assertThat(tools.stream().filter(tool -> tool.name().endsWith(".read") || tool.name().equals("model.chat") || tool.name().equals("audit.query") || tool.name().equals("search.query")))
+                .allSatisfy(tool -> {
+                    assertThat(tool.mode()).isEqualTo(WeaverToolMode.READ);
+                    assertThat(tool.approvalRequirement()).isEqualTo(WeaverApprovalRequirement.NONE);
+                });
+
+        var unknown = registry.invoke(new WeaverToolInvocationRequest(
+                "raw.unknown",
+                "user:abc123",
+                "sha256:unknown000000000000000000000000000000000000000000000000",
+                "user:abc123",
+                signature(),
+                false,
+                future(),
+                true,
+                List.of("weaver.raw_read"),
+                List.of("raw.unknown"),
+                Map.of("prompt", "do not leak"),
+                null));
+
+        assertThat(unknown.status()).isEqualTo("blocked");
+        assertThat(unknown.supportSafeMessage()).doesNotContain("do not leak");
+        assertThat(audit.events().get(0).payload()).containsEntry("reason", "not_granted");
     }
 
     private WeaverToolInvocationRequest governedRequest(

--- a/tools/product_trust_claim_matrix_check.py
+++ b/tools/product_trust_claim_matrix_check.py
@@ -46,7 +46,14 @@ FORBIDDEN_UNQUALIFIED_CLAIMS = [
     "guaranteed compliant",
     "legally sovereign",
     "compliant by default",
+    "fully sovereign",
+    "compliance certified",
+    "public/customer-ready",
+    "full accessibility",
+    "broad Weaver availability",
 ]
+
+SOVEREIGN_FOUNDATION = ROOT / "docs" / "sovereign-domain-mcp-weaver-foundation.md"
 
 STALE_PENDING_PHRASES = [
     "Matrix fixtures still pending",
@@ -81,9 +88,21 @@ def main() -> None:
     for stale in STALE_PENDING_PHRASES:
         if stale in text:
             fail(f"claim matrix still carries stale pending phrase: {stale}")
+    foundation = SOVEREIGN_FOUNDATION.read_text(encoding="utf-8") if SOVEREIGN_FOUNDATION.exists() else ""
+    combined = text + "\n" + foundation
     for forbidden in FORBIDDEN_UNQUALIFIED_CLAIMS:
-        if forbidden not in text:
-            fail(f"claim matrix must explicitly forbid overclaim phrase: {forbidden}")
+        if forbidden not in combined:
+            fail(f"claim controls must explicitly forbid overclaim phrase: {forbidden}")
+    for phrase in [
+        "provider and jurisdiction exposure visible",
+        "reduces dependency on single-vendor stacks",
+        "Cloud-Act-proof",
+        "#591",
+        "model.chat",
+        "write-like tools without a valid `ApprovalReceipt` fail closed",
+    ]:
+        if phrase not in combined:
+            fail(f"sovereign foundation claim control missing phrase: {phrase}")
 
     lossless_pattern = re.compile(r"\|[^\n]*(lossless|Lossless)[^\n]*\|[^\n]*\*\*(Ready|Usable)", re.IGNORECASE)
     if lossless_pattern.search(text):


### PR DESCRIPTION
## Summary

Implements a compact sovereign Weave/Weaver foundation slice across the new issue set:

- Adds Wave 1 governed read-only/model-first Weaver MCP facade tool definitions for `model.chat`, `identity.read`, `registry.tools.read`, `audit.query`, `files.read`, `calendar.read`, `contacts.read`, `chat.read`, `tasks.read`, and `search.query`.
- Keeps unknown/provider-raw tools, overbroad grants, unsigned/revoked/expired/mismatched profiles, and write-like tools without `ApprovalReceipt` fail-closed.
- Extends Admin Control Room suite-domain readiness API/sample normalization with provider/jurisdiction exposure notes, portability contract, audit requirement, and Weaver mode fields.
- Adds cautious sovereign foundation claim-control documentation and extends claim matrix checks for prohibited wording classes and #591/public-accessibility boundary.

Closes: #744
Refs: #743, #711, #708, #710, #591

## Evidence

- `cd server && ./gradlew test --tests 'com.massimotter.weave.backend.weaver.WeaverToolRegistryTest' --tests 'com.massimotter.weave.backend.service.AdminControlPlaneServiceTest' --console=plain`
- `python3 tools/domain_registry_check.py`
- `python3 tools/product_trust_claim_matrix_check.py`
- `./gradlew acceptanceContract docsCheck releaseEvidenceCheck --console=plain`
- `cd admin-console && npm test -- --run`
- `git diff --check`

## Claim boundaries

This PR does not claim Cloud-Act-proof, fully sovereign, compliance certified, public/customer-ready, full accessibility, broad Weaver availability, autonomous PA availability, live provider proof, or closure of #591.
