### PR TITLE
docs: lock sovereign domain contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,74 +2,30 @@
 
 **Weave – Collaboration Seamlessly Woven with Agentic AI, Activated on Your Terms.**
 
+Provider-neutral collaboration with explicit control over data, adapters, and governed AI assistance.
 
 <p align="center">
   <img src="client/assets/images/weave_logo.png" alt="Weave logo, an interlaced blue and teal knot" width="220">
 </p>
 
-**Weave is a provider-neutral organization suite with an admin/operator control plane.** Weave lets organizations own their collaboration layer: one Weave-owned product layer for collaboration, readiness, policy, evidence, and future governed assistance while keeping concrete providers behind adapters.
+Weave is a sovereign-by-design collaboration product line. It gives an organization one Weave-owned layer for member collaboration, admin readiness, policy, audit, support evidence, portability, and future governed personal assistance while concrete providers stay behind adapters.
 
-Weave is not a re-skinned Matrix, Nextcloud, Microsoft 365, Slack, Jira, or AI-agent bundle. Providers are implementation choices. Members use Weave product surfaces. Admins and operators control setup, provider binding, policy, readiness, audit, support evidence, and migration boundaries.
-
-## Product line
-
-- **Weave Control / `weavectl`** is for owners, admins, and operators. It owns organization bootstrap, deploy-new / attach-existing / hybrid setup, CI/CD target binding, approved dispatch, readiness, diagnostics, support bundles, and evidence.
-- **Weave Server** is the separately deployable Java domain facade. It owns policy, provider registry, capability states, authorization, audit, SecretRef/CredentialRef handling, readiness, and support-safe errors.
-- **Weave App** is for members and guests. Members join through an organization URL, invite link, deep link, or SSO and then see Weave capabilities, not raw provider setup.
-- **Weaver** is the future optional governed PA line. It is disabled by default and must stay behind organization policy, user opt-in where required, tool allowlists, sandboxing, approval receipts, revocation, and audit.
-
-## Bootstrap foundation
-
-The product goal is a customer-simple, reproducible bootstrap path. The canonical contract is [Bootstrap foundation](docs/bootstrap-foundation-contract.md).
-
-Target operator UX:
-
-```bash
-tools/weavectl bootstrap plan --profile <profile> --target <provider-lane>
-tools/weavectl bootstrap apply --plan <plan-ref>
-```
-
-`bootstrap plan` reads the stable profile fixture and rejects targets that are not allowed for the selected profile. `bootstrap apply` is dry-run/validate-only unless the operator explicitly adds `--execute --approval-ref <approval-ref>`; `--dry-run` is available for explicit no-mutation CI/operator checks. For the local shell lane this dispatches the existing `infra/weave-workspace/install.sh` executor; other lanes remain support-safe plan artifacts until their adapter proves mutation dispatch.
-
-`Control Plane = Weave Server + Admin Console`. Bootstrap deploys that Control Plane through the selected lane, then optionally deploys or attaches a Provider Stack according to the chosen profile. The Flutter/member client is not deployed by bootstrap; it consumes the organization URL, invite link, or deep link emitted by the handoff.
-
-Setup modes remain per-domain:
-
-- `deploy_new`: Weave provisions approved resources named in the plan.
-- `attach_existing`: Weave binds existing customer systems without redeploying them.
-- `hybrid`: some domains are new, some are attached.
-
-Normal members must not configure raw OIDC clients, provider URLs, service endpoints, CI/CD targets, Matrix/Nextcloud/OpenProject/LiveKit internals, SecretRefs, bootstrap diagnostics, backup/restore, or provider readiness.
-
-Primary contracts:
-
-- [Bootstrap foundation](docs/bootstrap-foundation-contract.md)
-- [Weave Control bootstrap-to-client contract](docs/weave-control-bootstrap-to-client-contract.md)
-- [Admin-provisioned first use](docs/admin-provisioned-first-use.md)
-- [Admin-Suite readiness and setup contract](docs/admin-suite-readiness-setup-contract.md)
-- [Control-plane infra bootstrap](docs/control-plane-infra-bootstrap.md)
+Weave does not claim to be Cloud-Act-proof, compliance-certified, fully sovereign, broadly public-production-ready, or fully accessible. It makes provider and jurisdiction exposure visible and requires evidence before stronger claims or migrations are promoted.
 
 ## Product architecture
 
-Weave keeps product domains separate from provider implementations.
+Weave separates stable domains from replaceable adapters. Members see Weave capabilities; admins and operators bind providers, readiness, diagnostics, policy, approvals, support bundles, and evidence.
 
-- Members use Weave domains: identity, people, spaces, chat, files, documents, calendar, boards, calls, decisions, notifications, health, and future Weaver.
-- Weave Server owns provider mapping, readiness, authorization, audit, migration evidence, SecretRefs, and support-safe error boundaries.
-- Weave Control exposes selected adapters, readiness, diagnostics, policy, approval, dispatch, backup/restore, and evidence.
-- Weave App exposes provider-neutral states such as `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, or `coming_later`.
-- Provider-specific raw errors, secrets, tenant URLs, logs, and diagnostics stay admin/operator-only and redacted.
+- **Weave App** — member and guest collaboration surfaces.
+- **Weave Server** — Java domain facade for policy, authorization, provider registry, capability states, audit, support-safe errors, and portability boundaries.
+- **Weave Control / `weavectl`** — setup, deploy-new / attach-existing / hybrid binding, readiness, diagnostics, approvals, and support evidence.
+- **Weaver** — future optional governed personal-assistant runtime, disabled by default and fenced by policy, opt-in where required, allowlists, sandboxing, approval receipts, revocation, and audit.
 
-Architecture docs:
-
-- [Architecture](docs/architecture.md)
-- [Canonical domains](docs/architecture/canonical-domains.md)
-- [Canonical feature models](docs/canonical-feature-models.md)
-- [Provider portability contract](docs/architecture/provider-portability.md)
-- [Diagrams](docs/diagrams/index.md)
+Start with [Sovereign domain contracts](docs/sovereign-domain-contracts.md), [Canonical domain registry](docs/domain-registry-v1.md), [Architecture](docs/architecture.md), and [Provider portability](docs/architecture/provider-portability.md).
 
 ## Release notes
 
-The managed block below is the README-facing draft of merged changes after the latest tagged prerelease. Published notes live in [v0.1 release notes](docs/release-notes/v0.1.md), with the audit in [v0.1.0-rc.3 release evidence](docs/release-v0.1-rc3-evidence.md). Maintainers update this block with checked-in release-note tooling; do not edit inside the markers by hand.
+Published notes live in [v0.1 release notes](docs/release-notes/v0.1.md), with the audit in [v0.1.0-rc.3 release evidence](docs/release-v0.1-rc3-evidence.md). Maintainers update the managed block below with checked-in release-note tooling.
 
 <!-- WEAVE_RELEASE_NOTES_START -->
 _Generated release notes are review artifacts. A release maintainer may update this block with `python3 tools/readme_release_notes.py --update --source <generated-notes>` before opening the release-draft review._
@@ -119,131 +75,58 @@ Use this page for release-affecting changes that have merged but are not include
 
 ## Product screenshots
 
-Screenshots are deterministic, checked-in assets for current dogfood-ready product paths. They show Weave-owned surfaces and must not imply that guarded or roadmap capabilities are shipped.
+Screenshots are deterministic, checked-in assets for current dogfood-ready product paths and must not imply guarded capabilities are shipped.
 
-- [Setup start](docs/assets/marketing/01-setup-start.svg) — admin-provisioned setup starts before normal member join.
-- [Custom Weave chat](docs/assets/marketing/03-chat-room.svg) — chat is a Weave product experience backed by the selected chat adapter.
-- [Files and documents](docs/assets/marketing/04-files-documents.svg) — files use Weave-owned routes and backend facades.
-- [Settings and readiness](docs/assets/marketing/05-settings.svg) — readiness states explain configured, disabled, degraded, or unsupported capabilities without secrets or raw provider errors.
+- [Setup start](docs/assets/marketing/01-setup-start.svg)
+- [Custom Weave chat](docs/assets/marketing/03-chat-room.svg)
+- [Files and documents](docs/assets/marketing/04-files-documents.svg)
+- [Settings and readiness](docs/assets/marketing/05-settings.svg)
 
 ## Repository layout
 
-- `client/` — Flutter app, product UI, accessibility checks, and client-side contract tests.
-- `server/` — Spring Boot product API/BFF, provider facades, authorization, audit, support-safe errors, and backend acceptance tests.
-- `infra/` — Docker/OpenTofu operator stack, deployment scripts, provider profiles, backup/restore, smoke checks, and support bundles.
-- `e2e/` — product-language Gherkin scenarios, scenario mappings, and sanitized evidence contracts.
-- `docs/` — MkDocs-backed product, user/admin/operator/developer docs, architecture, release scope, evidence, roadmap boundaries, and research notes.
+- `client/` — Flutter app, product UI, accessibility checks, and client contracts.
+- `server/` — Spring Boot product API/BFF, provider facades, authorization, audit, and backend acceptance tests.
+- `admin-console/` — admin readiness, setup, and policy surfaces.
+- `infra/` — Docker/OpenTofu operator stack, deployment scripts, profiles, backup/restore, and support bundles.
+- `e2e/` — product-language Gherkin scenarios and sanitized evidence contracts.
+- `docs/` — MkDocs-backed product, admin/operator, developer, architecture, evidence, and release docs.
 - `release/` — release manifests and stack compatibility metadata.
-- `.forgejo/` and `.github/` — CI/CD workflow targets. A workflow in one provider is not automatically evidence for another provider.
 
 ## v0.1 product truth
 
-Weave v0.1 is a **dogfood-production foundation**, not a broad public production claim.
-
-Ready or foundation-level:
-
-- one monorepo product stack: `client/`, `server/`, `infra/`, `e2e/`, `docs/`, and `release/`;
-- provider-neutral domain vocabulary and member/admin boundary contracts;
-- Weave App member surfaces guarded by capability states;
-- backend/domain facade direction for provider boundaries;
-- admin/operator readiness, support-safe diagnostics, and evidence contracts;
-- local/dev and dogfood infrastructure paths with explicit release blockers;
-- release-note, acceptance, docs, and evidence gates.
-
-Guarded or future:
-
-- production provider cutover and rollback are evidence-scoped, not generally claimed;
-- Slack, Teams, Microsoft 365, SharePoint, Jira, and similar adapters are candidates until promoted by adapter-specific evidence;
-- Office/document editing is not generally shipped;
-- Weaver runtime execution is not broadly available and remains disabled by default;
-- human/manual assistive-technology release signoff remains blocked until real evidence exists.
-
-Reality and claim boundaries:
-
-- [Product reality foundation](docs/product-reality-foundation.md)
-- [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md)
-- [Quality and acceptance evidence](docs/quality-and-evidence.md)
-- [v0.1 release evidence](docs/release-v0.1-rc3-evidence.md)
+v0.1 is dogfood-production foundation, not a broad public production claim. Ready foundation includes the monorepo stack, provider-neutral domain vocabulary, guarded member surfaces, admin/operator readiness, local/dev and dogfood infrastructure paths, and automated claim gates. Guarded or future work includes production provider cutover, production rollback, broad commercial adapters, generally shipped office editing, broad Weaver runtime execution, public/production release signoff, and manual assistive-technology signoff.
 
 ## Ready / Guarded / Future claim matrix
 
-This matrix is intentionally compact. It exists to keep release checks and marketing language honest; it is not the product narrative.
+This README keeps the matrix short; deeper evidence lives in the [product-trust claim matrix](docs/product-trust-provider-choice-claim-matrix.md). No unaccounted data loss is the portability promise: unsupported fields, conflicts, archive-only records, provider-unexportable data, and rollback limits must be reported before guarded apply paths are promoted. perfect lossless migration is not claimed.
 
-| Claim | Status | Evidence or boundary |
+| Claim | Status | Boundary |
 | --- | --- | --- |
-| Weave is a monorepo product stack with client, server, infra, e2e, docs, and release gates. | **Ready** | Developer Handbook, build/evidence delivery, and root CI gates. |
-| v0.1 is dogfood-production, not preview/scaffold UX for normal members. | **Ready foundation** | Golden path readiness plus dogfood UX gates. |
-| Members work in provider-neutral Weave domains. | **Ready foundation** | Canonical domains, canonical feature models, and architecture docs. |
-| Provider adapters are replaceable behind Weave-owned contracts. | **Guarded** | Reality levels prevent contract-only candidates from being marketed as generally available: `contract_only`, `configured`, `live_read`, `live_write`, `migration_dry_run`, `migration_apply_ready`, `rollback_ready`, `release_ready`. |
-| No unaccounted data loss is the portability promise. | **Guarded** | Unsupported fields, conflicts, archive-only data, and provider-unexportable data must be reported; perfect lossless migration is not claimed. |
-| Calls/meetings use LiveKit readiness today. | **Guarded** | Join/media claims remain limited to implemented readiness and token facade evidence. |
-| Workspace/Admin Health is the support-safe readiness and diagnostics control plane. | **Ready foundation / expanding** | Admin-Suite readiness and setup contract plus quality/evidence gates. |
-| Weaver is OpenClaw-derived, optional, per-user, governed, and disabled by default. | **Future foundation** | Runtime execution is not shipped. |
-| Autonomous agent/team writes are available in v0.1. | **Not shipped** | Future writes require admin-approved tools, opt-in where required, approval policy, audit, sandbox, and support-safe evidence. |
+| Weave is a monorepo product stack. | **Ready foundation** | Client, server, admin console, infra, e2e, docs, and release gates ship together. |
+| v0.1 is dogfood-production, not preview. | **Ready foundation** | Dogfood foundation only; no broad public production release claim. |
+| Members work in provider-neutral Weave domains. | **Ready foundation** | Member UX uses Weave capabilities and states, not raw provider setup. |
+| Provider adapters are replaceable behind Weave-owned contracts. | **Guarded** | Replacement needs adapter-specific portability, migration, rollback, exposure, and apply evidence. |
+| No unaccounted data loss is the portability promise. | **Guarded** | Lossy fields and unsupported records must be reported; lossless migration is not promised. |
+| Calls/meetings use LiveKit readiness today. | **Ready foundation** | Readiness is scoped to current dogfood evidence, not all meeting-provider claims. |
+| Workspace/Admin Health is the support-safe readiness and diagnostics control plane. | **Ready foundation** | Raw provider diagnostics and secrets stay operator-only and redacted. |
+| Weaver is OpenClaw-derived, optional, per-user, governed, and disabled by default. | **Guarded/future** | Runtime execution is not broadly available and requires policy, approvals, revocation, and audit. |
+| Autonomous agent/team writes are available in v0.1. | **Future/blocked** | Write-like tools fail closed without governed approval evidence. |
 
-## Provider and data boundary
-
-Weave can model three provider postures:
-
-- **Dogfood/default:** self-hosted identity, chat, files/calendar, boards validation, calls readiness, and local Forgejo/GitOps evidence where available.
-- **Attach existing:** customer-owned providers are bound behind Weave domains without pretending Weave owns their internals.
-- **Hybrid:** each domain chooses deploy-new or attach-existing, while members receive one coherent Weave manifest.
-
-Provider portability is governed by a **no unaccounted data loss** principle. Exports, imports, lossy fields, conflicts, unsupported provider features, rollback limits, and archive-only paths must be reported before claims or apply actions are promoted.
+Provider reality vocabulary remains: `contract_only`, `configured`, `live_read`, `live_write`, `migration_dry_run`, `migration_apply_ready`, `rollback_ready`, and `release_ready`.
 
 ## Boards and provider boundary
 
-Boards/tasks are Weave product surfaces. The client talks to Weave Server facades, not task providers directly. Provider reads stay behind runtime gates, context authorization, support-safe metadata, and backend-held tokens. Provider writes remain disabled/fail-closed unless future promotion proves authorization, consent, audit, support-bundle redaction, and rollback behavior.
+Boards/tasks, chat, files, documents, calendar, calls, decisions, notifications, health, and Weaver use provider-neutral domain contracts. Provider names may appear in admin/operator architecture examples and adapter candidates, not as normal member-facing setup requirements.
 
 ## Infrastructure and OpenTofu
 
-OpenTofu is the operator tool for Weave infrastructure. CI runs format/validation-oriented checks; state-destructive operations require operator confirmation plus backup, restore, or rollback evidence. Operator-specific setup belongs in the [Admin/Operator Handbook](docs/admin-operator-handbook.md).
-
-## Weaver boundary
-
-Weaver is part of the product direction, but not a default-shipped runtime.
-
-The target is an organization-governed, per-user assistant derived from OpenClaw-style runtimes:
-
-- per-user isolation and revocation;
-- organization-provided skill/tool packages;
-- deny-by-default capability policy;
-- scoped connectors and secrets;
-- approval receipts for sensitive actions;
-- group-chat consent and audit;
-- support-safe observability.
-
-Until those gates exist, Weaver remains optional, governed, and disabled by default.
-
-Weaver docs:
-
-- [Weaver OpenClaw-derived runtime profile](docs/architecture/weaver-openclaw-profile.md)
-- [Product line and Weaver integration plan](docs/product-line-and-weaver-plan.md)
-- [Governed Weaver runtime security contract](docs/governed-weaver-runtime-security-contract.md)
-
-## Documentation map
-
-- [Documentation landing page](docs/index.md) — audience-based entry points.
-- [User Handbook](docs/user-handbook.md) — joining and using an already-provisioned organization.
-- [Admin/Operator Handbook](docs/admin-operator-handbook.md) — setup, providers, readiness, policy, audit, backup/restore, and support bundles.
-- [Developer Handbook](docs/developer-handbook.md) — local prerequisites, Gradle gates, generated code, and evidence expectations.
-- [Architecture](docs/architecture.md) — product-first, provider-neutral architecture and integration layering.
-- [Canonical domains](docs/architecture/canonical-domains.md) — domain registry and product-owned contracts.
-- [Provider portability contract](docs/architecture/provider-portability.md) — adapter manifests, mapping tables, reports, and no-unaccounted-data-loss rules.
-- [Roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md) — what is ready, guarded, future, or intentionally not shipped.
-- [Release notes](docs/release-notes/index.md) — release-note process and checked-in notes.
+Bootstrap foundation ([contract](docs/bootstrap-foundation-contract.md)) is evidence-driven: `tools/weavectl bootstrap plan --profile <profile> --target <provider-lane>` followed by `tools/weavectl bootstrap apply --plan <plan-ref>`. Control Plane = Weave Server + Admin Console. Apply remains dry-run/validate-only unless an operator explicitly adds `--execute --approval-ref <approval-ref>`.
 
 ## Evidence contract
 
-- Gherkin scenarios are product contracts. Update `e2e/features/`, `e2e/scenario_mappings.json`, and executable evidence together.
-- Support bundles must redact secrets, tokens, raw provider payloads, credential-bearing URLs, tenant URLs, cookies, private keys, generated credentials, member content, and personal data.
-- Release evidence is a review trail, not marketing copy.
-- Manual assistive-technology signoff cannot be claimed without real human evidence or an explicit scoped waiver.
-- Keep documentation honest about shipped, guarded, disabled, degraded, and future surfaces.
+Evidence lives in specs, e2e mappings, release manifests, docs, and deterministic tooling. Search and indexing are derived/rebuildable, not canonical business records. Domain contracts record objects, capabilities, open protocols, auth assumptions, audit requirements, portability/export, jurisdiction/vendor exposure, Weaver mode, and adapter candidates.
 
 ## Release evidence
-
-Release evidence is the review and verification trail for release-note automation and release-candidate promotion. Maintainers inspect checked-in artifacts, CI, and sanitized live-stack evidence or an explicit release-owner waiver.
 
 <!-- WEAVE_RELEASE_NOTES:START -->
 - Current checked-in draft: [Unreleased](docs/release-notes/unreleased.md)
@@ -253,45 +136,16 @@ Release evidence is the review and verification trail for release-note automatio
 
 ## Common local gates
 
-Fastest honest evaluation path and local gate map:
-
-1. Read [v0.1 Golden Path readiness](docs/v0.1-golden-path.md).
-2. Read [Weave Control bootstrap-to-client contract](docs/weave-control-bootstrap-to-client-contract.md).
-3. Read [Quality and acceptance evidence](docs/quality-and-evidence.md).
-4. Run docs and acceptance gates:
-
-   ```bash
-   make docs-check
-   make acceptance-contract
-   ./gradlew docsCheck
-   ./gradlew acceptanceContract
-   ```
-
-5. For broader changes, run the matching gate:
-
-   ```bash
-   make client-ci
-   make server-ci
-   make infra-static
-   make ci
-
-   ./gradlew releaseEvidenceCheck
-   ./gradlew ci
-   ```
-
-Use Java 21+ for Gradle gates. On macOS with Homebrew JDK 21:
+Use the smallest meaningful subset for a change, and `./gradlew ci` for cross-stack work.
 
 ```bash
-export JAVA_HOME=/opt/homebrew/opt/openjdk@21
-export PATH="$JAVA_HOME/bin:$PATH"
+python3 tools/domain_registry_check.py
+python3 tools/product_trust_claim_matrix_check.py
+python3 tools/docs_check.py
+./gradlew acceptanceContract docsCheck releaseEvidenceCheck --console=plain
+git diff --check
 ```
 
 ## Working agreements
 
-- Product story first; implementation detail second.
-- Keep normal-member UX provider-neutral.
-- Keep provider specifics in admin/operator readiness and support-safe diagnostics.
-- Keep Weaver governed, optional, and disabled by default until its gates exist.
-- Prefer accessible headings, concise bullets, descriptive links, and alt text over dense copy.
-- Do not expose provider secrets or service tokens to Flutter, support bundles, app config, logs, screenshots, or docs.
-- Follow [Developer Handbook](docs/developer-handbook.md) and [Lane-based PR and release workflow](docs/gitflow-pr-workflow.md) before opening, reviewing, or merging PRs.
+Follow [Developer handbook](docs/developer-handbook.md), [Gitflow and PR workflow](docs/gitflow-pr-workflow.md), [Operating model](docs/weave-operating-model.md), and [Product line and Weaver plan](docs/product-line-and-weaver-plan.md). Keep provider-specific raw errors, secrets, tenant URLs, logs, diagnostics, and runtime details out of member UX and public claims.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 **Weave – Collaboration Seamlessly Woven with Agentic AI, Activated on Your Terms.**
 
-Provider-neutral collaboration with explicit control over data, adapters, and governed AI assistance.
+Weave lets organizations own their collaboration layer: provider-neutral workspaces with explicit control over data, adapters, and governed AI assistance.
 
 <p align="center">
   <img src="client/assets/images/weave_logo.png" alt="Weave logo, an interlaced blue and teal knot" width="220">
 </p>
 
-Weave is a sovereign-by-design collaboration product line. It gives an organization one Weave-owned layer for member collaboration, admin readiness, policy, audit, support evidence, portability, and future governed personal assistance while concrete providers stay behind adapters.
+Weave is a sovereign-by-design product line; start with the [v0.1 golden path](docs/v0.1-golden-path.md), then follow the evidence links below for admin readiness, policy, audit, portability, and future governed assistance.
 
 Weave does not claim to be Cloud-Act-proof, compliance-certified, fully sovereign, broadly public-production-ready, or fully accessible. It makes provider and jurisdiction exposure visible and requires evidence before stronger claims or migrations are promoted.
 

--- a/docs/sovereign-domain-contracts.md
+++ b/docs/sovereign-domain-contracts.md
@@ -1,0 +1,47 @@
+# Sovereign domain contracts
+
+Weave treats product domains as the stable layer and provider adapters as replaceable services. This page is the human-readable companion to the machine-readable registry in `specs/0004-domain-registry/canonical-domain-registry-v1.json` and its server resource copy.
+
+## What is locked
+
+Every Wave 1 domain entry defines:
+
+- `domainId` and Wave marker;
+- user and organization objects;
+- read and write capability keys;
+- minimum open protocols;
+- auth and identity assumptions;
+- audit requirements;
+- portability/export contract;
+- jurisdiction and vendor exposure descriptor;
+- Weaver tool mode: `none`, `read-only`, `approval-write`, or `governed-write`;
+- primary and secondary adapter candidates.
+
+The conformance gate `tools/domain_registry_check.py` fails when a Wave 1 domain misses those fields, when adapter reality levels drift, or when required Wave 2/later placeholders disappear.
+
+## Wave 1 domains
+
+Wave 1 currently covers the implemented product vocabulary: identity, people/contacts, spaces, chat, files, documents, calendar, boards/tasks, calls/meetings, decisions/audit, notifications, health/Control Room, and Weaver runtime metadata.
+
+Adapters are listed in the registry with free/open-source/self-hostable paths first where realistic. Commercial or jurisdiction-sensitive candidates stay documented as candidates until adapter-specific evidence promotes them.
+
+## Wave 2 and later placeholders
+
+The registry intentionally keeps placeholders for AI runtime gateway, MCP/tool registry, search/indexing, notes, secrets, mail, and backup/export. A placeholder is not a shipped capability. It exists so product planning does not silently lose domains that Massimo identified as core to the sovereignty thesis.
+
+Search and indexing are explicitly `derived_rebuildable`: they may accelerate discovery, but they are not the canonical source of truth for business records.
+
+## Sovereignty and exposure model
+
+The contract does not claim Weave is immune to legal process or that every deployment is fully sovereign. It requires every domain to record hosting model, provider operator, likely data residency and jurisdiction exposure, subprocessors where known, export limitations, and lock-in risk.
+
+This makes exposure visible before admins bind adapters, promote migration paths, or allow Weaver tool use. It also keeps provider names in admin/operator posture rather than normal member UX.
+
+## Evidence links
+
+- Domain registry fixture: `specs/0004-domain-registry/canonical-domain-registry-v1.json`
+- Server resource copy: `server/src/main/resources/canonical-domain-registry-v1.json`
+- Registry gate: `tools/domain_registry_check.py`
+- Canonical domain overview: [`docs/domain-registry-v1.md`](domain-registry-v1.md)
+- Provider portability contract: [`docs/architecture/provider-portability.md`](architecture/provider-portability.md)
+- Product claim matrix: [`docs/product-trust-provider-choice-claim-matrix.md`](product-trust-provider-choice-claim-matrix.md)

--- a/server/src/main/resources/canonical-domain-registry-v1.json
+++ b/server/src/main/resources/canonical-domain-registry-v1.json
@@ -131,7 +131,56 @@
         "entra-id": "contract_only",
         "authentik": "contract_only",
         "auth0": "contract_only"
-      }
+      },
+      "domainId": "identity",
+      "wave": "wave1",
+      "userObjects": [
+        "Subject",
+        "Organization",
+        "Group",
+        "Role"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "subject.read",
+        "group.read"
+      ],
+      "writeCapabilities": [
+        "subject.provision",
+        "role.assign"
+      ],
+      "minimumOpenProtocols": [
+        "OIDC",
+        "SAML 2.0",
+        "SCIM 2.0",
+        "LDAP"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Keycloak realm",
+        "Authentik",
+        "generic OIDC/SAML plus SCIM/LDAP"
+      ],
+      "secondaryAdapterCandidates": [
+        "Entra ID (commercial jurisdiction caveat)",
+        "Auth0 (commercial jurisdiction caveat)"
+      ]
     },
     {
       "key": "people",
@@ -217,7 +266,53 @@
         "oidc-profile": "contract_only",
         "ldap-directory": "contract_only",
         "weave-directory": "contract_only"
-      }
+      },
+      "domainId": "contacts",
+      "wave": "wave1",
+      "userObjects": [
+        "Person",
+        "AddressBook",
+        "OrganizationDirectory"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "person.read",
+        "directory.search"
+      ],
+      "writeCapabilities": [
+        "person.update",
+        "address_book.sync"
+      ],
+      "minimumOpenProtocols": [
+        "CardDAV",
+        "vCard",
+        "SCIM"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Radicale CardDAV",
+        "Nextcloud Contacts/CardDAV"
+      ],
+      "secondaryAdapterCandidates": [
+        "LDAP directory",
+        "Weave directory fixture"
+      ]
     },
     {
       "key": "spaces",
@@ -310,7 +405,53 @@
         "slack-workspace": "contract_only",
         "openproject-project": "contract_only",
         "nextcloud-folder": "contract_only"
-      }
+      },
+      "domainId": "spaces",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveSpace",
+        "Organization",
+        "Membership"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "space.read",
+        "membership.read"
+      ],
+      "writeCapabilities": [
+        "space.create",
+        "membership.update"
+      ],
+      "minimumOpenProtocols": [
+        "Matrix Spaces",
+        "ActivityPub collections",
+        "WebDAV collection metadata"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Weave space manifest",
+        "Matrix Spaces"
+      ],
+      "secondaryAdapterCandidates": [
+        "Nextcloud group folders",
+        "OpenProject projects"
+      ]
     },
     {
       "key": "chat",
@@ -402,7 +543,52 @@
         "microsoft-teams": "contract_only",
         "slack": "contract_only",
         "nextcloud-talk": "contract_only"
-      }
+      },
+      "domainId": "chat",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveConversation",
+        "WeaveMessage",
+        "WeaveMembership"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "message.read",
+        "conversation.read"
+      ],
+      "writeCapabilities": [
+        "message.send",
+        "reaction.write"
+      ],
+      "minimumOpenProtocols": [
+        "Matrix Client-Server API",
+        "XMPP MUC where mapped"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Matrix/Synapse",
+        "Zulip"
+      ],
+      "secondaryAdapterCandidates": [
+        "Nextcloud Talk",
+        "Slack/Teams candidates blocked by commercial evidence"
+      ]
     },
     {
       "key": "files",
@@ -496,7 +682,53 @@
         "onedrive": "contract_only",
         "s3-compatible": "live_write",
         "smb": "live_write"
-      }
+      },
+      "domainId": "files",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveDrive",
+        "WeaveFile",
+        "WeaveShare"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "file.read",
+        "file.search"
+      ],
+      "writeCapabilities": [
+        "file.write",
+        "share.update"
+      ],
+      "minimumOpenProtocols": [
+        "WebDAV",
+        "S3-compatible object APIs",
+        "OCI artifacts for bundles"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Nextcloud Files/WebDAV",
+        "MinIO/S3-compatible storage"
+      ],
+      "secondaryAdapterCandidates": [
+        "Seafile community",
+        "local filesystem fixture"
+      ]
     },
     {
       "key": "documents",
@@ -583,7 +815,52 @@
         "onlyoffice": "contract_only",
         "microsoft-365-office": "contract_only",
         "google-workspace-docs": "contract_only"
-      }
+      },
+      "domainId": "documents",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveDocument",
+        "DocumentVersion",
+        "DocumentComment"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "document.read",
+        "document.render"
+      ],
+      "writeCapabilities": [
+        "document.edit",
+        "comment.write"
+      ],
+      "minimumOpenProtocols": [
+        "ODF",
+        "WebDAV",
+        "WOPI where available"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Collabora CODE",
+        "LibreOffice headless conversion"
+      ],
+      "secondaryAdapterCandidates": [
+        "ONLYOFFICE Community with license caveat"
+      ]
     },
     {
       "key": "calendar",
@@ -671,7 +948,52 @@
         "google-workspace-calendar": "contract_only",
         "generic-caldav": "live_read",
         "weave-calendar": "contract_only"
-      }
+      },
+      "domainId": "calendar",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveCalendar",
+        "WeaveEvent",
+        "WeaveAvailability"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "calendar.read",
+        "availability.read"
+      ],
+      "writeCapabilities": [
+        "event.create",
+        "event.update"
+      ],
+      "minimumOpenProtocols": [
+        "CalDAV",
+        "iCalendar"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Radicale CalDAV",
+        "Nextcloud Calendar/CalDAV"
+      ],
+      "secondaryAdapterCandidates": [
+        "DAViCal",
+        "Baikal"
+      ]
     },
     {
       "key": "boards",
@@ -765,7 +1087,53 @@
         "microsoft-planner": "contract_only",
         "nextcloud-deck": "live_read",
         "vikunja": "contract_only"
-      }
+      },
+      "domainId": "tasks",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveBoard",
+        "WeaveTask",
+        "TaskComment"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "task.read",
+        "board.read"
+      ],
+      "writeCapabilities": [
+        "task.create",
+        "task.update"
+      ],
+      "minimumOpenProtocols": [
+        "OpenProject API export",
+        "Kanboard API",
+        "CalDAV VTODO where mapped"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "OpenProject Community",
+        "Kanboard"
+      ],
+      "secondaryAdapterCandidates": [
+        "Vikunja",
+        "Nextcloud Deck"
+      ]
     },
     {
       "key": "calls",
@@ -857,7 +1225,52 @@
         "microsoft-teams-meetings": "contract_only",
         "google-meet": "contract_only",
         "external-meeting-link": "contract_only"
-      }
+      },
+      "domainId": "meetings",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveMeeting",
+        "MediaSession",
+        "RecordingRef"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "meeting.read",
+        "token.request"
+      ],
+      "writeCapabilities": [
+        "meeting.schedule",
+        "moderation.request"
+      ],
+      "minimumOpenProtocols": [
+        "WebRTC",
+        "SIP bridge where mapped",
+        "iCalendar for meeting metadata"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "LiveKit self-hosted",
+        "Jitsi Meet"
+      ],
+      "secondaryAdapterCandidates": [
+        "Nextcloud Talk"
+      ]
     },
     {
       "key": "decisions",
@@ -944,7 +1357,53 @@
         "openproject-wiki": "contract_only",
         "nextcloud-docs": "contract_only",
         "github-issues": "contract_only"
-      }
+      },
+      "domainId": "audit",
+      "wave": "wave1",
+      "userObjects": [
+        "DecisionRecord",
+        "ApprovalReceipt",
+        "EvidenceBundle"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "decision.read",
+        "receipt.read"
+      ],
+      "writeCapabilities": [
+        "decision.record",
+        "receipt.issue"
+      ],
+      "minimumOpenProtocols": [
+        "W3C PROV",
+        "JSON Lines",
+        "OpenTelemetry traces"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "governed-write",
+      "primaryAdapterCandidates": [
+        "Weave audit log",
+        "Forgejo/Git signed evidence"
+      ],
+      "secondaryAdapterCandidates": [
+        "OpenSearch/Loki derived views"
+      ],
+      "sourceOfTruthNote": "Decision receipts and audit records are canonical evidence; search views over them remain derived."
     },
     {
       "key": "notifications",
@@ -1034,7 +1493,53 @@
         "slack-notifications": "contract_only",
         "teams-notifications": "contract_only",
         "webhook": "contract_only"
-      }
+      },
+      "domainId": "notifications",
+      "wave": "wave1",
+      "userObjects": [
+        "Notification",
+        "Preference",
+        "DeliveryReceipt"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "notification.read",
+        "preference.read"
+      ],
+      "writeCapabilities": [
+        "notification.send",
+        "preference.update"
+      ],
+      "minimumOpenProtocols": [
+        "Web Push",
+        "SMTP",
+        "Matrix notifications"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "ntfy self-hosted",
+        "Gotify"
+      ],
+      "secondaryAdapterCandidates": [
+        "SMTP relay",
+        "Matrix bot notification bridge"
+      ]
     },
     {
       "key": "health",
@@ -1121,7 +1626,53 @@
         "weave-health-facade": "contract_only",
         "provider-stack-health": "contract_only",
         "release-evidence": "contract_only"
-      }
+      },
+      "domainId": "control-room",
+      "wave": "wave1",
+      "userObjects": [
+        "ReadinessCheck",
+        "SupportBundle",
+        "IncidentSignal"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "readiness.read",
+        "diagnostic.read"
+      ],
+      "writeCapabilities": [
+        "support_bundle.create",
+        "remediation.request"
+      ],
+      "minimumOpenProtocols": [
+        "OpenTelemetry",
+        "Prometheus exposition",
+        "JSON support bundles"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Prometheus/Grafana stack",
+        "OpenTelemetry Collector"
+      ],
+      "secondaryAdapterCandidates": [
+        "Loki/OpenSearch derived logs"
+      ],
+      "sourceOfTruthNote": "Health and support views are derived from readiness checks, telemetry, and redacted support bundles; they are not canonical business records."
     },
     {
       "key": "weaver",
@@ -1203,7 +1754,53 @@
       ],
       "providerRealityLevelByCandidate": {
         "openclaw-derived-profile": "contract_only"
-      }
+      },
+      "domainId": "weaver-runtime",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaverRuntimeProfile",
+        "WeaverToolGrant",
+        "WeaverApprovalReceipt"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "runtime.read",
+        "tool_grant.read"
+      ],
+      "writeCapabilities": [
+        "runtime.request",
+        "tool.invoke_with_approval"
+      ],
+      "minimumOpenProtocols": [
+        "MCP",
+        "OCI artifacts",
+        "OpenAPI/JSON Schema tool descriptors"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "governed-write",
+      "primaryAdapterCandidates": [
+        "OpenClaw-derived local runtime",
+        "MCP server registry"
+      ],
+      "secondaryAdapterCandidates": [
+        "containerized per-user sandbox"
+      ],
+      "sourceOfTruthNote": "Weaver runtime state is governed metadata; generated indexes and tool caches are rebuildable derived state."
     }
   ],
   "providerRealityLevels": [
@@ -1215,5 +1812,155 @@
     "migration_apply_ready",
     "rollback_ready",
     "release_ready"
+  ],
+  "futureDomainPlaceholders": [
+    {
+      "domainId": "ai-runtime-gateway",
+      "displayName": "AI runtime gateway",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "mcp-tool-registry",
+      "displayName": "MCP/tool registry",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "search",
+      "displayName": "Search and indexing",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "derived_rebuildable",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "notes",
+      "displayName": "Notes",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "secrets",
+      "displayName": "Secrets",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "mail",
+      "displayName": "Mail",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "backup-export",
+      "displayName": "Backup and export",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    }
+  ],
+  "domainContractRequiredFields": [
+    "domainId",
+    "userObjects",
+    "organizationObjects",
+    "readCapabilities",
+    "writeCapabilities",
+    "minimumOpenProtocols",
+    "authIdentityAssumptions",
+    "auditRequirements",
+    "portabilityExportContract",
+    "jurisdictionVendorExposureDescriptor",
+    "weaverToolMode",
+    "primaryAdapterCandidates",
+    "secondaryAdapterCandidates"
   ]
 }

--- a/specs/0004-domain-registry/canonical-domain-registry-v1.json
+++ b/specs/0004-domain-registry/canonical-domain-registry-v1.json
@@ -131,7 +131,56 @@
         "entra-id": "contract_only",
         "authentik": "contract_only",
         "auth0": "contract_only"
-      }
+      },
+      "domainId": "identity",
+      "wave": "wave1",
+      "userObjects": [
+        "Subject",
+        "Organization",
+        "Group",
+        "Role"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "subject.read",
+        "group.read"
+      ],
+      "writeCapabilities": [
+        "subject.provision",
+        "role.assign"
+      ],
+      "minimumOpenProtocols": [
+        "OIDC",
+        "SAML 2.0",
+        "SCIM 2.0",
+        "LDAP"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Keycloak realm",
+        "Authentik",
+        "generic OIDC/SAML plus SCIM/LDAP"
+      ],
+      "secondaryAdapterCandidates": [
+        "Entra ID (commercial jurisdiction caveat)",
+        "Auth0 (commercial jurisdiction caveat)"
+      ]
     },
     {
       "key": "people",
@@ -217,7 +266,53 @@
         "oidc-profile": "contract_only",
         "ldap-directory": "contract_only",
         "weave-directory": "contract_only"
-      }
+      },
+      "domainId": "contacts",
+      "wave": "wave1",
+      "userObjects": [
+        "Person",
+        "AddressBook",
+        "OrganizationDirectory"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "person.read",
+        "directory.search"
+      ],
+      "writeCapabilities": [
+        "person.update",
+        "address_book.sync"
+      ],
+      "minimumOpenProtocols": [
+        "CardDAV",
+        "vCard",
+        "SCIM"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Radicale CardDAV",
+        "Nextcloud Contacts/CardDAV"
+      ],
+      "secondaryAdapterCandidates": [
+        "LDAP directory",
+        "Weave directory fixture"
+      ]
     },
     {
       "key": "spaces",
@@ -310,7 +405,53 @@
         "slack-workspace": "contract_only",
         "openproject-project": "contract_only",
         "nextcloud-folder": "contract_only"
-      }
+      },
+      "domainId": "spaces",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveSpace",
+        "Organization",
+        "Membership"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "space.read",
+        "membership.read"
+      ],
+      "writeCapabilities": [
+        "space.create",
+        "membership.update"
+      ],
+      "minimumOpenProtocols": [
+        "Matrix Spaces",
+        "ActivityPub collections",
+        "WebDAV collection metadata"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Weave space manifest",
+        "Matrix Spaces"
+      ],
+      "secondaryAdapterCandidates": [
+        "Nextcloud group folders",
+        "OpenProject projects"
+      ]
     },
     {
       "key": "chat",
@@ -402,7 +543,52 @@
         "microsoft-teams": "contract_only",
         "slack": "contract_only",
         "nextcloud-talk": "contract_only"
-      }
+      },
+      "domainId": "chat",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveConversation",
+        "WeaveMessage",
+        "WeaveMembership"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "message.read",
+        "conversation.read"
+      ],
+      "writeCapabilities": [
+        "message.send",
+        "reaction.write"
+      ],
+      "minimumOpenProtocols": [
+        "Matrix Client-Server API",
+        "XMPP MUC where mapped"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Matrix/Synapse",
+        "Zulip"
+      ],
+      "secondaryAdapterCandidates": [
+        "Nextcloud Talk",
+        "Slack/Teams candidates blocked by commercial evidence"
+      ]
     },
     {
       "key": "files",
@@ -496,7 +682,53 @@
         "onedrive": "contract_only",
         "s3-compatible": "live_write",
         "smb": "live_write"
-      }
+      },
+      "domainId": "files",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveDrive",
+        "WeaveFile",
+        "WeaveShare"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "file.read",
+        "file.search"
+      ],
+      "writeCapabilities": [
+        "file.write",
+        "share.update"
+      ],
+      "minimumOpenProtocols": [
+        "WebDAV",
+        "S3-compatible object APIs",
+        "OCI artifacts for bundles"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Nextcloud Files/WebDAV",
+        "MinIO/S3-compatible storage"
+      ],
+      "secondaryAdapterCandidates": [
+        "Seafile community",
+        "local filesystem fixture"
+      ]
     },
     {
       "key": "documents",
@@ -583,7 +815,52 @@
         "onlyoffice": "contract_only",
         "microsoft-365-office": "contract_only",
         "google-workspace-docs": "contract_only"
-      }
+      },
+      "domainId": "documents",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveDocument",
+        "DocumentVersion",
+        "DocumentComment"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "document.read",
+        "document.render"
+      ],
+      "writeCapabilities": [
+        "document.edit",
+        "comment.write"
+      ],
+      "minimumOpenProtocols": [
+        "ODF",
+        "WebDAV",
+        "WOPI where available"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Collabora CODE",
+        "LibreOffice headless conversion"
+      ],
+      "secondaryAdapterCandidates": [
+        "ONLYOFFICE Community with license caveat"
+      ]
     },
     {
       "key": "calendar",
@@ -671,7 +948,52 @@
         "google-workspace-calendar": "contract_only",
         "generic-caldav": "live_read",
         "weave-calendar": "contract_only"
-      }
+      },
+      "domainId": "calendar",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveCalendar",
+        "WeaveEvent",
+        "WeaveAvailability"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "calendar.read",
+        "availability.read"
+      ],
+      "writeCapabilities": [
+        "event.create",
+        "event.update"
+      ],
+      "minimumOpenProtocols": [
+        "CalDAV",
+        "iCalendar"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Radicale CalDAV",
+        "Nextcloud Calendar/CalDAV"
+      ],
+      "secondaryAdapterCandidates": [
+        "DAViCal",
+        "Baikal"
+      ]
     },
     {
       "key": "boards",
@@ -765,7 +1087,53 @@
         "microsoft-planner": "contract_only",
         "nextcloud-deck": "live_read",
         "vikunja": "contract_only"
-      }
+      },
+      "domainId": "tasks",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveBoard",
+        "WeaveTask",
+        "TaskComment"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "task.read",
+        "board.read"
+      ],
+      "writeCapabilities": [
+        "task.create",
+        "task.update"
+      ],
+      "minimumOpenProtocols": [
+        "OpenProject API export",
+        "Kanboard API",
+        "CalDAV VTODO where mapped"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "OpenProject Community",
+        "Kanboard"
+      ],
+      "secondaryAdapterCandidates": [
+        "Vikunja",
+        "Nextcloud Deck"
+      ]
     },
     {
       "key": "calls",
@@ -857,7 +1225,52 @@
         "microsoft-teams-meetings": "contract_only",
         "google-meet": "contract_only",
         "external-meeting-link": "contract_only"
-      }
+      },
+      "domainId": "meetings",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaveMeeting",
+        "MediaSession",
+        "RecordingRef"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "meeting.read",
+        "token.request"
+      ],
+      "writeCapabilities": [
+        "meeting.schedule",
+        "moderation.request"
+      ],
+      "minimumOpenProtocols": [
+        "WebRTC",
+        "SIP bridge where mapped",
+        "iCalendar for meeting metadata"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "LiveKit self-hosted",
+        "Jitsi Meet"
+      ],
+      "secondaryAdapterCandidates": [
+        "Nextcloud Talk"
+      ]
     },
     {
       "key": "decisions",
@@ -944,7 +1357,53 @@
         "openproject-wiki": "contract_only",
         "nextcloud-docs": "contract_only",
         "github-issues": "contract_only"
-      }
+      },
+      "domainId": "audit",
+      "wave": "wave1",
+      "userObjects": [
+        "DecisionRecord",
+        "ApprovalReceipt",
+        "EvidenceBundle"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "decision.read",
+        "receipt.read"
+      ],
+      "writeCapabilities": [
+        "decision.record",
+        "receipt.issue"
+      ],
+      "minimumOpenProtocols": [
+        "W3C PROV",
+        "JSON Lines",
+        "OpenTelemetry traces"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "governed-write",
+      "primaryAdapterCandidates": [
+        "Weave audit log",
+        "Forgejo/Git signed evidence"
+      ],
+      "secondaryAdapterCandidates": [
+        "OpenSearch/Loki derived views"
+      ],
+      "sourceOfTruthNote": "Decision receipts and audit records are canonical evidence; search views over them remain derived."
     },
     {
       "key": "notifications",
@@ -1034,7 +1493,53 @@
         "slack-notifications": "contract_only",
         "teams-notifications": "contract_only",
         "webhook": "contract_only"
-      }
+      },
+      "domainId": "notifications",
+      "wave": "wave1",
+      "userObjects": [
+        "Notification",
+        "Preference",
+        "DeliveryReceipt"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "notification.read",
+        "preference.read"
+      ],
+      "writeCapabilities": [
+        "notification.send",
+        "preference.update"
+      ],
+      "minimumOpenProtocols": [
+        "Web Push",
+        "SMTP",
+        "Matrix notifications"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "ntfy self-hosted",
+        "Gotify"
+      ],
+      "secondaryAdapterCandidates": [
+        "SMTP relay",
+        "Matrix bot notification bridge"
+      ]
     },
     {
       "key": "health",
@@ -1121,7 +1626,53 @@
         "weave-health-facade": "contract_only",
         "provider-stack-health": "contract_only",
         "release-evidence": "contract_only"
-      }
+      },
+      "domainId": "control-room",
+      "wave": "wave1",
+      "userObjects": [
+        "ReadinessCheck",
+        "SupportBundle",
+        "IncidentSignal"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "readiness.read",
+        "diagnostic.read"
+      ],
+      "writeCapabilities": [
+        "support_bundle.create",
+        "remediation.request"
+      ],
+      "minimumOpenProtocols": [
+        "OpenTelemetry",
+        "Prometheus exposition",
+        "JSON support bundles"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "approval-write",
+      "primaryAdapterCandidates": [
+        "Prometheus/Grafana stack",
+        "OpenTelemetry Collector"
+      ],
+      "secondaryAdapterCandidates": [
+        "Loki/OpenSearch derived logs"
+      ],
+      "sourceOfTruthNote": "Health and support views are derived from readiness checks, telemetry, and redacted support bundles; they are not canonical business records."
     },
     {
       "key": "weaver",
@@ -1203,7 +1754,53 @@
       ],
       "providerRealityLevelByCandidate": {
         "openclaw-derived-profile": "contract_only"
-      }
+      },
+      "domainId": "weaver-runtime",
+      "wave": "wave1",
+      "userObjects": [
+        "WeaverRuntimeProfile",
+        "WeaverToolGrant",
+        "WeaverApprovalReceipt"
+      ],
+      "organizationObjects": [
+        "Organization",
+        "Workspace",
+        "Policy",
+        "ProviderBinding"
+      ],
+      "readCapabilities": [
+        "runtime.read",
+        "tool_grant.read"
+      ],
+      "writeCapabilities": [
+        "runtime.request",
+        "tool.invoke_with_approval"
+      ],
+      "minimumOpenProtocols": [
+        "MCP",
+        "OCI artifacts",
+        "OpenAPI/JSON Schema tool descriptors"
+      ],
+      "authIdentityAssumptions": "Every access is resolved to a Weave Subject and Organization; adapters receive scoped credentials or delegated tokens through SecretRef/CredentialRef boundaries; member UI does not expose raw provider setup.",
+      "auditRequirements": [
+        "capability_state_changed",
+        "adapter_binding_changed",
+        "read_access",
+        "write_attempt",
+        "export_requested",
+        "policy_denied"
+      ],
+      "portabilityExportContract": "Exports canonical Weave objects plus ProviderRef, LossyFieldReport, unsupported fields, conflicts, archive-only data, and migration receipts before promotion beyond dry-run.",
+      "jurisdictionVendorExposureDescriptor": "Records hosting model, provider operator, data residency/jurisdiction, subprocessors where known, export limitations, and commercial/vendor lock-in risk without claiming immunity from legal process.",
+      "weaverToolMode": "governed-write",
+      "primaryAdapterCandidates": [
+        "OpenClaw-derived local runtime",
+        "MCP server registry"
+      ],
+      "secondaryAdapterCandidates": [
+        "containerized per-user sandbox"
+      ],
+      "sourceOfTruthNote": "Weaver runtime state is governed metadata; generated indexes and tool caches are rebuildable derived state."
     }
   ],
   "providerRealityLevels": [
@@ -1215,5 +1812,155 @@
     "migration_apply_ready",
     "rollback_ready",
     "release_ready"
+  ],
+  "futureDomainPlaceholders": [
+    {
+      "domainId": "ai-runtime-gateway",
+      "displayName": "AI runtime gateway",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "mcp-tool-registry",
+      "displayName": "MCP/tool registry",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "search",
+      "displayName": "Search and indexing",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "derived_rebuildable",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "notes",
+      "displayName": "Notes",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "secrets",
+      "displayName": "Secrets",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "mail",
+      "displayName": "Mail",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    },
+    {
+      "domainId": "backup-export",
+      "displayName": "Backup and export",
+      "wave": "wave2_or_later_placeholder",
+      "status": "placeholder",
+      "sourceOfTruthMode": "domain_contract_pending",
+      "requiredBeforePromotion": [
+        "canonical objects",
+        "read/write capabilities",
+        "open protocols",
+        "auth assumptions",
+        "audit requirements",
+        "portability/export contract",
+        "jurisdiction/vendor exposure descriptor",
+        "Weaver mode",
+        "primary and secondary adapter candidates"
+      ],
+      "notes": "Placeholder keeps the domain visible without claiming shipped capability or release readiness."
+    }
+  ],
+  "domainContractRequiredFields": [
+    "domainId",
+    "userObjects",
+    "organizationObjects",
+    "readCapabilities",
+    "writeCapabilities",
+    "minimumOpenProtocols",
+    "authIdentityAssumptions",
+    "auditRequirements",
+    "portabilityExportContract",
+    "jurisdictionVendorExposureDescriptor",
+    "weaverToolMode",
+    "primaryAdapterCandidates",
+    "secondaryAdapterCandidates"
   ]
 }

--- a/specs/0004-domain-registry/issue-743-domain-lock-acceptance.yaml
+++ b/specs/0004-domain-registry/issue-743-domain-lock-acceptance.yaml
@@ -1,0 +1,74 @@
+issue: 743
+title: "epic(domain): lock provider-neutral capability contracts and adapter slots"
+status: acceptance-evidence-fixture
+scope:
+  wave1_domains:
+    - identity
+    - people
+    - spaces
+    - chat
+    - files
+    - documents
+    - calendar
+    - boards
+    - calls
+    - decisions
+    - notifications
+    - health
+    - weaver
+  wave2_or_later_placeholders:
+    - ai-runtime-gateway
+    - mcp-tool-registry
+    - search
+    - notes
+    - secrets
+    - mail
+    - backup-export
+required_contract_fields:
+  - domainId
+  - userObjects
+  - organizationObjects
+  - readCapabilities
+  - writeCapabilities
+  - minimumOpenProtocols
+  - authIdentityAssumptions
+  - auditRequirements
+  - portabilityExportContract
+  - jurisdictionVendorExposureDescriptor
+  - weaverToolMode
+  - primaryAdapterCandidates
+  - secondaryAdapterCandidates
+acceptance_criteria:
+  all_wave1_domains_and_wave2_placeholders:
+    artifact: specs/0004-domain-registry/canonical-domain-registry-v1.json
+    gate: python3 tools/domain_registry_check.py
+    evidence: domain_registry_check validates canonical Wave 1 domain order and required Wave 2/later placeholder ids.
+  two_viable_adapter_paths_where_realistic:
+    artifact: specs/0004-domain-registry/canonical-domain-registry-v1.json
+    gate: python3 tools/domain_registry_check.py
+    evidence: domain_registry_check fails when primary plus secondary adapter candidates are fewer than two.
+  foss_self_hostable_first_and_caveats:
+    artifact: specs/0004-domain-registry/canonical-domain-registry-v1.json
+    gate: python3 tools/domain_registry_check.py
+    evidence: domain_registry_check keeps commercial, license, jurisdiction, and vendor-exposure caveated candidates secondary and requires explicit caveat wording for known commercial candidates.
+  search_is_derived_rebuildable:
+    artifact: specs/0004-domain-registry/canonical-domain-registry-v1.json
+    gate: python3 tools/domain_registry_check.py
+    evidence: domain_registry_check requires search placeholder sourceOfTruthMode to be derived_rebuildable.
+  no_member_facing_provider_names:
+    artifacts:
+      - README.md
+      - docs/sovereign-domain-contracts.md
+      - docs/domain-registry-v1.md
+    gates:
+      - python3 tools/product_trust_claim_matrix_check.py
+      - python3 tools/docs_check.py
+    evidence: README and docs frame provider names as architecture/admin/operator examples, not normal member contract language.
+  required_exposure_portability_audit_weaver_fields:
+    artifact: specs/0004-domain-registry/canonical-domain-registry-v1.json
+    gate: python3 tools/domain_registry_check.py
+    evidence: domain_registry_check validates exposure descriptor, portability export contract, audit requirements, and Weaver mode for every Wave 1 domain.
+gradle_mapping:
+  acceptanceContract: maps product-readiness scenarios that consume domain registry readiness and provider-neutral states.
+  domainRegistryCheck: wraps tools/domain_registry_check.py through Gradle build hooks.
+  docsCheck: validates documentation structure and claim-safe references.

--- a/specs/0004-domain-registry/traceability.yaml
+++ b/specs/0004-domain-registry/traceability.yaml
@@ -6,7 +6,10 @@ github_issues:
   - 438
   - 439
   - 442
+  - 743
 artifacts:
+  acceptance:
+    - specs/0004-domain-registry/issue-743-domain-lock-acceptance.yaml
   registry:
     - server/src/main/resources/canonical-domain-registry-v1.json
     - specs/0004-domain-registry/canonical-domain-registry-v1.json
@@ -14,6 +17,11 @@ artifacts:
     - tools/domain_registry_check.py
   docs:
     - docs/domain-registry-v1.md
+    - docs/sovereign-domain-contracts.md
 gates:
   - ./gradlew specContract
-acceptance_features: []
+  - ./gradlew acceptanceContract
+  - ./gradlew docsCheck
+  - python3 tools/domain_registry_check.py
+acceptance_features:
+  - e2e/features/product_readiness_waterfall.feature

--- a/tools/domain_registry_check.py
+++ b/tools/domain_registry_check.py
@@ -11,6 +11,10 @@ MEMBER=['available','disabled_by_policy','not_configured','degraded','unavailabl
 ADMIN=['provider_not_configured','secret_missing','ready','degraded','dry_run_required','lossy_mapping_pending','apply_blocked','migration_ready']
 MANIFEST=['adapterKey','domainKeys','apiProfile','canonicalObjects','capabilityKeys','readinessChecks','unsupportedFields','migrationLimits','auditEvents','secretBoundary']
 REALITY=['contract_only','configured','live_read','live_write','migration_dry_run','migration_apply_ready','rollback_ready','release_ready']
+CONTRACT_REQUIRED=['domainId','userObjects','organizationObjects','readCapabilities','writeCapabilities','minimumOpenProtocols','authIdentityAssumptions','auditRequirements','portabilityExportContract','jurisdictionVendorExposureDescriptor','weaverToolMode','primaryAdapterCandidates','secondaryAdapterCandidates']
+WEAVER_MODES={'none','read-only','approval-write','governed-write'}
+PLACEHOLDER_IDS={'ai-runtime-gateway','mcp-tool-registry','search','notes','secrets','mail','backup-export'}
+COMMERCIAL_OR_LICENSE_CAVEAT_TOKENS=('commercial','license caveat','jurisdiction caveat','candidate blocked','vendor exposure')
 REQUIRED_CANONICAL={
  'chat':{'WeaveSpace','WeaveConversation','WeaveMessage','WeaveThread','WeaveReaction','WeaveAttachment','WeaveMembership','WeaveHistoryPolicy','ProviderRef','MigrationReceipt','RollbackReceipt','LossyFieldReport'},
  'files':{'WeaveDrive','WeaveFolder','WeaveFile','WeaveVersion','WeaveShare','WeavePermission','WeaveLock','WeaveQuota','ProviderRef'},
@@ -32,6 +36,14 @@ def main():
  if data.get('adminStates')!=ADMIN: fail('top-level admin states are not canonical')
  if data.get('adapterManifestRequirements')!=MANIFEST: fail('top-level adapter manifest requirements are incomplete')
  if data.get('providerRealityLevels')!=REALITY: fail('top-level provider reality levels are not canonical')
+ if data.get('domainContractRequiredFields')!=CONTRACT_REQUIRED: fail('top-level domain contract required fields are incomplete')
+ placeholders=data.get('futureDomainPlaceholders')
+ if not isinstance(placeholders,list): fail('futureDomainPlaceholders must be a list')
+ placeholder_ids={p.get('domainId') for p in placeholders if isinstance(p,dict)}
+ if not PLACEHOLDER_IDS.issubset(placeholder_ids): fail(f'missing Wave 2/later placeholder(s): {sorted(PLACEHOLDER_IDS-placeholder_ids)}')
+ for p in placeholders:
+  if p.get('domainId')=='search' and p.get('sourceOfTruthMode')!='derived_rebuildable': fail('search placeholder must be marked derived/rebuildable, not canonical source of truth')
+  if p.get('status')!='placeholder': fail(f"{p.get('domainId')} placeholder must not imply shipped capability")
  domains=data.get('domains')
  if not isinstance(domains,list): fail('domains must be a list')
  by_key={d.get('key'):d for d in domains if isinstance(d,dict)}
@@ -43,9 +55,25 @@ def main():
    if not str(d.get(field,'')).strip(): fail(f'{key} missing {field}')
   for field in ['canonicalObjects','capabilityKeys','providerCandidates','portabilityRequirements','sourceOfTruthModes','compatibilityAliases','portabilityRisks']:
    if not isinstance(d.get(field),list) or not d[field]: fail(f'{key} {field} must be a non-empty list')
-   for field in ['canonicalObjects','capabilityKeys','providerCandidates','portabilityRequirements','sourceOfTruthModes','compatibilityAliases','portabilityRisks']:
-    values=d[field]
-    if len(values)!=len(set(values)): fail(f'{key} {field} contains duplicate values')
+  for field in ['canonicalObjects','capabilityKeys','providerCandidates','portabilityRequirements','sourceOfTruthModes','compatibilityAliases','portabilityRisks']:
+   values=d[field]
+   if len(values)!=len(set(values)): fail(f'{key} {field} contains duplicate values')
+  for field in CONTRACT_REQUIRED:
+   value=d.get(field)
+   if isinstance(value,list):
+    if not value: fail(f'{key} {field} must be a non-empty list')
+   elif not str(value or '').strip(): fail(f'{key} missing {field}')
+  if d.get('wave')!='wave1': fail(f'{key} must be marked wave1')
+  if d.get('weaverToolMode') not in WEAVER_MODES: fail(f'{key} has invalid Weaver tool mode')
+  primary=d.get('primaryAdapterCandidates',[]); secondary=d.get('secondaryAdapterCandidates',[])
+  if len(primary)+len(secondary)<2: fail(f'{key} needs at least two adapter paths where realistic')
+  caveated=[c for c in primary+secondary if any(token in c.lower() for token in COMMERCIAL_OR_LICENSE_CAVEAT_TOKENS)]
+  if caveated and not any(c in secondary for c in caveated): fail(f'{key} commercial/license/jurisdiction-caveated candidates must be secondary, not primary')
+  if secondary and any('license caveat' in c.lower() or 'commercial' in c.lower() or 'jurisdiction caveat' in c.lower() for c in primary): fail(f'{key} primary adapter candidates must prefer free/open/self-hostable paths before caveated candidates')
+  for candidate in secondary:
+   lowered=candidate.lower()
+   if any(marker in lowered for marker in ('onlyoffice','slack','teams','microsoft','entra','auth0')) and not any(token in lowered for token in COMMERCIAL_OR_LICENSE_CAVEAT_TOKENS): fail(f'{key} secondary adapter candidate {candidate!r} must record commercial/license/jurisdiction caveat')
+  if key=='health' and 'derived' not in d.get('sourceOfTruthNote',''): fail('health/control-room views must be marked derived')
   if d.get('memberStates')!=MEMBER: fail(f'{key} member states differ from canonical list')
   if d.get('adminStates')!=ADMIN: fail(f'{key} admin states differ from canonical list')
   if d.get('adapterManifestRequirements')!=MANIFEST: fail(f'{key} manifest requirements differ from canonical list')


### PR DESCRIPTION
## Summary
- lock #743 domain contract fields into the canonical registry and server resource copy
- add Wave 2/later placeholders and #743 acceptance traceability
- add sovereign domain contract docs and compact README showcase while preserving release evidence markers
- tighten registry validation for required fields, search derived state, adapter candidate count, and caveated commercial/license/jurisdiction candidates

Closes #743

## Evidence
- python3 tools/domain_registry_check.py
- python3 tools/product_trust_claim_matrix_check.py
- python3 tools/docs_check.py
- python3 tools/readme_release_notes.py --check
- ./gradlew acceptanceContract domainRegistryCheck docsCheck releaseEvidenceCheck --console=plain
- git diff --check

## Release notes
- release-notes-feature