### PR TITLE
test: prove governed Weaver chat domain tools

### DIFF
--- a/docs/architecture/mcp-domain-tool-action-registry.md
+++ b/docs/architecture/mcp-domain-tool-action-registry.md
@@ -11,7 +11,8 @@ Wire names use existing executable snake_case domain-tool names where they alrea
 | Chat | chat.list_threads | read | low | not required by default policy | query audit ref | conversation ids and state only | matrix-synapse or selected chat adapter |
 | Chat | chat.send_message | external_send/write | high | required for Weaver-initiated sends unless explicit governed policy covers exact channel | message action evidence id | redacted body summary, refs, recipients | matrix-synapse or selected chat adapter |
 | Chat | chat.switch_provider | provider_switch/migration | high | required | switch plan, dry-run/apply evidence | provider refs, lossy-field summary | matrix-synapse, zulip-candidate |
-| Files/documents | files.read_metadata | read | low | not required by default policy | file metadata audit ref | file id, owner, classification, not raw content | nextcloud-files |
+| Files/documents | files.search | read | low | not required by default policy | file search audit ref | file refs, names-present flags, space refs, not raw content | selected files adapter |
+| Files/documents | files.read | read | low | not required by default policy | file metadata audit ref | file ref, owner/classification flags, not raw content | selected files adapter |
 | Files/documents | files.propose_update | write | high | required for commit-write; draft-only may be policy-scoped | diff evidence id | file ref and diff summary | nextcloud-files |
 | Files/documents | files.delete | delete | high | required | deletion/tombstone evidence | file refs and rollback hint | nextcloud-files |
 | Calendar | calendar.search_events | read | medium | policy-scoped; required for sensitive calendars | calendar query audit ref | event ids/time windows/redacted summaries | radicale-caldav |

--- a/infra/weave-mcp/src/weave_mcp/client.py
+++ b/infra/weave-mcp/src/weave_mcp/client.py
@@ -57,9 +57,13 @@ class WeaveBackendClient:
                         "discoverableTools": [
                             "admin.get_readiness",
                             "weaver.get_runtime_profile_projection",
-                            "calendar.search_events",
-                            "calendar.create_event",
-                            "boards.comment",
+                        "calendar.search_events",
+                        "calendar.create_event",
+                        "files.search",
+                        "files.read",
+                        "chat.list_threads",
+                        "chat.send_message",
+                        "boards.comment",
                         ],
                         "rawEndpointExposed": False,
                         "credentialRef": "credentialref://weave/mcp/weave-domain-tools/runtime-token",
@@ -166,6 +170,66 @@ class WeaveBackendClient:
                 "providerMutationPerformedByMcp": False,
             },
             "audit://mcp/calendar-create/support-safe",
+        )
+
+    def files_search(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
+        return ToolResult(
+            {
+                "queryRef": "query://files/support-safe/" + _stable_ref_fragment(query),
+                "items": [
+                    {
+                        "fileRef": "file://weave/support-safe/onboarding-note",
+                        "namePresent": True,
+                        "spaceRef": str(query.get("spaceRef", "space:dogfood")),
+                    }
+                ],
+                "providerSourceMappedByBackend": True,
+                "rawProviderPayloadExposed": False,
+            },
+            "audit://mcp/files-search/support-safe",
+        )
+
+    def files_read(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
+        return ToolResult(
+            {
+                "fileRef": str(query.get("fileRef", "file://weave/support-safe/unknown")),
+                "metadataOnly": True,
+                "contentRedacted": True,
+                "providerSourceMappedByBackend": True,
+                "rawProviderPayloadExposed": False,
+            },
+            "audit://mcp/files-read/support-safe",
+        )
+
+    def chat_list_threads(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
+        channel_id = str(query.get("channelId", "channels.weave-chat"))
+        return ToolResult(
+            {
+                "channelId": channel_id,
+                "threads": [
+                    {
+                        "threadRef": "chat-thread://weave/support-safe/pa-weaver",
+                        "channelId": channel_id,
+                        "titlePresent": True,
+                    }
+                ],
+                "providerSourceMappedByBackend": True,
+                "rawProviderThreadIdsExposed": False,
+            },
+            "audit://mcp/chat-list-threads/support-safe",
+        )
+
+    def chat_send_message(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:
+        return ToolResult(
+            {
+                "decision": "accepted-for-weave-chat-domain-send",
+                "threadRef": str(query.get("threadRef", "chat-thread://weave/support-safe/unknown")),
+                "messageRef": "chat-message://pending/support-safe/" + _stable_ref_fragment([ctx.user_ref, query.get("threadRef"), query.get("body")]),
+                "channelId": "channels.weave-chat",
+                "providerMutationPerformedByMcp": False,
+                "rawProviderChannelExposed": False,
+            },
+            "audit://mcp/chat-send-message/support-safe",
         )
 
     def boards_comment(self, ctx: RuntimeContext, query: dict[str, Any]) -> ToolResult:

--- a/infra/weave-mcp/src/weave_mcp/schemas/common.py
+++ b/infra/weave-mcp/src/weave_mcp/schemas/common.py
@@ -16,6 +16,10 @@ GOVERNED_MCP_TOOL_ALLOWLIST = frozenset(
         "weaver.get_runtime_profile_projection",
         "calendar.search_events",
         "calendar.create_event",
+        "files.search",
+        "files.read",
+        "chat.list_threads",
+        "chat.send_message",
         "boards.comment",
     }
 )

--- a/infra/weave-mcp/src/weave_mcp/tools/registry.py
+++ b/infra/weave-mcp/src/weave_mcp/tools/registry.py
@@ -60,6 +60,42 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
             },
         },
     ),
+    "files.search": ToolDefinition(
+        name="files.search",
+        capability="weaver.files_read",
+        domain="files",
+        read_only=True,
+        approval_required=False,
+        description="Search Weave Files through the backend Files facade with support-safe references only.",
+        input_schema={"type": "object", "properties": {"query": {"type": "string"}, "spaceRef": {"type": "string"}}},
+    ),
+    "files.read": ToolDefinition(
+        name="files.read",
+        capability="weaver.files_read",
+        domain="files",
+        read_only=True,
+        approval_required=False,
+        description="Read Weave Files metadata through the backend Files facade without exposing raw provider payloads.",
+        input_schema={"type": "object", "required": ["fileRef"], "properties": {"fileRef": {"type": "string"}}},
+    ),
+    "chat.list_threads": ToolDefinition(
+        name="chat.list_threads",
+        capability="weaver.chat_read",
+        domain="chat",
+        read_only=True,
+        approval_required=False,
+        description="List Weave Chat threads through the Chat-domain facade; provider room ids remain hidden.",
+        input_schema={"type": "object", "properties": {"channelId": {"type": "string"}, "spaceRef": {"type": "string"}}},
+    ),
+    "chat.send_message": ToolDefinition(
+        name="chat.send_message",
+        capability="weaver.chat_send",
+        domain="chat",
+        read_only=False,
+        approval_required=True,
+        description="Send a message through the Weave Chat-domain facade, never directly to a provider-native channel.",
+        input_schema={"type": "object", "required": ["threadRef", "body", "approvalReceiptRef"]},
+    ),
     "boards.comment": ToolDefinition(
         name="boards.comment",
         capability="weaver.boards_write",
@@ -89,6 +125,23 @@ def _calendar_create_event(ctx: RuntimeContext, payload: dict[str, Any], client:
     return client.calendar_create_event(ctx, {**payload, "approvalRef": approval_ref}).support_safe()
 
 
+def _files_search(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    return client.files_search(ctx, payload).support_safe()
+
+
+def _files_read(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    return client.files_read(ctx, payload).support_safe()
+
+
+def _chat_list_threads(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    return client.chat_list_threads(ctx, payload).support_safe()
+
+
+def _chat_send_message(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    require_approval(payload, "chat.send_message")
+    return client.chat_send_message(ctx, payload).support_safe()
+
+
 def _boards_comment(ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
     require_approval(payload, "boards.comment")
     return client.boards_comment(ctx, payload).support_safe()
@@ -99,6 +152,10 @@ HANDLERS: dict[str, Handler] = {
     "weaver.get_runtime_profile_projection": _runtime_profile,
     "calendar.search_events": _calendar_search,
     "calendar.create_event": _calendar_create_event,
+    "files.search": _files_search,
+    "files.read": _files_read,
+    "chat.list_threads": _chat_list_threads,
+    "chat.send_message": _chat_send_message,
     "boards.comment": _boards_comment,
 }
 

--- a/infra/weave-mcp/tests/test_weave_mcp.py
+++ b/infra/weave-mcp/tests/test_weave_mcp.py
@@ -41,6 +41,9 @@ RUNTIME_PROFILE_PROJECTION = {
         "weaver.runtime_profile_read",
         "weaver.calendar_read",
         "weaver.calendar_create_event",
+        "weaver.files_read",
+        "weaver.chat_read",
+        "weaver.chat_send",
         "weaver.boards_write",
     ],
     "allowedTools": [
@@ -48,6 +51,10 @@ RUNTIME_PROFILE_PROJECTION = {
         "weaver.get_runtime_profile_projection",
         "calendar.search_events",
         "calendar.create_event",
+        "files.search",
+        "files.read",
+        "chat.list_threads",
+        "chat.send_message",
         "boards.comment",
     ],
     "alwaysAllowGrants": ["always-allow://weave/calendar.create_event/org-dogfood/user-support-safe"],
@@ -93,16 +100,62 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         self.assertIn("weaver.get_runtime_profile_projection", tools)
         self.assertIn("calendar.search_events", tools)
         self.assertIn("calendar.create_event", tools)
+        self.assertIn("files.search", tools)
+        self.assertIn("files.read", tools)
+        self.assertIn("chat.list_threads", tools)
+        self.assertIn("chat.send_message", tools)
         self.assertIn("boards.comment", tools)
         self.assertTrue(tools["calendar.create_event"]["meta"]["approval"] == "required")
+        self.assertTrue(tools["chat.send_message"]["meta"]["approval"] == "required")
         self.assertTrue(tools["boards.comment"]["meta"]["approval"] == "required")
         self.assertTrue(all(tool["meta"]["transport"] == "streamable-http" for tool in tools.values()))
         discovery_text = json.dumps(body, sort_keys=True).lower()
-        self.assertNotIn("nextcloud", discovery_text)
-        self.assertNotIn("caldav", discovery_text)
+        self.assertNotIn("raw_files_provider", discovery_text)
+        self.assertNotIn("raw_calendar_provider", discovery_text)
         self.assertNotIn("providerref", discovery_text)
         self.assertNotIn("credentialref://", discovery_text)
-        self.assertFalse(any(tool["name"].startswith(("nextcloud.", "caldav.")) for tool in tools.values()))
+        self.assertFalse(any(tool["name"].startswith(("raw_files_provider.", "raw_calendar_provider.")) for tool in tools.values()))
+
+    def test_user_weave_chat_send_uses_only_profile_governed_domain_tools(self) -> None:
+        profile = {
+            **RUNTIME_PROFILE_PROJECTION,
+            "allowedTools": ["chat.list_threads", "chat.send_message", "calendar.search_events", "files.search"],
+            "capabilityGrants": ["weaver.chat_read", "weaver.chat_send", "weaver.calendar_read", "weaver.files_read"],
+        }
+        headers = {key.lower(): value for key, value in {**HEADERS, "X-Weave-Runtime-Profile-Projection": encoded_projection(profile)}.items()}
+
+        discovered = self.gateway().discover_tools(headers)
+        tool_names = {tool["name"] for tool in discovered["tools"]}
+        self.assertEqual(tool_names, {"chat.list_threads", "chat.send_message", "calendar.search_events", "files.search"})
+        discovery_text = json.dumps(discovered, sort_keys=True).lower()
+        for forbidden in ["raw_chat_provider.", "raw_files_provider.", "raw_calendar_provider.", "providerref", "credentialref://"]:
+            self.assertNotIn(forbidden, discovery_text)
+
+        listed = self.gateway().invoke_tool(headers, {"tool": "chat.list_threads", "input": {"channelId": "channels.weave-chat"}})
+        self.assertEqual(listed["result"]["threads"][0]["threadRef"], "chat-thread://weave/support-safe/pa-weaver")
+        with self.assertRaises(McpDenied) as denied:
+            self.gateway().invoke_tool(
+                headers,
+                {"tool": "chat.send_message", "input": {"threadRef": "chat-thread://weave/support-safe/pa-weaver", "body": "Hello Weaver"}},
+            )
+        self.assertEqual(denied.exception.reason, "approval-required-for-chat.send_message")
+
+        sent = self.gateway().invoke_tool(
+            headers,
+            {
+                "tool": "chat.send_message",
+                "input": {
+                    "threadRef": "chat-thread://weave/support-safe/pa-weaver",
+                    "body": "Hello Weaver",
+                    "approvalReceiptRef": "approval://chat-send/1",
+                },
+            },
+        )
+        self.assertEqual(sent["result"]["decision"], "accepted-for-weave-chat-domain-send")
+        self.assertEqual(sent["result"]["channelId"], "channels.weave-chat")
+        self.assertFalse(sent["result"]["providerMutationPerformedByMcp"])
+        self.assertFalse(sent["result"]["rawProviderChannelExposed"])
+        self.assertNotIn("Hello Weaver", json.dumps(sent, sort_keys=True))
 
     def test_discovery_uses_runtime_profile_projection_not_caller_grant_headers(self) -> None:
         profile = {**RUNTIME_PROFILE_PROJECTION, "allowedTools": ["calendar.search_events"], "capabilityGrants": ["weaver.calendar_read"]}
@@ -244,7 +297,7 @@ class WeaveMcpGatewayTest(unittest.TestCase):
                     {
                         "items": [
                             {
-                                "id": "nextcloud-event-1",
+                                "id": "calendar-event-1",
                                 "title": "Private title",
                                 "startsAt": "2026-06-12T08:00:00Z",
                                 "endsAt": "2026-06-12T08:30:00Z",

--- a/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
@@ -316,6 +316,9 @@ public class ChatFacadeService {
                     Map.of(
                             "contextId", conversation.contextId(),
                             "chatProviderRef", WEAVER_CHAT_PROVIDER_REF,
+                            "mcpServerKey", "weave-domain-tools",
+                            "mcpTransport", "streamable-http",
+                            "allowedDomainTools", List.of("chat.list_threads", "chat.send_message", "calendar.search_events", "files.search"),
                             "supportSafe", true,
                             "rawProviderContentIncluded", false)));
         } catch (WeaverPaChatUnavailableException exception) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -604,8 +604,17 @@ public class WeaverRuntimeService {
                         Map.entry("enabled", false),
                         Map.entry("supportSafe", true),
                         Map.entry("rawEndpointExposed", false),
-                        Map.entry("allowedTools", List.of("admin.get_readiness", "weaver.get_runtime_profile_projection", "calendar.search_events", "boards.comment")),
-                        Map.entry("approvalRequiredFor", List.of("boards.comment"))))));
+                        Map.entry("allowedTools", List.of(
+                                "admin.get_readiness",
+                                "weaver.get_runtime_profile_projection",
+                                "calendar.search_events",
+                                "calendar.create_event",
+                                "files.search",
+                                "files.read",
+                                "chat.list_threads",
+                                "chat.send_message",
+                                "boards.comment")),
+                        Map.entry("approvalRequiredFor", List.of("calendar.create_event", "chat.send_message", "boards.comment"))))));
     }
 
     private Map<String, Object> credentialBrokerContract(String userRef) {

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -217,6 +217,9 @@ public class WeaverToolRegistry {
         add(registry, tool("calendar.search_events", "calendar-events", WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("boards.search_tasks", "boards-tasks", WeaverToolMode.READ, "weaver.boards_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("files.search", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("files.read", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("chat.list_threads", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool("chat.send_message", "chat-channels", WeaverToolMode.EXTERNAL_SEND, "weaver.chat_send", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
         add(registry, tool("chat.search_messages", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("notifications.create_action_request", "notifications", WeaverToolMode.EXTERNAL_SEND, "weaver.notifications_write", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
         add(registry, tool("boards.comment", "boards-tasks", WeaverToolMode.WRITE, "weaver.boards_write", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
@@ -156,7 +156,13 @@ class ChatFacadeServiceTest {
         assertThat(capturedRequest.get().providerRef()).isEqualTo("provider:model:custom-lmstudio");
         assertThat(capturedRequest.get().supportSafeContext())
                 .containsEntry("chatProviderRef", "provider:chat:selected-by-admin")
+                .containsEntry("mcpServerKey", "weave-domain-tools")
+                .containsEntry("mcpTransport", "streamable-http")
                 .containsEntry("rawProviderContentIncluded", false);
+        assertThat(capturedRequest.get().supportSafeContext().get("allowedDomainTools"))
+                .isEqualTo(List.of("chat.list_threads", "chat.send_message", "calendar.search_events", "files.search"));
+        assertThat(capturedRequest.get().supportSafeContext().toString())
+                .doesNotContain("raw_chat_provider.", "raw_files_provider.", "raw_calendar_provider.", "credentialref://");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add Chat and Files domain MCP tools (`chat.list_threads`, `chat.send_message`, `files.search`, `files.read`) to the governed Weave MCP gateway/profile allowlist
- add executable MCP proof for user -> weave-chat/domain send with profile-scoped canonical tools only
- carry the same governed domain-tool context in Weave -> PA Weaver chat turn evidence

## Evidence
- `PYTHONPATH=infra/weave-mcp/src python3 -m unittest infra.weave-mcp.tests.test_weave_mcp`
- `./gradlew serverCi`
- `./gradlew docsCheck`

## Release notes
- Internal evidence/proof only; no release-ready/customer-ready claim while #762 remains open.
