### PR TITLE
fix: separate Weave domain MCP projection

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -2,11 +2,15 @@ package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.model.ApiErrorResponse;
 import com.massimotter.weave.backend.model.OrganizationManifestResponse;
+import com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
 import com.massimotter.weave.backend.model.WorkspaceHomeResponse;
 import com.massimotter.weave.backend.model.WorkspaceReleaseReadinessResponse;
 import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
+import com.massimotter.weave.backend.weaver.WeaverToolInvocationResult;
+import java.util.List;
+import java.util.Map;
 import com.massimotter.weave.backend.service.OrganizationManifestService;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import com.massimotter.weave.backend.service.WorkspaceHomeService;
@@ -24,6 +28,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -147,6 +154,31 @@ public class WorkspaceController {
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable String runtimeProfileHash) {
         return weaverRuntimeService.profileByHash(jwt, runtimeProfileHash);
+    }
+
+    @GetMapping({"/api/workspace/weaver/mcp/servers/{serverKey}", "/api/v1/workspace/weaver/mcp/servers/{serverKey}"})
+    public Map<String, Object> weaverMcpServerProjection(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String serverKey,
+            @RequestParam String runtimeProfileHash) {
+        return weaverRuntimeService.mcpServerProjection(jwt, runtimeProfileHash, serverKey);
+    }
+
+    @GetMapping({"/api/workspace/weaver/mcp/servers/{serverKey}/tools", "/api/v1/workspace/weaver/mcp/servers/{serverKey}/tools"})
+    public List<Map<String, Object>> weaverMcpToolDiscovery(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String serverKey,
+            @RequestParam String runtimeProfileHash) {
+        return weaverRuntimeService.discoverMcpTools(jwt, runtimeProfileHash, serverKey);
+    }
+
+    @PostMapping({"/api/workspace/weaver/mcp/servers/{serverKey}/tools/{toolName}:invoke", "/api/v1/workspace/weaver/mcp/servers/{serverKey}/tools/{toolName}:invoke"})
+    public WeaverToolInvocationResult weaverMcpToolInvoke(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String serverKey,
+            @PathVariable String toolName,
+            @RequestBody WeaverMcpToolInvocationRequest request) {
+        return weaverRuntimeService.invokeMcpTool(jwt, serverKey, toolName, request);
     }
 
     @GetMapping({"/api/workspace/release-readiness", "/api/v1/workspace/release-readiness"})

--- a/server/src/main/java/com/massimotter/weave/backend/model/WeaverMcpToolInvocationRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/WeaverMcpToolInvocationRequest.java
@@ -1,0 +1,15 @@
+package com.massimotter.weave.backend.model;
+
+import com.massimotter.weave.backend.weaver.WeaverApprovalReceipt;
+import java.util.Map;
+
+public record WeaverMcpToolInvocationRequest(
+        String runtimeProfileHash,
+        Map<String, Object> input,
+        WeaverApprovalReceipt approvalReceipt) {
+
+    public WeaverMcpToolInvocationRequest {
+        runtimeProfileHash = runtimeProfileHash == null ? "" : runtimeProfileHash.trim();
+        input = Map.copyOf(input == null ? Map.of() : input);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/WeaverRuntimeProfileResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/WeaverRuntimeProfileResponse.java
@@ -33,6 +33,7 @@ public record WeaverRuntimeProfileResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean auditRequired,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean forkRequired,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Map<String, Object> channelProjection,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Map<String, Object> mcpProjection,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Map<String, Object> credentialBrokerContract,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Map<String, Object> auditPolicy,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Map<String, Object> supportSafeProfileReceipt,
@@ -46,6 +47,7 @@ public record WeaverRuntimeProfileResponse(
         pluginAllowlist = List.copyOf(pluginAllowlist == null ? List.of() : pluginAllowlist);
         toolAllowlist = List.copyOf(toolAllowlist == null ? List.of() : toolAllowlist);
         channelProjection = Map.copyOf(channelProjection == null ? Map.of() : channelProjection);
+        mcpProjection = Map.copyOf(mcpProjection == null ? Map.of() : mcpProjection);
         credentialBrokerContract = Map.copyOf(credentialBrokerContract == null ? Map.of() : credentialBrokerContract);
         auditPolicy = Map.copyOf(auditPolicy == null ? Map.of() : auditPolicy);
         supportSafeProfileReceipt = Map.copyOf(supportSafeProfileReceipt == null ? Map.of() : supportSafeProfileReceipt);

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -6,7 +6,10 @@ import com.massimotter.weave.backend.audit.AuditEventPublisher;
 import com.massimotter.weave.backend.audit.AuditRedactionLevel;
 import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest;
 import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
+import com.massimotter.weave.backend.weaver.WeaverToolInvocationResult;
+import com.massimotter.weave.backend.weaver.WeaverToolRegistry;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -42,16 +45,19 @@ public class WeaverRuntimeService {
     private final WorkspaceCapabilityProperties workspaceCapabilityProperties;
     private final WeaverRuntimeProperties weaverRuntimeProperties;
     private final AuditEventPublisher auditEventPublisher;
+    private final WeaverToolRegistry weaverToolRegistry;
 
     public WeaverRuntimeService(
             WorkspaceCapabilityService workspaceCapabilityService,
             WorkspaceCapabilityProperties workspaceCapabilityProperties,
             WeaverRuntimeProperties weaverRuntimeProperties,
-            AuditEventPublisher auditEventPublisher) {
+            AuditEventPublisher auditEventPublisher,
+            WeaverToolRegistry weaverToolRegistry) {
         this.workspaceCapabilityService = workspaceCapabilityService;
         this.workspaceCapabilityProperties = workspaceCapabilityProperties;
         this.weaverRuntimeProperties = weaverRuntimeProperties;
         this.auditEventPublisher = auditEventPublisher;
+        this.weaverToolRegistry = weaverToolRegistry;
     }
 
     public WeaverRuntimeProfileResponse profileFor(Jwt jwt) {
@@ -135,6 +141,7 @@ public class WeaverRuntimeService {
                 weaverRuntimeProperties.auditRequired(),
                 weaverRuntimeProperties.forkRequired(),
                 channelProjection(runtimeProfileHash, profileVersion, previousProfileHash, userRef, expiresAt, runtimeTokenExpiresAt),
+                mcpProjection(runtimeProfileHash, profileVersion, previousProfileHash, userRef, expiresAt, runtimeTokenExpiresAt, toolAllowlist, allowedCapabilities),
                 credentialBrokerContract(userRef),
                 auditPolicy(runtimeProfileHash, userRef),
                 supportSafeProfileReceipt(profileVersion, runtimeProfileHash, signature, expiresAt, runtimeTokenExpiresAt, false, "active"),
@@ -352,6 +359,7 @@ public class WeaverRuntimeService {
                 true,
                 false,
                 channelProjection(runtimeProfileHash, profileVersion, "none", userRef, expiresAt, expiresAt),
+                mcpProjection(runtimeProfileHash, profileVersion, "none", userRef, expiresAt, expiresAt, List.of(), List.of()),
                 credentialBrokerContract(userRef),
                 auditPolicy(runtimeProfileHash, userRef),
                 supportSafeProfileReceipt(
@@ -593,28 +601,115 @@ public class WeaverRuntimeService {
                 Map.entry("reloadStrategy", "reload-or-restart-stable-channel"),
                 Map.entry("rawProviderChannelConfigsRendered", false),
                 Map.entry("memberMaySwitchProviderAdapters", false),
-                Map.entry("mcpServerBindings", List.of(Map.ofEntries(
-                        Map.entry("serverKey", "weave-domain-tools"),
-                        Map.entry("transport", "streamable-http"),
-                        Map.entry("endpointRef", "internal://weave-mcp/streamable-http"),
-                        Map.entry("credentialRef", "credentialref://weave/mcp/weave-domain-tools/runtime-token"),
-                        Map.entry("runtimeTokenRef", runtimeTokenRef),
-                        Map.entry("runtimeTokenExpiresAt", runtimeTokenExpiresAt),
-                        Map.entry("runtimeProfileFetchRef", "weave-runtime-profile://" + runtimeProfileHash),
-                        Map.entry("enabled", false),
-                        Map.entry("supportSafe", true),
-                        Map.entry("rawEndpointExposed", false),
-                        Map.entry("allowedTools", List.of(
-                                "admin.get_readiness",
-                                "weaver.get_runtime_profile_projection",
-                                "calendar.search_events",
-                                "calendar.create_event",
-                                "files.search",
-                                "files.read",
-                                "chat.list_threads",
-                                "chat.send_message",
-                                "boards.comment")),
-                        Map.entry("approvalRequiredFor", List.of("calendar.create_event", "chat.send_message", "boards.comment"))))));
+                Map.entry("mcpServersProjectedSeparately", true));
+    }
+
+    private Map<String, Object> mcpProjection(
+            String runtimeProfileHash,
+            String profileVersion,
+            String previousProfileHash,
+            String userRef,
+            String expiresAt,
+            String runtimeTokenExpiresAt,
+            List<String> toolAllowlist,
+            List<String> allowedCapabilities) {
+        String runtimeTokenRef = "credentialref://weave/runtime/short-lived/" + userRef.replace("user:", "");
+        Map<String, Object> binding = Map.ofEntries(
+                Map.entry("serverKey", "weave-domain-tools"),
+                Map.entry("displayName", "Weave governed domain tools"),
+                Map.entry("transport", "streamable-http"),
+                Map.entry("endpointRef", "internal://weave-mcp/streamable-http"),
+                Map.entry("credentialRef", "credentialref://weave/mcp/weave-domain-tools/runtime-token"),
+                Map.entry("runtimeTokenRef", runtimeTokenRef),
+                Map.entry("runtimeTokenExpiresAt", runtimeTokenExpiresAt),
+                Map.entry("runtimeProfileFetchRef", "weave-runtime-profile://" + runtimeProfileHash),
+                Map.entry("routingChannelRef", "channels.weave-chat"),
+                Map.entry("routingPlaneSeparated", true),
+                Map.entry("enabled", !toolAllowlist.isEmpty()),
+                Map.entry("supportSafe", true),
+                Map.entry("rawEndpointExposed", false),
+                Map.entry("rawServerConfigExposed", false),
+                Map.entry("secretValuesExposed", false),
+                Map.entry("previousProfileHash", previousProfileHash),
+                Map.entry("profileVersion", profileVersion),
+                Map.entry("expiresAt", expiresAt),
+                Map.entry("allowedTools", toolAllowlist),
+                Map.entry("allowedCapabilities", allowedCapabilities),
+                Map.entry("approvalRequiredFor", List.of("calendar.create_event", "chat.send_message", "boards.comment")));
+        return Map.of(
+                "servers", Map.of("weave-domain-tools", binding),
+                "supportSafe", true,
+                "denyByDefault", true,
+                "channelPlaneRef", "channels.weave-chat",
+                "memberMayMutateServerBindings", false,
+                "rawProviderEndpointsExposed", false);
+    }
+
+    public Map<String, Object> mcpServerProjection(Jwt jwt, String runtimeProfileHash, String serverKey) {
+        WeaverRuntimeProfileResponse profile = profileByHash(jwt, runtimeProfileHash);
+        if (!profile.enabled()) {
+            return Map.of(
+                    "serverKey", serverKey,
+                    "status", profile.posture(),
+                    "enabled", false,
+                    "supportSafe", true,
+                    "message", "MCP server discovery failed closed.");
+        }
+        Object server = profile.mcpProjection().getOrDefault("servers", Map.of());
+        if (!(server instanceof Map<?, ?> servers) || !servers.containsKey(serverKey)) {
+            return Map.of(
+                    "serverKey", serverKey,
+                    "status", "server_not_projected",
+                    "enabled", false,
+                    "supportSafe", true,
+                    "message", "Requested MCP server is not projected by this RuntimeProfile.");
+        }
+        return Map.of("server", servers.get(serverKey), "supportSafe", true);
+    }
+
+    public List<Map<String, Object>> discoverMcpTools(Jwt jwt, String runtimeProfileHash, String serverKey) {
+        WeaverRuntimeProfileResponse profile = profileByHash(jwt, runtimeProfileHash);
+        if (!profile.enabled() || !"weave-domain-tools".equals(serverKey)) {
+            return List.of();
+        }
+        return weaverToolRegistry.discover(profile.allowedCapabilities()).stream()
+                .filter(definition -> profile.toolAllowlist().contains(definition.name()))
+                .map(definition -> Map.<String, Object>of(
+                        "name", definition.name(),
+                        "version", definition.version(),
+                        "domain", definition.domain(),
+                        "mode", definition.mode().name(),
+                        "requiredCapability", definition.requiredCapability(),
+                        "approvalRequirement", definition.approvalRequirement().name(),
+                        "inputSchema", definition.inputSchema(),
+                        "supportSafeDescription", definition.supportSafeDescription(),
+                        "resultRedactionRules", definition.resultRedactionRules()))
+                .toList();
+    }
+
+    public WeaverToolInvocationResult invokeMcpTool(
+            Jwt jwt,
+            String serverKey,
+            String toolName,
+            WeaverMcpToolInvocationRequest request) {
+        WeaverRuntimeProfileResponse profile = profileByHash(jwt, request.runtimeProfileHash());
+        if (!profile.enabled() || !"weave-domain-tools".equals(serverKey)) {
+            return new WeaverToolInvocationResult(toolName, "runtime_profile_fetch_denied", false, true, Map.of("supportSafe", true), "MCP invocation failed closed.");
+        }
+        return weaverToolRegistry.invoke(new com.massimotter.weave.backend.weaver.WeaverToolInvocationRequest(
+                toolName,
+                profile.userRef(),
+                profile.runtimeProfileHash(),
+                profile.userRef(),
+                profile.signature(),
+                profile.revoked(),
+                String.valueOf(profile.supportSafeProfileReceipt().getOrDefault("runtimeTokenExpiresAt", "")),
+                true,
+                profile.allowedCapabilities(),
+                profile.toolAllowlist(),
+                request.input(),
+                request.approvalReceipt() == null ? null : request.approvalReceipt().receiptRef(),
+                request.approvalReceipt()));
     }
 
     private Map<String, Object> credentialBrokerContract(String userRef) {

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -87,14 +87,37 @@ public class WeaverToolRegistry {
                 "ok",
                 false,
                 true,
-                Map.of(
-                        "domain", definition.domain(),
-                        "result", "support-safe-placeholder",
-                        "canonicalRefs", canonicalRefs(request.input()),
-                        "approvalReceiptAuditRef", request.approvalReceipt() == null ? "none" : request.approvalReceipt().auditRef(),
-                        "rawProviderPayload", "redacted",
-                        "auditRef", auditRef(request.toolName(), "invoked")),
+                successResult(request, definition),
                 "Tool invocation went through a Weave domain capability boundary; raw provider APIs are not exposed.");
+    }
+
+    private Map<String, Object> successResult(WeaverToolInvocationRequest request, WeaverDomainToolDefinition definition) {
+        Map<String, Object> base = new LinkedHashMap<>();
+        base.put("domain", definition.domain());
+        base.put("canonicalRefs", canonicalRefs(request.input()));
+        base.put("approvalReceiptAuditRef", request.approvalReceipt() == null ? "none" : request.approvalReceipt().auditRef());
+        base.put("rawProviderPayload", "redacted");
+        base.put("auditRef", auditRef(request.toolName(), "invoked"));
+        if ("identity.read".equals(definition.name())) {
+            base.put("identity", Map.of(
+                    "userRef", request.userRef(),
+                    "runtimeProfileHash", request.runtimeProfileHash(),
+                    "supportSafe", true,
+                    "rawClaimsExposed", false));
+        } else if ("registry.tools.read".equals(definition.name())) {
+            base.put("tools", definitions.values().stream()
+                    .filter(tool -> request.grantedCapabilities().contains(tool.requiredCapability()))
+                    .filter(tool -> request.scopedToolGrants().contains(tool.name()))
+                    .map(tool -> Map.of(
+                            "name", tool.name(),
+                            "mode", tool.mode().name(),
+                            "domain", tool.domain(),
+                            "approvalRequirement", tool.approvalRequirement().name()))
+                    .toList());
+        } else {
+            base.put("result", "support-safe-placeholder");
+        }
+        return Map.copyOf(base);
     }
 
     private String governanceDenial(WeaverToolInvocationRequest request, WeaverDomainToolDefinition definition) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -14,6 +14,7 @@ import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import com.massimotter.weave.backend.service.WorkspaceHomeService;
 import com.massimotter.weave.backend.service.WorkspaceReleaseReadinessService;
 import com.massimotter.weave.backend.service.WeaverRuntimeService;
+import com.massimotter.weave.backend.weaver.WeaverToolRegistry;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         WorkspaceReleaseReadinessService.class,
         WorkspaceHomeService.class,
         WeaverRuntimeService.class,
+        WeaverToolRegistry.class,
         ApiAuthenticationEntryPoint.class,
         ApiAccessDeniedHandler.class,
         ApiErrorResponseWriter.class

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -6,6 +6,7 @@ import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.weaver.WeaverToolRegistry;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -94,12 +95,18 @@ class WeaverRuntimeServiceTest {
                 .containsEntry("runtimeTokenExpiresAt", profile.supportSafeProfileReceipt().get("runtimeTokenExpiresAt"))
                 .containsEntry("rawProviderChannelConfigsRendered", false)
                 .containsEntry("memberMaySwitchProviderAdapters", false)
-                .containsKey("mcpServerBindings");
+                .containsEntry("mcpServersProjectedSeparately", true)
+                .doesNotContainKeys("mcp", "mcpServerBindings");
         assertThat(profile.channelProjection().get("runtimeProfileFetch").toString())
                 .contains("fetchRef=weave-runtime-profile://" + profile.runtimeProfileHash())
                 .contains("signatureRequired=true", "revocationChecked=true", "rawProfileBodyReturnedToMembers=false");
-        assertThat(profile.channelProjection().get("mcpServerBindings").toString())
-                .contains("weave-domain-tools", "streamable-http", "calendar.search_events", "boards.comment")
+        assertThat(profile.mcpProjection())
+                .containsEntry("supportSafe", true)
+                .containsEntry("denyByDefault", true)
+                .containsEntry("channelPlaneRef", "channels.weave-chat")
+                .containsEntry("memberMayMutateServerBindings", false);
+        assertThat(profile.mcpProjection().get("servers").toString())
+                .contains("weave-domain-tools", "streamable-http")
                 .contains("runtimeProfileFetchRef=weave-runtime-profile://" + profile.runtimeProfileHash())
                 .contains("runtimeTokenRef=credentialref://weave/runtime/short-lived/")
                 .doesNotContain("Bearer ", "openclaw.json", "rawMcpServerConfig");
@@ -138,6 +145,29 @@ class WeaverRuntimeServiceTest {
                 .containsEntry("decision", "generated");
         assertThat(audit.events().get(0).payload()).containsEntry("supportSafe", true);
         assertThat(audit.events().get(0).payload()).containsEntry("execEnabled", false);
+    }
+
+    @Test
+    void exposesSeparateMcpProjectionAndSafeReadOnlyFixtureTool() {
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+
+        var profile = service.profileFor(member);
+        var serverProjection = service.mcpServerProjection(member, profile.runtimeProfileHash(), "weave-domain-tools");
+        var tools = service.discoverMcpTools(member, profile.runtimeProfileHash(), "weave-domain-tools");
+        var invocation = service.invokeMcpTool(
+                member,
+                "weave-domain-tools",
+                "files.read",
+                new com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest(profile.runtimeProfileHash(), Map.of("spaceRef", "space:control-room"), null));
+
+        assertThat(serverProjection.toString())
+                .contains("weave-domain-tools", "routingPlaneSeparated=true", "channels.weave-chat")
+                .doesNotContain("Bearer ", "openclaw.json");
+        assertThat(tools).extracting(tool -> tool.get("name")).containsExactly("files.read");
+        assertThat(invocation.status()).isEqualTo("ok");
+        assertThat(invocation.redactedResult()).containsEntry("rawProviderPayload", "redacted");
+        assertThat(invocation.redactedResult().get("canonicalRefs").toString()).contains("space:control-room");
     }
 
     @Test
@@ -345,7 +375,7 @@ class WeaverRuntimeServiceTest {
                 new WeaveSecurityProperties("weave-app", "weave-app"),
                 capabilities,
                 runtimeProperties);
-        return new WeaverRuntimeService(capabilityService, capabilities, runtimeProperties, audit);
+        return new WeaverRuntimeService(capabilityService, capabilities, runtimeProperties, audit, new WeaverToolRegistry(audit));
     }
 
     private WeaverRuntimeProperties runtimeProperties(boolean enabled) {


### PR DESCRIPTION
## Summary
- separate RuntimeProfile MCP server projection from `channels.weave-chat`
- add support-safe MCP server discovery/list and governed invoke endpoints for `weave-domain-tools`
- prove fail-closed policy, audit, and read-only fixture behavior with server tests

## Testing
- ./gradlew test --tests 'com.massimotter.weave.backend.weaver.WeaverToolRegistryTest' --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest' --tests 'com.massimotter.weave.backend.controller.WorkspaceControllerTest'

Fixes #764