### PR TITLE
feat(server): add governed board search MCP fixture

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
@@ -27,9 +27,9 @@ public record WeaverRuntimeProperties(
         isolatedAgentDirectory = hasText(isolatedAgentDirectory) ? isolatedAgentDirectory : ".weaver/agents";
         dockerNetworkMode = hasText(dockerNetworkMode) ? dockerNetworkMode : "none";
         enabledGroups = normalize(enabledGroups, List.of("weave-weaver-runtime"));
-        allowedCapabilities = normalize(allowedCapabilities, List.of("weaver.files_read", "weaver.exec_disabled"));
-        pluginAllowlist = normalize(pluginAllowlist, List.of("weave-files-readonly"));
-        toolAllowlist = normalize(toolAllowlist, List.of("files.read"));
+        allowedCapabilities = normalize(allowedCapabilities, List.of("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"));
+        pluginAllowlist = normalize(pluginAllowlist, List.of("weave-files-readonly", "weave-boards-readonly"));
+        toolAllowlist = normalize(toolAllowlist, List.of("files.read", "boards.search_tasks"));
         // Even when an admin enables the runtime, audit remains required by default.
         auditRequired = true;
     }

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
@@ -113,7 +113,7 @@ public final class ProviderCapabilityContracts {
                     "export support-safe readiness/audit records; delete follows audit retention policy",
                     "admin tooling replacement requires policy/readiness/audit dry-run and delegated-scope review")),
             Map.entry("weaver", new Definition(
-                    List.of("weaver.enabled", "weaver.files_read", "weaver.exec_disabled"),
+                    List.of("weaver.enabled", "weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"),
                     List.of("openclaw-derived-profile"),
                     List.of(),
                     List.of("WeaverRuntimeProfile", "WeaverRuntimeInstance", "WeaverUserWorkspace", "WeaverToolGrant", "WeaverApprovalReceipt", "WeaverAuditEvent", "WeaverCustomizationProfile"),

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -103,7 +103,7 @@ public class AdminControlPlaneService {
             "weave-meeting-hosts", List.of("meetings.host"),
             "weave-document-editors", List.of("documents.edit"),
             "weave-decision-recorders", List.of("decisions.record"),
-            "weave-weaver-pilot", List.of("weaver.files_read", "weaver.exec_disabled"));
+            "weave-weaver-pilot", List.of("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"));
     private static final Set<String> SIMULATION_KNOWN_CAPABILITIES = Set.of(
             "chat.read", "chat.send", "files.read", "files.upload", "calendar.read", "calendar.manage_events",
             "boards.read", "boards.update_task", "meetings.join", "meetings.host", "documents.view", "documents.edit",
@@ -885,7 +885,7 @@ public class AdminControlPlaneService {
         profileCapabilities.put("member-default", List.of(
                 "chat.read", "chat.send", "files.read", "files.upload", "calendar.read", "boards.read", "weaver.exec_disabled"));
         profileCapabilities.put("guest-deny-default", List.of());
-        profileCapabilities.put("group:weave-weaver-pilot", List.of("weaver.files_read", "weaver.exec_disabled"));
+        profileCapabilities.put("group:weave-weaver-pilot", List.of("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"));
         return new CapabilityWhitelistResponse(
                 policy.denyByDefault(),
                 false,

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -74,7 +74,7 @@ public class WorkspaceCapabilityService {
             "weave-meeting-hosts", List.of("meetings.host"),
             "weave-document-editors", List.of("documents.edit"),
             "weave-decision-recorders", List.of("decisions.record"),
-            "weave-weaver-pilot", List.of("weaver.files_read", "weaver.exec_disabled"));
+            "weave-weaver-pilot", List.of("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"));
 
     private final OAuth2ResourceServerProperties resourceServerProperties;
     private final WeaveSecurityProperties weaveSecurityProperties;
@@ -193,7 +193,7 @@ public class WorkspaceCapabilityService {
                         workspaceCapabilityProperties.weaver(),
                         WorkspaceCapabilityReadiness.UNAVAILABLE,
                         "Weaver",
-                        List.of("weaver.enabled", "weaver.files_read", "weaver.exec_disabled"),
+                        List.of("weaver.enabled", "weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"),
                         policy,
                         "Weaver is disabled by default until an admin enables a governed runtime profile."));
     }

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -9,6 +9,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -51,6 +52,14 @@ public class WeaverToolRegistry {
                     "requiredTool", request.toolName(),
                     "auditRef", auditRef(request.toolName(), "scoped_grant_missing")));
             return blocked(request.toolName(), "scoped_grant_missing", "Tool is not included in the signed scoped grant.");
+        }
+        String inputDenial = inputDenial(request, definition);
+        if (inputDenial != null) {
+            audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), inputDenial, Map.of(
+                    "reason", inputDenial,
+                    "domain", definition.domain(),
+                    "auditRef", auditRef(request.toolName(), inputDenial)));
+            return blocked(request.toolName(), inputDenial, "Tool input was rejected by Weave policy before provider access.");
         }
         boolean approvalReceiptValidated = false;
         if (definition.writeLike()) {
@@ -114,10 +123,75 @@ public class WeaverToolRegistry {
                             "domain", tool.domain(),
                             "approvalRequirement", tool.approvalRequirement().name()))
                     .toList());
+        } else if ("boards.search_tasks".equals(definition.name())) {
+            base.put("tasks", boardSearchResults(request.input()));
         } else {
             base.put("result", "support-safe-placeholder");
         }
         return Map.copyOf(base);
+    }
+
+    private String inputDenial(WeaverToolInvocationRequest request, WeaverDomainToolDefinition definition) {
+        if (definition == null) {
+            return null;
+        }
+        if ("boards.search_tasks".equals(definition.name())) {
+            return boardsSearchInputDenial(request.input());
+        }
+        return null;
+    }
+
+    private String boardsSearchInputDenial(Map<String, Object> input) {
+        if (!input.keySet().stream().allMatch(key -> List.of("spaceRef", "query", "limit").contains(key))) {
+            return "overbroad_args";
+        }
+        Object spaceRef = input.get("spaceRef");
+        if (!(spaceRef instanceof String ref) || !canonicalRef(ref) || !ref.startsWith("space:")) {
+            return "invalid_args";
+        }
+        Object query = input.get("query");
+        if (!(query instanceof String queryText)) {
+            return "invalid_args";
+        }
+        String normalizedQuery = queryText.trim();
+        if (normalizedQuery.length() < 2 || normalizedQuery.length() > 80 || normalizedQuery.contains("*") || normalizedQuery.contains("..")) {
+            return "overbroad_args";
+        }
+        Object limit = input.getOrDefault("limit", 3);
+        if (!(limit instanceof Number number) || number.intValue() < 1 || number.intValue() > 5) {
+            return "overbroad_args";
+        }
+        return null;
+    }
+
+    private List<Map<String, Object>> boardSearchResults(Map<String, Object> input) {
+        String query = String.valueOf(input.getOrDefault("query", "")).trim().toLowerCase(Locale.ROOT);
+        int limit = ((Number) input.getOrDefault("limit", 3)).intValue();
+        List<Map<String, Object>> catalog = List.of(
+                Map.of(
+                        "taskRef", "board-task:WEAVE-771",
+                        "title", "Prove governed Qwen tool-call loop",
+                        "status", "in_progress",
+                        "spaceRef", "space:control-room",
+                        "supportSafeSummary", "Validates local tool call routing through Weave MCP."),
+                Map.of(
+                        "taskRef", "board-task:WEAVE-762",
+                        "title", "Preserve release blocker reconciliation",
+                        "status", "blocked",
+                        "spaceRef", "space:control-room",
+                        "supportSafeSummary", "Keeps release/customer-ready claims blocked until docs are reconciled."),
+                Map.of(
+                        "taskRef", "board-task:WEAVE-768",
+                        "title", "Weaver chat bridge answered through local Qwen",
+                        "status", "done",
+                        "spaceRef", "space:control-room",
+                        "supportSafeSummary", "Earlier slice proved channel-plane answer path without exposing provider secrets."));
+        return catalog.stream()
+                .filter(task -> task.get("title").toString().toLowerCase(Locale.ROOT).contains(query)
+                        || task.get("supportSafeSummary").toString().toLowerCase(Locale.ROOT).contains(query)
+                        || task.get("status").toString().toLowerCase(Locale.ROOT).contains(query))
+                .limit(limit)
+                .toList();
     }
 
     private String governanceDenial(WeaverToolInvocationRequest request, WeaverDomainToolDefinition definition) {
@@ -238,7 +312,22 @@ public class WeaverToolRegistry {
         add(registry, tool("tasks.read", "boards-tasks", WeaverToolMode.READ, "weaver.tasks_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("search.query", "weave-search", WeaverToolMode.READ, "weaver.search_query", WeaverApprovalRequirement.NONE));
         add(registry, tool("calendar.search_events", "calendar-events", WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("boards.search_tasks", "boards-tasks", WeaverToolMode.READ, "weaver.boards_read", WeaverApprovalRequirement.NONE));
+        add(registry, tool(
+                "boards.search_tasks",
+                "boards-tasks",
+                WeaverToolMode.READ,
+                "weaver.boards_read",
+                WeaverApprovalRequirement.NONE,
+                Map.of(
+                        "type", "object",
+                        "additionalProperties", false,
+                        "required", List.of("spaceRef", "query"),
+                        "properties", Map.of(
+                                "spaceRef", Map.of("type", "string", "pattern", "^space:[a-z0-9-]+$"),
+                                "query", Map.of("type", "string", "minLength", 2, "maxLength", 80),
+                                "limit", Map.of("type", "integer", "minimum", 1, "maximum", 5)),
+                        "description", "Searches support-safe board tasks within one canonical space."),
+                "Support-safe board task search fixture exposed only through Weave capability grants."));
         add(registry, tool("files.search", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("files.read", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("chat.list_threads", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
@@ -259,9 +348,8 @@ public class WeaverToolRegistry {
             WeaverToolMode mode,
             String requiredCapability,
             WeaverApprovalRequirement approvalRequirement) {
-        return new WeaverDomainToolDefinition(
+        return tool(
                 name,
-                "v1",
                 domain,
                 mode,
                 requiredCapability,
@@ -270,7 +358,26 @@ public class WeaverToolRegistry {
                         "type", "object",
                         "additionalProperties", false,
                         "description", "Validated by the Weave " + domain + " facade before provider access."),
-                List.of("providerCredentials", "rawProviderPayload", "secretRef.value"),
                 "Weaver domain tool exposed only through Weave capability grants.");
+    }
+
+    private WeaverDomainToolDefinition tool(
+            String name,
+            String domain,
+            WeaverToolMode mode,
+            String requiredCapability,
+            WeaverApprovalRequirement approvalRequirement,
+            Map<String, Object> inputSchema,
+            String supportSafeDescription) {
+        return new WeaverDomainToolDefinition(
+                name,
+                "v1",
+                domain,
+                mode,
+                requiredCapability,
+                approvalRequirement,
+                inputSchema,
+                List.of("providerCredentials", "rawProviderPayload", "secretRef.value"),
+                supportSafeDescription);
     }
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -118,9 +118,9 @@ weave:
       isolated-agent-directory: ${WEAVE_WEAVER_RUNTIME_AGENT_DIRECTORY:.weaver/agents}
       docker-network-mode: ${WEAVE_WEAVER_RUNTIME_DOCKER_NETWORK_MODE:none}
       enabled-groups: ${WEAVE_WEAVER_RUNTIME_ENABLED_GROUPS:weave-weaver-runtime}
-      allowed-capabilities: ${WEAVE_WEAVER_RUNTIME_ALLOWED_CAPABILITIES:weaver.files_read,weaver.exec_disabled}
-      plugin-allowlist: ${WEAVE_WEAVER_RUNTIME_PLUGIN_ALLOWLIST:weave-files-readonly}
-      tool-allowlist: ${WEAVE_WEAVER_RUNTIME_TOOL_ALLOWLIST:files.read}
+      allowed-capabilities: ${WEAVE_WEAVER_RUNTIME_ALLOWED_CAPABILITIES:weaver.files_read,weaver.boards_read,weaver.exec_disabled}
+      plugin-allowlist: ${WEAVE_WEAVER_RUNTIME_PLUGIN_ALLOWLIST:weave-files-readonly,weave-boards-readonly}
+      tool-allowlist: ${WEAVE_WEAVER_RUNTIME_TOOL_ALLOWLIST:files.read,boards.search_tasks}
       exec-enabled: ${WEAVE_WEAVER_RUNTIME_EXEC_ENABLED:false}
       elevated-enabled: ${WEAVE_WEAVER_RUNTIME_ELEVATED_ENABLED:false}
       audit-required: true

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceLiveWeaverRoundTripTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceLiveWeaverRoundTripTest.java
@@ -210,7 +210,7 @@ class ChatFacadeServiceLiveWeaverRoundTripTest {
                         ".weaver/agents",
                         "weave-runtime-net",
                         List.of("weave-weaver-runtime"),
-                        List.of("weaver.files_read", "weaver.exec_disabled"),
+                        List.of("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"),
                         List.of("weave-chat"),
                         List.of("message.send"),
                         false,

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
@@ -289,7 +289,7 @@ class ChatFacadeServiceTest {
                 ".weaver/agents",
                 "weave-runtime-net",
                 List.of("weave-weaver-runtime"),
-                List.of("weaver.files_read", "weaver.exec_disabled"),
+                List.of("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"),
                 List.of("weave-chat"),
                 List.of("message.send"),
                 false,

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -82,9 +82,9 @@ class WeaverRuntimeServiceTest {
         assertThat(profile.workspacePath()).startsWith("/var/lib/weave/weaver/");
         assertThat(profile.isolatedAgentDirectory()).isEqualTo(".weaver/agents");
         assertThat(profile.dockerNetworkMode()).isEqualTo("none");
-        assertThat(profile.allowedCapabilities()).containsExactly("weaver.files_read", "weaver.exec_disabled");
-        assertThat(profile.pluginAllowlist()).containsExactly("weave-files-readonly");
-        assertThat(profile.toolAllowlist()).containsExactly("files.read");
+        assertThat(profile.allowedCapabilities()).containsExactly("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled");
+        assertThat(profile.pluginAllowlist()).containsExactly("weave-files-readonly", "weave-boards-readonly");
+        assertThat(profile.toolAllowlist()).containsExactly("files.read", "boards.search_tasks");
         assertThat(profile.execEnabled()).isFalse();
         assertThat(profile.elevatedEnabled()).isFalse();
         assertThat(profile.auditRequired()).isTrue();
@@ -164,10 +164,53 @@ class WeaverRuntimeServiceTest {
         assertThat(serverProjection.toString())
                 .contains("weave-domain-tools", "routingPlaneSeparated=true", "channels.weave-chat")
                 .doesNotContain("Bearer ", "openclaw.json");
-        assertThat(tools).extracting(tool -> tool.get("name")).containsExactly("files.read");
+        assertThat(tools).extracting(tool -> tool.get("name")).containsExactly("files.read", "boards.search_tasks");
         assertThat(invocation.status()).isEqualTo("ok");
         assertThat(invocation.redactedResult()).containsEntry("rawProviderPayload", "redacted");
         assertThat(invocation.redactedResult().get("canonicalRefs").toString()).contains("space:control-room");
+
+        var boardSearch = service.invokeMcpTool(
+                member,
+                "weave-domain-tools",
+                "boards.search_tasks",
+                new com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest(
+                        profile.runtimeProfileHash(),
+                        Map.of("spaceRef", "space:control-room", "query", "tool", "limit", 2),
+                        null));
+        assertThat(boardSearch.status()).isEqualTo("ok");
+        assertThat(boardSearch.redactedResult().get("tasks").toString())
+                .contains("board-task:WEAVE-771")
+                .doesNotContain("providerRoom", "Bearer ");
+    }
+
+    @Test
+    void deniesCrossUserProfileHashAndWriteToolOutsideScopedRuntimeProfile() {
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+        Jwt otherMember = jwt("other@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+
+        var active = service.profileFor(member);
+        var crossUser = service.invokeMcpTool(
+                otherMember,
+                "weave-domain-tools",
+                "boards.search_tasks",
+                new com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest(
+                        active.runtimeProfileHash(),
+                        Map.of("spaceRef", "space:control-room", "query", "tool"),
+                        null));
+        var unsafeWrite = service.invokeMcpTool(
+                member,
+                "weave-domain-tools",
+                "boards.comment",
+                new com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest(
+                        active.runtimeProfileHash(),
+                        Map.of("spaceRef", "space:control-room", "boardTaskRef", "board-task:WEAVE-771", "body", "ship it"),
+                        null));
+
+        assertThat(crossUser.status()).isEqualTo("runtime_profile_fetch_denied");
+        assertThat(unsafeWrite.status()).isEqualTo("blocked");
+        assertThat(unsafeWrite.approvalRequired()).isFalse();
+        assertThat(unsafeWrite.redactedResult()).containsEntry("auditRef", "audit://weaver-tool/boards.comment/blocked");
     }
 
     @Test
@@ -387,9 +430,9 @@ class WeaverRuntimeServiceTest {
                 null,
                 null,
                 List.of("weave-weaver-runtime"),
-                List.of("weaver.files_read", "weaver.exec_disabled"),
-                List.of("weave-files-readonly"),
-                List.of("files.read"),
+                List.of("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled"),
+                List.of("weave-files-readonly", "weave-boards-readonly"),
+                List.of("files.read", "boards.search_tasks"),
                 false,
                 false,
                 true,

--- a/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WorkspaceCapabilityServiceTest.java
@@ -238,7 +238,7 @@ class WorkspaceCapabilityServiceTest {
         assertThat(snapshot.weaver().enabled()).isFalse();
         assertThat(snapshot.weaver().readiness()).isEqualTo(WorkspaceCapabilityReadiness.UNAVAILABLE);
         assertThat(snapshot.weaver().policyState()).isEqualTo(WorkspaceCapabilityPolicyState.DISABLED);
-        assertThat(snapshot.weaver().grantedCapabilities()).contains("weaver.files_read", "weaver.exec_disabled");
+        assertThat(snapshot.weaver().grantedCapabilities()).contains("weaver.files_read", "weaver.boards_read", "weaver.exec_disabled");
         assertThat(snapshot.weaver().grantedCapabilities()).doesNotContain("weaver.enabled");
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -192,7 +192,8 @@ class WeaverToolRegistryTest {
                 "weaver.contacts_read",
                 "weaver.chat_read",
                 "weaver.tasks_read",
-                "weaver.search_query"));
+                "weaver.search_query",
+                "weaver.boards_read"));
 
         assertThat(tools).extracting(WeaverDomainToolDefinition::name).contains(
                 "model.chat",
@@ -204,7 +205,8 @@ class WeaverToolRegistryTest {
                 "contacts.read",
                 "chat.read",
                 "tasks.read",
-                "search.query");
+                "search.query",
+                "boards.search_tasks");
         assertThat(tools.stream().filter(tool -> tool.name().endsWith(".read") || tool.name().equals("model.chat") || tool.name().equals("audit.query") || tool.name().equals("search.query")))
                 .allSatisfy(tool -> {
                     assertThat(tool.mode()).isEqualTo(WeaverToolMode.READ);
@@ -228,6 +230,47 @@ class WeaverToolRegistryTest {
         assertThat(unknown.status()).isEqualTo("blocked");
         assertThat(unknown.supportSafeMessage()).doesNotContain("do not leak");
         assertThat(audit.events().get(0).payload()).containsEntry("reason", "not_granted");
+    }
+
+    @Test
+    void deniesOverbroadBoardSearchArgsAndReturnsSupportSafeFixtureForScopedReadTool() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverToolRegistry registry = new WeaverToolRegistry(audit);
+
+        var denied = registry.invoke(new WeaverToolInvocationRequest(
+                "boards.search_tasks",
+                "user:abc123",
+                "sha256:boardsargs000000000000000000000000000000000000000000000000",
+                "user:abc123",
+                signature(),
+                false,
+                future(),
+                true,
+                List.of("weaver.boards_read"),
+                List.of("boards.search_tasks"),
+                Map.of("spaceRef", "space:control-room", "query", "tool*", "limit", 50),
+                null));
+
+        assertThat(denied.status()).isEqualTo("overbroad_args");
+        assertThat(audit.events().get(0).payload()).containsEntry("decision", "overbroad_args");
+
+        var allowed = registry.invoke(new WeaverToolInvocationRequest(
+                "boards.search_tasks",
+                "user:abc123",
+                "sha256:boardsok00000000000000000000000000000000000000000000000000",
+                "user:abc123",
+                signature(),
+                false,
+                future(),
+                true,
+                List.of("weaver.boards_read"),
+                List.of("boards.search_tasks"),
+                Map.of("spaceRef", "space:control-room", "query", "tool", "limit", 2),
+                null));
+
+        assertThat(allowed.status()).isEqualTo("ok");
+        assertThat(allowed.redactedResult().get("tasks").toString()).contains("board-task:WEAVE-771");
+        assertThat(allowed.redactedResult().toString()).doesNotContain("Bearer ", "providerRoom");
     }
 
     private WeaverToolInvocationRequest governedRequest(


### PR DESCRIPTION
## Summary\n- Adds a governed read-only boards.search_tasks MCP fixture for the local Qwen tool-calling slice.\n- Grants the read capability through RuntimeProfile defaults/policy previews.\n- Adds negative coverage for unknown tools, overbroad args, revoked profiles, scoped grants, and approval-required write tools.\n\n## Evidence\n- ./gradlew test --tests 'com.massimotter.weave.backend.weaver.WeaverToolRegistryTest' --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest' --tests 'com.massimotter.weave.backend.service.WorkspaceCapabilityServiceTest'\n\n## Release / blocker note\n- Supports masssi164/weave#771.\n- Does not clear or weaken release blocker masssi164/weave#762.\n\n## Release notes\n- release-notes-feature