### PR TITLE
feat: add attach-existing portability plan MVP

### DIFF
--- a/docs/architecture/no-unaccounted-data-loss.md
+++ b/docs/architecture/no-unaccounted-data-loss.md
@@ -36,6 +36,14 @@ Machine-readable schemas live under `server/src/main/resources/contracts/portabi
 
 Provider migration apply is impossible until a successful dry-run report exists. A `MigrationRun` follows the canonical lifecycle `discovered`, `preflight_failed`, `preflight_passed`, `exported`, `dry_run_completed`, `blocked`, `approved`, `applying`, `applied`, `verified`, `rolled_back`, and `archived`. A run with `applyAllowed: true` must be in `approved`, `applying`, `applied`, or `verified` state and must include a non-empty dry-run report reference, provider mapping reference, object counts, content hashes, audit references, admin approval, rollback/archive boundary, and post-apply verification reference. Missing reports, conflicts, unclassified losses, incomplete identity mapping, unavailable audit sink, or unsafe redaction force `applyAllowed: false`.
 
+## Attach-existing portability plan MVP
+
+The attach-existing path starts with read-only discovery for organizations that already run a provider landscape and want Weave to reduce hyperscaler dependence without redeploying or destructively migrating current systems. `specs/0006-portability-contract/attach-existing-files-portability-plan-mvp.json` is the bounded Files-domain fixture for this product slice.
+
+The fixture keeps exactly one active Files binding: the existing cloud Files adapter remains `active`, a second handle may be `discovery_read_only`, and the self-hosted/sovereign Files adapter remains `candidate` until separate migration evidence exists. Other canonical binding states remain available for future plans: `migration_source`, `migration_target`, and `coexistence_preflight`.
+
+The AdapterMapper output is intentionally admin/operator-facing. It records a capability map, permission-impact report ref, loss report ref, conflict report ref, audit refs, a recommended self-hosted/sovereign target where the evidence supports it, and cutover/rollback next steps. Discovery mode must not rotate credentials, mutate the provider, import data, delete data, or claim release readiness. Member/App clients consume only stable provider-neutral capability states such as `available`, `degraded`, or `coming_later`; provider names, opaque configuration handles, report refs, and target recommendations stay behind Admin/Operator surfaces.
+
 ## Support-safe redaction
 
 Portability artifacts must contain support-safe identifiers and hashes, not raw provider tokens, credentials, internal endpoints, or opaque downstream error payloads. Raw provider payloads stay server/operator-side and must be redacted before they enter evidence, member preview, issue comments, or docs.

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -2026,6 +2026,17 @@
             "member_provider_neutral_join_passed",
             "weave_client_e2e_passed"
           ]
+        },
+        {
+          "path": "specs/0006-portability-contract/attach-existing-files-portability-plan-mvp.json",
+          "fragments": [
+            "attach_existing",
+            "discovery_read_only",
+            "nextcloud-files-sovereign-target",
+            "noDestructiveActionInDiscoveryMode",
+            "noMemberVisibleProviderInternals",
+            "exactlyOneActiveBindingPerDomain"
+          ]
         }
       ]
     },

--- a/specs/0006-portability-contract/attach-existing-files-portability-plan-mvp.json
+++ b/specs/0006-portability-contract/attach-existing-files-portability-plan-mvp.json
@@ -1,0 +1,125 @@
+{
+  "planId": "attach-existing-files-portability-plan-mvp",
+  "scenario": "existing organization attaches current cloud files provider for discovery before any migration",
+  "domainKey": "files",
+  "redaction": "support_safe",
+  "mode": "attach_existing",
+  "claimBoundary": "Read-only discovery and portability planning only. This does not prove destructive migration, production cutover, release readiness, legal compliance, or lossless provider migration.",
+  "adapterMapper": {
+    "mapperKey": "files-attach-existing-portability-mapper",
+    "capabilityMap": [
+      {
+        "canonicalCapability": "files.read",
+        "sourceProviderCapability": "cloud-drive-file-read",
+        "targetProviderCapability": "nextcloud-files-read",
+        "memberState": "available"
+      },
+      {
+        "canonicalCapability": "files.share_links",
+        "sourceProviderCapability": "cloud-drive-external-link-read",
+        "targetProviderCapability": "nextcloud-share-link-policy-review",
+        "memberState": "degraded"
+      },
+      {
+        "canonicalCapability": "files.retention_labels",
+        "sourceProviderCapability": "cloud-drive-proprietary-retention-labels",
+        "targetProviderCapability": "manual-policy-rebuild-required",
+        "memberState": "coming_later"
+      }
+    ],
+    "permissionImpactRef": "permission-impact:attach-existing-files:mvp",
+    "lossReportRef": "loss-report:attach-existing-files:mvp",
+    "conflictReportRef": "conflict-report:attach-existing-files:mvp",
+    "auditRefs": [
+      "audit:attach-existing-files:discovery-read-only",
+      "audit:attach-existing-files:plan-generated"
+    ],
+    "recommendedTarget": {
+      "providerKey": "nextcloud-files-sovereign-target",
+      "reason": "Self-hosted Files candidate improves data-sovereignty posture because data plane, audit sink, and retention policy can be operated under the organization-controlled stack after a separately approved migration path."
+    },
+    "nextSteps": {
+      "cutover": [
+        "Keep cloud-drive-files active while discovery_read_only evidence is reviewed.",
+        "Run export dry-run and archive manifest checks before requesting migration_source or migration_target status.",
+        "Require admin approval of loss, permission, and conflict reports before any guarded apply."
+      ],
+      "rollback": [
+        "Retain the existing cloud-drive-files binding as the active binding until post-cutover verification passes.",
+        "Keep rollback retention and restore-smoke refs support-safe and admin-visible only."
+      ]
+    }
+  },
+  "adapterBindings": [
+    {
+      "adapterKey": "cloud-drive-files-existing",
+      "domainKeys": ["files"],
+      "providerPosture": "hyperscaler_cloud_existing",
+      "activeBindingStatus": "active",
+      "discoveryMode": "read_only",
+      "providerMutationPerformed": false,
+      "memberVisibleProviderInternals": false,
+      "auditRef": "audit:attach-existing-files:current-active-binding"
+    },
+    {
+      "adapterKey": "cloud-drive-files-discovery-source",
+      "domainKeys": ["files"],
+      "providerPosture": "hyperscaler_cloud_existing",
+      "activeBindingStatus": "discovery_read_only",
+      "discoveryMode": "read_only",
+      "providerMutationPerformed": false,
+      "memberVisibleProviderInternals": false,
+      "auditRef": "audit:attach-existing-files:discovery-source"
+    },
+    {
+      "adapterKey": "nextcloud-files-sovereign-target",
+      "domainKeys": ["files"],
+      "providerPosture": "self_hosted_sovereign_candidate",
+      "activeBindingStatus": "candidate",
+      "discoveryMode": "plan_only",
+      "providerMutationPerformed": false,
+      "memberVisibleProviderInternals": false,
+      "auditRef": "audit:attach-existing-files:candidate-target"
+    }
+  ],
+  "reports": {
+    "permissionImpact": [
+      {
+        "canonicalObject": "FileShare",
+        "impact": "External share links need admin policy review before a Nextcloud target can reproduce equivalent exposure.",
+        "fieldClass": "manual_review"
+      }
+    ],
+    "loss": [
+      {
+        "canonicalObject": "File",
+        "field": "provider_native_retention_label",
+        "fieldClass": "vendor_locked",
+        "reason": "Source retention labels are proprietary metadata and must be exported to an archive report or manually rebuilt."
+      },
+      {
+        "canonicalObject": "FileVersion",
+        "field": "historic_version_blob",
+        "fieldClass": "archive_only",
+        "reason": "Historic versions are discoverable but not imported in this MVP plan."
+      }
+    ],
+    "conflicts": [
+      {
+        "canonicalObject": "FileShare",
+        "reason": "Two source groups map to one target group slug; admin must choose merge or split before cutover."
+      }
+    ]
+  },
+  "memberCapabilityStates": [
+    "available",
+    "degraded",
+    "coming_later"
+  ],
+  "adminOnlyProviderDetails": true,
+  "negativeChecks": {
+    "noDestructiveActionInDiscoveryMode": true,
+    "noMemberVisibleProviderInternals": true,
+    "exactlyOneActiveBindingPerDomain": true
+  }
+}

--- a/tools/portability_contract_check.py
+++ b/tools/portability_contract_check.py
@@ -83,6 +83,37 @@ def main():
  for negative in ['provider-portability-v2-silent-drop-negative.json','provider-portability-v2-raw-provider-leak-negative.json']:
   fixture=load(FIXTURES/negative)
   if fixture.get('expectedOutcome') != 'reject': fail(f'{negative} must reject unsafe portability behavior')
+ attach=load(FIXTURES/'attach-existing-files-portability-plan-mvp.json')
+ if attach.get('mode')!='attach_existing' or attach.get('domainKey')!='files' or attach.get('redaction')!='support_safe':
+  fail('Attach-existing Files portability plan must be support_safe files attach_existing evidence')
+ attach_raw=json.dumps(attach).lower()
+ for forbidden in ['access_token','refresh_token','clientsecret','password','https://','secretref://']:
+  if forbidden in attach_raw: fail(f'Attach-existing Files plan must not leak raw provider credential or endpoint data: {forbidden}')
+ boundary=attach.get('claimBoundary', '').lower()
+ for phrase in ['read-only discovery', 'does not prove destructive migration', 'release readiness', 'lossless provider migration']:
+  if phrase not in boundary: fail(f'Attach-existing Files claim boundary missing {phrase}')
+ mapper=attach.get('adapterMapper', {})
+ for field in ['capabilityMap','permissionImpactRef','lossReportRef','conflictReportRef','auditRefs','recommendedTarget','nextSteps']:
+  if not mapper.get(field): fail(f'Attach-existing Files AdapterMapper plan missing {field}')
+ if 'self-hosted' not in mapper.get('recommendedTarget', {}).get('reason', '').lower() or 'data-sovereignty' not in mapper.get('recommendedTarget', {}).get('reason', '').lower():
+  fail('Attach-existing Files plan must recommend a self-hosted/sovereign target where appropriate')
+ bindings=attach.get('adapterBindings', [])
+ if not bindings: fail('Attach-existing Files plan missing adapter bindings')
+ active_by_domain={}
+ for binding in bindings:
+  status=binding.get('activeBindingStatus')
+  if status not in binding_enum: fail(f'Attach-existing Files plan uses non-canonical binding status {status}')
+  if binding.get('providerMutationPerformed') is not False: fail('Attach-existing discovery must not mutate providers')
+  if binding.get('memberVisibleProviderInternals') is not False: fail('Attach-existing provider internals must stay admin/operator-only')
+  for domain in binding.get('domainKeys', []):
+   if status == 'active': active_by_domain[domain]=active_by_domain.get(domain, 0)+1
+ if active_by_domain.get('files') != 1: fail('Attach-existing Files plan must keep exactly one active files binding')
+ checks=attach.get('negativeChecks', {})
+ for check in ['noDestructiveActionInDiscoveryMode','noMemberVisibleProviderInternals','exactlyOneActiveBindingPerDomain']:
+  if checks.get(check) is not True: fail(f'Attach-existing Files plan missing negative check {check}')
+ for state in attach.get('memberCapabilityStates', []):
+  if state not in ['available','disabled_by_policy','not_configured','degraded','unavailable','coming_later']:
+   fail(f'Attach-existing Files plan uses non-canonical member capability state {state}')
  matrix=load(FIXTURES/'matrix-synapse-chat-migration-proof.json')
  if matrix.get('domainKey')!='chat' or matrix.get('sourceProvider')!='matrix-synapse' or matrix.get('redaction')!='support_safe':
   fail('Matrix Synapse Chat proof must be a support_safe chat-domain fixture')


### PR DESCRIPTION
## Summary

- Add a bounded Attach-Existing Files portability plan fixture for existing organizations that want Weave discovery before migration.
- Extend the portability contract gate to validate AdapterMapper plan contents, read-only discovery, admin-only provider details, and exactly one active Files binding.
- Map the attach-existing acceptance scenario to the new fixture and document the no-overclaim boundary.

## Scope and user impact

- Admin/Operator-facing contract evidence only; no broad UI or server runtime changes.
- Members remain provider-agnostic via stable capability states (`available`, `degraded`, `coming_later`).
- Discovery mode explicitly avoids destructive provider mutation, credential rotation, import, delete, or cutover claims.

## Spec / acceptance link

- Issue: next product slice after PR #773 (Attach-Existing Discovery → Portability Plan MVP)
- Repo spec or spec note: `specs/0006-portability-contract/attach-existing-files-portability-plan-mvp.json`, `docs/architecture/no-unaccounted-data-loss.md`
- Acceptance scenario / mapping marker when product behavior changed: `@weave-control-attach-existing-preflight-boundary` / `WEAVE_CONTROL_ATTACH_EXISTING_PREFLIGHT`
- Product-core questions intentionally left unresolved: Full migration automation, production cutover, release readiness, legal compliance, and lossless migration remain explicitly out of scope.

## Branch, target lane, and release path

- Target lane: main exception (continuation branch from current `origin/main` per assigned slice)
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

Choose one and explain when needed.

- [ ] none
- [x] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

Use exactly one form.

- Release note: Add an Attach-Existing Files portability plan MVP that lets admins inspect read-only discovery evidence, capability mapping, loss/permission/conflict reports, and sovereign target recommendations without claiming migration readiness.
- Release note: none — reason:

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- Docs updated in `docs/architecture/no-unaccounted-data-loss.md`; no screenshots because this is contract/evidence work only.

## Accessibility and localization

- No member UI or localization change. The fixture preserves provider-neutral member capability states and keeps provider details admin/operator-only.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: Attach-existing Files portability fixture and contract gate validation.
- [x] `./gradlew specContract` run for spec/product-contract changes

## Review readiness

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance`
- [x] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [x] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes) — via `./gradlew docsCheck`
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): Not relevant; offline contract/docs slice only.

Additional focused checks:

- [x] `python3 -m json.tool specs/0006-portability-contract/attach-existing-files-portability-plan-mvp.json >/dev/null`
- [x] `python3 -m json.tool e2e/scenario_mappings.json >/dev/null`
- [x] `./gradlew portabilityContractCheck`
- [x] `./gradlew domainRegistryCheck specContract acceptanceContract docsCheck`

## Notes for reviewers

- This PR deliberately does not claim release/final-test readiness. Open items remain: Weave PR #772, release blocker #762, Weaver PR #21, and recent Weaver main CI failures.
