### PR TITLE
feat: expose attach-existing files portability plan

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
+++ b/server/src/main/java/com/massimotter/weave/backend/audit/AuditAction.java
@@ -17,6 +17,7 @@ public enum AuditAction {
     EFFECTIVE_POLICY_SIMULATED("effective_policy.simulated"),
     IDENTITY_REALM_APPLY_GUARDED("identity.realm.apply.guarded"),
     ADMIN_POLICY_UPDATED("admin.policy.updated"),
+    ATTACH_EXISTING_PORTABILITY_PLAN_INSPECTED("attach_existing.portability_plan.inspected"),
     PROVIDER_READINESS_TESTED("provider.readiness.tested"),
     PROVIDER_REPLACEMENT_DRY_RUN("provider.replacement.dry_run"),
     CHAT_MIGRATION_PREFLIGHTED("chat.migration.preflighted"),

--- a/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/AdminControlPlaneController.java
@@ -7,6 +7,7 @@ import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunRequest;
 import com.massimotter.weave.backend.model.ApiErrorResponse;
 import com.massimotter.weave.backend.model.admin.AdminAuditEventResponse;
 import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
+import com.massimotter.weave.backend.model.admin.AttachExistingPortabilityPlanResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
@@ -179,6 +180,15 @@ public class AdminControlPlaneController {
             @Valid @RequestBody ProviderReplacementDryRunRequest request,
             @AuthenticationPrincipal Jwt jwt) {
         return adminControlPlaneService.dryRunProviderReplacement(request, jwt);
+    }
+
+    @GetMapping({"/api/admin/portability/attach-existing/files/plan", "/api/v1/admin/portability/attach-existing/files/plan"})
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
+    @Operation(summary = "Inspect the support-safe attach-existing Files portability plan")
+    @ApiResponse(responseCode = "200", description = "Read-only Admin/Operator portability plan inspection.",
+            content = @Content(schema = @Schema(implementation = AttachExistingPortabilityPlanResponse.class)))
+    public AttachExistingPortabilityPlanResponse attachExistingFilesPortabilityPlan(@AuthenticationPrincipal Jwt jwt) {
+        return adminControlPlaneService.attachExistingFilesPortabilityPlan(jwt);
     }
 
     @GetMapping({"/api/admin/audit/events", "/api/v1/admin/audit/events"})

--- a/server/src/main/java/com/massimotter/weave/backend/model/admin/AttachExistingPortabilityPlanResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/admin/AttachExistingPortabilityPlanResponse.java
@@ -1,0 +1,91 @@
+package com.massimotter.weave.backend.model.admin;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Support-safe Admin/Operator attach-existing portability plan inspection response.")
+public record AttachExistingPortabilityPlanResponse(
+        String planId,
+        String contractVersion,
+        String mode,
+        String domainKey,
+        String status,
+        String claimBoundary,
+        boolean supportSafe,
+        boolean adminOnlyProviderDetails,
+        boolean destructiveActionAllowed,
+        boolean providerMutationPerformed,
+        boolean memberVisibleProviderInternals,
+        List<CapabilityMapItem> capabilityMap,
+        List<AdapterBinding> adapterBindings,
+        String permissionImpactRef,
+        List<ReportItem> permissionImpact,
+        String lossReportRef,
+        List<ReportItem> lossReport,
+        String conflictReportRef,
+        List<ReportItem> conflictReport,
+        List<String> auditRefs,
+        RecommendedTarget recommendedTarget,
+        NextSteps nextSteps,
+        List<String> memberCapabilityStates,
+        NegativeChecks negativeChecks) {
+    public AttachExistingPortabilityPlanResponse {
+        capabilityMap = capabilityMap == null ? List.of() : List.copyOf(capabilityMap);
+        adapterBindings = adapterBindings == null ? List.of() : List.copyOf(adapterBindings);
+        permissionImpact = permissionImpact == null ? List.of() : List.copyOf(permissionImpact);
+        lossReport = lossReport == null ? List.of() : List.copyOf(lossReport);
+        conflictReport = conflictReport == null ? List.of() : List.copyOf(conflictReport);
+        auditRefs = auditRefs == null ? List.of() : List.copyOf(auditRefs);
+        memberCapabilityStates = memberCapabilityStates == null ? List.of() : List.copyOf(memberCapabilityStates);
+    }
+
+    public record CapabilityMapItem(
+            String canonicalCapability,
+            String sourceProviderCapability,
+            String targetProviderCapability,
+            String memberState) {
+    }
+
+    public record AdapterBinding(
+            String adapterKey,
+            List<String> domainKeys,
+            String providerPosture,
+            String bindingStatus,
+            String discoveryMode,
+            boolean activeBinding,
+            boolean providerMutationPerformed,
+            boolean memberVisibleProviderInternals,
+            String auditRef) {
+        public AdapterBinding {
+            domainKeys = domainKeys == null ? List.of() : List.copyOf(domainKeys);
+        }
+    }
+
+    public record ReportItem(
+            String canonicalObject,
+            String field,
+            String fieldClass,
+            String impact,
+            String reason) {
+    }
+
+    public record RecommendedTarget(
+            String providerKey,
+            String reason) {
+    }
+
+    public record NextSteps(
+            List<String> cutover,
+            List<String> rollback) {
+        public NextSteps {
+            cutover = cutover == null ? List.of() : List.copyOf(cutover);
+            rollback = rollback == null ? List.of() : List.copyOf(rollback);
+        }
+    }
+
+    public record NegativeChecks(
+            boolean noDestructiveActionInDiscoveryMode,
+            boolean noMemberVisibleProviderInternals,
+            boolean exactlyOneActiveBindingPerDomain) {
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -23,6 +23,7 @@ import com.massimotter.weave.backend.identity.realm.KeycloakRealmLiveApplyAdapte
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
 import com.massimotter.weave.backend.model.admin.AdminAuditEventResponse;
 import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
+import com.massimotter.weave.backend.model.admin.AttachExistingPortabilityPlanResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistResponse;
 import com.massimotter.weave.backend.model.admin.CapabilityWhitelistUpdateRequest;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
@@ -231,6 +232,7 @@ public class AdminControlPlaneService {
                         Map.entry("audit", "/api/admin/audit/events"),
                         Map.entry("readinessTest", "/api/admin/providers/readiness-tests"),
                         Map.entry("providerReplacementDryRun", "/api/admin/providers/replacements/dry-run"),
+                        Map.entry("attachExistingFilesPortabilityPlan", "/api/admin/portability/attach-existing/files/plan"),
                         Map.entry("identityReadiness", "/api/admin/identity/readiness"),
                         Map.entry("identityRealmDryRun", "/api/admin/identity/realm/dry-run"),
                         Map.entry("identityRealmApply", "/api/admin/identity/realm/apply"),
@@ -1026,6 +1028,74 @@ public class AdminControlPlaneService {
                         "secretsReturned", false,
                         "rawProviderErrorsReturned", false,
                         "secretRef", safeSecretRef(request.secretRef())));
+    }
+
+    public AttachExistingPortabilityPlanResponse attachExistingFilesPortabilityPlan(Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "attach-existing-files-portability-plan");
+        Instant inspectedAt = Instant.now(clock);
+        String auditRef = "attach-existing-files-portability-plan-inspected-" + inspectedAt.toEpochMilli();
+        List<AttachExistingPortabilityPlanResponse.AdapterBinding> bindings = List.of(
+                new AttachExistingPortabilityPlanResponse.AdapterBinding("cloud-drive-files-existing", List.of("files"), "hyperscaler_cloud_existing", "active", "read_only", true, false, false, "audit:attach-existing-files:current-active-binding"),
+                new AttachExistingPortabilityPlanResponse.AdapterBinding("cloud-drive-files-discovery-source", List.of("files"), "hyperscaler_cloud_existing", "discovery_read_only", "read_only", false, false, false, "audit:attach-existing-files:discovery-source"),
+                new AttachExistingPortabilityPlanResponse.AdapterBinding("nextcloud-files-sovereign-target", List.of("files"), "self_hosted_sovereign_candidate", "candidate", "plan_only", false, false, false, "audit:attach-existing-files:candidate-target"));
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef(jwt),
+                "attach-existing-files-portability-plan",
+                AuditAction.ATTACH_EXISTING_PORTABILITY_PLAN_INSPECTED,
+                inspectedAt,
+                auditRef,
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.of(
+                        "planId", "attach-existing-files-portability-plan-mvp",
+                        "mode", "attach_existing",
+                        "domainKey", "files",
+                        "destructiveActionAllowed", false,
+                        "providerMutationPerformed", false,
+                        "memberVisibleProviderInternals", false,
+                        "providerDetailsAudience", "admin_operator_only",
+                        "token", "not-stored")));
+        return new AttachExistingPortabilityPlanResponse(
+                "attach-existing-files-portability-plan-mvp",
+                "admin-attach-existing-portability-plan-v1",
+                "attach_existing",
+                "files",
+                "inspection-ready-read-only",
+                "Read-only discovery and portability planning only. This does not prove destructive migration, production cutover, release readiness, legal compliance, or lossless provider migration.",
+                true,
+                true,
+                false,
+                false,
+                false,
+                List.of(
+                        new AttachExistingPortabilityPlanResponse.CapabilityMapItem("files.read", "cloud-drive-file-read", "nextcloud-files-read", "available"),
+                        new AttachExistingPortabilityPlanResponse.CapabilityMapItem("files.share_links", "cloud-drive-external-link-read", "nextcloud-share-link-policy-review", "degraded"),
+                        new AttachExistingPortabilityPlanResponse.CapabilityMapItem("files.retention_labels", "cloud-drive-proprietary-retention-labels", "manual-policy-rebuild-required", "coming_later")),
+                bindings,
+                "permission-impact:attach-existing-files:mvp",
+                List.of(new AttachExistingPortabilityPlanResponse.ReportItem("FileShare", null, "manual_review", "External share links need admin policy review before a Nextcloud target can reproduce equivalent exposure.", null)),
+                "loss-report:attach-existing-files:mvp",
+                List.of(
+                        new AttachExistingPortabilityPlanResponse.ReportItem("File", "provider_native_retention_label", "vendor_locked", null, "Source retention labels are proprietary metadata and must be exported to an archive report or manually rebuilt."),
+                        new AttachExistingPortabilityPlanResponse.ReportItem("FileVersion", "historic_version_blob", "archive_only", null, "Historic versions are discoverable but not imported in this MVP plan.")),
+                "conflict-report:attach-existing-files:mvp",
+                List.of(new AttachExistingPortabilityPlanResponse.ReportItem("FileShare", null, null, null, "Two source groups map to one target group slug; admin must choose merge or split before cutover.")),
+                List.of("audit:attach-existing-files:discovery-read-only", "audit:attach-existing-files:plan-generated", auditRef),
+                new AttachExistingPortabilityPlanResponse.RecommendedTarget("nextcloud-files-sovereign-target", "Self-hosted Files candidate improves data-sovereignty posture because data plane, audit sink, and retention policy can be operated under the organization-controlled stack after a separately approved migration path."),
+                new AttachExistingPortabilityPlanResponse.NextSteps(
+                        List.of("Keep cloud-drive-files active while discovery_read_only evidence is reviewed.", "Run export dry-run and archive manifest checks before requesting migration_source or migration_target status.", "Require admin approval of loss, permission, and conflict reports before any guarded apply."),
+                        List.of("Retain the existing cloud-drive-files binding as the active binding until post-cutover verification passes.", "Keep rollback retention and restore-smoke refs support-safe and admin-visible only.")),
+                List.of("available", "degraded", "coming_later"),
+                new AttachExistingPortabilityPlanResponse.NegativeChecks(true, true, exactlyOneActiveBindingPerDomain(bindings)));
+    }
+
+    private boolean exactlyOneActiveBindingPerDomain(List<AttachExistingPortabilityPlanResponse.AdapterBinding> bindings) {
+        Map<String, Long> activeCounts = bindings.stream()
+                .filter(AttachExistingPortabilityPlanResponse.AdapterBinding::activeBinding)
+                .flatMap(binding -> binding.domainKeys().stream())
+                .collect(java.util.stream.Collectors.groupingBy(domain -> domain, LinkedHashMap::new, java.util.stream.Collectors.counting()));
+        return activeCounts.values().stream().allMatch(count -> count == 1L);
     }
 
     public List<AdminAuditEventResponse> auditEvents(Jwt jwt) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -824,6 +824,60 @@ class AdminControlPlaneControllerTest {
                 .andExpect(jsonPath("$.details.diagnosticsRedacted").value(true));
     }
 
+    @Test
+    void operatorCanInspectAttachExistingFilesPortabilityPlanWithoutApplySurface() throws Exception {
+        mockMvc.perform(get("/api/admin/portability/attach-existing/files/plan").with(operatorJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.contractVersion").value("admin-attach-existing-portability-plan-v1"))
+                .andExpect(jsonPath("$.mode").value("attach_existing"))
+                .andExpect(jsonPath("$.domainKey").value("files"))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.adminOnlyProviderDetails").value(true))
+                .andExpect(jsonPath("$.destructiveActionAllowed").value(false))
+                .andExpect(jsonPath("$.providerMutationPerformed").value(false))
+                .andExpect(jsonPath("$.memberVisibleProviderInternals").value(false))
+                .andExpect(jsonPath("$.negativeChecks.noDestructiveActionInDiscoveryMode").value(true))
+                .andExpect(jsonPath("$.negativeChecks.noMemberVisibleProviderInternals").value(true))
+                .andExpect(jsonPath("$.negativeChecks.exactlyOneActiveBindingPerDomain").value(true))
+                .andExpect(jsonPath("$.capabilityMap[*].canonicalCapability", hasItems("files.read", "files.share_links", "files.retention_labels")))
+                .andExpect(jsonPath("$.capabilityMap[*].memberState", hasItems("available", "degraded", "coming_later")))
+                .andExpect(jsonPath("$.adapterBindings[?(@.bindingStatus == 'active')].adapterKey", hasItems("cloud-drive-files-existing")))
+                .andExpect(jsonPath("$.adapterBindings[?(@.activeBinding == true)]").isArray())
+                .andExpect(jsonPath("$.permissionImpactRef").value("permission-impact:attach-existing-files:mvp"))
+                .andExpect(jsonPath("$.lossReportRef").value("loss-report:attach-existing-files:mvp"))
+                .andExpect(jsonPath("$.conflictReportRef").value("conflict-report:attach-existing-files:mvp"))
+                .andExpect(jsonPath("$.recommendedTarget.providerKey").value("nextcloud-files-sovereign-target"))
+                .andExpect(jsonPath("$.nextSteps.cutover[*]", hasItems("Keep cloud-drive-files active while discovery_read_only evidence is reviewed.")))
+                .andExpect(content().string(not(containsString("applyUrl"))))
+                .andExpect(content().string(not(containsString("secretref://"))))
+                .andExpect(content().string(not(containsString("token"))));
+
+        mockMvc.perform(get("/api/admin/audit/events").with(operatorJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].action", hasItems("attach_existing.portability_plan.inspected")))
+                .andExpect(jsonPath("$[*].payload.planId", hasItems("attach-existing-files-portability-plan-mvp")))
+                .andExpect(jsonPath("$[*].payload.destructiveActionAllowed", hasItems(false)))
+                .andExpect(jsonPath("$[*].payload.providerMutationPerformed", hasItems(false)))
+                .andExpect(jsonPath("$[*].payload.memberVisibleProviderInternals", hasItems(false)))
+                .andExpect(jsonPath("$[*].payload.token", hasItems("[redacted]")))
+                .andExpect(content().string(not(containsString("secretref://"))))
+                .andExpect(content().string(not(containsString("Bearer"))));
+    }
+
+    @Test
+    void memberCannotInspectAttachExistingFilesPortabilityPlan() throws Exception {
+        mockMvc.perform(get("/api/admin/portability/attach-existing/files/plan").with(memberJwt()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"))
+                .andExpect(jsonPath("$.details.diagnosticsRedacted").value(true))
+                .andExpect(content().string(not(containsString("cloud-drive-files-existing"))))
+                .andExpect(content().string(not(containsString("nextcloud-files-sovereign-target"))))
+                .andExpect(content().string(not(containsString("provider_native_retention_label"))))
+                .andExpect(content().string(not(containsString("secretref://"))))
+                .andExpect(content().string(not(containsString("token"))));
+    }
+
     private WorkspaceCapabilityStatusResponse capability(
             WorkspaceCapabilityReadiness readiness,
             WorkspaceCapabilityPolicyState policyState,


### PR DESCRIPTION
## Summary

- Adds an admin/operator-only read endpoint for the attach-existing Files portability plan.
- Returns the bounded capability map, active/discovery/candidate bindings, permission/loss/conflict report refs, and negative checks from the locked MVP fixture.
- Records a support-safe audit event for plan inspection without exposing secrets or provider internals to members.

## Scope and user impact

- Admin Console/Operator API can inspect read-only attach-existing Files portability planning before any migration work.
- Members remain blocked from the surface; the response contains no apply URL, SecretRef, token, or provider credential payload.

## Spec / acceptance link

- Issue: none — scoped implementation slice from `specs/0006-portability-contract/attach-existing-files-portability-plan-mvp.json`
- Repo spec or spec note: `specs/0006-portability-contract/attach-existing-files-portability-plan-mvp.json`
- Acceptance scenario / mapping marker when product behavior changed: controller coverage in `AdminControlPlaneControllerTest.operatorCanInspectAttachExistingFilesPortabilityPlanWithoutApplySurface`
- Product-core questions intentionally left unresolved: none

## Branch, target lane, and release path

- Target lane: main exception (current repo sprint work is based on protected `main`; production release is not implied)
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [ ] none
- [x] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

- Release note: Admin/Operator API can inspect the support-safe attach-existing Files portability plan before migration cutover work.

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- No UI screenshot impact; backend API/model/test slice only.

## Accessibility and localization

- Not applicable; no user-facing UI copy or localization files changed.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: new admin/operator endpoint documented through OpenAPI annotations and response model.
- [x] `./gradlew specContract` run for spec/product-contract changes

## Review readiness

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented

Fallback review evidence: `weave-quality-lead` red-team review flagged missing audit trace and thin forbidden-path redaction assertions; both were addressed before PR creation.

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance`
- [x] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [x] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant; read-only backend contract slice.

Additional checks run:
- [x] `./gradlew test --tests '*AdminControlPlaneControllerTest*'` from `server/`
- [x] `./gradlew portabilityContractCheck domainRegistryCheck specContract acceptanceContract docsCheck`
- [x] `./gradlew serverCi`

## Notes for reviewers

- The endpoint is intentionally read-only and bounded to `/api/admin/portability/attach-existing/files/plan` plus `/api/v1/...`.
- The service publishes `attach_existing.portability_plan.inspected` audit events with redacted token placeholders and no provider credentials.
