### PR TITLE
feat: source attach-existing files plan from contract

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -124,6 +124,7 @@ public class AdminControlPlaneService {
     private final IdentityRealmEvidenceRepository identityRealmEvidenceRepository;
     private final List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters;
     private final IdentityRealmApplyProperties identityRealmApplyProperties;
+    private final AttachExistingPortabilityPlanLoader attachExistingPortabilityPlanLoader;
     private final Clock clock;
 
     @Autowired
@@ -136,7 +137,8 @@ public class AdminControlPlaneService {
             List<IdentityRealmProvider> identityRealmProviders,
             ObjectProvider<IdentityRealmEvidenceRepository> identityRealmEvidenceRepository,
             ObjectProvider<List<IdentityRealmLiveApplyAdapter>> identityRealmLiveApplyAdapters,
-            ObjectProvider<IdentityRealmApplyProperties> identityRealmApplyProperties) {
+            ObjectProvider<IdentityRealmApplyProperties> identityRealmApplyProperties,
+            AttachExistingPortabilityPlanLoader attachExistingPortabilityPlanLoader) {
         IdentityRealmApplyProperties properties = identityRealmApplyProperties.getIfAvailable(IdentityRealmApplyProperties::new);
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
@@ -148,6 +150,7 @@ public class AdminControlPlaneService {
                 : List.copyOf(identityRealmProviders);
         this.identityRealmEvidenceRepository = identityRealmEvidenceRepository.getIfAvailable(InMemoryIdentityRealmEvidenceRepository::new);
         this.identityRealmApplyProperties = properties;
+        this.attachExistingPortabilityPlanLoader = attachExistingPortabilityPlanLoader;
         List<IdentityRealmLiveApplyAdapter> adapters = identityRealmLiveApplyAdapters.getIfAvailable(List::of);
         this.identityRealmLiveApplyAdapters = adapters == null || adapters.isEmpty()
                 ? List.of(new KeycloakRealmLiveApplyAdapter(this.identityRealmApplyProperties))
@@ -163,7 +166,7 @@ public class AdminControlPlaneService {
             AuditEventPublisher auditEventPublisher,
             Clock clock) {
         this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher,
-                List.of(new KeycloakRealmDryRunProvider()), new InMemoryIdentityRealmEvidenceRepository(), List.of(new KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), clock);
+                List.of(new KeycloakRealmDryRunProvider()), new InMemoryIdentityRealmEvidenceRepository(), List.of(new KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), new AttachExistingPortabilityPlanLoader(new com.fasterxml.jackson.databind.ObjectMapper()), clock);
     }
 
     AdminControlPlaneService(
@@ -176,6 +179,23 @@ public class AdminControlPlaneService {
             IdentityRealmEvidenceRepository identityRealmEvidenceRepository,
             List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters,
             IdentityRealmApplyProperties identityRealmApplyProperties,
+            Clock clock) {
+        this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher,
+                identityRealmProviders, identityRealmEvidenceRepository, identityRealmLiveApplyAdapters, identityRealmApplyProperties,
+                new AttachExistingPortabilityPlanLoader(new com.fasterxml.jackson.databind.ObjectMapper()), clock);
+    }
+
+    AdminControlPlaneService(
+            ProviderRegistry providerRegistry,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            ProviderSelectionRepository providerSelectionRepository,
+            OrganizationBootstrapRepository organizationBootstrapRepository,
+            AuditEventPublisher auditEventPublisher,
+            List<IdentityRealmProvider> identityRealmProviders,
+            IdentityRealmEvidenceRepository identityRealmEvidenceRepository,
+            List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters,
+            IdentityRealmApplyProperties identityRealmApplyProperties,
+            AttachExistingPortabilityPlanLoader attachExistingPortabilityPlanLoader,
             Clock clock) {
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
@@ -194,6 +214,9 @@ public class AdminControlPlaneService {
         this.identityRealmLiveApplyAdapters = identityRealmLiveApplyAdapters == null || identityRealmLiveApplyAdapters.isEmpty()
                 ? List.of(new KeycloakRealmLiveApplyAdapter(this.identityRealmApplyProperties))
                 : List.copyOf(identityRealmLiveApplyAdapters);
+        this.attachExistingPortabilityPlanLoader = attachExistingPortabilityPlanLoader == null
+                ? new AttachExistingPortabilityPlanLoader(new com.fasterxml.jackson.databind.ObjectMapper())
+                : attachExistingPortabilityPlanLoader;
         this.clock = clock;
     }
 
@@ -1034,10 +1057,7 @@ public class AdminControlPlaneService {
         workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "admin-control-plane", "attach-existing-files-portability-plan");
         Instant inspectedAt = Instant.now(clock);
         String auditRef = "attach-existing-files-portability-plan-inspected-" + inspectedAt.toEpochMilli();
-        List<AttachExistingPortabilityPlanResponse.AdapterBinding> bindings = List.of(
-                new AttachExistingPortabilityPlanResponse.AdapterBinding("cloud-drive-files-existing", List.of("files"), "hyperscaler_cloud_existing", "active", "read_only", true, false, false, "audit:attach-existing-files:current-active-binding"),
-                new AttachExistingPortabilityPlanResponse.AdapterBinding("cloud-drive-files-discovery-source", List.of("files"), "hyperscaler_cloud_existing", "discovery_read_only", "read_only", false, false, false, "audit:attach-existing-files:discovery-source"),
-                new AttachExistingPortabilityPlanResponse.AdapterBinding("nextcloud-files-sovereign-target", List.of("files"), "self_hosted_sovereign_candidate", "candidate", "plan_only", false, false, false, "audit:attach-existing-files:candidate-target"));
+        AttachExistingPortabilityPlanResponse plan = attachExistingPortabilityPlanLoader.load(auditRef);
         auditEventPublisher.publish(new AuditEvent(
                 organizationId(jwt),
                 "admin-control-plane",
@@ -1048,54 +1068,15 @@ public class AdminControlPlaneService {
                 auditRef,
                 AuditRedactionLevel.SECRET_REDACTED,
                 Map.of(
-                        "planId", "attach-existing-files-portability-plan-mvp",
-                        "mode", "attach_existing",
-                        "domainKey", "files",
-                        "destructiveActionAllowed", false,
-                        "providerMutationPerformed", false,
-                        "memberVisibleProviderInternals", false,
+                        "planId", plan.planId(),
+                        "mode", plan.mode(),
+                        "domainKey", plan.domainKey(),
+                        "destructiveActionAllowed", plan.destructiveActionAllowed(),
+                        "providerMutationPerformed", plan.providerMutationPerformed(),
+                        "memberVisibleProviderInternals", plan.memberVisibleProviderInternals(),
                         "providerDetailsAudience", "admin_operator_only",
                         "token", "not-stored")));
-        return new AttachExistingPortabilityPlanResponse(
-                "attach-existing-files-portability-plan-mvp",
-                "admin-attach-existing-portability-plan-v1",
-                "attach_existing",
-                "files",
-                "inspection-ready-read-only",
-                "Read-only discovery and portability planning only. This does not prove destructive migration, production cutover, release readiness, legal compliance, or lossless provider migration.",
-                true,
-                true,
-                false,
-                false,
-                false,
-                List.of(
-                        new AttachExistingPortabilityPlanResponse.CapabilityMapItem("files.read", "cloud-drive-file-read", "nextcloud-files-read", "available"),
-                        new AttachExistingPortabilityPlanResponse.CapabilityMapItem("files.share_links", "cloud-drive-external-link-read", "nextcloud-share-link-policy-review", "degraded"),
-                        new AttachExistingPortabilityPlanResponse.CapabilityMapItem("files.retention_labels", "cloud-drive-proprietary-retention-labels", "manual-policy-rebuild-required", "coming_later")),
-                bindings,
-                "permission-impact:attach-existing-files:mvp",
-                List.of(new AttachExistingPortabilityPlanResponse.ReportItem("FileShare", null, "manual_review", "External share links need admin policy review before a Nextcloud target can reproduce equivalent exposure.", null)),
-                "loss-report:attach-existing-files:mvp",
-                List.of(
-                        new AttachExistingPortabilityPlanResponse.ReportItem("File", "provider_native_retention_label", "vendor_locked", null, "Source retention labels are proprietary metadata and must be exported to an archive report or manually rebuilt."),
-                        new AttachExistingPortabilityPlanResponse.ReportItem("FileVersion", "historic_version_blob", "archive_only", null, "Historic versions are discoverable but not imported in this MVP plan.")),
-                "conflict-report:attach-existing-files:mvp",
-                List.of(new AttachExistingPortabilityPlanResponse.ReportItem("FileShare", null, null, null, "Two source groups map to one target group slug; admin must choose merge or split before cutover.")),
-                List.of("audit:attach-existing-files:discovery-read-only", "audit:attach-existing-files:plan-generated", auditRef),
-                new AttachExistingPortabilityPlanResponse.RecommendedTarget("nextcloud-files-sovereign-target", "Self-hosted Files candidate improves data-sovereignty posture because data plane, audit sink, and retention policy can be operated under the organization-controlled stack after a separately approved migration path."),
-                new AttachExistingPortabilityPlanResponse.NextSteps(
-                        List.of("Keep cloud-drive-files active while discovery_read_only evidence is reviewed.", "Run export dry-run and archive manifest checks before requesting migration_source or migration_target status.", "Require admin approval of loss, permission, and conflict reports before any guarded apply."),
-                        List.of("Retain the existing cloud-drive-files binding as the active binding until post-cutover verification passes.", "Keep rollback retention and restore-smoke refs support-safe and admin-visible only.")),
-                List.of("available", "degraded", "coming_later"),
-                new AttachExistingPortabilityPlanResponse.NegativeChecks(true, true, exactlyOneActiveBindingPerDomain(bindings)));
-    }
-
-    private boolean exactlyOneActiveBindingPerDomain(List<AttachExistingPortabilityPlanResponse.AdapterBinding> bindings) {
-        Map<String, Long> activeCounts = bindings.stream()
-                .filter(AttachExistingPortabilityPlanResponse.AdapterBinding::activeBinding)
-                .flatMap(binding -> binding.domainKeys().stream())
-                .collect(java.util.stream.Collectors.groupingBy(domain -> domain, LinkedHashMap::new, java.util.stream.Collectors.counting()));
-        return activeCounts.values().stream().allMatch(count -> count == 1L);
+        return plan;
     }
 
     public List<AdminAuditEventResponse> auditEvents(Jwt jwt) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/AttachExistingPortabilityPlanLoader.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AttachExistingPortabilityPlanLoader.java
@@ -1,0 +1,139 @@
+package com.massimotter.weave.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.massimotter.weave.backend.model.admin.AttachExistingPortabilityPlanResponse;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AttachExistingPortabilityPlanLoader {
+    static final String RESOURCE_PATH = "admin/portability/attach-existing-files-portability-plan-mvp.json";
+    static final String CONTRACT_VERSION = "admin-attach-existing-portability-plan-v1";
+    static final String STATUS = "inspection-ready-read-only";
+
+    private final ObjectMapper objectMapper;
+    private final Resource resource;
+
+    @Autowired
+    public AttachExistingPortabilityPlanLoader(ObjectMapper objectMapper) {
+        this(objectMapper, new ClassPathResource(RESOURCE_PATH));
+    }
+
+    AttachExistingPortabilityPlanLoader(ObjectMapper objectMapper, Resource resource) {
+        this.objectMapper = objectMapper;
+        this.resource = resource;
+    }
+
+    AttachExistingPortabilityPlanResponse load(String inspectionAuditRef) {
+        try (var input = resource.getInputStream()) {
+            JsonNode root = objectMapper.readTree(input);
+            AttachExistingPortabilityPlanResponse response = toResponse(root, inspectionAuditRef);
+            validate(response);
+            return response;
+        } catch (IOException ex) {
+            throw new UncheckedIOException("Unable to load attach-existing Files portability plan resource", ex);
+        }
+    }
+
+    private AttachExistingPortabilityPlanResponse toResponse(JsonNode root, String inspectionAuditRef) {
+        JsonNode mapper = required(root, "adapterMapper");
+        JsonNode reports = required(root, "reports");
+        List<AttachExistingPortabilityPlanResponse.AdapterBinding> bindings = stream(required(root, "adapterBindings"))
+                .map(binding -> new AttachExistingPortabilityPlanResponse.AdapterBinding(
+                        text(binding, "adapterKey"),
+                        textList(required(binding, "domainKeys")),
+                        text(binding, "providerPosture"),
+                        text(binding, "activeBindingStatus"),
+                        text(binding, "discoveryMode"),
+                        "active".equals(text(binding, "activeBindingStatus")),
+                        bool(binding, "providerMutationPerformed"),
+                        bool(binding, "memberVisibleProviderInternals"),
+                        text(binding, "auditRef")))
+                .toList();
+        List<String> auditRefs = new java.util.ArrayList<>(textList(required(mapper, "auditRefs")));
+        auditRefs.add(inspectionAuditRef);
+        return new AttachExistingPortabilityPlanResponse(
+                text(root, "planId"),
+                CONTRACT_VERSION,
+                text(root, "mode"),
+                text(root, "domainKey"),
+                STATUS,
+                text(root, "claimBoundary"),
+                "support_safe".equals(text(root, "redaction")),
+                bool(root, "adminOnlyProviderDetails"),
+                false,
+                bindings.stream().anyMatch(AttachExistingPortabilityPlanResponse.AdapterBinding::providerMutationPerformed),
+                bindings.stream().anyMatch(AttachExistingPortabilityPlanResponse.AdapterBinding::memberVisibleProviderInternals),
+                stream(required(mapper, "capabilityMap"))
+                        .map(item -> new AttachExistingPortabilityPlanResponse.CapabilityMapItem(text(item, "canonicalCapability"), text(item, "sourceProviderCapability"), text(item, "targetProviderCapability"), text(item, "memberState")))
+                        .toList(),
+                bindings,
+                text(mapper, "permissionImpactRef"),
+                reportItems(required(reports, "permissionImpact")),
+                text(mapper, "lossReportRef"),
+                reportItems(required(reports, "loss")),
+                text(mapper, "conflictReportRef"),
+                reportItems(required(reports, "conflicts")),
+                auditRefs,
+                new AttachExistingPortabilityPlanResponse.RecommendedTarget(text(required(mapper, "recommendedTarget"), "providerKey"), text(required(mapper, "recommendedTarget"), "reason")),
+                new AttachExistingPortabilityPlanResponse.NextSteps(textList(required(required(mapper, "nextSteps"), "cutover")), textList(required(required(mapper, "nextSteps"), "rollback"))),
+                textList(required(root, "memberCapabilityStates")),
+                new AttachExistingPortabilityPlanResponse.NegativeChecks(
+                        bool(required(root, "negativeChecks"), "noDestructiveActionInDiscoveryMode"),
+                        bool(required(root, "negativeChecks"), "noMemberVisibleProviderInternals"),
+                        exactlyOneActiveBindingPerDomain(bindings)));
+    }
+
+    private void validate(AttachExistingPortabilityPlanResponse response) {
+        if (!"attach_existing".equals(response.mode()) || !"files".equals(response.domainKey()) || !response.supportSafe() || !response.adminOnlyProviderDetails()) {
+            throw new IllegalStateException("Attach-existing Files portability plan violates support-safe discovery invariants");
+        }
+        if (response.destructiveActionAllowed() || response.providerMutationPerformed() || response.memberVisibleProviderInternals()) {
+            throw new IllegalStateException("Attach-existing Files portability plan must remain read-only and member-neutral");
+        }
+        if (!response.negativeChecks().noDestructiveActionInDiscoveryMode() || !response.negativeChecks().noMemberVisibleProviderInternals() || !response.negativeChecks().exactlyOneActiveBindingPerDomain()) {
+            throw new IllegalStateException("Attach-existing Files portability plan negative checks failed");
+        }
+    }
+
+    private static boolean exactlyOneActiveBindingPerDomain(List<AttachExistingPortabilityPlanResponse.AdapterBinding> bindings) {
+        Map<String, Long> activeCounts = bindings.stream()
+                .filter(AttachExistingPortabilityPlanResponse.AdapterBinding::activeBinding)
+                .flatMap(binding -> binding.domainKeys().stream())
+                .collect(java.util.stream.Collectors.groupingBy(domain -> domain, LinkedHashMap::new, java.util.stream.Collectors.counting()));
+        return activeCounts.values().stream().allMatch(count -> count == 1L);
+    }
+
+    private static List<AttachExistingPortabilityPlanResponse.ReportItem> reportItems(JsonNode node) {
+        return stream(node).map(item -> new AttachExistingPortabilityPlanResponse.ReportItem(optionalText(item, "canonicalObject"), optionalText(item, "field"), optionalText(item, "fieldClass"), optionalText(item, "impact"), optionalText(item, "reason"))).toList();
+    }
+
+    private static List<String> textList(JsonNode node) {
+        if (!node.isArray()) throw new IllegalStateException("Expected JSON array");
+        return stream(node).map(JsonNode::asText).toList();
+    }
+
+    private static java.util.stream.Stream<JsonNode> stream(JsonNode node) {
+        if (!node.isArray()) throw new IllegalStateException("Expected JSON array");
+        return StreamSupport.stream(node.spliterator(), false);
+    }
+
+    private static JsonNode required(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isMissingNode() || value.isNull()) throw new IllegalStateException("Missing portability plan field: " + field);
+        return value;
+    }
+
+    private static String text(JsonNode node, String field) { return required(node, field).asText(); }
+    private static String optionalText(JsonNode node, String field) { JsonNode value = node.get(field); return value == null || value.isNull() ? null : value.asText(); }
+    private static boolean bool(JsonNode node, String field) { return required(node, field).asBoolean(); }
+}

--- a/server/src/main/resources/admin/portability/attach-existing-files-portability-plan-mvp.json
+++ b/server/src/main/resources/admin/portability/attach-existing-files-portability-plan-mvp.json
@@ -1,0 +1,125 @@
+{
+  "planId": "attach-existing-files-portability-plan-mvp",
+  "scenario": "existing organization attaches current cloud files provider for discovery before any migration",
+  "domainKey": "files",
+  "redaction": "support_safe",
+  "mode": "attach_existing",
+  "claimBoundary": "Read-only discovery and portability planning only. This does not prove destructive migration, production cutover, release readiness, legal compliance, or lossless provider migration.",
+  "adapterMapper": {
+    "mapperKey": "files-attach-existing-portability-mapper",
+    "capabilityMap": [
+      {
+        "canonicalCapability": "files.read",
+        "sourceProviderCapability": "cloud-drive-file-read",
+        "targetProviderCapability": "nextcloud-files-read",
+        "memberState": "available"
+      },
+      {
+        "canonicalCapability": "files.share_links",
+        "sourceProviderCapability": "cloud-drive-external-link-read",
+        "targetProviderCapability": "nextcloud-share-link-policy-review",
+        "memberState": "degraded"
+      },
+      {
+        "canonicalCapability": "files.retention_labels",
+        "sourceProviderCapability": "cloud-drive-proprietary-retention-labels",
+        "targetProviderCapability": "manual-policy-rebuild-required",
+        "memberState": "coming_later"
+      }
+    ],
+    "permissionImpactRef": "permission-impact:attach-existing-files:mvp",
+    "lossReportRef": "loss-report:attach-existing-files:mvp",
+    "conflictReportRef": "conflict-report:attach-existing-files:mvp",
+    "auditRefs": [
+      "audit:attach-existing-files:discovery-read-only",
+      "audit:attach-existing-files:plan-generated"
+    ],
+    "recommendedTarget": {
+      "providerKey": "nextcloud-files-sovereign-target",
+      "reason": "Self-hosted Files candidate improves data-sovereignty posture because data plane, audit sink, and retention policy can be operated under the organization-controlled stack after a separately approved migration path."
+    },
+    "nextSteps": {
+      "cutover": [
+        "Keep cloud-drive-files active while discovery_read_only evidence is reviewed.",
+        "Run export dry-run and archive manifest checks before requesting migration_source or migration_target status.",
+        "Require admin approval of loss, permission, and conflict reports before any guarded apply."
+      ],
+      "rollback": [
+        "Retain the existing cloud-drive-files binding as the active binding until post-cutover verification passes.",
+        "Keep rollback retention and restore-smoke refs support-safe and admin-visible only."
+      ]
+    }
+  },
+  "adapterBindings": [
+    {
+      "adapterKey": "cloud-drive-files-existing",
+      "domainKeys": ["files"],
+      "providerPosture": "hyperscaler_cloud_existing",
+      "activeBindingStatus": "active",
+      "discoveryMode": "read_only",
+      "providerMutationPerformed": false,
+      "memberVisibleProviderInternals": false,
+      "auditRef": "audit:attach-existing-files:current-active-binding"
+    },
+    {
+      "adapterKey": "cloud-drive-files-discovery-source",
+      "domainKeys": ["files"],
+      "providerPosture": "hyperscaler_cloud_existing",
+      "activeBindingStatus": "discovery_read_only",
+      "discoveryMode": "read_only",
+      "providerMutationPerformed": false,
+      "memberVisibleProviderInternals": false,
+      "auditRef": "audit:attach-existing-files:discovery-source"
+    },
+    {
+      "adapterKey": "nextcloud-files-sovereign-target",
+      "domainKeys": ["files"],
+      "providerPosture": "self_hosted_sovereign_candidate",
+      "activeBindingStatus": "candidate",
+      "discoveryMode": "plan_only",
+      "providerMutationPerformed": false,
+      "memberVisibleProviderInternals": false,
+      "auditRef": "audit:attach-existing-files:candidate-target"
+    }
+  ],
+  "reports": {
+    "permissionImpact": [
+      {
+        "canonicalObject": "FileShare",
+        "impact": "External share links need admin policy review before a Nextcloud target can reproduce equivalent exposure.",
+        "fieldClass": "manual_review"
+      }
+    ],
+    "loss": [
+      {
+        "canonicalObject": "File",
+        "field": "provider_native_retention_label",
+        "fieldClass": "vendor_locked",
+        "reason": "Source retention labels are proprietary metadata and must be exported to an archive report or manually rebuilt."
+      },
+      {
+        "canonicalObject": "FileVersion",
+        "field": "historic_version_blob",
+        "fieldClass": "archive_only",
+        "reason": "Historic versions are discoverable but not imported in this MVP plan."
+      }
+    ],
+    "conflicts": [
+      {
+        "canonicalObject": "FileShare",
+        "reason": "Two source groups map to one target group slug; admin must choose merge or split before cutover."
+      }
+    ]
+  },
+  "memberCapabilityStates": [
+    "available",
+    "degraded",
+    "coming_later"
+  ],
+  "adminOnlyProviderDetails": true,
+  "negativeChecks": {
+    "noDestructiveActionInDiscoveryMode": true,
+    "noMemberVisibleProviderInternals": true,
+    "exactlyOneActiveBindingPerDomain": true
+  }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -26,6 +26,7 @@ import com.massimotter.weave.backend.provider.ProviderSelection;
 import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import java.time.Instant;
 import com.massimotter.weave.backend.service.AdminControlPlaneService;
+import com.massimotter.weave.backend.service.AttachExistingPortabilityPlanLoader;
 import com.massimotter.weave.backend.service.InMemoryOrganizationBootstrapRepository;
 import com.massimotter.weave.backend.service.OrganizationBootstrapRepository;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
@@ -77,6 +78,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         DevopsProviderConfiguration.class,
         DisabledOfficeProvider.class,
         AdminControlPlaneService.class,
+        AttachExistingPortabilityPlanLoader.class,
         AdminControlPlaneControllerTest.AuditTestConfig.class
 })
 @TestPropertySource(properties = {

--- a/server/src/test/java/com/massimotter/weave/backend/service/AttachExistingPortabilityPlanLoaderTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AttachExistingPortabilityPlanLoaderTest.java
@@ -1,0 +1,78 @@
+package com.massimotter.weave.backend.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ClassPathResource;
+
+class AttachExistingPortabilityPlanLoaderTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void loadsSupportSafePlanFromPackagedContractProjection() throws Exception {
+        AttachExistingPortabilityPlanLoader loader = new AttachExistingPortabilityPlanLoader(objectMapper);
+
+        var plan = loader.load("audit:inspection:test");
+
+        assertThat(plan.planId()).isEqualTo("attach-existing-files-portability-plan-mvp");
+        assertThat(plan.contractVersion()).isEqualTo(AttachExistingPortabilityPlanLoader.CONTRACT_VERSION);
+        assertThat(plan.mode()).isEqualTo("attach_existing");
+        assertThat(plan.domainKey()).isEqualTo("files");
+        assertThat(plan.supportSafe()).isTrue();
+        assertThat(plan.destructiveActionAllowed()).isFalse();
+        assertThat(plan.providerMutationPerformed()).isFalse();
+        assertThat(plan.memberVisibleProviderInternals()).isFalse();
+        assertThat(plan.adapterBindings()).filteredOn(binding -> binding.activeBinding()).hasSize(1);
+        assertThat(plan.auditRefs()).contains("audit:inspection:test");
+        assertThat(plan.capabilityMap()).extracting("canonicalCapability")
+                .containsExactly("files.read", "files.share_links", "files.retention_labels");
+    }
+
+    @Test
+    void packagedProjectionMatchesCheckedInPortabilityContractFixture() throws Exception {
+        String packaged = new String(new ClassPathResource(AttachExistingPortabilityPlanLoader.RESOURCE_PATH).getInputStream().readAllBytes());
+        String fixture = Files.readString(Path.of("..", "specs", "0006-portability-contract", "attach-existing-files-portability-plan-mvp.json"));
+
+        assertThat(objectMapper.readTree(packaged)).isEqualTo(objectMapper.readTree(fixture));
+    }
+
+    @Test
+    void rejectsProviderMutationInMalformedPlan() throws Exception {
+        String malformed = """
+                {
+                  "planId": "attach-existing-files-portability-plan-mvp",
+                  "domainKey": "files",
+                  "redaction": "support_safe",
+                  "mode": "attach_existing",
+                  "claimBoundary": "Read-only discovery only.",
+                  "adapterMapper": {
+                    "capabilityMap": [{"canonicalCapability":"files.read","sourceProviderCapability":"source","targetProviderCapability":"target","memberState":"available"}],
+                    "permissionImpactRef": "permission-impact:attach-existing-files:mvp",
+                    "lossReportRef": "loss-report:attach-existing-files:mvp",
+                    "conflictReportRef": "conflict-report:attach-existing-files:mvp",
+                    "auditRefs": ["audit:plan-generated"],
+                    "recommendedTarget": {"providerKey":"target","reason":"support-safe candidate"},
+                    "nextSteps": {"cutover": ["review only"], "rollback": ["keep active binding"]}
+                  },
+                  "adapterBindings": [{"adapterKey":"source","domainKeys":["files"],"providerPosture":"existing","activeBindingStatus":"active","discoveryMode":"read_only","providerMutationPerformed":true,"memberVisibleProviderInternals":false,"auditRef":"audit:source"}],
+                  "reports": {"permissionImpact": [], "loss": [], "conflicts": []},
+                  "memberCapabilityStates": ["available"],
+                  "adminOnlyProviderDetails": true,
+                  "negativeChecks": {"noDestructiveActionInDiscoveryMode": true, "noMemberVisibleProviderInternals": true, "exactlyOneActiveBindingPerDomain": true}
+                }
+                """;
+
+        AttachExistingPortabilityPlanLoader loader = new AttachExistingPortabilityPlanLoader(
+                objectMapper,
+                new ByteArrayResource(malformed.getBytes()));
+
+        assertThatThrownBy(() -> loader.load("audit:inspection:test"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("read-only");
+    }
+}


### PR DESCRIPTION
## Summary
- load the Admin/Operator attach-existing Files portability plan from a packaged projection of the checked-in portability contract fixture
- validate support-safe/read-only/member-neutral invariants before returning the plan
- add loader tests for fixture parity and malformed-plan rejection while preserving member forbidden/no-leak controller coverage

## Evidence
- `git diff --check`
- `cd server && ./gradlew test --tests 'com.massimotter.weave.backend.service.AttachExistingPortabilityPlanLoaderTest' --tests 'com.massimotter.weave.backend.controller.AdminControlPlaneControllerTest' --console=plain`
- `./gradlew portabilityContractCheck domainRegistryCheck specContract acceptanceContract docsCheck --console=plain`
- `./gradlew serverCi --console=plain`

## Release notes
- Admin/Operator inspect endpoint now uses a source-backed contract projection for the attach-existing Files portability plan.

## Boundaries
- read-only/preflight only; no provider mutation, migration apply, cutover, or release-readiness claim
- member/client response remains provider-neutral and forbidden path remains leak-safe
