### PR TITLE
Add canonical domain provider bindings

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/controller/ProviderRegistryController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/ProviderRegistryController.java
@@ -1,6 +1,7 @@
 package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.model.ApiErrorResponse;
+import com.massimotter.weave.backend.provider.DomainBindingsResponse;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
 import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
@@ -15,6 +16,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -45,5 +47,16 @@ public class ProviderRegistryController {
     public ProviderRegistryResponse status(@AuthenticationPrincipal Jwt jwt) {
         workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "provider-registry", "status");
         return providerRegistry.status();
+    }
+
+    @GetMapping({"/api/admin/domains/bindings", "/api/admin/domains/{domainKey}/bindings"})
+    @PreAuthorize("hasAuthority('SCOPE_weave:workspace')")
+    @Operation(summary = "Read generic domain binding and provider connection readiness state")
+    @ApiResponse(responseCode = "200", description = "Provider-neutral domain binding snapshot.",
+            content = @Content(schema = @Schema(implementation = DomainBindingsResponse.class)))
+    public DomainBindingsResponse domainBindings(@AuthenticationPrincipal Jwt jwt,
+            @PathVariable(name = "domainKey", required = false) String domainKey) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "domain-bindings", "status");
+        return providerRegistry.domainBindings(domainKey);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/provider/CanonicalDomainBindingCatalog.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/CanonicalDomainBindingCatalog.java
@@ -1,0 +1,57 @@
+package com.massimotter.weave.backend.provider;
+
+import com.massimotter.weave.backend.domainregistry.CanonicalDomainRegistry;
+import com.massimotter.weave.backend.domainregistry.CanonicalDomainRegistryEntryResponse;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Maps provider category taxonomy to canonical domain identifiers.
+ *
+ * <p>Provider categories are adapter/admin grouping metadata. Public domain binding and adapter registry surfaces
+ * must use canonical domain keys from {@link CanonicalDomainRegistry}; compatibility aliases in that registry are the
+ * only bridge from legacy/category keys to stable domain identities.</p>
+ */
+final class CanonicalDomainBindingCatalog {
+
+    private static final List<String> INTERNAL_OR_NON_BINDING_DOMAINS = List.of("health", "weaver");
+
+    private CanonicalDomainBindingCatalog() {
+    }
+
+    static List<CanonicalDomainRegistryEntryResponse> domainsForCategory(String categoryKey) {
+        if (categoryKey == null || categoryKey.isBlank()) {
+            return List.of();
+        }
+        return CanonicalDomainRegistry.domains().stream()
+                .filter(domain -> !INTERNAL_OR_NON_BINDING_DOMAINS.contains(domain.key()))
+                .filter(domain -> domain.key().equals(categoryKey) || domain.compatibilityAliases().contains(categoryKey))
+                .toList();
+    }
+
+    static Optional<CanonicalDomainRegistryEntryResponse> primaryDomainForCategory(String categoryKey) {
+        return domainsForCategory(categoryKey).stream().findFirst();
+    }
+
+    static String stableBindingId(CanonicalDomainRegistryEntryResponse domain, String providerKey) {
+        return "binding:" + requireDomain(domain).key() + ":provider:" + requireText(providerKey, "providerKey");
+    }
+
+    static String stableConnectionId(String providerKey) {
+        return "provider-connection:" + requireText(providerKey, "providerKey");
+    }
+
+    private static CanonicalDomainRegistryEntryResponse requireDomain(CanonicalDomainRegistryEntryResponse domain) {
+        if (domain == null || domain.key() == null || domain.key().isBlank()) {
+            throw new IllegalArgumentException("domain must have a canonical key");
+        }
+        return domain;
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapper.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapper.java
@@ -13,7 +13,8 @@ final class DomainAdapterRegistryMapper {
 
     static DomainAdapterRegistryResponse fromCategories(List<ProviderCategoryStatusResponse> categories, Instant generatedAt) {
         List<DomainAdapterStatusResponse> domains = (categories == null ? List.<ProviderCategoryStatusResponse>of() : categories).stream()
-                .map(DomainAdapterRegistryMapper::fromCategory)
+                .flatMap(category -> CanonicalDomainBindingCatalog.domainsForCategory(category.category()).stream()
+                        .map(domain -> fromCategory(category, domain.key(), domain.displayName())))
                 .toList();
         return new DomainAdapterRegistryResponse(
                 "domain-adapter-registry-preview",
@@ -25,6 +26,12 @@ final class DomainAdapterRegistryMapper {
     }
 
     static DomainAdapterStatusResponse fromCategory(ProviderCategoryStatusResponse category) {
+        return CanonicalDomainBindingCatalog.primaryDomainForCategory(category.category())
+                .map(domain -> fromCategory(category, domain.key(), domain.displayName()))
+                .orElseGet(() -> fromCategory(category, category.category(), category.label()));
+    }
+
+    private static DomainAdapterStatusResponse fromCategory(ProviderCategoryStatusResponse category, String domainKey, String label) {
         boolean enabled = category.policyState() != WorkspaceCapabilityPolicyState.DISABLED
                 && category.readiness() != ProviderCategoryReadiness.DISABLED;
         List<String> adapterKeys = new ArrayList<>();
@@ -55,8 +62,8 @@ final class DomainAdapterRegistryMapper {
             failClosed = true;
         }
         return new DomainAdapterStatusResponse(
-                category.category(),
-                category.label(),
+                domainKey,
+                label,
                 enabled,
                 activeCount == 1 ? activeAdapter : null,
                 failClosed ? ProviderCategoryReadiness.MISCONFIGURED : category.readiness(),

--- a/server/src/main/java/com/massimotter/weave/backend/provider/DomainBindingResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/DomainBindingResponse.java
@@ -1,0 +1,36 @@
+package com.massimotter.weave.backend.provider;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Provider-neutral Admin domain binding state. Plans/impact reports are transition artifacts; this binding is the primary admin object.")
+public record DomainBindingResponse(
+        String domainKey,
+        String label,
+        ProviderCategoryReadiness posture,
+        String activeBinding,
+        ProviderConnectionRefResponse providerConnectionRef,
+        List<DomainAdapterCandidateResponse> candidateBindings,
+        List<ProviderAdapterReadinessEvidenceResponse> capabilityStates,
+        List<String> transitionArtifacts,
+        boolean exactlyOneActiveBinding,
+        boolean supportSafe) {
+
+    public DomainBindingResponse {
+        domainKey = requireText(domainKey, "domainKey");
+        label = requireText(label, "label");
+        posture = posture == null ? ProviderCategoryReadiness.DISABLED : posture;
+        candidateBindings = candidateBindings == null ? List.of() : List.copyOf(candidateBindings);
+        capabilityStates = capabilityStates == null ? List.of() : List.copyOf(capabilityStates);
+        transitionArtifacts = transitionArtifacts == null ? List.of() : List.copyOf(transitionArtifacts);
+        exactlyOneActiveBinding = candidateBindings.stream().filter(DomainAdapterCandidateResponse::active).count() == 1;
+        supportSafe = supportSafe && (providerConnectionRef == null || providerConnectionRef.supportSafe());
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/DomainBindingsResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/DomainBindingsResponse.java
@@ -1,0 +1,30 @@
+package com.massimotter.weave.backend.provider;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+
+@Schema(description = "Generic Admin domain binding/readiness view across selected Weave domains. Provider internals stay out of member APIs.")
+public record DomainBindingsResponse(
+        String releaseStatus,
+        String providerConfigSource,
+        boolean transitionPlansAreSecondaryArtifacts,
+        boolean memberProviderInternalsExposed,
+        boolean supportSafe,
+        Instant generatedAt,
+        List<DomainBindingResponse> bindings) {
+
+    public DomainBindingsResponse {
+        releaseStatus = releaseStatus == null || releaseStatus.isBlank()
+                ? "domain-binding-provider-connection-v1"
+                : releaseStatus.trim();
+        providerConfigSource = providerConfigSource == null || providerConfigSource.isBlank()
+                ? ProviderRegistry.PROVIDER_CONFIG_SOURCE
+                : providerConfigSource.trim();
+        transitionPlansAreSecondaryArtifacts = true;
+        memberProviderInternalsExposed = false;
+        generatedAt = generatedAt == null ? Instant.now() : generatedAt;
+        bindings = bindings == null ? List.of() : List.copyOf(bindings);
+        supportSafe = supportSafe && bindings.stream().allMatch(DomainBindingResponse::supportSafe);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderConnectionRefResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderConnectionRefResponse.java
@@ -1,0 +1,38 @@
+package com.massimotter.weave.backend.provider;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.List;
+
+@Schema(description = "Support-safe provider connection reference for Admin domain bindings. Contains SecretRef/GrantRef metadata only; never raw credentials, endpoints, or provider payloads.")
+public record ProviderConnectionRefResponse(
+        String providerKey,
+        String connectionId,
+        List<String> domainKeys,
+        ProviderCategoryReadiness status,
+        String credentialRefKind,
+        boolean credentialRefConfigured,
+        List<String> scopes,
+        Instant lastReadinessCheck,
+        boolean readOnlyDiscovery,
+        boolean supportSafe) {
+
+    public ProviderConnectionRefResponse {
+        providerKey = requireText(providerKey, "providerKey");
+        connectionId = requireText(connectionId, "connectionId");
+        domainKeys = domainKeys == null ? List.of() : List.copyOf(domainKeys);
+        status = status == null ? ProviderCategoryReadiness.DISABLED : status;
+        credentialRefKind = credentialRefKind == null || credentialRefKind.isBlank() ? "none" : credentialRefKind.trim();
+        scopes = scopes == null ? List.of() : List.copyOf(scopes);
+        lastReadinessCheck = lastReadinessCheck == null ? Instant.EPOCH : lastReadinessCheck;
+        readOnlyDiscovery = true;
+        supportSafe = true;
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
@@ -1,6 +1,7 @@
 package com.massimotter.weave.backend.provider;
 
 import com.massimotter.weave.backend.domainregistry.CanonicalDomainRegistry;
+import com.massimotter.weave.backend.domainregistry.CanonicalDomainRegistryEntryResponse;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.time.Instant;
 import java.util.Comparator;
@@ -31,13 +32,7 @@ public class ProviderRegistry {
 
     public ProviderRegistryResponse status() {
         List<ProviderSelection> selections = selectionRepository.findAll();
-        List<ProviderStatusResponse> statuses = providers.stream()
-                .map(ProviderPort::status)
-                .map(status -> applyAdminSelection(status, selections))
-                .sorted(Comparator
-                        .comparing((ProviderStatusResponse status) -> status.module().contractName())
-                        .thenComparing(ProviderStatusResponse::providerKey))
-                .toList();
+        List<ProviderStatusResponse> statuses = providerStatuses(selections);
         Instant generatedAt = Instant.now();
         List<ProviderCategoryStatusResponse> categories = ProviderCategoryHealthMapper.categories(
                 statuses,
@@ -58,6 +53,83 @@ public class ProviderRegistry {
                 selections,
                 categories,
                 statuses);
+    }
+
+    public DomainBindingsResponse domainBindings(String requestedDomainKey) {
+        ProviderRegistryResponse snapshot = status();
+        String normalizedDomainKey = requestedDomainKey == null ? null : requestedDomainKey.trim();
+        List<DomainBindingResponse> bindings = snapshot.categories().stream()
+                .flatMap(category -> CanonicalDomainBindingCatalog.domainsForCategory(category.category()).stream()
+                        .filter(domain -> normalizedDomainKey == null || normalizedDomainKey.isBlank() || domain.key().equals(normalizedDomainKey))
+                        .map(domain -> binding(domain, category, snapshot.selectedProviderMappings(), snapshot.generatedAt())))
+                .toList();
+        return new DomainBindingsResponse(
+                "domain-binding-provider-connection-v1",
+                PROVIDER_CONFIG_SOURCE,
+                true,
+                false,
+                bindings.stream().allMatch(DomainBindingResponse::supportSafe),
+                snapshot.generatedAt(),
+                bindings);
+    }
+
+    private List<ProviderStatusResponse> providerStatuses(List<ProviderSelection> selections) {
+        return providers.stream()
+                .map(ProviderPort::status)
+                .map(status -> applyAdminSelection(status, selections))
+                .sorted(Comparator
+                        .comparing((ProviderStatusResponse status) -> status.module().contractName())
+                        .thenComparing(ProviderStatusResponse::providerKey))
+                .toList();
+    }
+
+    private DomainBindingResponse binding(
+            CanonicalDomainRegistryEntryResponse domain,
+            ProviderCategoryStatusResponse category,
+            List<ProviderSelection> selections,
+            Instant generatedAt) {
+        String activeBinding = category.selectedByAdmin()
+                ? CanonicalDomainBindingCatalog.stableBindingId(domain, category.selectedProviderKey())
+                : null;
+        ProviderConnectionRefResponse connectionRef = category.selectedByAdmin()
+                ? connectionRef(domain, category, selections, generatedAt)
+                : null;
+        List<String> transitionArtifacts = category.contract().replacementRequirement() == null
+                ? List.of("preflight_or_impact_report_required_for_attach_existing_switch_export_import_migration_cutover_rollback")
+                : List.of(category.contract().replacementRequirement());
+        return new DomainBindingResponse(
+                domain.key(),
+                domain.displayName(),
+                category.readiness(),
+                activeBinding,
+                connectionRef,
+                DomainAdapterRegistryMapper.fromCategory(category).candidates(),
+                category.adapterEvidence(),
+                transitionArtifacts,
+                true,
+                true);
+    }
+
+    private ProviderConnectionRefResponse connectionRef(
+            CanonicalDomainRegistryEntryResponse domain,
+            ProviderCategoryStatusResponse category,
+            List<ProviderSelection> selections,
+            Instant generatedAt) {
+        Optional<ProviderSelection> selection = selections.stream()
+                .filter(value -> value.category().equals(category.category()))
+                .findFirst();
+        boolean hasSecretRef = selection.map(ProviderSelection::hasSecretRef).orElse(false);
+        return new ProviderConnectionRefResponse(
+                category.selectedProviderKey(),
+                CanonicalDomainBindingCatalog.stableConnectionId(category.selectedProviderKey()),
+                List.of(domain.key()),
+                category.readiness(),
+                hasSecretRef ? "SecretRef" : "GrantRef-or-none",
+                hasSecretRef,
+                domain.capabilityKeys(),
+                generatedAt,
+                true,
+                true);
     }
 
     private ProviderStatusResponse applyAdminSelection(ProviderStatusResponse status, List<ProviderSelection> selections) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
@@ -160,6 +160,55 @@ class ProviderRegistryControllerTest {
     }
 
     @Test
+    void adminDomainBindingsRejectMembers() throws Exception {
+        mockMvc.perform(get("/api/admin/domains/bindings").with(memberJwt()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("capability-policy-blocked"))
+                .andExpect(jsonPath("$.details.requiredCapability").value("admin_control_plane.readiness_read"));
+    }
+
+    @Test
+    void adminDomainBindingsExposeGenericProviderConnectionRefsWithoutSecrets() throws Exception {
+        mockMvc.perform(get("/api/admin/domains/bindings").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.releaseStatus").value("domain-binding-provider-connection-v1"))
+                .andExpect(jsonPath("$.transitionPlansAreSecondaryArtifacts").value(true))
+                .andExpect(jsonPath("$.memberProviderInternalsExposed").value(false))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.bindings[*].domainKey", hasItems(
+                        "identity", "chat", "files", "calendar", "boards", "calls", "documents")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'files')].activeBinding", hasItems("binding:files:provider:nextcloud-files")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'chat')].activeBinding", hasItems("binding:chat:provider:synapse-homeserver")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'files')].providerConnectionRef.providerKey", hasItems("nextcloud-files")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'files')].providerConnectionRef.connectionId", hasItems("provider-connection:nextcloud-files")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'files')].providerConnectionRef.domainKeys[0]", hasItems("files")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'boards')].providerConnectionRef.connectionId", hasItems("provider-connection:openproject-primary")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'calls')].providerConnectionRef.connectionId", hasItems("provider-connection:livekit")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'files')].providerConnectionRef.credentialRefKind", hasItems("SecretRef")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'chat')].providerConnectionRef.credentialRefConfigured", hasItems(true)))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'chat')].providerConnectionRef.readOnlyDiscovery", hasItems(true)))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'files')].candidateBindings[?(@.active == true)].adapterKey", hasItems("nextcloud-files")))
+                .andExpect(jsonPath("$.bindings[?(@.domainKey == 'chat')].candidateBindings[?(@.active == true)].adapterKey", hasItems("synapse-homeserver")))
+                .andExpect(jsonPath("$.bindings[*].exactlyOneActiveBinding", hasItems(true)))
+                .andExpect(jsonPath("$.bindings[*].transitionArtifacts[*]", hasItems(containsString("replacement requires"))))
+                .andExpect(content().string(not(containsString("secretref://"))))
+                .andExpect(content().string(not(containsString("password"))))
+                .andExpect(content().string(not(containsString("access_token"))))
+                .andExpect(content().string(not(containsString("Authorization: Bearer"))));
+
+        mockMvc.perform(get("/api/admin/domains/chat/bindings").with(adminJwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bindings[*].domainKey", hasItems("chat")))
+                .andExpect(jsonPath("$.bindings[0].activeBinding").value("binding:chat:provider:synapse-homeserver"))
+                .andExpect(jsonPath("$.bindings[0].providerConnectionRef.connectionId").value("provider-connection:synapse-homeserver"))
+                .andExpect(content().string(not(containsString("nextcloud-files"))))
+                .andExpect(content().string(not(containsString("identity-idm"))))
+                .andExpect(content().string(not(containsString("boards-tasks"))))
+                .andExpect(content().string(not(containsString("meetings-calls"))))
+                .andExpect(content().string(not(containsString("documents-collaboration"))));
+    }
+
+    @Test
     void providerStatusReportsAllFacadeSeamsWithoutSecrets() throws Exception {
         mockMvc.perform(get("/api/providers/status").with(adminJwt()))
                 .andExpect(status().isOk())
@@ -183,7 +232,10 @@ class ProviderRegistryControllerTest {
                 .andExpect(jsonPath("$.canonicalDomainRegistry.domains[?(@.key == 'boards')].adapterManifestRequirements[*]", hasItems("secret_ref_only", "support_safe_diagnostics")))
                 .andExpect(jsonPath("$.domainAdapterRegistry.singleActiveAdapterEnforced").value(true))
                 .andExpect(jsonPath("$.domainAdapterRegistry.memberProviderConfigurationAllowed").value(false))
+                .andExpect(jsonPath("$.domainAdapterRegistry.domains[*].domain", hasItems("identity", "chat", "files", "calendar", "boards", "calls", "documents")))
                 .andExpect(jsonPath("$.domainAdapterRegistry.domains[?(@.domain == 'chat')].activeAdapter", hasItems("synapse-homeserver")))
+                .andExpect(jsonPath("$.domainAdapterRegistry.domains[?(@.domain == 'identity')].activeAdapter", hasItems("keycloak-realm")))
+                .andExpect(jsonPath("$.domainAdapterRegistry.domains[?(@.domain == 'boards')].activeAdapter", hasItems("openproject-primary")))
                 .andExpect(jsonPath("$.domainAdapterRegistry.domains[?(@.domain == 'chat')].candidates[*].diagnostics.secretsReturned", hasItems(false)))
                 .andExpect(jsonPath("$.categories[*].category", hasItems(
                         "identity-idm", "chat", "files", "calendar", "boards-tasks", "meetings-calls", "documents-collaboration", "decisions-evidence", "manuals-help", "release-evidence", "admin-control-plane", "weaver")))

--- a/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
@@ -153,7 +153,7 @@ class DomainAdapterRegistryMapperTest {
                 category("meetings-calls", ProviderCategoryReadiness.READY, ProviderModule.MEETINGS)), null).domains();
 
         assertThat(domains).extracting(DomainAdapterStatusResponse::domain)
-                .contains("chat", "files", "calendar", "boards-tasks", "meetings-calls");
+                .contains("identity", "chat", "files", "calendar", "boards", "calls");
         assertThat(domains).allSatisfy(domain -> {
             assertThat(domain.singleActiveAdapterValid()).isTrue();
             assertThat(domain.supportSafe()).isTrue();
@@ -164,8 +164,15 @@ class DomainAdapterRegistryMapperTest {
                         .containsEntry("rawProviderErrorsReturned", false);
             });
         });
+        Map<String, String> canonicalDomainsByCategory = Map.of(
+                "identity-idm", "identity",
+                "chat", "chat",
+                "files", "files",
+                "calendar", "calendar",
+                "boards-tasks", "boards",
+                "meetings-calls", "calls");
         MIXED_PROVIDER_POSTURE.forEach((category, adapterKeys) -> assertThat(domains)
-                .filteredOn(domain -> domain.domain().equals(category))
+                .filteredOn(domain -> domain.domain().equals(canonicalDomainsByCategory.get(category)))
                 .singleElement()
                 .satisfies(domain -> assertThat(domain.candidates())
                         .extracting(DomainAdapterCandidateResponse::adapterKey)


### PR DESCRIPTION
## Summary
- Add a generic Admin domain binding/provider connection API at `/api/admin/domains/bindings` and `/api/admin/domains/{domainKey}/bindings`.
- Map provider category readiness to canonical domain keys from the canonical domain registry (`identity`, `chat`, `files`, `calendar`, `boards`, `calls`, `documents`) instead of exposing Files-only or category-shaped contracts.
- Return support-safe `ProviderConnectionRef` metadata only (SecretRef/GrantRef state, scopes, readiness, read-only discovery), never raw secrets, endpoints, provider payloads, or member-facing provider internals.
- Keep transition/preflight/impact plans as secondary artifacts for risky transitions, not the central admin object.

## Target lane
Backend/admin control-plane provider registry slice.

## Linked issue / context
- Release blocker context: #762 remains open; this PR does not claim release readiness.
- Reframes #777 direction: Files attach-existing plans should become transition artifacts below the generic domain binding/provider connection architecture.

## Spec impact
- Implements the provider-neutral Admin-Suite direction from the canonical domain registry and Spec 0001 posture: admins manage provider bindings/readiness, members see provider-neutral capabilities.
- No Weaver runtime implementation.

## Release note
- Added: Admin domain binding/provider connection readiness API for canonical Weave domains.

## Gates run
- `git diff --check`
- `cd server && ./gradlew test --tests com.massimotter.weave.backend.controller.ProviderRegistryControllerTest --console=plain`
- `cd server && ./gradlew test --tests com.massimotter.weave.backend.provider.DomainAdapterRegistryMapperTest --tests com.massimotter.weave.backend.controller.ProviderRegistryControllerTest --console=plain`
- `./gradlew portabilityContractCheck domainRegistryCheck specContract acceptanceContract docsCheck --console=plain --no-daemon --max-workers=1`
- `./gradlew serverCi --console=plain --no-daemon --max-workers=1`

Note: one earlier `serverCi` attempt failed with Gradle test-result/binary output corruption while multiple daemons were busy; after `./gradlew --stop` and clearing test outputs, the same gate passed with `--no-daemon --max-workers=1`.

## Review evidence
- Independent architecture/red-team review initially blocked category-shaped binding IDs/domain keys.
- Fix applied: canonical domain registry aliases now bridge internal provider categories to public domain keys, and stable binding/connection IDs no longer include legacy category keys.
