### PR TITLE
refactor(server): extract domain binding service

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/provider/DomainBindingService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/DomainBindingService.java
@@ -1,0 +1,102 @@
+package com.massimotter.weave.backend.provider;
+
+import com.massimotter.weave.backend.domainregistry.CanonicalDomainRegistryEntryResponse;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+/**
+ * Builds the generic domain-binding surface from provider-category readiness.
+ *
+ * <p>Provider categories are adapter/control-plane taxonomy. This service keeps the domain binding contract centered on
+ * canonical domain registry entries, stable connection identifiers, and redacted connection handles so future domains can
+ * reuse the same mapping path without adding provider-specific controller logic.</p>
+ */
+@Service
+public class DomainBindingService {
+
+    public DomainBindingsResponse bindings(ProviderRegistryResponse snapshot, String requestedDomainKey) {
+        if (snapshot == null) {
+            throw new IllegalArgumentException("provider registry snapshot must not be null");
+        }
+        String normalizedDomainKey = normalize(requestedDomainKey);
+        List<DomainBindingResponse> bindings = snapshot.categories().stream()
+                .flatMap(category -> CanonicalDomainBindingCatalog.domainsForCategory(category.category()).stream()
+                        .filter(domain -> matchesRequestedDomain(domain, normalizedDomainKey))
+                        .map(domain -> binding(
+                                domain,
+                                category,
+                                snapshot.selectedProviderMappings(),
+                                snapshot.generatedAt())))
+                .toList();
+        return new DomainBindingsResponse(
+                "domain-binding-provider-connection-v1",
+                ProviderRegistry.PROVIDER_CONFIG_SOURCE,
+                true,
+                false,
+                bindings.stream().allMatch(DomainBindingResponse::supportSafe),
+                snapshot.generatedAt(),
+                bindings);
+    }
+
+    private boolean matchesRequestedDomain(CanonicalDomainRegistryEntryResponse domain, String requestedDomainKey) {
+        return requestedDomainKey == null || domain.key().equals(requestedDomainKey);
+    }
+
+    private DomainBindingResponse binding(
+            CanonicalDomainRegistryEntryResponse domain,
+            ProviderCategoryStatusResponse category,
+            List<ProviderSelection> selections,
+            Instant generatedAt) {
+        String activeBinding = category.selectedByAdmin()
+                ? CanonicalDomainBindingCatalog.stableBindingId(domain, category.selectedProviderKey())
+                : null;
+        ProviderConnectionRefResponse connectionRef = category.selectedByAdmin()
+                ? connectionRef(domain, category, selections, generatedAt)
+                : null;
+        List<String> transitionArtifacts = category.contract().replacementRequirement() == null
+                ? List.of("preflight_or_impact_report_required_for_attach_existing_switch_export_import_migration_cutover_rollback")
+                : List.of(category.contract().replacementRequirement());
+        return new DomainBindingResponse(
+                domain.key(),
+                domain.displayName(),
+                category.readiness(),
+                activeBinding,
+                connectionRef,
+                DomainAdapterRegistryMapper.fromCategory(category).candidates(),
+                category.adapterEvidence(),
+                transitionArtifacts,
+                true,
+                true);
+    }
+
+    private ProviderConnectionRefResponse connectionRef(
+            CanonicalDomainRegistryEntryResponse domain,
+            ProviderCategoryStatusResponse category,
+            List<ProviderSelection> selections,
+            Instant generatedAt) {
+        Optional<ProviderSelection> selection = selections.stream()
+                .filter(value -> value.category().equals(category.category()))
+                .findFirst();
+        boolean hasSecretRef = selection.map(ProviderSelection::hasSecretRef).orElse(false);
+        return new ProviderConnectionRefResponse(
+                category.selectedProviderKey(),
+                CanonicalDomainBindingCatalog.stableConnectionId(category.selectedProviderKey()),
+                List.of(domain.key()),
+                category.readiness(),
+                hasSecretRef ? "SecretRef" : "GrantRef-or-none",
+                hasSecretRef,
+                domain.capabilityKeys(),
+                generatedAt,
+                true,
+                true);
+    }
+
+    private String normalize(String requestedDomainKey) {
+        if (requestedDomainKey == null || requestedDomainKey.isBlank()) {
+            return null;
+        }
+        return requestedDomainKey.trim();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderRegistry.java
@@ -1,7 +1,6 @@
 package com.massimotter.weave.backend.provider;
 
 import com.massimotter.weave.backend.domainregistry.CanonicalDomainRegistry;
-import com.massimotter.weave.backend.domainregistry.CanonicalDomainRegistryEntryResponse;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.time.Instant;
 import java.util.Comparator;
@@ -10,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,14 +20,25 @@ public class ProviderRegistry {
     private final List<ProviderPort> providers;
     private final WorkspaceCapabilityService workspaceCapabilityService;
     private final ProviderSelectionRepository selectionRepository;
+    private final DomainBindingService domainBindingService;
 
+    @Autowired
     public ProviderRegistry(
             List<ProviderPort> providers,
             WorkspaceCapabilityService workspaceCapabilityService,
             ProviderSelectionRepository selectionRepository) {
+        this(providers, workspaceCapabilityService, selectionRepository, new DomainBindingService());
+    }
+
+    ProviderRegistry(
+            List<ProviderPort> providers,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            ProviderSelectionRepository selectionRepository,
+            DomainBindingService domainBindingService) {
         this.providers = providers == null ? List.of() : List.copyOf(providers);
         this.workspaceCapabilityService = workspaceCapabilityService;
         this.selectionRepository = selectionRepository;
+        this.domainBindingService = domainBindingService == null ? new DomainBindingService() : domainBindingService;
     }
 
     public ProviderRegistryResponse status() {
@@ -56,21 +67,7 @@ public class ProviderRegistry {
     }
 
     public DomainBindingsResponse domainBindings(String requestedDomainKey) {
-        ProviderRegistryResponse snapshot = status();
-        String normalizedDomainKey = requestedDomainKey == null ? null : requestedDomainKey.trim();
-        List<DomainBindingResponse> bindings = snapshot.categories().stream()
-                .flatMap(category -> CanonicalDomainBindingCatalog.domainsForCategory(category.category()).stream()
-                        .filter(domain -> normalizedDomainKey == null || normalizedDomainKey.isBlank() || domain.key().equals(normalizedDomainKey))
-                        .map(domain -> binding(domain, category, snapshot.selectedProviderMappings(), snapshot.generatedAt())))
-                .toList();
-        return new DomainBindingsResponse(
-                "domain-binding-provider-connection-v1",
-                PROVIDER_CONFIG_SOURCE,
-                true,
-                false,
-                bindings.stream().allMatch(DomainBindingResponse::supportSafe),
-                snapshot.generatedAt(),
-                bindings);
+        return domainBindingService.bindings(status(), requestedDomainKey);
     }
 
     private List<ProviderStatusResponse> providerStatuses(List<ProviderSelection> selections) {
@@ -83,54 +80,6 @@ public class ProviderRegistry {
                 .toList();
     }
 
-    private DomainBindingResponse binding(
-            CanonicalDomainRegistryEntryResponse domain,
-            ProviderCategoryStatusResponse category,
-            List<ProviderSelection> selections,
-            Instant generatedAt) {
-        String activeBinding = category.selectedByAdmin()
-                ? CanonicalDomainBindingCatalog.stableBindingId(domain, category.selectedProviderKey())
-                : null;
-        ProviderConnectionRefResponse connectionRef = category.selectedByAdmin()
-                ? connectionRef(domain, category, selections, generatedAt)
-                : null;
-        List<String> transitionArtifacts = category.contract().replacementRequirement() == null
-                ? List.of("preflight_or_impact_report_required_for_attach_existing_switch_export_import_migration_cutover_rollback")
-                : List.of(category.contract().replacementRequirement());
-        return new DomainBindingResponse(
-                domain.key(),
-                domain.displayName(),
-                category.readiness(),
-                activeBinding,
-                connectionRef,
-                DomainAdapterRegistryMapper.fromCategory(category).candidates(),
-                category.adapterEvidence(),
-                transitionArtifacts,
-                true,
-                true);
-    }
-
-    private ProviderConnectionRefResponse connectionRef(
-            CanonicalDomainRegistryEntryResponse domain,
-            ProviderCategoryStatusResponse category,
-            List<ProviderSelection> selections,
-            Instant generatedAt) {
-        Optional<ProviderSelection> selection = selections.stream()
-                .filter(value -> value.category().equals(category.category()))
-                .findFirst();
-        boolean hasSecretRef = selection.map(ProviderSelection::hasSecretRef).orElse(false);
-        return new ProviderConnectionRefResponse(
-                category.selectedProviderKey(),
-                CanonicalDomainBindingCatalog.stableConnectionId(category.selectedProviderKey()),
-                List.of(domain.key()),
-                category.readiness(),
-                hasSecretRef ? "SecretRef" : "GrantRef-or-none",
-                hasSecretRef,
-                domain.capabilityKeys(),
-                generatedAt,
-                true,
-                true);
-    }
 
     private ProviderStatusResponse applyAdminSelection(ProviderStatusResponse status, List<ProviderSelection> selections) {
         Optional<String> maybeCategory = ProviderCategoryCatalog.categoryForModule(status.module());

--- a/server/src/test/java/com/massimotter/weave/backend/provider/ProviderRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/ProviderRegistryTest.java
@@ -115,6 +115,74 @@ class ProviderRegistryTest {
                 .containsEntry("rawProviderErrorsReturned", false);
     }
 
+    @Test
+    void domainBindingServiceBuildsCanonicalSecretFreeConnectionRefs() {
+        InMemoryProviderSelectionRepository selections = new InMemoryProviderSelectionRepository();
+        selections.save(new ProviderSelection(
+                "chat",
+                "slack",
+                "external_existing_provider",
+                "secretref://weave/provider/slack",
+                "actor:admin",
+                Instant.parse("2026-05-24T18:00:00Z"),
+                true,
+                true,
+                true,
+                List.of("Thread and channel semantics require migration dry-run.")));
+        ProviderRegistry registry = new ProviderRegistry(
+                List.of(StaticProviderPort.pending(
+                        ProviderModule.MATRIX,
+                        "synapse-homeserver",
+                        "Chat adapter candidate.",
+                        Set.of("chat.read"),
+                        Set.of("direct-flutter-provider-api"),
+                        List.of("synapse", "slack", "microsoft-teams"),
+                        Map.of())),
+                capabilityService(),
+                selections,
+                new DomainBindingService());
+
+        DomainBindingsResponse response = registry.domainBindings(" chat ");
+
+        assertThat(response.releaseStatus()).isEqualTo("domain-binding-provider-connection-v1");
+        assertThat(response.transitionPlansAreSecondaryArtifacts()).isTrue();
+        assertThat(response.memberProviderInternalsExposed()).isFalse();
+        assertThat(response.bindings()).singleElement().satisfies(binding -> {
+            assertThat(binding.domainKey()).isEqualTo("chat");
+            assertThat(binding.activeBinding()).isEqualTo("binding:chat:provider:slack");
+            assertThat(binding.providerConnectionRef()).satisfies(connection -> {
+                assertThat(connection.providerKey()).isEqualTo("slack");
+                assertThat(connection.connectionId()).isEqualTo("provider-connection:slack");
+                assertThat(connection.domainKeys()).containsExactly("chat");
+                assertThat(connection.credentialRefKind()).isEqualTo("SecretRef");
+                assertThat(connection.credentialRefConfigured()).isTrue();
+                assertThat(connection.supportSafe()).isTrue();
+            });
+            assertThat(binding.supportSafe()).isTrue();
+        });
+        assertThat(response.toString()).doesNotContain("secretref://");
+    }
+
+    @Test
+    void domainBindingFilterDoesNotLeakProviderCategoriesAsDomains() {
+        ProviderRegistry registry = new ProviderRegistry(
+                List.of(StaticProviderPort.pending(
+                        ProviderModule.FILES,
+                        "nextcloud",
+                        "Files adapter candidate.",
+                        Set.of("files.read"),
+                        Set.of("direct-flutter-provider-api"),
+                        List.of("nextcloud", "sharepoint"),
+                        Map.of())),
+                capabilityService(),
+                new InMemoryProviderSelectionRepository(),
+                new DomainBindingService());
+
+        DomainBindingsResponse response = registry.domainBindings("storage");
+
+        assertThat(response.bindings()).isEmpty();
+    }
+
     private WorkspaceCapabilityService capabilityService() {
         WorkspaceCapabilityService service = Mockito.mock(WorkspaceCapabilityService.class);
         when(service.snapshot()).thenReturn(new WorkspaceCapabilitiesResponse(


### PR DESCRIPTION
## Summary
- Extract generic domain-binding response construction from `ProviderRegistry` into `DomainBindingService`
- Keep external provider/domain binding API behavior stable while reducing registry orchestration scope
- Add provider tests for canonical domain filtering and support-safe provider connection refs without raw SecretRef output

## Target lane
main

## Linked issue/spec
- Follow-up to PR #778 server architecture refactoring direction; no release readiness claim.

## Release notes
- release-notes-skip: pure server refactor with test coverage, no user/operator behavior change intended.

## Spec impact
- None intended. The existing `domain-binding-provider-connection-v1` contract is preserved.

## User/admin/operator impact
- None intended externally. Admin domain-binding responses continue to expose provider-neutral, support-safe connection refs only.

## Checks run
- `server/gradlew -p server test --tests 'com.massimotter.weave.backend.provider.ProviderRegistryTest' --console=plain`
- `server/gradlew -p server test --tests 'com.massimotter.weave.backend.provider.ProviderRegistryTest' --tests 'com.massimotter.weave.backend.controller.ProviderRegistryControllerTest' --tests 'com.massimotter.weave.backend.controller.AdminControlPlaneControllerTest' --console=plain`
- `git diff --check`
- `./gradlew portabilityContractCheck domainRegistryCheck specContract acceptanceContract docsCheck --console=plain`
- `./gradlew serverCi --console=plain`

## Architecture notes
Audit/red-team map found larger risks that should stay separate from this first slice:
1. Provider/domain/category/capability metadata is split across registry, provider contracts, domain facade definitions, workspace capabilities, and admin simulation.
2. `AdminControlPlaneService` remains a god-service mixing provider selection, replacement dry-runs, policy simulation, identity workflows, audit shaping, and suite readiness.
3. Selection/persistence seams have drift risks, including choice-model/category normalization inconsistencies that need targeted follow-up.

This PR deliberately avoids a broad rewrite and only moves the generic domain-binding construction behind a reusable collaborator.
