### PR TITLE
fix(server): share provider choice validation

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/provider/FileProviderSelectionRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/FileProviderSelectionRepository.java
@@ -8,7 +8,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -46,7 +45,7 @@ public class FileProviderSelectionRepository implements ProviderSelectionReposit
         if (category == null || category.isBlank()) {
             return Optional.empty();
         }
-        return Optional.ofNullable(selections.get(normalizeCategory(category)));
+        return Optional.ofNullable(selections.get(ProviderSelectionKey.category(category)));
     }
 
     @Override
@@ -63,9 +62,10 @@ public class FileProviderSelectionRepository implements ProviderSelectionReposit
         }
         synchronized (persistenceLock) {
             Map<String, ProviderSelection> nextSelections = new TreeMap<>(selections);
-            nextSelections.put(normalizeCategory(selection.category()), selection);
+            String categoryKey = ProviderSelectionKey.category(selection.category());
+            nextSelections.put(categoryKey, selection);
             persist(nextSelections);
-            selections.put(normalizeCategory(selection.category()), selection);
+            selections.put(categoryKey, selection);
             return selection;
         }
     }
@@ -83,7 +83,7 @@ public class FileProviderSelectionRepository implements ProviderSelectionReposit
             Map<String, ProviderSelection> loaded = objectMapper.readValue(storagePath.toFile(), SELECTION_MAP);
             selections.clear();
             if (loaded != null) {
-                loaded.values().forEach(selection -> selections.put(normalizeCategory(selection.category()), selection));
+                loaded.values().forEach(selection -> selections.put(ProviderSelectionKey.category(selection.category()), selection));
             }
         } catch (IOException exception) {
             throw new ProviderSelectionStoreException(
@@ -108,9 +108,5 @@ public class FileProviderSelectionRepository implements ProviderSelectionReposit
             throw new ProviderSelectionStoreException(
                     "Failed to persist provider selections to " + storagePath, exception);
         }
-    }
-
-    private String normalizeCategory(String category) {
-        return category.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/provider/InMemoryProviderSelectionRepository.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/InMemoryProviderSelectionRepository.java
@@ -4,6 +4,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+
 public class InMemoryProviderSelectionRepository implements ProviderSelectionRepository {
 
     private final ConcurrentHashMap<String, ProviderSelection> selections = new ConcurrentHashMap<>();
@@ -13,7 +14,7 @@ public class InMemoryProviderSelectionRepository implements ProviderSelectionRep
         if (category == null || category.isBlank()) {
             return Optional.empty();
         }
-        return Optional.ofNullable(selections.get(category.trim()));
+        return Optional.ofNullable(selections.get(ProviderSelectionKey.category(category)));
     }
 
     @Override
@@ -25,7 +26,10 @@ public class InMemoryProviderSelectionRepository implements ProviderSelectionRep
 
     @Override
     public ProviderSelection save(ProviderSelection selection) {
-        selections.put(selection.category(), selection);
+        if (selection == null) {
+            throw new IllegalArgumentException("Provider selection must not be null.");
+        }
+        selections.put(ProviderSelectionKey.category(selection.category()), selection);
         return selection;
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
@@ -206,28 +206,28 @@ public final class ProviderCapabilityContracts {
             List<String> externalAdapters) {
         return List.of(
                 new ProviderChoiceModelResponse(
-                        "recommended_self_hosted_default",
+                        ProviderChoiceModel.RECOMMENDED_SELF_HOSTED_DEFAULT,
                         defaultAdapters,
                         List.of(
                                 "recommended sovereign/default posture",
                                 "admin still verifies backup, jurisdiction, lifecycle, and operator evidence"),
                         true),
                 new ProviderChoiceModelResponse(
-                        "external_existing_provider",
+                        ProviderChoiceModel.EXTERNAL_EXISTING_PROVIDER,
                         externalAdapters,
                         List.of(
                                 "allowed when the organization already operates this provider category elsewhere",
                                 "admin records tenant, data residency, retention, audit, and support boundary risk outside member UX"),
                         false),
                 new ProviderChoiceModelResponse(
-                        "managed_cloud_provider",
+                        ProviderChoiceModel.MANAGED_CLOUD_PROVIDER,
                         externalAdapters,
                         List.of(
                                 "allowed as an interchangeable adapter posture, not a product boundary",
                                 "admin must assess privacy, compliance, export, availability, and vendor lock-in risks"),
                         false),
                 new ProviderChoiceModelResponse(
-                        "hybrid_composite",
+                        ProviderChoiceModel.HYBRID_COMPOSITE,
                         java.util.stream.Stream.concat(defaultAdapters.stream(), externalAdapters.stream()).distinct().sorted().toList(),
                         List.of(
                                 "allowed when an organization mixes self-hosted, managed-cloud, and external providers across one capability boundary",

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryStatusResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCategoryStatusResponse.java
@@ -21,7 +21,7 @@ public record ProviderCategoryStatusResponse(
         @Schema(description = "Provider registry modules contributing to this category.") List<String> modules,
         @Schema(description = "Support-safe provider choices/candidates for admin diagnostics.") List<String> providerCandidates,
         @Schema(description = "Admin Console-selected provider key, or awaiting_admin_selection when not applied.") String selectedProviderKey,
-        @Schema(description = "Selected provider choice model: recommended_self_hosted_default, external_existing_provider, or managed_cloud_provider.") String choiceModel,
+        @Schema(description = "Selected provider choice model: recommended_self_hosted_default, external_existing_provider, managed_cloud_provider, or hybrid_composite.") String choiceModel,
         @Schema(description = "True only after an admin has applied a provider mapping for this category.") boolean selectedByAdmin,
         @Schema(description = "True when defaults are being shown only as bootstrap/profile suggestions, not product truth.") boolean bootstrapSuggestionOnly,
         @Schema(description = "Support-safe notes for known lossy mappings across provider families.") List<String> lossyMappingNotes,

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderChoiceModel.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderChoiceModel.java
@@ -1,0 +1,40 @@
+package com.massimotter.weave.backend.provider;
+
+import java.util.List;
+
+/** Shared provider selection choice model contract for admin and domain/provider selection flows. */
+public final class ProviderChoiceModel {
+
+    public static final String RECOMMENDED_SELF_HOSTED_DEFAULT = "recommended_self_hosted_default";
+    public static final String EXTERNAL_EXISTING_PROVIDER = "external_existing_provider";
+    public static final String MANAGED_CLOUD_PROVIDER = "managed_cloud_provider";
+    public static final String HYBRID_COMPOSITE = "hybrid_composite";
+
+    private static final List<String> SUPPORTED = List.of(
+            RECOMMENDED_SELF_HOSTED_DEFAULT,
+            EXTERNAL_EXISTING_PROVIDER,
+            MANAGED_CLOUD_PROVIDER,
+            HYBRID_COMPOSITE);
+
+    private ProviderChoiceModel() {
+    }
+
+    public static String defaultValue() {
+        return RECOMMENDED_SELF_HOSTED_DEFAULT;
+    }
+
+    public static List<String> supportedValues() {
+        return SUPPORTED;
+    }
+
+    public static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return defaultValue();
+        }
+        String normalized = value.trim();
+        if (SUPPORTED.contains(normalized)) {
+            return normalized;
+        }
+        throw new IllegalArgumentException("choiceModel must be a provider choice contract value");
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderChoiceModelResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderChoiceModelResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 @Schema(description = "Admin-visible provider choice posture for a category. It records privacy/compliance risk notes without changing member-facing product semantics.")
 public record ProviderChoiceModelResponse(
-        @Schema(description = "Stable choice model key: recommended_self_hosted_default, external_existing_provider, or managed_cloud_provider.") String choiceModel,
+        @Schema(description = "Stable choice model key: recommended_self_hosted_default, external_existing_provider, managed_cloud_provider, or hybrid_composite.") String choiceModel,
         @Schema(description = "Support-safe adapter keys covered by this choice model.") List<String> adapters,
         @Schema(description = "Support-safe admin/operator risk notes. No secrets, URLs, tenant IDs, or raw provider errors.") List<String> adminRiskNotes,
         @Schema(description = "Whether this is the recommended sovereign/default posture.") boolean recommended) {

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderSelection.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderSelection.java
@@ -17,9 +17,9 @@ public record ProviderSelection(
         List<String> lossyMappingNotes) {
 
     public ProviderSelection {
-        category = requireText(category, "category");
+        category = ProviderSelectionKey.category(category);
         providerKey = requireText(providerKey, "providerKey");
-        choiceModel = normalizeChoiceModel(choiceModel);
+        choiceModel = ProviderChoiceModel.normalize(choiceModel);
         secretRef = normalizeSecretRef(secretRef);
         selectedBy = selectedBy == null || selectedBy.isBlank() ? "actor:system" : selectedBy.trim();
         selectedAt = selectedAt == null ? Instant.EPOCH : selectedAt;
@@ -36,19 +36,6 @@ public record ProviderSelection(
             throw new IllegalArgumentException(field + " must not be blank");
         }
         return value.trim();
-    }
-
-    private static String normalizeChoiceModel(String value) {
-        if (value == null || value.isBlank()) {
-            return "recommended_self_hosted_default";
-        }
-        String normalized = value.trim();
-        if (normalized.equals("recommended_self_hosted_default")
-                || normalized.equals("external_existing_provider")
-                || normalized.equals("managed_cloud_provider")) {
-            return normalized;
-        }
-        throw new IllegalArgumentException("choiceModel must be a provider choice contract value");
     }
 
     private static String normalizeSecretRef(String value) {

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderSelectionKey.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderSelectionKey.java
@@ -1,0 +1,17 @@
+package com.massimotter.weave.backend.provider;
+
+import java.util.Locale;
+
+/** Stable storage/lookup key normalization for provider selection categories. */
+public final class ProviderSelectionKey {
+
+    private ProviderSelectionKey() {
+    }
+
+    public static String category(String category) {
+        if (category == null || category.isBlank()) {
+            throw new IllegalArgumentException("category must not be blank");
+        }
+        return category.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -56,6 +56,7 @@ import com.massimotter.weave.backend.provider.ProviderCategoryCatalog;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
 import com.massimotter.weave.backend.provider.ProviderModule;
 import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
+import com.massimotter.weave.backend.provider.ProviderChoiceModel;
 import com.massimotter.weave.backend.provider.ProviderSelection;
 import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import com.massimotter.weave.backend.provider.ProviderState;
@@ -1459,21 +1460,15 @@ public class AdminControlPlaneService {
     }
 
     private String selectionChoiceModel(String value) {
-        if (value == null || value.isBlank()) {
-            return "recommended_self_hosted_default";
+        try {
+            return ProviderChoiceModel.normalize(value);
+        } catch (IllegalArgumentException exception) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-selection-choice-model-invalid",
+                    "Provider selection choice model is not part of the Weave provider choice contract.",
+                    Map.of("choiceModel", "invalid-choice-model-redacted"));
         }
-        String trimmed = value.trim();
-        if (trimmed.equals("recommended_self_hosted_default")
-                || trimmed.equals("external_existing_provider")
-                || trimmed.equals("managed_cloud_provider")
-                || trimmed.equals("hybrid_composite")) {
-            return trimmed;
-        }
-        throw new ApiErrorException(
-                HttpStatus.BAD_REQUEST,
-                "provider-selection-choice-model-invalid",
-                "Provider selection choice model is not part of the Weave provider choice contract.",
-                Map.of("choiceModel", "invalid-choice-model-redacted"));
     }
 
     private String selectionSecretRef(String value) {
@@ -1528,9 +1523,9 @@ public class AdminControlPlaneService {
 
     private boolean requiresMigrationDryRun(ProviderSelectionRequest request) {
         return request.lossyMappingNotes() != null && !request.lossyMappingNotes().isEmpty()
-                || "external_existing_provider".equals(request.choiceModel())
-                || "managed_cloud_provider".equals(request.choiceModel())
-                || "hybrid_composite".equals(request.choiceModel());
+                || ProviderChoiceModel.EXTERNAL_EXISTING_PROVIDER.equals(request.choiceModel())
+                || ProviderChoiceModel.MANAGED_CLOUD_PROVIDER.equals(request.choiceModel())
+                || ProviderChoiceModel.HYBRID_COMPOSITE.equals(request.choiceModel());
     }
 
     private List<String> safeLossyMappingNotes(List<String> notes) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -744,13 +744,15 @@ class AdminControlPlaneControllerTest {
         mockMvc.perform(post("/api/admin/providers/selections")
                         .with(adminJwt())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"category\":\"chat\",\"providerKey\":\"slack\",\"choiceModel\":\"external_existing_provider\",\"secretRef\":\"secretref://weave/provider/slack\",\"lossyMappingNotes\":[\"Slack thread/broadcast semantics require migration dry-run.\"],\"reason\":\"compare external provider\"}"))
+                        .content("{\"category\":\"chat\",\"providerKey\":\"slack\",\"choiceModel\":\"hybrid_composite\",\"secretRef\":\"secretref://weave/provider/slack\",\"lossyMappingNotes\":[\"Slack thread/broadcast semantics require migration dry-run.\"],\"reason\":\"compare external provider\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.category").value("chat"))
                 .andExpect(jsonPath("$.providerKey").value("slack"))
+                .andExpect(jsonPath("$.choiceModel").value("hybrid_composite"))
                 .andExpect(jsonPath("$.applied").value(true))
                 .andExpect(jsonPath("$.supportSafe").value(true))
-                .andExpect(jsonPath("$.migrationDryRunRequired").value(true));
+                .andExpect(jsonPath("$.migrationDryRunRequired").value(true))
+                .andExpect(content().string(not(containsString("xoxb-raw-token"))));
 
         mockMvc.perform(post("/api/admin/providers/selections")
                         .with(adminJwt())

--- a/server/src/test/java/com/massimotter/weave/backend/provider/FileProviderSelectionRepositoryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/FileProviderSelectionRepositoryTest.java
@@ -57,6 +57,35 @@ class FileProviderSelectionRepositoryTest {
     }
 
     @Test
+    void fileAndMemoryRepositoriesNormalizeCategoryKeysEquivalently() {
+        Path storagePath = tempDir.resolve("provider-selections.json");
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        var fileRepository = new FileProviderSelectionRepository(objectMapper, storagePath);
+        var memoryRepository = new InMemoryProviderSelectionRepository();
+        ProviderSelection selection = new ProviderSelection(
+                " CHAT ",
+                "slack",
+                "hybrid_composite",
+                "secretref://weave/provider/slack",
+                "actor:admin-123",
+                Instant.parse("2026-05-31T08:00:00Z"),
+                true,
+                true,
+                true,
+                List.of("support-safe note"));
+
+        fileRepository.save(selection);
+        memoryRepository.save(selection);
+
+        assertThat(fileRepository.findByCategory("chat")).isPresent();
+        assertThat(memoryRepository.findByCategory("chat")).isPresent();
+        assertThat(fileRepository.findByCategory(" CHAT ")).map(ProviderSelection::category).contains("chat");
+        assertThat(memoryRepository.findByCategory(" CHAT ")).map(ProviderSelection::category).contains("chat");
+        assertThat(fileRepository.findAll()).extracting(ProviderSelection::category).containsExactly("chat");
+        assertThat(memoryRepository.findAll()).extracting(ProviderSelection::category).containsExactly("chat");
+    }
+
+    @Test
     void failedJsonWriteDoesNotExposeUnpersistedProviderSelection() throws IOException {
         Path storagePath = tempDir.resolve("provider-selections.json");
         ObjectMapper objectMapper = mock(ObjectMapper.class);

--- a/server/src/test/java/com/massimotter/weave/backend/provider/FileProviderSelectionRepositoryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/FileProviderSelectionRepositoryTest.java
@@ -64,9 +64,9 @@ class FileProviderSelectionRepositoryTest {
         var memoryRepository = new InMemoryProviderSelectionRepository();
         ProviderSelection selection = new ProviderSelection(
                 " CHAT ",
-                "slack",
+                "synapse-homeserver",
                 "hybrid_composite",
-                "secretref://weave/provider/slack",
+                "secretref://weave/provider/synapse-homeserver",
                 "actor:admin-123",
                 Instant.parse("2026-05-31T08:00:00Z"),
                 true,

--- a/server/src/test/java/com/massimotter/weave/backend/provider/ProviderChoiceModelTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/ProviderChoiceModelTest.java
@@ -30,9 +30,9 @@ class ProviderChoiceModelTest {
     void providerSelectionRoundTripsHybridComposite() {
         ProviderSelection selection = new ProviderSelection(
                 " CHAT ",
-                "slack",
+                "synapse-homeserver",
                 " hybrid_composite ",
-                "secretref://weave/provider/slack",
+                "secretref://weave/provider/synapse-homeserver",
                 "actor:admin-123",
                 null,
                 true,
@@ -43,6 +43,6 @@ class ProviderChoiceModelTest {
         assertThat(selection.category()).isEqualTo("chat");
         assertThat(selection.choiceModel()).isEqualTo("hybrid_composite");
         assertThat(selection.supportSafe()).isTrue();
-        assertThat(selection.secretRef()).isEqualTo("secretref://weave/provider/slack");
+        assertThat(selection.secretRef()).isEqualTo("secretref://weave/provider/synapse-homeserver");
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/provider/ProviderChoiceModelTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/ProviderChoiceModelTest.java
@@ -1,0 +1,48 @@
+package com.massimotter.weave.backend.provider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProviderChoiceModelTest {
+
+    @Test
+    void supportedChoiceModelsAreCentralizedAndIncludeHybridComposite() {
+        assertThat(ProviderChoiceModel.supportedValues()).containsExactly(
+                "recommended_self_hosted_default",
+                "external_existing_provider",
+                "managed_cloud_provider",
+                "hybrid_composite");
+    }
+
+    @Test
+    void normalizesBlankChoiceModelToRecommendedDefaultAndRejectsUnknownValues() {
+        assertThat(ProviderChoiceModel.normalize("  ")).isEqualTo("recommended_self_hosted_default");
+        assertThat(ProviderChoiceModel.normalize(" hybrid_composite ")).isEqualTo("hybrid_composite");
+
+        assertThatThrownBy(() -> ProviderChoiceModel.normalize("hardcoded_default"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("provider choice contract value");
+    }
+
+    @Test
+    void providerSelectionRoundTripsHybridComposite() {
+        ProviderSelection selection = new ProviderSelection(
+                " CHAT ",
+                "slack",
+                " hybrid_composite ",
+                "secretref://weave/provider/slack",
+                "actor:admin-123",
+                null,
+                true,
+                false,
+                true,
+                null);
+
+        assertThat(selection.category()).isEqualTo("chat");
+        assertThat(selection.choiceModel()).isEqualTo("hybrid_composite");
+        assertThat(selection.supportSafe()).isTrue();
+        assertThat(selection.secretRef()).isEqualTo("secretref://weave/provider/slack");
+    }
+}


### PR DESCRIPTION
## Summary
- centralize provider choice-model validation/defaulting, including `hybrid_composite`
- share provider selection category key normalization across file and memory repositories
- add regression tests for hybrid selection round-trip, repository lookup parity, and admin redaction behavior

## Evidence
- `./gradlew test --tests '*ProviderChoiceModelTest' --tests '*FileProviderSelectionRepositoryTest' --tests '*AdminControlPlaneControllerTest' --tests '*DomainAdapterRegistryMapperTest' --console=plain`
- `./gradlew portabilityContractCheck domainRegistryCheck specContract acceptanceContract docsCheck --console=plain`
- `./gradlew serverCi --console=plain`
- Independent red-team review: PASS, no required fixes

## Release notes
- Bugfix: provider selection now accepts and persists the documented `hybrid_composite` choice model consistently.
