### PR TITLE
Extract provider selection service

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderChoiceModel.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderChoiceModel.java
@@ -27,6 +27,12 @@ public final class ProviderChoiceModel {
         return SUPPORTED;
     }
 
+    public static boolean requiresMigrationDryRun(String value) {
+        return EXTERNAL_EXISTING_PROVIDER.equals(value)
+                || MANAGED_CLOUD_PROVIDER.equals(value)
+                || HYBRID_COMPOSITE.equals(value);
+    }
+
     public static String normalize(String value) {
         if (value == null || value.isBlank()) {
             return defaultValue();

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -56,7 +56,6 @@ import com.massimotter.weave.backend.provider.ProviderCategoryCatalog;
 import com.massimotter.weave.backend.provider.ProviderRegistry;
 import com.massimotter.weave.backend.provider.ProviderModule;
 import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
-import com.massimotter.weave.backend.provider.ProviderChoiceModel;
 import com.massimotter.weave.backend.provider.ProviderSelection;
 import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import com.massimotter.weave.backend.provider.ProviderState;
@@ -118,7 +117,7 @@ public class AdminControlPlaneService {
 
     private final ProviderRegistry providerRegistry;
     private final WorkspaceCapabilityService workspaceCapabilityService;
-    private final ProviderSelectionRepository providerSelectionRepository;
+    private final ProviderSelectionService providerSelectionService;
     private final OrganizationBootstrapRepository organizationBootstrapRepository;
     private final AuditEventPublisher auditEventPublisher;
     private final List<IdentityRealmProvider> identityRealmProviders;
@@ -131,7 +130,7 @@ public class AdminControlPlaneService {
     public AdminControlPlaneService(
             ProviderRegistry providerRegistry,
             WorkspaceCapabilityService workspaceCapabilityService,
-            ProviderSelectionRepository providerSelectionRepository,
+            ProviderSelectionService providerSelectionService,
             OrganizationBootstrapRepository organizationBootstrapRepository,
             AuditEventPublisher auditEventPublisher,
             List<IdentityRealmProvider> identityRealmProviders,
@@ -141,7 +140,7 @@ public class AdminControlPlaneService {
         IdentityRealmApplyProperties properties = identityRealmApplyProperties.getIfAvailable(IdentityRealmApplyProperties::new);
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
-        this.providerSelectionRepository = providerSelectionRepository;
+        this.providerSelectionService = providerSelectionService;
         this.organizationBootstrapRepository = organizationBootstrapRepository;
         this.auditEventPublisher = auditEventPublisher;
         this.identityRealmProviders = identityRealmProviders == null || identityRealmProviders.isEmpty()
@@ -163,14 +162,14 @@ public class AdminControlPlaneService {
             OrganizationBootstrapRepository organizationBootstrapRepository,
             AuditEventPublisher auditEventPublisher,
             Clock clock) {
-        this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher,
+        this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), organizationBootstrapRepository, auditEventPublisher,
                 List.of(new KeycloakRealmDryRunProvider()), new InMemoryIdentityRealmEvidenceRepository(), List.of(new KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), clock);
     }
 
     AdminControlPlaneService(
             ProviderRegistry providerRegistry,
             WorkspaceCapabilityService workspaceCapabilityService,
-            ProviderSelectionRepository providerSelectionRepository,
+            ProviderSelectionService providerSelectionService,
             OrganizationBootstrapRepository organizationBootstrapRepository,
             AuditEventPublisher auditEventPublisher,
             List<IdentityRealmProvider> identityRealmProviders,
@@ -180,7 +179,7 @@ public class AdminControlPlaneService {
             Clock clock) {
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
-        this.providerSelectionRepository = providerSelectionRepository;
+        this.providerSelectionService = providerSelectionService;
         this.organizationBootstrapRepository = organizationBootstrapRepository;
         this.auditEventPublisher = auditEventPublisher;
         this.identityRealmProviders = identityRealmProviders == null || identityRealmProviders.isEmpty()
@@ -196,6 +195,21 @@ public class AdminControlPlaneService {
                 ? List.of(new KeycloakRealmLiveApplyAdapter(this.identityRealmApplyProperties))
                 : List.copyOf(identityRealmLiveApplyAdapters);
         this.clock = clock;
+    }
+
+    AdminControlPlaneService(
+            ProviderRegistry providerRegistry,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            ProviderSelectionRepository providerSelectionRepository,
+            OrganizationBootstrapRepository organizationBootstrapRepository,
+            AuditEventPublisher auditEventPublisher,
+            List<IdentityRealmProvider> identityRealmProviders,
+            IdentityRealmEvidenceRepository identityRealmEvidenceRepository,
+            List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters,
+            IdentityRealmApplyProperties identityRealmApplyProperties,
+            Clock clock) {
+        this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), organizationBootstrapRepository, auditEventPublisher,
+                identityRealmProviders, identityRealmEvidenceRepository, identityRealmLiveApplyAdapters, identityRealmApplyProperties, clock);
     }
 
     public AdminControlPlaneResponse overview(Jwt jwt) {
@@ -217,7 +231,7 @@ public class AdminControlPlaneService {
                 Instant.now(clock),
                 registry.categories(),
                 registry.selectedProviderMappings().stream()
-                        .map(selection -> toSelectionResponse(selection, false, readinessFor(selection.category(), registry)))
+                        .map(selection -> providerSelectionService.toResponse(selection, false, providerSelectionService.readinessFor(selection.category(), registry)))
                         .toList(),
                 whitelist(jwt),
                 weaverDistributionPolicy(registry),
@@ -251,9 +265,9 @@ public class AdminControlPlaneService {
 
     public ProviderSelectionResponse selectProvider(ProviderSelectionRequest request, Jwt jwt) {
         workspaceCapabilityService.requireCapability(jwt, "admin.provider.configure", "admin-control-plane", "select-provider");
-        ProviderSelection selection = validateProviderSelection(request, jwt);
+        ProviderSelection selection = providerSelectionService.validate(request, actorRef(jwt));
         boolean dryRun = request.dryRun();
-        ProviderSelection applied = dryRun ? selection : providerSelectionRepository.save(selection);
+        ProviderSelection applied = dryRun ? selection : providerSelectionService.save(selection);
         if (!dryRun) {
             auditEventPublisher.publish(new AuditEvent(
                     organizationId(jwt),
@@ -277,7 +291,7 @@ public class AdminControlPlaneService {
                             Map.entry("dryRunEvidenceRequired", selection.migrationDryRunRequired()),
                             Map.entry("token", "not-stored"))));
         }
-        return toSelectionResponse(applied, dryRun, dryRun ? "dry_run_valid" : "admin_selected_pending_readiness");
+        return providerSelectionService.toResponse(applied, dryRun, dryRun ? "dry_run_valid" : "admin_selected_pending_readiness");
     }
 
     public ProviderReplacementDryRunResponse dryRunProviderReplacement(ProviderReplacementDryRunRequest request, Jwt jwt) {
@@ -301,14 +315,14 @@ public class AdminControlPlaneService {
                     "Provider category is not part of the Weave canonical control-plane contract.",
                     Map.of("category", category));
         }
-        if (!providerMatchesCategory(currentAdapter, category) || !providerMatchesCategory(targetAdapter, category)) {
+        if (!providerSelectionService.providerMatchesCategory(currentAdapter, category) || !providerSelectionService.providerMatchesCategory(targetAdapter, category)) {
             throw new ApiErrorException(
                     HttpStatus.BAD_REQUEST,
                     "provider-replacement-category-mismatch",
                     "Provider replacement adapters must both be registered as support-safe candidates for the selected category.",
                     Map.of("category", category, "adapters", "unsupported-adapter-redacted"));
         }
-        String choiceModel = selectionChoiceModel(request.choiceModel());
+        String choiceModel = providerSelectionChoiceModel(request.choiceModel());
         requiredSecretRef(request.secretRef());
         String declaredSourceOfTruth = safeSourceOfTruth(request.sourceOfTruth());
         List<String> adminNotes = safeLossyMappingNotes(request.lossyMappingNotes());
@@ -1324,43 +1338,6 @@ public class AdminControlPlaneService {
                 .orElseGet(() -> new KeycloakRealmLiveApplyAdapter(identityRealmApplyProperties));
     }
 
-    private ProviderSelection validateProviderSelection(ProviderSelectionRequest request, Jwt jwt) {
-        if (request == null || request.category() == null || request.category().isBlank()
-                || request.providerKey() == null || request.providerKey().isBlank()) {
-            throw new ApiErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "provider-selection-invalid",
-                    "Provider selection requires category and provider key.",
-                    Map.of("reason", "category and providerKey are required"));
-        }
-        String category = request.category().trim();
-        String providerKey = request.providerKey().trim();
-        if (ProviderCategoryCatalog.category(category).isEmpty()) {
-            throw new ApiErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "provider-category-unknown",
-                    "Provider category is not part of the Weave canonical control-plane contract.",
-                    Map.of("category", category));
-        }
-        if (!providerMatchesCategory(providerKey, category)) {
-            throw new ApiErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "provider-selection-category-mismatch",
-                    "Provider key is not registered as a support-safe candidate for the selected category.",
-                    Map.of("category", category, "providerKey", providerKey));
-        }
-        return new ProviderSelection(
-                category,
-                providerKey,
-                selectionChoiceModel(request.choiceModel()),
-                selectionSecretRef(request.secretRef()),
-                actorRef(jwt),
-                Instant.now(clock),
-                !request.dryRun(),
-                true,
-                requiresMigrationDryRun(request),
-                safeLossyMappingNotes(request.lossyMappingNotes()));
-    }
 
     private void enforceLastAdminGuard(CapabilityWhitelistUpdateRequest request) {
         if (!"workspace-admin".equals(request.profileKey().trim().toLowerCase(Locale.ROOT))) {
@@ -1440,43 +1417,9 @@ public class AdminControlPlaneService {
         return value.length() > MAX_BOOTSTRAP_ADMIN_KEY_LENGTH || !PRIMARY_IDENTITY_KEY_REGEX.matcher(value).matches();
     }
 
-    private boolean providerMatchesCategory(String providerKey, String category) {
-        boolean registeredCandidate = providerRegistry.status().providers().stream()
-                .filter(provider -> ProviderCategoryCatalog.providerMatchesCategory(provider, category))
-                .anyMatch(provider -> providerKeyMatches(provider, providerKey));
-        if (registeredCandidate) {
-            return true;
-        }
-        String normalized = providerKey.toLowerCase(Locale.ROOT);
-        return ProviderCapabilityContracts.providerCandidates(category).stream()
-                .map(value -> value.toLowerCase(Locale.ROOT))
-                .anyMatch(normalized::equals);
-    }
 
-    private boolean providerKeyMatches(ProviderStatusResponse provider, String providerKey) {
-        String normalized = providerKey.toLowerCase(Locale.ROOT);
-        return provider.providerKey().equals(providerKey)
-                || provider.candidates().stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(normalized::equals);
-    }
 
-    private String selectionChoiceModel(String value) {
-        try {
-            return ProviderChoiceModel.normalize(value);
-        } catch (IllegalArgumentException exception) {
-            throw new ApiErrorException(
-                    HttpStatus.BAD_REQUEST,
-                    "provider-selection-choice-model-invalid",
-                    "Provider selection choice model is not part of the Weave provider choice contract.",
-                    Map.of("choiceModel", "invalid-choice-model-redacted"));
-        }
-    }
 
-    private String selectionSecretRef(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return validateSecretRef(value, "provider-selection-secretref-invalid", "Provider selections may reference credentials only through SecretRef URIs.");
-    }
 
     private String requiredSecretRef(String value) {
         if (value == null || value.isBlank()) {
@@ -1521,43 +1464,8 @@ public class AdminControlPlaneService {
         return trimmed;
     }
 
-    private boolean requiresMigrationDryRun(ProviderSelectionRequest request) {
-        return request.lossyMappingNotes() != null && !request.lossyMappingNotes().isEmpty()
-                || ProviderChoiceModel.EXTERNAL_EXISTING_PROVIDER.equals(request.choiceModel())
-                || ProviderChoiceModel.MANAGED_CLOUD_PROVIDER.equals(request.choiceModel())
-                || ProviderChoiceModel.HYBRID_COMPOSITE.equals(request.choiceModel());
-    }
 
-    private List<String> safeLossyMappingNotes(List<String> notes) {
-        if (notes == null) {
-            return List.of();
-        }
-        return notes.stream()
-                .filter(value -> value != null && !value.isBlank())
-                .map(this::safeText)
-                .distinct()
-                .limit(10)
-                .toList();
-    }
 
-    private ProviderSelectionResponse toSelectionResponse(ProviderSelection selection, boolean dryRun, String readiness) {
-        return new ProviderSelectionResponse(
-                selection.category(),
-                selection.providerKey(),
-                selection.choiceModel(),
-                selection.secretRef(),
-                selection.selectedBy(),
-                selection.selectedAt(),
-                selection.applied() && !dryRun,
-                dryRun,
-                true,
-                !selection.applied() || dryRun,
-                selection.migrationDryRunRequired(),
-                selection.lossyMappingNotes(),
-                readiness,
-                providerSelectionRepository.persistencePosture(),
-                selection.selectedAt());
-    }
 
     private List<SuiteDomainReadinessResponse> suiteDomainReadiness(ProviderRegistryResponse registry) {
         return List.of(
@@ -1582,7 +1490,7 @@ public class AdminControlPlaneService {
             List<String> portabilityNotes,
             String nextAction) {
         List<String> readinessStates = definition.providerCategoryKeys().stream()
-                .map(category -> readinessFor(category, registry))
+                .map(category -> providerSelectionService.readinessFor(category, registry))
                 .filter(state -> !"unknown".equals(state))
                 .toList();
         String adminReadiness = aggregateDomainReadiness(readinessStates);
@@ -1772,9 +1680,9 @@ public class AdminControlPlaneService {
                 List.of("audit://weaver/runtime-profile/projection"),
                 List.of(
                         projectionItem("chat-route", "chat", "channels.weave-chat via " + chatProviderKey, "ready", "available", "Stable chat route only; provider rooms stay behind Weave Chat.", false),
-                        projectionItem("model-alias-general", "model", "general-assistant via " + modelProviderKey, readinessFor("model", registry), "disabled_by_policy", "Alias is admin-selected but runtime remains disabled by default.", false),
-                        projectionItem("tool-calendar-search", "tool", "calendar.search_events", readinessFor("calendar", registry), "disabled_by_policy", "Read-only discovery requires weaver.calendar_read and calendar.read grants.", false),
-                        projectionItem("tool-boards-comment", "tool", "boards.comment", readinessFor("boards-tasks", registry), "disabled_by_policy", "Write-like tool requires explicit approval receipt and audit.", true),
+                        projectionItem("model-alias-general", "model", "general-assistant via " + modelProviderKey, providerSelectionService.readinessFor("model", registry), "disabled_by_policy", "Alias is admin-selected but runtime remains disabled by default.", false),
+                        projectionItem("tool-calendar-search", "tool", "calendar.search_events", providerSelectionService.readinessFor("calendar", registry), "disabled_by_policy", "Read-only discovery requires weaver.calendar_read and calendar.read grants.", false),
+                        projectionItem("tool-boards-comment", "tool", "boards.comment", providerSelectionService.readinessFor("boards-tasks", registry), "disabled_by_policy", "Write-like tool requires explicit approval receipt and audit.", true),
                         projectionItem("mcp-weave-domain-tools", "mcp", "weave-domain-tools via streamable-http", "configured", "disabled_by_policy", "Admin-bound MCP server is discoverable only to granted RuntimeProfiles and remains disabled until org policy enables Weaver.", true),
                         projectionItem("consent-shared-space", "mcp", "shared-space consent gate", "admin-action-required", "disabled_by_policy", "Group chat/shared-space participation requires org policy and consent evidence.", true)));
     }
@@ -1812,7 +1720,7 @@ public class AdminControlPlaneService {
                 .map(ProviderSelection::providerKey)
                 .findFirst()
                 .orElse("matrix-chat");
-        String readiness = readinessFor("model", registry);
+        String readiness = providerSelectionService.readinessFor("model", registry);
         if ("unknown".equals(readiness)) {
             readiness = "admin-action-required";
         }
@@ -1852,13 +1760,6 @@ public class AdminControlPlaneService {
                         "Admin-selected model provider is projected into Weaver aliases without exposing provider secrets to members.")));
     }
 
-    private String readinessFor(String category, ProviderRegistryResponse registry) {
-        return registry.categories().stream()
-                .filter(value -> value.category().equals(category))
-                .map(value -> value.readiness().value())
-                .findFirst()
-                .orElse("unknown");
-    }
 
     private List<McpServerBindingResponse> mcpServerBindings(ProviderRegistryResponse registry) {
         return List.of(new McpServerBindingResponse(
@@ -1980,6 +1881,38 @@ public class AdminControlPlaneService {
             return "identity-ref-redacted";
         }
         return safeText(trimmed);
+    }
+
+
+
+    private boolean providerKeyMatches(ProviderStatusResponse provider, String providerKey) {
+        String normalized = providerKey.toLowerCase(Locale.ROOT);
+        return provider.providerKey().equals(providerKey)
+                || provider.candidates().stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(normalized::equals);
+    }
+
+    private String providerSelectionChoiceModel(String value) {
+        try {
+            return com.massimotter.weave.backend.provider.ProviderChoiceModel.normalize(value);
+        } catch (IllegalArgumentException exception) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-selection-choice-model-invalid",
+                    "Provider selection choice model is not part of the Weave provider choice contract.",
+                    Map.of("choiceModel", "invalid-choice-model-redacted"));
+        }
+    }
+
+    private List<String> safeLossyMappingNotes(List<String> notes) {
+        if (notes == null) {
+            return List.of();
+        }
+        return notes.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(this::safeText)
+                .distinct()
+                .limit(10)
+                .toList();
     }
 
     private boolean safePrimaryIdentityKey(String value) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/ProviderSelectionService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ProviderSelectionService.java
@@ -1,0 +1,188 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
+import com.massimotter.weave.backend.model.admin.ProviderSelectionResponse;
+import com.massimotter.weave.backend.provider.ProviderCapabilityContracts;
+import com.massimotter.weave.backend.provider.ProviderCategoryCatalog;
+import com.massimotter.weave.backend.provider.ProviderChoiceModel;
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
+import com.massimotter.weave.backend.provider.ProviderSelection;
+import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
+import com.massimotter.weave.backend.provider.ProviderStatusResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProviderSelectionService {
+
+    private final ProviderRegistry providerRegistry;
+    private final ProviderSelectionRepository providerSelectionRepository;
+    private final Clock clock;
+
+    @Autowired
+    public ProviderSelectionService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository) {
+        this(providerRegistry, providerSelectionRepository, Clock.systemUTC());
+    }
+
+    ProviderSelectionService(
+            ProviderRegistry providerRegistry,
+            ProviderSelectionRepository providerSelectionRepository,
+            Clock clock) {
+        this.providerRegistry = providerRegistry;
+        this.providerSelectionRepository = providerSelectionRepository;
+        this.clock = clock;
+    }
+
+    public ProviderSelection validate(ProviderSelectionRequest request, String actorRef) {
+        if (request == null || request.category() == null || request.category().isBlank()
+                || request.providerKey() == null || request.providerKey().isBlank()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-selection-invalid",
+                    "Provider selection requires category and provider key.",
+                    Map.of("reason", "category and providerKey are required"));
+        }
+        String category = request.category().trim();
+        String providerKey = request.providerKey().trim();
+        if (ProviderCategoryCatalog.category(category).isEmpty()) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-category-unknown",
+                    "Provider category is not part of the Weave canonical control-plane contract.",
+                    Map.of("category", category));
+        }
+        if (!providerMatchesCategory(providerKey, category)) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-selection-category-mismatch",
+                    "Provider key is not registered as a support-safe candidate for the selected category.",
+                    Map.of("category", category, "providerKey", providerKey));
+        }
+        return new ProviderSelection(
+                category,
+                providerKey,
+                selectionChoiceModel(request.choiceModel()),
+                selectionSecretRef(request.secretRef()),
+                actorRef,
+                Instant.now(clock),
+                !request.dryRun(),
+                true,
+                requiresMigrationDryRun(request),
+                safeLossyMappingNotes(request.lossyMappingNotes()));
+    }
+
+    public ProviderSelection save(ProviderSelection selection) {
+        return providerSelectionRepository.save(selection);
+    }
+
+    public ProviderSelectionResponse toResponse(ProviderSelection selection, boolean dryRun, String readiness) {
+        return new ProviderSelectionResponse(
+                selection.category(),
+                selection.providerKey(),
+                selection.choiceModel(),
+                selection.secretRef(),
+                selection.selectedBy(),
+                selection.selectedAt(),
+                selection.applied() && !dryRun,
+                dryRun,
+                true,
+                !selection.applied() || dryRun,
+                selection.migrationDryRunRequired(),
+                selection.lossyMappingNotes(),
+                readiness,
+                providerSelectionRepository.persistencePosture(),
+                selection.selectedAt());
+    }
+
+    public boolean providerMatchesCategory(String providerKey, String category) {
+        boolean registeredCandidate = providerRegistry.status().providers().stream()
+                .filter(provider -> ProviderCategoryCatalog.providerMatchesCategory(provider, category))
+                .anyMatch(provider -> providerKeyMatches(provider, providerKey));
+        if (registeredCandidate) {
+            return true;
+        }
+        String normalized = providerKey.toLowerCase(Locale.ROOT);
+        return ProviderCapabilityContracts.providerCandidates(category).stream()
+                .map(value -> value.toLowerCase(Locale.ROOT))
+                .anyMatch(normalized::equals);
+    }
+
+    public String readinessFor(String category, ProviderRegistryResponse registry) {
+        return registry.categories().stream()
+                .filter(value -> value.category().equals(category))
+                .map(value -> value.readiness().value())
+                .findFirst()
+                .orElse("unknown");
+    }
+
+    private boolean providerKeyMatches(ProviderStatusResponse provider, String providerKey) {
+        String normalized = providerKey.toLowerCase(Locale.ROOT);
+        return provider.providerKey().equals(providerKey)
+                || provider.candidates().stream().map(value -> value.toLowerCase(Locale.ROOT)).anyMatch(normalized::equals);
+    }
+
+    private String selectionChoiceModel(String value) {
+        try {
+            return ProviderChoiceModel.normalize(value);
+        } catch (IllegalArgumentException exception) {
+            throw new ApiErrorException(
+                    HttpStatus.BAD_REQUEST,
+                    "provider-selection-choice-model-invalid",
+                    "Provider selection choice model is not part of the Weave provider choice contract.",
+                    Map.of("choiceModel", "invalid-choice-model-redacted"));
+        }
+    }
+
+    private String selectionSecretRef(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.toLowerCase(Locale.ROOT).startsWith("secretref://")) {
+            return trimmed;
+        }
+        throw new ApiErrorException(
+                HttpStatus.BAD_REQUEST,
+                "provider-selection-secretref-invalid",
+                "Provider selections may reference credentials only through SecretRef URIs.",
+                Map.of("secretRef", "invalid-secret-ref-redacted"));
+    }
+
+    private boolean requiresMigrationDryRun(ProviderSelectionRequest request) {
+        return request.lossyMappingNotes() != null && !request.lossyMappingNotes().isEmpty()
+                || ProviderChoiceModel.requiresMigrationDryRun(request.choiceModel());
+    }
+
+    private List<String> safeLossyMappingNotes(List<String> notes) {
+        if (notes == null) {
+            return List.of();
+        }
+        return notes.stream()
+                .filter(value -> value != null && !value.isBlank())
+                .map(this::safeText)
+                .distinct()
+                .limit(10)
+                .toList();
+    }
+
+    private String safeText(String value) {
+        if (value == null || value.isBlank()) {
+            return "not-provided";
+        }
+        return value.trim()
+                .replaceAll("(?i)bearer\\s+[^\\s]+", "Bearer [redacted]")
+                .replaceAll("(?i)xox[baprs]-[A-Za-z0-9-]+", "chat-token-[redacted]")
+                .replaceAll("(?i)https?://[^\\s]+", "url-[redacted]")
+                .replaceAll("(?i)secret(ref)?://[^\\s]+", "secret-ref-[redacted]");
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import com.massimotter.weave.backend.service.AdminControlPlaneService;
 import com.massimotter.weave.backend.service.InMemoryOrganizationBootstrapRepository;
 import com.massimotter.weave.backend.service.OrganizationBootstrapRepository;
+import com.massimotter.weave.backend.service.ProviderSelectionService;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +78,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         DevopsProviderConfiguration.class,
         DisabledOfficeProvider.class,
         AdminControlPlaneService.class,
+        ProviderSelectionService.class,
         AdminControlPlaneControllerTest.AuditTestConfig.class
 })
 @TestPropertySource(properties = {

--- a/server/src/test/java/com/massimotter/weave/backend/service/ProviderSelectionServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ProviderSelectionServiceTest.java
@@ -1,0 +1,142 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.exception.ApiErrorException;
+import com.massimotter.weave.backend.model.admin.ProviderSelectionRequest;
+import com.massimotter.weave.backend.provider.InMemoryProviderSelectionRepository;
+import com.massimotter.weave.backend.provider.ProviderRegistry;
+import com.massimotter.weave.backend.provider.ProviderRegistryResponse;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProviderSelectionServiceTest {
+
+    private final InMemoryProviderSelectionRepository repository = new InMemoryProviderSelectionRepository();
+    private final ProviderRegistry registry = mock(ProviderRegistry.class);
+    private final ProviderSelectionService service = new ProviderSelectionService(
+            registry,
+            repository,
+            Clock.fixed(Instant.parse("2026-05-27T01:03:39Z"), ZoneOffset.UTC));
+
+    @Test
+    void hybridCompositeSelectionRoundTripsThroughSupportSafeResponse() {
+        when(registry.status()).thenReturn(emptyRegistry());
+        ProviderSelectionRequest request = new ProviderSelectionRequest(
+                "chat",
+                "matrix-chat",
+                " hybrid_composite ",
+                "secretref://weave/provider/matrix-chat/admin-token",
+                false,
+                List.of("manual note with Bearer raw-token and https://provider.example.invalid/path"),
+                "operator-selected hybrid chat");
+
+        var selection = service.validate(request, "user:admin-123");
+        var applied = service.save(selection);
+        var response = service.toResponse(applied, false, "admin_selected_pending_readiness");
+
+        assertThat(response.category()).isEqualTo("chat");
+        assertThat(response.providerKey()).isEqualTo("matrix-chat");
+        assertThat(response.choiceModel()).isEqualTo("hybrid_composite");
+        assertThat(response.secretRef()).isEqualTo("secretref://weave/provider/matrix-chat/admin-token");
+        assertThat(response.applied()).isTrue();
+        assertThat(response.dryRun()).isFalse();
+        assertThat(response.migrationDryRunRequired()).isTrue();
+        assertThat(response.lossyMappingNotes()).containsExactly("manual note with Bearer [redacted] and url-[redacted]");
+        assertThat(response.toString()).doesNotContain("raw-token", "provider.example.invalid/path");
+    }
+
+    @Test
+    void invalidCategoryAndProviderAreRejectedWithSupportSafeDetails() {
+        when(registry.status()).thenReturn(emptyRegistry());
+
+        assertThatThrownBy(() -> service.validate(new ProviderSelectionRequest(
+                "unknown-category",
+                "matrix-chat",
+                "recommended_self_hosted_default",
+                null,
+                true,
+                List.of(),
+                "bad category"), "user:admin-123"))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.code()).isEqualTo("provider-category-unknown");
+                    assertThat(exception.details()).containsEntry("category", "unknown-category");
+                    assertThat(exception.toString()).doesNotContain("secret", "token");
+                });
+
+        assertThatThrownBy(() -> service.validate(new ProviderSelectionRequest(
+                "chat",
+                "unregistered-provider",
+                "recommended_self_hosted_default",
+                "not-a-secret-value",
+                true,
+                List.of("Bearer should-not-leak"),
+                "bad provider"), "user:admin-123"))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.code()).isEqualTo("provider-selection-category-mismatch");
+                    assertThat(exception.details()).containsEntry("category", "chat");
+                    assertThat(exception.details()).containsEntry("providerKey", "unregistered-provider");
+                    assertThat(exception.toString()).doesNotContain("should-not-leak", "not-a-secret-value");
+                });
+    }
+
+    @Test
+    void contractOnlyProviderCandidateBehaviorRemainsAccepted() {
+        when(registry.status()).thenReturn(emptyRegistry());
+
+        var selection = service.validate(new ProviderSelectionRequest(
+                "model",
+                "lmstudio-openai-compatible",
+                "external_existing_provider",
+                null,
+                true,
+                List.of(),
+                "contract-only model candidate"), "user:admin-123");
+
+        assertThat(selection.providerKey()).isEqualTo("lmstudio-openai-compatible");
+        assertThat(selection.migrationDryRunRequired()).isTrue();
+        assertThat(service.toResponse(selection, true, "dry_run_valid").dryRun()).isTrue();
+    }
+
+    @Test
+    void rawSecretValuesNeverPassSecretRefValidation() {
+        when(registry.status()).thenReturn(emptyRegistry());
+
+        assertThatThrownBy(() -> service.validate(new ProviderSelectionRequest(
+                "chat",
+                "matrix-chat",
+                "recommended_self_hosted_default",
+                "Bearer raw-secret-token",
+                false,
+                List.of(),
+                "raw secret attempt"), "user:admin-123"))
+                .isInstanceOfSatisfying(ApiErrorException.class, exception -> {
+                    assertThat(exception.code()).isEqualTo("provider-selection-secretref-invalid");
+                    assertThat(exception.details()).containsEntry("secretRef", "invalid-secret-ref-redacted");
+                    assertThat(exception.toString()).doesNotContain("raw-secret-token", "Bearer raw");
+                });
+    }
+
+    private ProviderRegistryResponse emptyRegistry() {
+        return new ProviderRegistryResponse(
+                "dogfood-production",
+                ProviderRegistry.PROVIDER_CONFIG_SOURCE,
+                true,
+                true,
+                true,
+                false,
+                true,
+                Instant.parse("2026-05-27T01:03:39Z"),
+                null,
+                null,
+                List.of(),
+                List.of(),
+                List.of());
+    }
+}


### PR DESCRIPTION
## Summary
- Extract provider-selection validation, response shaping, persistence, and readiness helpers into `ProviderSelectionService`.
- Inject the new Spring service into `AdminControlPlaneService` and remove direct repository ownership from the admin service.
- Add targeted provider-selection tests for round trip, support-safe failures, contract-only candidates, and raw secret rejection.

## Target lane
- `dev`

## Linked issue
- None. Internal refactor / maintainability hardening.

## Release notes
- None — backend-only refactor with no user-facing behavior change.

## Spec impact
- No spec change. Preserves provider-neutral control-plane behavior and support-safe provider-selection contracts.

## Gates run
- `git diff --check`
- `cd server && ./gradlew test --tests 'com.massimotter.weave.backend.service.ProviderSelectionServiceTest' --tests 'com.massimotter.weave.backend.service.AdminControlPlaneServiceTest' --tests 'com.massimotter.weave.backend.controller.AdminControlPlaneControllerTest' --console=plain`
- `./gradlew releaseEvidenceCheck --console=plain`
- `./gradlew portabilityContractCheck domainRegistryCheck specContract acceptanceContract docsCheck --console=plain`
- `./gradlew serverCi --console=plain`

## Review evidence
- Independent backend red-team review found no behavior drift or support-safety regression, then requested tighter service injection/repository-boundary cleanup; this PR includes those fixes.
