### PR TITLE
refactor: extract identity realm workflow service

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/config/TimeConfiguration.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/TimeConfiguration.java
@@ -1,0 +1,14 @@
+package com.massimotter.weave.backend.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfiguration {
+
+    @Bean
+    Clock systemClock() {
+        return Clock.systemUTC();
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -113,13 +113,9 @@ public class AdminControlPlaneService {
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
         this.providerSelectionService = providerSelectionService;
-        this.clock = clock == null ? Clock.systemUTC() : clock;
-        this.providerReplacementDryRunService = providerReplacementDryRunService == null
-                ? new ProviderReplacementDryRunService(providerSelectionService, auditEventPublisher, this.clock)
-                : providerReplacementDryRunService;
-        this.effectivePolicySimulationService = effectivePolicySimulationService == null
-                ? new EffectivePolicySimulationService(auditEventPublisher, this.clock)
-                : effectivePolicySimulationService;
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.providerReplacementDryRunService = Objects.requireNonNull(providerReplacementDryRunService, "providerReplacementDryRunService");
+        this.effectivePolicySimulationService = Objects.requireNonNull(effectivePolicySimulationService, "effectivePolicySimulationService");
         this.organizationBootstrapRepository = organizationBootstrapRepository;
         this.auditEventPublisher = auditEventPublisher;
         this.identityRealmWorkflowService = Objects.requireNonNull(identityRealmWorkflowService, "identityRealmWorkflowService");
@@ -132,7 +128,9 @@ public class AdminControlPlaneService {
             OrganizationBootstrapRepository organizationBootstrapRepository,
             AuditEventPublisher auditEventPublisher,
             Clock clock) {
-        this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), null, null, organizationBootstrapRepository, auditEventPublisher,
+        this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock),
+                new ProviderReplacementDryRunService(new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), auditEventPublisher, clock),
+                new EffectivePolicySimulationService(auditEventPublisher, clock), organizationBootstrapRepository, auditEventPublisher,
                 new IdentityRealmWorkflowService(workspaceCapabilityService, auditEventPublisher, List.of(new com.massimotter.weave.backend.identity.realm.KeycloakRealmDryRunProvider()), new com.massimotter.weave.backend.identity.realm.InMemoryIdentityRealmEvidenceRepository(), List.of(new com.massimotter.weave.backend.identity.realm.KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), clock), clock);
     }
 
@@ -147,7 +145,9 @@ public class AdminControlPlaneService {
             List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters,
             IdentityRealmApplyProperties identityRealmApplyProperties,
             Clock clock) {
-        this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), null, null, organizationBootstrapRepository, auditEventPublisher,
+        this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock),
+                new ProviderReplacementDryRunService(new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), auditEventPublisher, clock),
+                new EffectivePolicySimulationService(auditEventPublisher, clock), organizationBootstrapRepository, auditEventPublisher,
                 new IdentityRealmWorkflowService(workspaceCapabilityService, auditEventPublisher, identityRealmProviders, identityRealmEvidenceRepository, identityRealmLiveApplyAdapters, identityRealmApplyProperties, clock), clock);
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -7,19 +7,14 @@ import com.massimotter.weave.backend.audit.AuditRedactionLevel;
 import com.massimotter.weave.backend.audit.FileAuditEventPublisher;
 import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
 import com.massimotter.weave.backend.exception.ApiErrorException;
-import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyProperties;
 import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyReport;
 import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyRequest;
-import com.massimotter.weave.backend.identity.realm.IdentityRealmDesiredState;
-import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunEvidence;
 import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunReport;
 import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunRequest;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyProperties;
 import com.massimotter.weave.backend.identity.realm.IdentityRealmEvidenceRepository;
 import com.massimotter.weave.backend.identity.realm.IdentityRealmLiveApplyAdapter;
 import com.massimotter.weave.backend.identity.realm.IdentityRealmProvider;
-import com.massimotter.weave.backend.identity.realm.InMemoryIdentityRealmEvidenceRepository;
-import com.massimotter.weave.backend.identity.realm.KeycloakRealmDryRunProvider;
-import com.massimotter.weave.backend.identity.realm.KeycloakRealmLiveApplyAdapter;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
 import com.massimotter.weave.backend.model.admin.AdminAuditEventResponse;
 import com.massimotter.weave.backend.model.admin.AdminControlPlaneResponse;
@@ -69,11 +64,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -101,10 +96,7 @@ public class AdminControlPlaneService {
     private final EffectivePolicySimulationService effectivePolicySimulationService;
     private final OrganizationBootstrapRepository organizationBootstrapRepository;
     private final AuditEventPublisher auditEventPublisher;
-    private final List<IdentityRealmProvider> identityRealmProviders;
-    private final IdentityRealmEvidenceRepository identityRealmEvidenceRepository;
-    private final List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters;
-    private final IdentityRealmApplyProperties identityRealmApplyProperties;
+    private final IdentityRealmWorkflowService identityRealmWorkflowService;
     private final Clock clock;
 
     @Autowired
@@ -116,58 +108,12 @@ public class AdminControlPlaneService {
             EffectivePolicySimulationService effectivePolicySimulationService,
             OrganizationBootstrapRepository organizationBootstrapRepository,
             AuditEventPublisher auditEventPublisher,
-            List<IdentityRealmProvider> identityRealmProviders,
-            ObjectProvider<IdentityRealmEvidenceRepository> identityRealmEvidenceRepository,
-            ObjectProvider<List<IdentityRealmLiveApplyAdapter>> identityRealmLiveApplyAdapters,
-            ObjectProvider<IdentityRealmApplyProperties> identityRealmApplyProperties) {
-        IdentityRealmApplyProperties properties = identityRealmApplyProperties.getIfAvailable(IdentityRealmApplyProperties::new);
-        this.providerRegistry = providerRegistry;
-        this.workspaceCapabilityService = workspaceCapabilityService;
-        this.providerSelectionService = providerSelectionService;
-        this.clock = Clock.systemUTC();
-        this.providerReplacementDryRunService = providerReplacementDryRunService;
-        this.effectivePolicySimulationService = effectivePolicySimulationService;
-        this.organizationBootstrapRepository = organizationBootstrapRepository;
-        this.auditEventPublisher = auditEventPublisher;
-        this.identityRealmProviders = identityRealmProviders == null || identityRealmProviders.isEmpty()
-                ? List.of(new KeycloakRealmDryRunProvider())
-                : List.copyOf(identityRealmProviders);
-        this.identityRealmEvidenceRepository = identityRealmEvidenceRepository.getIfAvailable(InMemoryIdentityRealmEvidenceRepository::new);
-        this.identityRealmApplyProperties = properties;
-        List<IdentityRealmLiveApplyAdapter> adapters = identityRealmLiveApplyAdapters.getIfAvailable(List::of);
-        this.identityRealmLiveApplyAdapters = adapters == null || adapters.isEmpty()
-                ? List.of(new KeycloakRealmLiveApplyAdapter(this.identityRealmApplyProperties))
-                : List.copyOf(adapters);
-    }
-
-    AdminControlPlaneService(
-            ProviderRegistry providerRegistry,
-            WorkspaceCapabilityService workspaceCapabilityService,
-            ProviderSelectionRepository providerSelectionRepository,
-            OrganizationBootstrapRepository organizationBootstrapRepository,
-            AuditEventPublisher auditEventPublisher,
-            Clock clock) {
-        this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), null, null, organizationBootstrapRepository, auditEventPublisher,
-                List.of(new KeycloakRealmDryRunProvider()), new InMemoryIdentityRealmEvidenceRepository(), List.of(new KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), clock);
-    }
-
-    AdminControlPlaneService(
-            ProviderRegistry providerRegistry,
-            WorkspaceCapabilityService workspaceCapabilityService,
-            ProviderSelectionService providerSelectionService,
-            ProviderReplacementDryRunService providerReplacementDryRunService,
-            EffectivePolicySimulationService effectivePolicySimulationService,
-            OrganizationBootstrapRepository organizationBootstrapRepository,
-            AuditEventPublisher auditEventPublisher,
-            List<IdentityRealmProvider> identityRealmProviders,
-            IdentityRealmEvidenceRepository identityRealmEvidenceRepository,
-            List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters,
-            IdentityRealmApplyProperties identityRealmApplyProperties,
+            IdentityRealmWorkflowService identityRealmWorkflowService,
             Clock clock) {
         this.providerRegistry = providerRegistry;
         this.workspaceCapabilityService = workspaceCapabilityService;
         this.providerSelectionService = providerSelectionService;
-        this.clock = clock;
+        this.clock = clock == null ? Clock.systemUTC() : clock;
         this.providerReplacementDryRunService = providerReplacementDryRunService == null
                 ? new ProviderReplacementDryRunService(providerSelectionService, auditEventPublisher, this.clock)
                 : providerReplacementDryRunService;
@@ -176,18 +122,18 @@ public class AdminControlPlaneService {
                 : effectivePolicySimulationService;
         this.organizationBootstrapRepository = organizationBootstrapRepository;
         this.auditEventPublisher = auditEventPublisher;
-        this.identityRealmProviders = identityRealmProviders == null || identityRealmProviders.isEmpty()
-                ? List.of(new KeycloakRealmDryRunProvider())
-                : List.copyOf(identityRealmProviders);
-        this.identityRealmEvidenceRepository = identityRealmEvidenceRepository == null
-                ? new InMemoryIdentityRealmEvidenceRepository()
-                : identityRealmEvidenceRepository;
-        this.identityRealmApplyProperties = identityRealmApplyProperties == null
-                ? new IdentityRealmApplyProperties()
-                : identityRealmApplyProperties;
-        this.identityRealmLiveApplyAdapters = identityRealmLiveApplyAdapters == null || identityRealmLiveApplyAdapters.isEmpty()
-                ? List.of(new KeycloakRealmLiveApplyAdapter(this.identityRealmApplyProperties))
-                : List.copyOf(identityRealmLiveApplyAdapters);
+        this.identityRealmWorkflowService = Objects.requireNonNull(identityRealmWorkflowService, "identityRealmWorkflowService");
+    }
+
+    AdminControlPlaneService(
+            ProviderRegistry providerRegistry,
+            WorkspaceCapabilityService workspaceCapabilityService,
+            ProviderSelectionRepository providerSelectionRepository,
+            OrganizationBootstrapRepository organizationBootstrapRepository,
+            AuditEventPublisher auditEventPublisher,
+            Clock clock) {
+        this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), null, null, organizationBootstrapRepository, auditEventPublisher,
+                new IdentityRealmWorkflowService(workspaceCapabilityService, auditEventPublisher, List.of(new com.massimotter.weave.backend.identity.realm.KeycloakRealmDryRunProvider()), new com.massimotter.weave.backend.identity.realm.InMemoryIdentityRealmEvidenceRepository(), List.of(new com.massimotter.weave.backend.identity.realm.KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), clock), clock);
     }
 
     AdminControlPlaneService(
@@ -202,7 +148,7 @@ public class AdminControlPlaneService {
             IdentityRealmApplyProperties identityRealmApplyProperties,
             Clock clock) {
         this(providerRegistry, workspaceCapabilityService, new ProviderSelectionService(providerRegistry, providerSelectionRepository, clock), null, null, organizationBootstrapRepository, auditEventPublisher,
-                identityRealmProviders, identityRealmEvidenceRepository, identityRealmLiveApplyAdapters, identityRealmApplyProperties, clock);
+                new IdentityRealmWorkflowService(workspaceCapabilityService, auditEventPublisher, identityRealmProviders, identityRealmEvidenceRepository, identityRealmLiveApplyAdapters, identityRealmApplyProperties, clock), clock);
     }
 
     public AdminControlPlaneResponse overview(Jwt jwt) {
@@ -303,224 +249,11 @@ public class AdminControlPlaneService {
     }
 
     public IdentityRealmDryRunReport dryRunIdentityRealm(IdentityRealmDryRunRequest request, Jwt jwt) {
-        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "identity-realm", "dry-run");
-        IdentityRealmProvider provider = identityRealmProvider("keycloak-realm");
-        IdentityRealmDryRunReport report = provider.dryRun(request);
-        String auditRef = "identity-realm-dry-run-" + Instant.now(clock).toEpochMilli();
-        auditEventPublisher.publish(new AuditEvent(
-                organizationId(jwt),
-                "admin-control-plane",
-                actorRef(jwt),
-                "identity-realm-dry-run",
-                AuditAction.PROVIDER_REPLACEMENT_DRY_RUN,
-                Instant.now(clock),
-                auditRef,
-                AuditRedactionLevel.SECRET_REDACTED,
-                Map.of(
-                        "providerKey", provider.providerKey(),
-                        "realmId", report.realmId(),
-                        "readiness", report.readiness(),
-                        "changeCount", report.changes().size(),
-                        "blockerCount", report.blockers().size(),
-                        "supportSafe", report.supportSafe(),
-                        "rawSecretExposed", report.rawSecretExposed(),
-                        "destructiveApplyAvailable", report.destructiveApplyAvailable(),
-                        "dryRunReasonPresent", request != null && request.reason() != null && !request.reason().isBlank())));
-        IdentityRealmDryRunReport persistedReport = new IdentityRealmDryRunReport(
-                report.providerKey(),
-                report.realmId(),
-                report.dryRunId(),
-                report.operation(),
-                report.readiness(),
-                report.destructiveApplyAvailable(),
-                report.supportSafe(),
-                report.rawSecretExposed(),
-                report.changes(),
-                report.readinessChecks(),
-                report.diff(),
-                report.warnings(),
-                report.blockers(),
-                report.nextActions(),
-                List.of(auditRef));
-        identityRealmEvidenceRepository.save(new IdentityRealmDryRunEvidence(
-                persistedReport.dryRunId(),
-                auditRef,
-                provider.providerKey(),
-                persistedReport.realmId(),
-                persistedReport,
-                Instant.now(clock)));
-        return persistedReport;
+        return identityRealmWorkflowService.dryRunIdentityRealm(request, jwt);
     }
 
     public IdentityRealmApplyReport applyIdentityRealm(IdentityRealmApplyRequest request, Jwt jwt) {
-        workspaceCapabilityService.requireCapability(jwt, "admin.provider.configure", "identity-realm", "apply");
-        IdentityRealmProvider provider = identityRealmProvider("keycloak-realm");
-        IdentityRealmDryRunReport requestedDryRun = provider.dryRun(request == null ? null : request.dryRunRequest());
-        Optional<IdentityRealmDryRunEvidence> persistedEvidence = identityRealmEvidenceRepository.findDryRun(request == null ? null : request.dryRunId());
-        IdentityRealmDryRunReport dryRun = persistedEvidence.map(IdentityRealmDryRunEvidence::report).orElse(requestedDryRun);
-        long safeChangeCount = dryRun.changes().stream().filter(change -> "safe".equals(change.classification())).count();
-        long riskyChangeCount = dryRun.changes().stream().filter(change -> "risky".equals(change.classification())).count();
-        long destructiveChangeCount = dryRun.changes().stream().filter(change -> "destructive".equals(change.classification())).count();
-        boolean hasRisky = riskyChangeCount > 0;
-        boolean hasDestructive = destructiveChangeCount > 0;
-        boolean rollbackRequired = hasRisky || hasDestructive;
-        boolean rollbackAccepted = !rollbackRequired || hasText(request == null ? null : request.rollbackEvidenceRef());
-        boolean lastAdminGuardPassed = retainedAdminProofPresent(request);
-        boolean confirmationProvided = request != null && "APPLY WEAVE IDENTITY REALM".equals(request.confirmationPhrase());
-        boolean policySimulationPresent = request != null
-                && hasText(request.policySimulationRef())
-                && request.policySimulationRef().startsWith("effective-policy-simulation-");
-        boolean persistedDryRunFresh = persistedEvidence
-                .filter(evidence -> evidence.providerKey().equals(provider.providerKey()))
-                .filter(evidence -> evidence.dryRunId().equals(requestedDryRun.dryRunId()))
-                .filter(evidence -> !evidence.createdAt().plusSeconds(identityRealmApplyProperties.dryRunFreshnessSeconds()).isBefore(Instant.now(clock)))
-                .isPresent();
-        List<String> blocked = new ArrayList<>();
-        if (!persistedDryRunFresh) {
-            blocked.add("fresh persisted dry-run evidence is required before identity realm apply");
-        }
-        if (!policySimulationPresent) {
-            blocked.add("effective policy simulation evidence ref is required before identity realm apply");
-        }
-        if (!confirmationProvided) {
-            blocked.add("explicit confirmation phrase is required");
-        }
-        if (!lastAdminGuardPassed) {
-            blocked.add("last-admin guard requires at least one retained immutable admin identity key");
-        }
-        if (hasRisky && (request == null || !request.approveRisky())) {
-            blocked.add("risky changes require approveRisky=true");
-        }
-        if (hasDestructive && (request == null || !request.approveDestructive())) {
-            blocked.add("destructive changes require approveDestructive=true");
-        }
-        if (hasDestructive && !provider.destructiveApplyAvailable()) {
-            blocked.add("provider destructive apply is not available for this contract");
-        }
-        if (!rollbackAccepted) {
-            blocked.add("rollback/restore evidence ref is required for risky or destructive apply");
-        }
-        blocked.addAll(dryRun.blockers());
-        boolean guardsAccepted = blocked.isEmpty();
-        IdentityRealmLiveApplyAdapter.IdentityRealmLiveApplyResult liveApply = guardsAccepted
-                ? identityRealmLiveApplyAdapter(provider.providerKey()).apply(persistedEvidence.orElseThrow(), request)
-                : new IdentityRealmLiveApplyAdapter.IdentityRealmLiveApplyResult(false, false, "guarded-provider-apply-blocked-before-adapter", List.of(), List.of());
-        blocked.addAll(liveApply.blockedReasons());
-        boolean accepted = blocked.isEmpty();
-        boolean applied = accepted && liveApply.applied();
-        boolean providerMutationPerformed = accepted && liveApply.providerMutationPerformed();
-        String executionMode = accepted ? liveApply.executionMode() : "guarded-provider-apply-blocked-before-mutation";
-        List<String> nextActions = new ArrayList<>(applyNextActions(accepted, blocked, rollbackRequired, hasRisky, hasDestructive));
-        nextActions.addAll(liveApply.nextActions());
-        nextActions = nextActions.stream().distinct().toList();
-        String auditRef = "identity-realm-apply-" + Instant.now(clock).toEpochMilli();
-        String actorRef = actorRef(jwt);
-        auditEventPublisher.publish(new AuditEvent(
-                organizationId(jwt),
-                "admin-control-plane",
-                actorRef,
-                "identity-realm-apply",
-                AuditAction.IDENTITY_REALM_APPLY_GUARDED,
-                Instant.now(clock),
-                auditRef,
-                AuditRedactionLevel.SUPPORT_SAFE,
-                Map.ofEntries(
-                        Map.entry("actorRef", actorRef),
-                        Map.entry("candidateRef", "identity-realm:" + dryRun.realmId()),
-                        Map.entry("planRef", dryRun.dryRunId()),
-                        Map.entry("providerKey", provider.providerKey()),
-                        Map.entry("realmId", dryRun.realmId()),
-                        Map.entry("decision", accepted ? "accepted" : "blocked"),
-                        Map.entry("result", accepted ? (applied ? "accepted-with-provider-mutation" : "accepted-without-provider-mutation") : "blocked-before-provider-mutation"),
-                        Map.entry("executionMode", executionMode),
-                        Map.entry("liveApplyEnabled", identityRealmApplyProperties.liveApplyEnabled()),
-                        Map.entry("providerConfigured", identityRealmApplyProperties.providerConfigured()),
-                        Map.entry("providerMutationPerformed", providerMutationPerformed),
-                        Map.entry("safeChangeCount", safeChangeCount),
-                        Map.entry("riskyChangeCount", riskyChangeCount),
-                        Map.entry("destructiveChangeCount", destructiveChangeCount),
-                        Map.entry("blockedReasonCount", blocked.size()),
-                        Map.entry("nextActionCount", nextActions.size()),
-                        Map.entry("persistedDryRunEvidencePresent", persistedEvidence.isPresent()),
-                        Map.entry("persistedDryRunFresh", persistedDryRunFresh),
-                        Map.entry("effectivePolicySimulationEvidencePresent", policySimulationPresent),
-                        Map.entry("confirmationProvided", confirmationProvided),
-                        Map.entry("retainedAdminIdentityKeyCount", request == null ? 0 : request.retainedAdminPrimaryIdentityKeys().stream().filter(this::safePrimaryIdentityKey).count()),
-                        Map.entry("rollbackRestoreEvidencePresent", request != null && hasText(request.rollbackEvidenceRef())),
-                        Map.entry("lastAdminGuardPassed", lastAdminGuardPassed),
-                        Map.entry("rollbackEvidenceAccepted", rollbackAccepted),
-                        Map.entry("supportSafe", true))));
-        return new IdentityRealmApplyReport(
-                provider.providerKey(),
-                dryRun.realmId(),
-                dryRun.dryRunId(),
-                accepted ? "accepted" : "blocked",
-                executionMode,
-                applied,
-                providerMutationPerformed,
-                true,
-                false,
-                lastAdminGuardPassed,
-                rollbackRequired,
-                rollbackAccepted,
-                blocked.stream().distinct().toList(),
-                dryRun.changes(),
-                nextActions,
-                List.of(auditRef));
-    }
-
-    private boolean retainedAdminProofPresent(IdentityRealmApplyRequest request) {
-        if (request == null || request.retainedAdminPrimaryIdentityKeys().isEmpty()) {
-            return false;
-        }
-        IdentityRealmDesiredState desiredState = request.dryRunRequest().desiredState();
-        Set<String> retainedSafeKeys = request.retainedAdminPrimaryIdentityKeys().stream()
-                .filter(this::safePrimaryIdentityKey)
-                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
-        if (retainedSafeKeys.isEmpty()) {
-            return false;
-        }
-        Set<String> desiredLastAdminRefs = desiredState.lastAdminSubjectRefs().stream()
-                .filter(this::safePrimaryIdentityKey)
-                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
-        Set<String> recoveryAdminRefs = desiredState.breakGlassIdentities().stream()
-                .filter(identity -> identity != null && identity.breakGlass())
-                .filter(identity -> identity.roles().stream().map(role -> role.toLowerCase(Locale.ROOT)).anyMatch(role -> role.equals("owner") || role.equals("admin")))
-                .map(IdentityRealmDesiredState.RecoveryIdentity::subjectRef)
-                .filter(this::safePrimaryIdentityKey)
-                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
-        return retainedSafeKeys.stream().anyMatch(key -> desiredLastAdminRefs.contains(key) || recoveryAdminRefs.contains(key));
-    }
-
-    private List<String> applyNextActions(
-            boolean accepted,
-            List<String> blocked,
-            boolean rollbackRequired,
-            boolean hasRisky,
-            boolean hasDestructive) {
-        if (accepted) {
-            return List.of(
-                    "Guarded apply decision accepted after persisted dry-run, policy simulation, retained-admin, rollback, audit, and confirmation checks.",
-                    "Archive the dry-run, policy simulation, retained-admin, rollback/export evidence, and audit ref before any future provider adapter retry.");
-        }
-        List<String> nextActions = new ArrayList<>();
-        if (blocked.stream().anyMatch(reason -> reason.contains("confirmation"))) {
-            nextActions.add("Re-submit with confirmationPhrase=APPLY WEAVE IDENTITY REALM after reviewing the dry-run.");
-        }
-        if (blocked.stream().anyMatch(reason -> reason.contains("last-admin"))) {
-            nextActions.add("Retain at least one immutable owner/admin primary identity key such as issuer+subject before retrying.");
-        }
-        if (hasRisky) {
-            nextActions.add("Review risky change classifications, run effective policy simulation, and set approveRisky=true only with operator evidence.");
-        }
-        if (hasDestructive) {
-            nextActions.add("Treat destructive changes as unavailable until provider destructive apply support and restore evidence are explicitly proven.");
-        }
-        if (rollbackRequired && blocked.stream().anyMatch(reason -> reason.contains("rollback/restore evidence"))) {
-            nextActions.add("Attach a support-safe rollback/restore evidence reference before retrying risky or destructive apply.");
-        }
-        nextActions.add("Resolve blockedReasons and re-run /api/admin/identity/realm/dry-run before another apply attempt.");
-        return nextActions.stream().distinct().toList();
+        return identityRealmWorkflowService.applyIdentityRealm(request, jwt);
     }
 
     public CapabilityWhitelistResponse whitelist(Jwt jwt) {
@@ -956,21 +689,6 @@ public class AdminControlPlaneService {
         }
         return "ready";
     }
-
-    private IdentityRealmProvider identityRealmProvider(String providerKey) {
-        return identityRealmProviders.stream()
-                .filter(provider -> provider.providerKey().equals(providerKey))
-                .findFirst()
-                .orElseGet(KeycloakRealmDryRunProvider::new);
-    }
-
-    private IdentityRealmLiveApplyAdapter identityRealmLiveApplyAdapter(String providerKey) {
-        return identityRealmLiveApplyAdapters.stream()
-                .filter(adapter -> adapter.providerKey().equals(providerKey))
-                .findFirst()
-                .orElseGet(() -> new KeycloakRealmLiveApplyAdapter(identityRealmApplyProperties));
-    }
-
 
     private void enforceLastAdminGuard(CapabilityWhitelistUpdateRequest request) {
         if (!"workspace-admin".equals(request.profileKey().trim().toLowerCase(Locale.ROOT))) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/IdentityRealmWorkflowService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/IdentityRealmWorkflowService.java
@@ -1,0 +1,345 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.AuditEvent;
+import com.massimotter.weave.backend.audit.AuditEventPublisher;
+import com.massimotter.weave.backend.audit.AuditRedactionLevel;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyProperties;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyReport;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyRequest;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDesiredState;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunEvidence;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunReport;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunRequest;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmEvidenceRepository;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmLiveApplyAdapter;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmProvider;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+import static com.massimotter.weave.backend.model.IdentityKeyFormat.MAX_PRIMARY_IDENTITY_KEY_LENGTH;
+import static com.massimotter.weave.backend.model.IdentityKeyFormat.PRIMARY_IDENTITY_KEY_PATTERN;
+
+@Service
+public class IdentityRealmWorkflowService {
+
+    private static final int MAX_BOOTSTRAP_ADMIN_KEY_LENGTH = MAX_PRIMARY_IDENTITY_KEY_LENGTH;
+    private static final Pattern PRIMARY_IDENTITY_KEY_REGEX = Pattern.compile(PRIMARY_IDENTITY_KEY_PATTERN);
+
+    private final WorkspaceCapabilityService workspaceCapabilityService;
+    private final AuditEventPublisher auditEventPublisher;
+    private final List<IdentityRealmProvider> identityRealmProviders;
+    private final IdentityRealmEvidenceRepository identityRealmEvidenceRepository;
+    private final List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters;
+    private final IdentityRealmApplyProperties identityRealmApplyProperties;
+    private final Clock clock;
+
+    public IdentityRealmWorkflowService(
+            WorkspaceCapabilityService workspaceCapabilityService,
+            AuditEventPublisher auditEventPublisher,
+            List<IdentityRealmProvider> identityRealmProviders,
+            IdentityRealmEvidenceRepository identityRealmEvidenceRepository,
+            List<IdentityRealmLiveApplyAdapter> identityRealmLiveApplyAdapters,
+            IdentityRealmApplyProperties identityRealmApplyProperties,
+            Clock clock) {
+        this.workspaceCapabilityService = Objects.requireNonNull(workspaceCapabilityService, "workspaceCapabilityService");
+        this.auditEventPublisher = Objects.requireNonNull(auditEventPublisher, "auditEventPublisher");
+        this.clock = Objects.requireNonNull(clock, "clock");
+        this.identityRealmProviders = requireNonEmpty(identityRealmProviders, "identityRealmProviders");
+        this.identityRealmEvidenceRepository = Objects.requireNonNull(identityRealmEvidenceRepository, "identityRealmEvidenceRepository");
+        this.identityRealmApplyProperties = Objects.requireNonNull(identityRealmApplyProperties, "identityRealmApplyProperties");
+        this.identityRealmLiveApplyAdapters = requireNonEmpty(identityRealmLiveApplyAdapters, "identityRealmLiveApplyAdapters");
+    }
+
+    public IdentityRealmDryRunReport dryRunIdentityRealm(IdentityRealmDryRunRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin_control_plane.readiness_read", "identity-realm", "dry-run");
+        IdentityRealmProvider provider = identityRealmProvider("keycloak-realm");
+        IdentityRealmDryRunReport report = provider.dryRun(request);
+        String auditRef = "identity-realm-dry-run-" + Instant.now(clock).toEpochMilli();
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef(jwt),
+                "identity-realm-dry-run",
+                AuditAction.PROVIDER_REPLACEMENT_DRY_RUN,
+                Instant.now(clock),
+                auditRef,
+                AuditRedactionLevel.SECRET_REDACTED,
+                Map.of(
+                        "providerKey", provider.providerKey(),
+                        "realmId", report.realmId(),
+                        "readiness", report.readiness(),
+                        "changeCount", report.changes().size(),
+                        "blockerCount", report.blockers().size(),
+                        "supportSafe", report.supportSafe(),
+                        "rawSecretExposed", report.rawSecretExposed(),
+                        "destructiveApplyAvailable", report.destructiveApplyAvailable(),
+                        "dryRunReasonPresent", request != null && request.reason() != null && !request.reason().isBlank())));
+        IdentityRealmDryRunReport persistedReport = new IdentityRealmDryRunReport(
+                report.providerKey(),
+                report.realmId(),
+                report.dryRunId(),
+                report.operation(),
+                report.readiness(),
+                report.destructiveApplyAvailable(),
+                report.supportSafe(),
+                report.rawSecretExposed(),
+                report.changes(),
+                report.readinessChecks(),
+                report.diff(),
+                report.warnings(),
+                report.blockers(),
+                report.nextActions(),
+                List.of(auditRef));
+        identityRealmEvidenceRepository.save(new IdentityRealmDryRunEvidence(
+                persistedReport.dryRunId(),
+                auditRef,
+                provider.providerKey(),
+                persistedReport.realmId(),
+                persistedReport,
+                Instant.now(clock)));
+        return persistedReport;
+    }
+
+    public IdentityRealmApplyReport applyIdentityRealm(IdentityRealmApplyRequest request, Jwt jwt) {
+        workspaceCapabilityService.requireCapability(jwt, "admin.provider.configure", "identity-realm", "apply");
+        IdentityRealmProvider provider = identityRealmProvider("keycloak-realm");
+        IdentityRealmDryRunReport requestedDryRun = provider.dryRun(request == null ? null : request.dryRunRequest());
+        Optional<IdentityRealmDryRunEvidence> persistedEvidence = identityRealmEvidenceRepository.findDryRun(request == null ? null : request.dryRunId());
+        IdentityRealmDryRunReport dryRun = persistedEvidence.map(IdentityRealmDryRunEvidence::report).orElse(requestedDryRun);
+        long safeChangeCount = dryRun.changes().stream().filter(change -> "safe".equals(change.classification())).count();
+        long riskyChangeCount = dryRun.changes().stream().filter(change -> "risky".equals(change.classification())).count();
+        long destructiveChangeCount = dryRun.changes().stream().filter(change -> "destructive".equals(change.classification())).count();
+        boolean hasRisky = riskyChangeCount > 0;
+        boolean hasDestructive = destructiveChangeCount > 0;
+        boolean rollbackRequired = hasRisky || hasDestructive;
+        boolean rollbackAccepted = !rollbackRequired || hasText(request == null ? null : request.rollbackEvidenceRef());
+        boolean lastAdminGuardPassed = retainedAdminProofPresent(request);
+        boolean confirmationProvided = request != null && "APPLY WEAVE IDENTITY REALM".equals(request.confirmationPhrase());
+        boolean policySimulationPresent = request != null
+                && hasText(request.policySimulationRef())
+                && request.policySimulationRef().startsWith("effective-policy-simulation-");
+        boolean persistedDryRunFresh = persistedEvidence
+                .filter(evidence -> evidence.providerKey().equals(provider.providerKey()))
+                .filter(evidence -> evidence.dryRunId().equals(requestedDryRun.dryRunId()))
+                .filter(evidence -> !evidence.createdAt().plusSeconds(identityRealmApplyProperties.dryRunFreshnessSeconds()).isBefore(Instant.now(clock)))
+                .isPresent();
+        List<String> blocked = new ArrayList<>();
+        if (!persistedDryRunFresh) {
+            blocked.add("fresh persisted dry-run evidence is required before identity realm apply");
+        }
+        if (!policySimulationPresent) {
+            blocked.add("effective policy simulation evidence ref is required before identity realm apply");
+        }
+        if (!confirmationProvided) {
+            blocked.add("explicit confirmation phrase is required");
+        }
+        if (!lastAdminGuardPassed) {
+            blocked.add("last-admin guard requires at least one retained immutable admin identity key");
+        }
+        if (hasRisky && (request == null || !request.approveRisky())) {
+            blocked.add("risky changes require approveRisky=true");
+        }
+        if (hasDestructive && (request == null || !request.approveDestructive())) {
+            blocked.add("destructive changes require approveDestructive=true");
+        }
+        if (hasDestructive && !provider.destructiveApplyAvailable()) {
+            blocked.add("provider destructive apply is not available for this contract");
+        }
+        if (!rollbackAccepted) {
+            blocked.add("rollback/restore evidence ref is required for risky or destructive apply");
+        }
+        blocked.addAll(dryRun.blockers());
+        boolean guardsAccepted = blocked.isEmpty();
+        IdentityRealmLiveApplyAdapter.IdentityRealmLiveApplyResult liveApply = guardsAccepted
+                ? identityRealmLiveApplyAdapter(provider.providerKey()).apply(persistedEvidence.orElseThrow(), request)
+                : new IdentityRealmLiveApplyAdapter.IdentityRealmLiveApplyResult(false, false, "guarded-provider-apply-blocked-before-adapter", List.of(), List.of());
+        blocked.addAll(liveApply.blockedReasons());
+        boolean accepted = blocked.isEmpty();
+        boolean applied = accepted && liveApply.applied();
+        boolean providerMutationPerformed = accepted && liveApply.providerMutationPerformed();
+        String executionMode = accepted ? liveApply.executionMode() : "guarded-provider-apply-blocked-before-mutation";
+        List<String> nextActions = new ArrayList<>(applyNextActions(accepted, blocked, rollbackRequired, hasRisky, hasDestructive));
+        nextActions.addAll(liveApply.nextActions());
+        nextActions = nextActions.stream().distinct().toList();
+        String auditRef = "identity-realm-apply-" + Instant.now(clock).toEpochMilli();
+        String actorRef = actorRef(jwt);
+        auditEventPublisher.publish(new AuditEvent(
+                organizationId(jwt),
+                "admin-control-plane",
+                actorRef,
+                "identity-realm-apply",
+                AuditAction.IDENTITY_REALM_APPLY_GUARDED,
+                Instant.now(clock),
+                auditRef,
+                AuditRedactionLevel.SUPPORT_SAFE,
+                Map.ofEntries(
+                        Map.entry("actorRef", actorRef),
+                        Map.entry("candidateRef", "identity-realm:" + dryRun.realmId()),
+                        Map.entry("planRef", dryRun.dryRunId()),
+                        Map.entry("providerKey", provider.providerKey()),
+                        Map.entry("realmId", dryRun.realmId()),
+                        Map.entry("decision", accepted ? "accepted" : "blocked"),
+                        Map.entry("result", accepted ? (applied ? "accepted-with-provider-mutation" : "accepted-without-provider-mutation") : "blocked-before-provider-mutation"),
+                        Map.entry("executionMode", executionMode),
+                        Map.entry("liveApplyEnabled", identityRealmApplyProperties.liveApplyEnabled()),
+                        Map.entry("providerConfigured", identityRealmApplyProperties.providerConfigured()),
+                        Map.entry("providerMutationPerformed", providerMutationPerformed),
+                        Map.entry("safeChangeCount", safeChangeCount),
+                        Map.entry("riskyChangeCount", riskyChangeCount),
+                        Map.entry("destructiveChangeCount", destructiveChangeCount),
+                        Map.entry("blockedReasonCount", blocked.size()),
+                        Map.entry("nextActionCount", nextActions.size()),
+                        Map.entry("persistedDryRunEvidencePresent", persistedEvidence.isPresent()),
+                        Map.entry("persistedDryRunFresh", persistedDryRunFresh),
+                        Map.entry("effectivePolicySimulationEvidencePresent", policySimulationPresent),
+                        Map.entry("confirmationProvided", confirmationProvided),
+                        Map.entry("retainedAdminIdentityKeyCount", request == null ? 0 : request.retainedAdminPrimaryIdentityKeys().stream().filter(this::safePrimaryIdentityKey).count()),
+                        Map.entry("rollbackRestoreEvidencePresent", request != null && hasText(request.rollbackEvidenceRef())),
+                        Map.entry("lastAdminGuardPassed", lastAdminGuardPassed),
+                        Map.entry("rollbackEvidenceAccepted", rollbackAccepted),
+                        Map.entry("supportSafe", true))));
+        return new IdentityRealmApplyReport(
+                provider.providerKey(),
+                dryRun.realmId(),
+                dryRun.dryRunId(),
+                accepted ? "accepted" : "blocked",
+                executionMode,
+                applied,
+                providerMutationPerformed,
+                true,
+                false,
+                lastAdminGuardPassed,
+                rollbackRequired,
+                rollbackAccepted,
+                blocked.stream().distinct().toList(),
+                dryRun.changes(),
+                nextActions,
+                List.of(auditRef));
+    }
+
+    boolean retainedAdminProofPresent(IdentityRealmApplyRequest request) {
+        if (request == null || request.retainedAdminPrimaryIdentityKeys().isEmpty()) {
+            return false;
+        }
+        IdentityRealmDesiredState desiredState = request.dryRunRequest() == null ? null : request.dryRunRequest().desiredState();
+        if (desiredState == null) {
+            return false;
+        }
+        Set<String> retainedSafeKeys = request.retainedAdminPrimaryIdentityKeys().stream()
+                .filter(this::safePrimaryIdentityKey)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        if (retainedSafeKeys.isEmpty()) {
+            return false;
+        }
+        Set<String> desiredLastAdminRefs = desiredState.lastAdminSubjectRefs().stream()
+                .filter(this::safePrimaryIdentityKey)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        Set<String> recoveryAdminRefs = desiredState.breakGlassIdentities().stream()
+                .filter(identity -> identity != null && identity.breakGlass())
+                .filter(identity -> identity.roles().stream().map(role -> role.toLowerCase(Locale.ROOT)).anyMatch(role -> role.equals("owner") || role.equals("admin")))
+                .map(IdentityRealmDesiredState.RecoveryIdentity::subjectRef)
+                .filter(this::safePrimaryIdentityKey)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        return retainedSafeKeys.stream().anyMatch(key -> desiredLastAdminRefs.contains(key) || recoveryAdminRefs.contains(key));
+    }
+
+    List<String> applyNextActions(
+            boolean accepted,
+            List<String> blocked,
+            boolean rollbackRequired,
+            boolean hasRisky,
+            boolean hasDestructive) {
+        if (accepted) {
+            return List.of(
+                    "Guarded apply decision accepted after persisted dry-run, policy simulation, retained-admin, rollback, audit, and confirmation checks.",
+                    "Archive the dry-run, policy simulation, retained-admin, rollback/export evidence, and audit ref before any future provider adapter retry.");
+        }
+        List<String> nextActions = new ArrayList<>();
+        if (blocked.stream().anyMatch(reason -> reason.contains("confirmation"))) {
+            nextActions.add("Re-submit with confirmationPhrase=APPLY WEAVE IDENTITY REALM after reviewing the dry-run.");
+        }
+        if (blocked.stream().anyMatch(reason -> reason.contains("last-admin"))) {
+            nextActions.add("Retain at least one immutable owner/admin primary identity key such as issuer+subject before retrying.");
+        }
+        if (hasRisky) {
+            nextActions.add("Review risky change classifications, run effective policy simulation, and set approveRisky=true only with operator evidence.");
+        }
+        if (hasDestructive) {
+            nextActions.add("Treat destructive changes as unavailable until provider destructive apply support and restore evidence are explicitly proven.");
+        }
+        if (rollbackRequired && blocked.stream().anyMatch(reason -> reason.contains("rollback/restore evidence"))) {
+            nextActions.add("Attach a support-safe rollback/restore evidence reference before retrying risky or destructive apply.");
+        }
+        nextActions.add("Resolve blockedReasons and re-run /api/admin/identity/realm/dry-run before another apply attempt.");
+        return nextActions.stream().distinct().toList();
+    }
+
+    IdentityRealmProvider identityRealmProvider(String providerKey) {
+        return identityRealmProviders.stream()
+                .filter(provider -> provider.providerKey().equals(providerKey))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No identity realm provider configured for " + providerKey));
+    }
+
+    IdentityRealmLiveApplyAdapter identityRealmLiveApplyAdapter(String providerKey) {
+        return identityRealmLiveApplyAdapters.stream()
+                .filter(adapter -> adapter.providerKey().equals(providerKey))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No identity realm live apply adapter configured for " + providerKey));
+    }
+
+    private static <T> List<T> requireNonEmpty(List<T> values, String name) {
+        Objects.requireNonNull(values, name);
+        if (values.isEmpty()) {
+            throw new IllegalStateException(name + " must not be empty");
+        }
+        return List.copyOf(values);
+    }
+
+    private boolean safePrimaryIdentityKey(String value) {
+        return value != null
+                && value.length() <= MAX_BOOTSTRAP_ADMIN_KEY_LENGTH
+                && PRIMARY_IDENTITY_KEY_REGEX.matcher(value).matches();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private String organizationId(Jwt jwt) {
+        return claim(jwt, "weave_tenant")
+                .or(() -> claim(jwt, "tenant"))
+                .or(() -> claim(jwt, "tid"))
+                .orElse("weave-dogfood");
+    }
+
+    private String actorRef(Jwt jwt) {
+        if (jwt == null || jwt.getSubject() == null || jwt.getSubject().isBlank()) {
+            return "actor:system";
+        }
+        return "user:" + jwt.getSubject();
+    }
+
+    private Optional<String> claim(Jwt jwt, String claimName) {
+        if (jwt == null) {
+            return Optional.empty();
+        }
+        Object raw = jwt.getClaims().get(claimName);
+        if (raw instanceof String value && !value.isBlank()) {
+            return Optional.of(value.trim());
+        }
+        return Optional.empty();
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -10,6 +10,7 @@ import com.massimotter.weave.backend.config.ApiErrorResponseWriter;
 import com.massimotter.weave.backend.config.DevopsProviderConfiguration;
 import com.massimotter.weave.backend.config.ProviderCoreConfiguration;
 import com.massimotter.weave.backend.config.SecurityConfig;
+import com.massimotter.weave.backend.config.TimeConfiguration;
 import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.exception.ApiExceptionHandler;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
@@ -18,6 +19,10 @@ import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityStatusResponse;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyDenyResponse;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyProperties;
+import com.massimotter.weave.backend.identity.realm.InMemoryIdentityRealmEvidenceRepository;
+import com.massimotter.weave.backend.identity.realm.KeycloakRealmDryRunProvider;
+import com.massimotter.weave.backend.identity.realm.KeycloakRealmLiveApplyAdapter;
 import com.massimotter.weave.backend.model.admin.EffectivePolicyResponse;
 import com.massimotter.weave.backend.office.port.DisabledOfficeProvider;
 import com.massimotter.weave.backend.provider.InMemoryProviderSelectionRepository;
@@ -27,6 +32,7 @@ import com.massimotter.weave.backend.provider.ProviderSelectionRepository;
 import java.time.Instant;
 import com.massimotter.weave.backend.service.AdminControlPlaneService;
 import com.massimotter.weave.backend.service.EffectivePolicySimulationService;
+import com.massimotter.weave.backend.service.IdentityRealmWorkflowService;
 import com.massimotter.weave.backend.service.InMemoryOrganizationBootstrapRepository;
 import com.massimotter.weave.backend.service.OrganizationBootstrapRepository;
 import com.massimotter.weave.backend.service.ProviderReplacementDryRunService;
@@ -80,6 +86,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         DevopsProviderConfiguration.class,
         DisabledOfficeProvider.class,
         AdminControlPlaneService.class,
+        IdentityRealmWorkflowService.class,
+        TimeConfiguration.class,
+        IdentityRealmApplyProperties.class,
+        InMemoryIdentityRealmEvidenceRepository.class,
+        KeycloakRealmDryRunProvider.class,
+        KeycloakRealmLiveApplyAdapter.class,
         EffectivePolicySimulationService.class,
         ProviderSelectionService.class,
         ProviderReplacementDryRunService.class,

--- a/server/src/test/java/com/massimotter/weave/backend/service/IdentityRealmWorkflowServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/IdentityRealmWorkflowServiceTest.java
@@ -1,0 +1,104 @@
+package com.massimotter.weave.backend.service;
+
+import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmApplyProperties;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDesiredState;
+import com.massimotter.weave.backend.identity.realm.IdentityRealmDryRunRequest;
+import com.massimotter.weave.backend.identity.realm.InMemoryIdentityRealmEvidenceRepository;
+import com.massimotter.weave.backend.identity.realm.KeycloakRealmDryRunProvider;
+import com.massimotter.weave.backend.identity.realm.KeycloakRealmLiveApplyAdapter;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class IdentityRealmWorkflowServiceTest {
+
+    @Test
+    void dryRunUsesInjectedClockForDeterministicAuditRefAndEvidenceTimestamp() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        IdentityRealmWorkflowService service = identityRealmWorkflowService(auditPublisher);
+
+        var report = service.dryRunIdentityRealm(new IdentityRealmDryRunRequest(null, desiredState(), "deterministic clock check"), jwt());
+
+        assertThat(report.auditRefs()).containsExactly("identity-realm-dry-run-1779843819000");
+        assertThat(auditPublisher.events()).hasSize(1);
+        assertThat(auditPublisher.events().get(0).occurredAt()).isEqualTo(Instant.parse("2026-05-27T01:03:39Z"));
+        assertThat(auditPublisher.events().get(0).action()).isEqualTo(AuditAction.PROVIDER_REPLACEMENT_DRY_RUN);
+        assertThat(auditPublisher.events().get(0).payload())
+                .containsEntry("providerKey", "keycloak-realm")
+                .containsEntry("supportSafe", true)
+                .containsEntry("dryRunReasonPresent", true);
+    }
+
+    @Test
+    void malformedApplyWithMissingDesiredStateIsBlockedWithoutServerError() {
+        IdentityRealmWorkflowService service = identityRealmWorkflowService();
+        var request = new com.massimotter.weave.backend.identity.realm.IdentityRealmApplyRequest(
+                null,
+                null,
+                "missing desired state",
+                false,
+                false,
+                List.of("issuer+subject:admin"),
+                null,
+                "malformed apply check");
+
+        var report = service.applyIdentityRealm(request, jwt());
+
+        assertThat(report.decision()).isEqualTo("blocked");
+        assertThat(report.lastAdminGuardPassed()).isFalse();
+        assertThat(report.blockedReasons()).contains("last-admin guard requires at least one retained immutable admin identity key");
+    }
+
+    private IdentityRealmWorkflowService identityRealmWorkflowService() {
+        return identityRealmWorkflowService(new InMemoryAuditEventPublisher());
+    }
+
+    private IdentityRealmWorkflowService identityRealmWorkflowService(InMemoryAuditEventPublisher auditPublisher) {
+        return new IdentityRealmWorkflowService(
+                mock(WorkspaceCapabilityService.class),
+                auditPublisher,
+                List.of(new KeycloakRealmDryRunProvider()),
+                new InMemoryIdentityRealmEvidenceRepository(),
+                List.of(new KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())),
+                new IdentityRealmApplyProperties(),
+                Clock.fixed(Instant.parse("2026-05-27T01:03:39Z"), ZoneOffset.UTC));
+    }
+
+    private IdentityRealmDesiredState desiredState() {
+        return new IdentityRealmDesiredState(
+                "weave-dogfood",
+                "Weave Dogfood",
+                true,
+                List.of(),
+                List.of("owner", "admin", "member"),
+                List.of(),
+                List.of("openid", "profile", "email"),
+                List.of(),
+                List.of("https://app.weave.test/oauthredirect"),
+                List.of(),
+                List.of(),
+                List.of(new IdentityRealmDesiredState.RecoveryIdentity("issuer+subject:admin", "retained admin", true, List.of("owner"))),
+                List.of("issuer+subject:admin"),
+                "sub",
+                List.of(),
+                List.of());
+    }
+
+    private Jwt jwt() {
+        return new Jwt(
+                "token",
+                Instant.parse("2026-05-27T01:00:00Z"),
+                Instant.parse("2026-05-27T02:00:00Z"),
+                Map.of("alg", "none"),
+                Map.of("sub", "admin", "weave_tenant", "weave-dogfood"));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract identity realm dry-run/apply workflow from `AdminControlPlaneService` into `IdentityRealmWorkflowService`.
- Keep provider adapters/evidence repository Spring-wired and fail fast when identity realm workflow collaborators are missing.
- Add a shared UTC `Clock` bean and deterministic workflow tests, including malformed apply guard coverage.

## Target lane
- `main` (focused refactor branch cut from current `origin/main`).

## Linked issue
- None; maintenance refactor to reduce `AdminControlPlaneService` scope without changing product behavior.

## Release notes
- `release-notes-skip` — internal server refactor/test hardening only, no user/operator behavior change intended.

## Spec impact
- None. Identity realm dry-run/apply contract, support-safe audit payloads, and response shape are preserved.

## User/admin/operator impact
- No intended UX/API contract change.
- Malformed identity realm apply requests now stay in guarded blocked-report behavior instead of risking a null dereference.

## Checks run
- `git diff --cached --check`
- `cd server && ./gradlew test --tests com.massimotter.weave.backend.service.AdminControlPlaneServiceTest --tests com.massimotter.weave.backend.service.IdentityRealmWorkflowServiceTest --tests com.massimotter.weave.backend.controller.AdminControlPlaneControllerTest --tests '*IdentityRealm*' --console=plain`
- `./gradlew releaseEvidenceCheck --console=plain`
- `./gradlew portabilityContractCheck domainRegistryCheck specContract acceptanceContract docsCheck --console=plain`
- `./gradlew serverCi --console=plain`

## Review notes
- Red-team review initially blocked on clock injection, hidden fallback wiring, and malformed apply null-safety; this PR includes fixes for those findings.
