### PR TITLE
test: add support-safe redaction corpus scaffold

### DIFF
--- a/tools/fixtures/redaction_corpus/support_safe_redaction_corpus.json
+++ b/tools/fixtures/redaction_corpus/support_safe_redaction_corpus.json
@@ -1,0 +1,81 @@
+{
+  "artifactKind": "weave-support-safe-redaction-corpus-v1",
+  "issue": 793,
+  "scope": "shared_support_admin_release_runtime_evidence",
+  "requiredCategories": [
+    "bearer_and_api_tokens",
+    "private_keys_and_certificate_material",
+    "credential_urls_and_service_endpoints",
+    "secretref_payload_like_values",
+    "provider_response_bodies_and_diagnostic_blobs",
+    "homeserver_service_urls_and_provider_ids_when_forbidden",
+    "allowlisted_product_safe_refs_and_states"
+  ],
+  "cases": [
+    {
+      "category": "bearer_and_api_tokens",
+      "expectation": "block_or_redact",
+      "samples": [
+        "Authorization: Bearer sk_live_example_token",
+        "refresh_token=rt_example_value",
+        "api_key=abc123-secret-value"
+      ]
+    },
+    {
+      "category": "private_keys_and_certificate_material",
+      "expectation": "block_or_redact",
+      "samples": [
+        "-----BEGIN PRIVATE KEY-----",
+        "-----BEGIN OPENSSH PRIVATE KEY-----"
+      ]
+    },
+    {
+      "category": "credential_urls_and_service_endpoints",
+      "expectation": "block_or_redact",
+      "samples": [
+        "https://user:pass@example.invalid/private",
+        "https://matrix.example.invalid/_matrix/client/v3/login"
+      ]
+    },
+    {
+      "category": "secretref_payload_like_values",
+      "expectation": "block_or_redact",
+      "samples": [
+        "secretref://ops/prod/keycloak-admin",
+        "credentialBearingDownloadUrl",
+        "secretValue"
+      ]
+    },
+    {
+      "category": "provider_response_bodies_and_diagnostic_blobs",
+      "expectation": "block_or_redact",
+      "samples": [
+        "rawProviderPayload={\"error\":\"invalid_token\"}",
+        "openclaw.json {\"apiKey\":\"sk-secret\"}",
+        "memory://member/private-thread"
+      ]
+    },
+    {
+      "category": "homeserver_service_urls_and_provider_ids_when_forbidden",
+      "expectation": "block_or_redact",
+      "samples": [
+        "mxc://matrix.example.invalid/mediaid",
+        "provider.example.invalid",
+        "https://zulip.example.invalid/api/v1/messages"
+      ]
+    },
+    {
+      "category": "allowlisted_product_safe_refs_and_states",
+      "expectation": "allow",
+      "samples": [
+        "audit://mcp/denied/support-safe",
+        "provider:chat:selected-by-admin",
+        "space:control-room",
+        "available",
+        "disabled_by_policy",
+        "coming_later",
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+      ]
+    }
+  ]
+}

--- a/tools/support_safe_redaction_corpus_test.py
+++ b/tools/support_safe_redaction_corpus_test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Sanity-check the shared redaction corpus scaffold for issue #793."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS = ROOT / "tools" / "fixtures" / "redaction_corpus" / "support_safe_redaction_corpus.json"
+REQUIRED_CATEGORIES = {
+    "bearer_and_api_tokens",
+    "private_keys_and_certificate_material",
+    "credential_urls_and_service_endpoints",
+    "secretref_payload_like_values",
+    "provider_response_bodies_and_diagnostic_blobs",
+    "homeserver_service_urls_and_provider_ids_when_forbidden",
+    "allowlisted_product_safe_refs_and_states",
+}
+
+
+def main() -> int:
+    corpus = json.loads(CORPUS.read_text(encoding="utf-8"))
+    assert corpus["artifactKind"] == "weave-support-safe-redaction-corpus-v1"
+    assert corpus["issue"] == 793
+    assert set(corpus["requiredCategories"]) == REQUIRED_CATEGORIES
+    cases = corpus["cases"]
+    assert len(cases) == len(REQUIRED_CATEGORIES)
+    categories = {case["category"] for case in cases}
+    assert categories == REQUIRED_CATEGORIES
+    assert any(case["expectation"] == "allow" for case in cases)
+    assert all(case["samples"] for case in cases)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the initial support-safe redaction corpus scaffold for Sprint 32 issue #793
- cover unsafe token, key, credential URL, SecretRef-like, provider diagnostic, and forbidden service/provider identifier categories
- include allowlisted product-safe references/states so the future shared classifier can avoid noisy false positives

## Maintainability / Clean Code
- keeps the first slice small and evidence-focused instead of mixing Python tooling and Java runtime rewiring
- establishes a corpus artifact that later `tools/support_safe_redaction.py` and server-side classifier work can consume
- avoids open server PR conflict areas while preserving the architecture boundary for follow-up unification

## Teams / Review
- Owner: Security/Compliance
- Reviewers: QA/Evidence for releaseEvidenceCheck integration; Architecture/Server for the follow-up Java classifier boundary; DevOps/Ops for support bundle and release tooling fit; Docs/Marketing/Product Messaging for claim hygiene and safe public evidence wording

## Tests
- `python3 tools/support_safe_redaction_corpus_test.py`

Closes #793 only after the shared classifier and releaseEvidenceCheck integration land; this PR is the first corpus scaffold slice.
