### PR TITLE
test: add IDM RBAC readiness negative fixtures

### DIFF
--- a/tools/admin_readiness_negative_paths_test.py
+++ b/tools/admin_readiness_negative_paths_test.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Validate Sprint 32 IDM/RBAC readiness negative-path fixtures."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tools" / "fixtures" / "admin_readiness" / "idm_rbac_readiness_negative_paths.json"
+REQUIRED_CASES = {"issuer_unreachable", "role_mapping_missing", "group_claim_ambiguous"}
+
+
+def main() -> int:
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert data["artifactKind"] == "weave-idm-rbac-readiness-negative-paths-v1"
+    assert data["issue"] == 792
+    cases = data["cases"]
+    assert {case["id"] for case in cases} == REQUIRED_CASES
+    for case in cases:
+        assert case["state"] in {"not_ready", "policy_blocked", "needs_admin_action"}
+        assert case["adminMessage"]
+        assert case["memberMessage"]
+        assert case["expectedActions"]
+        combined = json.dumps(case)
+        for fragment in data["forbiddenEvidenceFragments"]:
+            assert fragment not in combined
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fixtures/admin_readiness/idm_rbac_readiness_negative_paths.json
+++ b/tools/fixtures/admin_readiness/idm_rbac_readiness_negative_paths.json
@@ -1,0 +1,41 @@
+{
+  "artifactKind": "weave-idm-rbac-readiness-negative-paths-v1",
+  "issue": 792,
+  "scope": "admin_console_idm_rbac_readiness",
+  "principles": [
+    "admin_readiness_is_not_member_onboarding",
+    "fail_closed_when_identity_or_role_mapping_is_ambiguous",
+    "support_safe_errors_do_not_expose_tokens_or_provider_payloads",
+    "readiness_copy_uses_admin_control_plane_language"
+  ],
+  "cases": [
+    {
+      "id": "issuer_unreachable",
+      "state": "not_ready",
+      "adminMessage": "Organization sign-in is not reachable. Keep member invites paused and ask an operator to verify the identity binding.",
+      "memberMessage": "Your organization is not ready for sign-in yet. Ask an admin for help.",
+      "expectedActions": ["pause_member_invites", "show_operator_recovery_link"]
+    },
+    {
+      "id": "role_mapping_missing",
+      "state": "policy_blocked",
+      "adminMessage": "Role mapping is incomplete. Members without a mapped role must be denied by default.",
+      "memberMessage": "Your account is waiting for workspace access approval.",
+      "expectedActions": ["deny_by_default", "show_mapping_preview"]
+    },
+    {
+      "id": "group_claim_ambiguous",
+      "state": "needs_admin_action",
+      "adminMessage": "Group claims are ambiguous. Preview the mapping before enabling access.",
+      "memberMessage": "Your workspace access needs admin review.",
+      "expectedActions": ["require_mapping_preview", "block_automatic_enablement"]
+    }
+  ],
+  "forbiddenEvidenceFragments": [
+    "access_token",
+    "refresh_token",
+    "client_secret",
+    "rawProviderPayload",
+    "Authorization: Bearer"
+  ]
+}


### PR DESCRIPTION
## Summary
- add IDM/RBAC readiness negative-path fixtures for issuer unreachable, missing role mapping, and ambiguous group claims
- add a sanity test that keeps admin/member support-safe messages and deny-by-default actions executable
- establish the first conflict-safe slice before deeper Admin Console/server readiness wiring

## Maintainability / Clean Code
- keeps readiness cases data-driven and support-safe
- separates admin control-plane readiness language from normal member onboarding copy
- avoids adjacent dirty server/control-plane implementation conflicts while creating executable acceptance

## Teams / Review
- Owner: Admin Console + Server/Domain readiness
- Reviewers: Security for deny-by-default/RBAC behavior; QA/Evidence for fixture coverage; DevOps/Ops for operator recovery impact; Docs/Marketing/Product Messaging for admin/member claim hygiene

## Tests
- `python3 tools/admin_readiness_negative_paths_test.py`

First vertical slice for #792. Follow-up: wire these fixtures into admin readiness UI/service tests and `adminCi`/release evidence gates.
