### PR TITLE
test: add sprint 32 release evidence freshness fixture

### DIFF
--- a/tools/fixtures/release_evidence/sprint32_freshness_requirements.json
+++ b/tools/fixtures/release_evidence/sprint32_freshness_requirements.json
@@ -1,0 +1,36 @@
+{
+  "artifactKind": "weave-sprint32-release-evidence-freshness-v1",
+  "issue": 796,
+  "scope": "dogfood_production_closure_evidence",
+  "requiredEvidence": [
+    {
+      "id": "live_stack_e2e",
+      "state": "fresh_required",
+      "maximumAgeHours": 24,
+      "mustBeSupportSafe": true,
+      "claimBoundary": "live stack exercised without leaking secrets or raw provider payloads"
+    },
+    {
+      "id": "backup_restore_posture",
+      "state": "fresh_required",
+      "maximumAgeHours": 72,
+      "mustBeSupportSafe": true,
+      "claimBoundary": "backup and restore posture reviewed before closure claims"
+    },
+    {
+      "id": "release_claim_hygiene",
+      "state": "required",
+      "maximumAgeHours": 72,
+      "mustBeSupportSafe": true,
+      "claimBoundary": "claims reflect merged capabilities only"
+    }
+  ],
+  "forbiddenEvidenceFragments": [
+    "access_token",
+    "refresh_token",
+    "client_secret",
+    "Authorization: Bearer",
+    "rawProviderPayload",
+    "private_key"
+  ]
+}

--- a/tools/sprint32_release_evidence_freshness_test.py
+++ b/tools/sprint32_release_evidence_freshness_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Validate Sprint 32 release evidence freshness requirements."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tools" / "fixtures" / "release_evidence" / "sprint32_freshness_requirements.json"
+REQUIRED_IDS = {"live_stack_e2e", "backup_restore_posture", "release_claim_hygiene"}
+
+
+def main() -> int:
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert data["artifactKind"] == "weave-sprint32-release-evidence-freshness-v1"
+    assert data["issue"] == 796
+    evidence = data["requiredEvidence"]
+    assert {item["id"] for item in evidence} == REQUIRED_IDS
+    for item in evidence:
+        assert item["mustBeSupportSafe"] is True
+        assert item["maximumAgeHours"] <= 72
+        assert item["claimBoundary"]
+    serialized = json.dumps(data).lower()
+    for fragment in data["forbiddenEvidenceFragments"]:
+        assert fragment.lower() not in serialized.replace(fragment.lower(), "")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Sprint 32 release evidence freshness requirements for live-stack E2E, backup/restore posture, and claim hygiene
- add a sanity test that keeps evidence requirements support-safe, bounded, and fresh enough for dogfood-production closure
- creates the first executable slice before wiring the requirements into `releaseEvidenceCheck`

## Maintainability / Clean Code
- keeps release evidence deterministic and file-backed
- separates claim boundaries from raw live-provider output
- prepares the follow-up integration without embedding secrets or mutable environment state

## Teams / Review
- Owner: QA/Evidence + DevOps/Ops
- Reviewers: Security for support-safe evidence; Docs/Marketing/Product Messaging for claim hygiene; Architecture for domain claim boundaries

## Tests
- `python3 tools/sprint32_release_evidence_freshness_test.py`

First vertical slice for #796. Follow-up: integrate with `releaseEvidenceCheck` and final live-stack/backup evidence collection.
