### PR TITLE
test: add runtime profile signing contract fixture

### DIFF
--- a/tools/fixtures/security/runtime_profile_signing_contract.json
+++ b/tools/fixtures/security/runtime_profile_signing_contract.json
@@ -1,0 +1,35 @@
+{
+  "artifactKind": "weave-runtime-profile-signing-contract-v1",
+  "issue": 794,
+  "scope": "weaver_runtime_profile_keyed_signing",
+  "acceptedEvidence": {
+    "signatureEnvelope": "required",
+    "algorithm": "keyed_signature_required",
+    "keySource": "secretref_or_runtime_key_provider",
+    "profileHash": "content_address_only_not_authenticity",
+    "verifiedAt": "required",
+    "supportSafeAudit": "required"
+  },
+  "rejectedEvidence": [
+    {
+      "id": "hash_only_marker",
+      "reason": "A content hash alone is not an authenticity proof."
+    },
+    {
+      "id": "unsigned_profile_payload",
+      "reason": "Unsigned runtime profiles must fail closed before runtime provisioning."
+    },
+    {
+      "id": "raw_key_material_in_response",
+      "reason": "Signing keys and provider payloads must never be returned as support evidence."
+    }
+  ],
+  "requiredFailureState": "policy_blocked",
+  "forbiddenResponseFragments": [
+    "private_key",
+    "client_secret",
+    "rawProviderPayload",
+    "Authorization: Bearer",
+    "signingKeyMaterial"
+  ]
+}

--- a/tools/runtime_profile_signing_contract_test.py
+++ b/tools/runtime_profile_signing_contract_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Validate the RuntimeProfile keyed-signing contract fixture."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tools" / "fixtures" / "security" / "runtime_profile_signing_contract.json"
+REJECTED = {"hash_only_marker", "unsigned_profile_payload", "raw_key_material_in_response"}
+
+
+def main() -> int:
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert data["artifactKind"] == "weave-runtime-profile-signing-contract-v1"
+    assert data["issue"] == 794
+    accepted = data["acceptedEvidence"]
+    assert accepted["signatureEnvelope"] == "required"
+    assert accepted["profileHash"] == "content_address_only_not_authenticity"
+    assert accepted["supportSafeAudit"] == "required"
+    assert {item["id"] for item in data["rejectedEvidence"]} == REJECTED
+    assert data["requiredFailureState"] == "policy_blocked"
+    serialized_rejections = json.dumps(data["rejectedEvidence"])
+    for fragment in data["forbiddenResponseFragments"]:
+        assert fragment not in serialized_rejections
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the first executable keyed-signing contract fixture for Weaver RuntimeProfile evidence
- mark hash-only markers and unsigned payloads as rejected evidence
- require support-safe audit behavior without returning raw key material or provider payloads

## Maintainability / Clean Code
- separates authenticity requirements from content-addressing (`profileHash` remains non-authoritative)
- establishes fixture-backed failure semantics before runtime service rewiring
- keeps key sourcing behind SecretRef/runtime key-provider seams for the follow-up implementation

## Teams / Review
- Owner: Security
- Reviewers: Server/Runtime, Architecture, QA/Evidence, DevOps/Ops, Docs for admin/operator wording

## Tests
- `python3 tools/runtime_profile_signing_contract_test.py`

First vertical slice for #794. Follow-up: implement verifier/envelope in server runtime tests and fail-closed unsigned/hash-only profile fetches.
