### PR TITLE
test: add runtime profile revocation contract fixture

### DIFF
--- a/tools/fixtures/security/runtime_profile_revocation_contract.json
+++ b/tools/fixtures/security/runtime_profile_revocation_contract.json
@@ -1,0 +1,30 @@
+{
+  "artifactKind": "weave-runtime-profile-revocation-contract-v1",
+  "issue": 795,
+  "scope": "weaver_runtime_profile_durable_revocation",
+  "dependsOn": [794],
+  "requiredBehavior": [
+    "revocation_is_durable_across_service_restart",
+    "revoked_profile_fails_closed_before_runtime_provisioning",
+    "revocation_event_is_audit_linked",
+    "revocation_decision_uses_signed_profile_identity",
+    "support_evidence_excludes_secrets_and_raw_provider_payloads"
+  ],
+  "revocationRecord": {
+    "runtimeProfileId": "signed-profile-id-required",
+    "profileSignatureId": "required",
+    "revokedAt": "required",
+    "revokedBy": "required_actor_ref",
+    "reason": "support_safe_required",
+    "auditEventRef": "required"
+  },
+  "requiredFailureState": "policy_blocked",
+  "forbiddenResponseFragments": [
+    "private_key",
+    "client_secret",
+    "rawProviderPayload",
+    "Authorization: Bearer",
+    "signingKeyMaterial",
+    "runtimeToken"
+  ]
+}

--- a/tools/runtime_profile_revocation_contract_test.py
+++ b/tools/runtime_profile_revocation_contract_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Validate the RuntimeProfile durable revocation contract fixture."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tools" / "fixtures" / "security" / "runtime_profile_revocation_contract.json"
+REQUIRED_BEHAVIOR = {
+    "revocation_is_durable_across_service_restart",
+    "revoked_profile_fails_closed_before_runtime_provisioning",
+    "revocation_event_is_audit_linked",
+    "revocation_decision_uses_signed_profile_identity",
+    "support_evidence_excludes_secrets_and_raw_provider_payloads",
+}
+RECORD_FIELDS = {"runtimeProfileId", "profileSignatureId", "revokedAt", "revokedBy", "reason", "auditEventRef"}
+
+
+def main() -> int:
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert data["artifactKind"] == "weave-runtime-profile-revocation-contract-v1"
+    assert data["issue"] == 795
+    assert data["dependsOn"] == [794]
+    assert set(data["requiredBehavior"]) == REQUIRED_BEHAVIOR
+    assert set(data["revocationRecord"].keys()) == RECORD_FIELDS
+    assert data["requiredFailureState"] == "policy_blocked"
+    serialized_record = json.dumps(data["revocationRecord"])
+    for fragment in data["forbiddenResponseFragments"]:
+        assert fragment not in serialized_record
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the durable RuntimeProfile revocation contract fixture for signed profile identities
- require durable fail-closed revocation, audit linkage, actor/reason evidence, and support-safe output
- create the first executable slice before persistence/enforcement wiring

## Maintainability / Clean Code
- separates revocation record semantics from runtime enforcement code
- makes #794 signed identity an explicit dependency instead of revoking ambiguous hash-only markers
- keeps support evidence free of runtime tokens, signing keys, and raw provider payloads

## Teams / Review
- Owner: Security
- Reviewers: Server/Runtime, Architecture, QA/Evidence, DevOps/Ops, Docs for admin/operator wording

## Tests
- `python3 tools/runtime_profile_revocation_contract_test.py`

First vertical slice for #795. Follow-up: implement durable store/enforcement tests after #794 verifier semantics are reviewed.
