### PR TITLE
test: add Calendar facade slice contract fixture

### DIFF
--- a/tools/calendar_facade_slice_contract_test.py
+++ b/tools/calendar_facade_slice_contract_test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tools" / "fixtures" / "domain_facades" / "calendar_facade_slice_contract.json"
+REQUIRED = {"capability_checked_before_provider_access", "space_context_authorized_before_operation", "write_delete_operations_are_audited", "canonical_ids_and_mapping_refs_are_returned", "support_safe_errors_hide_provider_internals", "product_callers_do_not_use_provider_adapters_directly"}
+
+def main() -> int:
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert data["artifactKind"] == "weave-domain-facade-slice-contract-v1"
+    assert data["issue"] == 790
+    assert data["dependsOn"] == [788]
+    assert set(data["requiredBoundary"]) == REQUIRED
+    assert data["firstSliceOperations"]
+    assert "policy_blocked" in data["requiredFailureStates"]
+    serialized_ops = json.dumps(data["firstSliceOperations"])
+    for fragment in data["forbiddenResponseFragments"]:
+        assert fragment not in serialized_ops
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/fixtures/domain_facades/calendar_facade_slice_contract.json
+++ b/tools/fixtures/domain_facades/calendar_facade_slice_contract.json
@@ -1,0 +1,17 @@
+{
+  "artifactKind": "weave-domain-facade-slice-contract-v1",
+  "issue": 790,
+  "domain": "Calendar",
+  "dependsOn": [788],
+  "requiredBoundary": [
+    "capability_checked_before_provider_access",
+    "space_context_authorized_before_operation",
+    "write_delete_operations_are_audited",
+    "canonical_ids_and_mapping_refs_are_returned",
+    "support_safe_errors_hide_provider_internals",
+    "product_callers_do_not_use_provider_adapters_directly"
+  ],
+  "firstSliceOperations": ["create_event", "update_event", "delete_event", "request_meeting_join"],
+  "requiredFailureStates": ["not_configured", "degraded", "policy_blocked", "unavailable", "provider_failure"],
+  "forbiddenResponseFragments": ["access_token", "refresh_token", "client_secret", "rawProviderPayload", "Authorization: Bearer", "provider_native_credential"]
+}


### PR DESCRIPTION
## Summary
- add the first executable Calendar facade slice contract fixture for Sprint 32 issue #790
- require capability-before-provider-access, Space/context authz, audited write/delete decisions, canonical IDs/mapping refs, support-safe failures, and adapter isolation
- creates a small reviewable first slice before server runtime rewiring

## Maintainability / Clean Code
- keeps domain semantics explicit while depending on the shared #788 contract
- avoids provider-native credentials/payloads in product-facing evidence
- enables follow-up implementation tests to target a stable fixture contract

## Teams / Review
- Owner: Server/Domain
- Reviewers: Architecture, Security, QA/Evidence, DevOps/Ops, Docs and Marketing/Product Messaging for bounded release claims

## Tests
- `python3 tools/calendar_facade_slice_contract_test.py`

First vertical slice for #790. Follow-up: implement server facade behavior and targeted domain tests after #788 review.
