### PR TITLE
test: add member handoff onboarding contract fixture

### DIFF
--- a/tools/fixtures/client_onboarding/member_handoff_onboarding_contract.json
+++ b/tools/fixtures/client_onboarding/member_handoff_onboarding_contract.json
@@ -1,0 +1,35 @@
+{
+  "artifactKind": "weave-member-handoff-onboarding-contract-v1",
+  "issue": 786,
+  "scope": "normal_member_onboarding",
+  "acceptedEntryPoints": ["invite_link", "join_url", "organization_auth_url", "signed_organization_manifest"],
+  "normalMemberMustNotConfigure": [
+    "oidc_issuer_url",
+    "matrix_homeserver",
+    "nextcloud_url",
+    "backend_service_endpoint",
+    "client_id",
+    "provider_diagnostics"
+  ],
+  "productStates": [
+    "handoff_valid",
+    "invite_expired",
+    "organization_not_ready",
+    "capability_disabled",
+    "admin_action_required",
+    "handoff_invalid"
+  ],
+  "supportSafeRecoveryCopy": {
+    "invite_expired": "This invite has expired. Ask your workspace admin for a new invite.",
+    "organization_not_ready": "Your organization is not ready for members yet. Ask an admin to finish workspace setup.",
+    "capability_disabled": "This workspace feature is not available for your account yet.",
+    "admin_action_required": "Your workspace needs admin review before you can continue.",
+    "handoff_invalid": "This join link cannot be used. Ask your admin for a fresh Weave invite."
+  },
+  "accessibilityRequirements": [
+    "screenreader_labels_for_state_and_action",
+    "deterministic_focus_order",
+    "no_image_only_state"
+  ],
+  "forbiddenMemberCopyFragments": ["OIDC", "Matrix", "Nextcloud", "homeserver", "issuer", "client ID", "service endpoint", "provider diagnostics"]
+}

--- a/tools/member_handoff_onboarding_contract_test.py
+++ b/tools/member_handoff_onboarding_contract_test.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Validate the member handoff-first onboarding contract fixture."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = ROOT / "tools" / "fixtures" / "client_onboarding" / "member_handoff_onboarding_contract.json"
+REQUIRED_ENTRY_POINTS = {"invite_link", "join_url", "organization_auth_url", "signed_organization_manifest"}
+REQUIRED_STATES = {"handoff_valid", "invite_expired", "organization_not_ready", "capability_disabled", "admin_action_required", "handoff_invalid"}
+
+
+def main() -> int:
+    data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert data["artifactKind"] == "weave-member-handoff-onboarding-contract-v1"
+    assert data["issue"] == 786
+    assert set(data["acceptedEntryPoints"]) == REQUIRED_ENTRY_POINTS
+    assert set(data["productStates"]) == REQUIRED_STATES
+    assert set(data["supportSafeRecoveryCopy"].keys()) == REQUIRED_STATES - {"handoff_valid"}
+    assert "no_image_only_state" in data["accessibilityRequirements"]
+    copy = json.dumps(data["supportSafeRecoveryCopy"])
+    for fragment in data["forbiddenMemberCopyFragments"]:
+        assert fragment.lower() not in copy.lower()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the first executable handoff-first onboarding contract fixture for normal members
- define accepted entry points, product-level failure states, support-safe recovery copy, and accessibility requirements
- explicitly forbids raw provider/server configuration concepts in normal member onboarding copy

## Maintainability / Clean Code
- keeps member onboarding contract separate from admin/operator recovery configuration
- gives follow-up Flutter state/UI work a fixture-backed acceptance target
- aligns with #787 vocabulary guard without touching the same UI files in this first slice

## Teams / Review
- Owner: Client UX/A11y
- Reviewers: Architecture for capability contract, Security for support-safe handoff errors, QA/Evidence for fixtures/tests, Docs and Marketing/Product Messaging for member-facing language

## Tests
- `python3 tools/member_handoff_onboarding_contract_test.py`

First vertical slice for #786. Follow-up: implement the Flutter handoff state model and route normal members away from raw endpoint editing.
