### PR TITLE
feat(server): expose Boards facade mapping refs

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/model/boards/BoardsSyncMetadataResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/boards/BoardsSyncMetadataResponse.java
@@ -14,9 +14,12 @@ public record BoardsSyncMetadataResponse(
         boolean contextScoped,
         boolean supportSafe,
         Map<String, String> nextCursors,
+        Map<String, String> mappingRefs,
+        String replacementPreviewState,
         Instant lastSyncedAt) {
 
     public BoardsSyncMetadataResponse {
         nextCursors = nextCursors == null ? Map.of() : Map.copyOf(nextCursors);
+        mappingRefs = mappingRefs == null ? Map.of() : Map.copyOf(mappingRefs);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/BoardsFacadeService.java
@@ -125,7 +125,8 @@ public class BoardsFacadeService {
             publishTaskWriteAudit(principal, AuditAction.BOARD_TASK_CREATED, "create_task:" + boardId, Map.of(
                     "command", "create_task",
                     "boardId", boardId,
-                    "columnId", request.columnId()));
+                    "columnId", request.columnId(),
+                    "mappingRef", mappingRef("task", boardId + ":" + request.columnId() + ":" + request.title())));
             return boardsRepository.createTask(new CreateTaskCommand(
                     boardId,
                     request.columnId(),
@@ -146,7 +147,8 @@ public class BoardsFacadeService {
                     "command", "move_task",
                     "taskId", taskId,
                     "targetColumnId", request.targetColumnId(),
-                    "targetPosition", request.targetPosition()));
+                    "targetPosition", request.targetPosition(),
+                    "mappingRef", mappingRef("task", taskId)));
             return boardsRepository.moveTask(new MoveTaskCommand(
                     taskId,
                     request.targetColumnId(),
@@ -161,7 +163,8 @@ public class BoardsFacadeService {
         try {
             publishTaskWriteAudit(principal, AuditAction.BOARD_TASK_COMPLETED, "complete_task:" + taskId, Map.of(
                     "command", "complete_task",
-                    "taskId", taskId));
+                    "taskId", taskId,
+                    "mappingRef", mappingRef("task", taskId)));
             return boardsRepository.completeTask(taskId);
         } catch (BoardsException exception) {
             throw apiError(exception);
@@ -176,7 +179,8 @@ public class BoardsFacadeService {
                     "command", "update_task_status",
                     "taskId", taskId,
                     "status", status.contractName(),
-                    "targetColumnId", request.targetColumnId() == null ? "" : request.targetColumnId()));
+                    "targetColumnId", request.targetColumnId() == null ? "" : request.targetColumnId(),
+                    "mappingRef", mappingRef("task", taskId)));
             return boardsRepository.updateTaskStatus(taskId, status, request.targetColumnId());
         } catch (BoardsException exception) {
             throw apiError(exception);
@@ -189,7 +193,8 @@ public class BoardsFacadeService {
             publishTaskWriteAudit(principal, AuditAction.TASK_DECISION_LINKED, "link_decision:" + taskId, Map.of(
                     "command", "link_decision",
                     "taskId", taskId,
-                    "decisionRef", request.decisionRef() == null ? "" : request.decisionRef()));
+                    "decisionRef", request.decisionRef() == null ? "" : request.decisionRef(),
+                    "mappingRef", mappingRef("task", taskId)));
             return boardsRepository.linkDecision(taskId, request.decisionRef());
         } catch (BoardsException exception) {
             throw apiError(exception);
@@ -324,7 +329,7 @@ public class BoardsFacadeService {
     private Map<String, Object> supportSafeAuditPayload(Map<String, Object> payload) {
         Map<String, Object> safePayload = new LinkedHashMap<>();
         payload.forEach((key, value) -> safePayload.put(key,
-                value instanceof String stringValue ? supportSafeAuditString(stringValue) : value));
+                value instanceof String stringValue && !"mappingRef".equals(key) ? supportSafeAuditString(stringValue) : value));
         return safePayload;
     }
 
@@ -370,7 +375,28 @@ public class BoardsFacadeService {
                 true,
                 true,
                 nextCursors,
+                mappingRefs(projects, boards, tasks),
+                "coming_later",
                 lastSyncedAt(projects, boards, tasks));
+    }
+
+    private Map<String, String> mappingRefs(List<WeaveProject> projects, List<Board> boards, List<TaskItem> tasks) {
+        Map<String, String> refs = new LinkedHashMap<>();
+        projects.forEach(project -> refs.put(project.id(), mappingRef("project", project.id())));
+        boards.forEach(board -> refs.put(board.id(), mappingRef("board", board.id())));
+        tasks.forEach(task -> refs.put(task.id(), mappingRef("task", task.id())));
+        return refs;
+    }
+
+    private String mappingRef(String type, String canonicalId) {
+        return "provider-mapping://boards/" + type + "/" + stableAuditRef(canonicalId);
+    }
+
+    private String stableAuditRef(String source) {
+        if (source == null || source.isBlank()) {
+            return "unknown";
+        }
+        return Integer.toHexString(source.hashCode());
     }
 
     private void addCursor(Map<String, String> nextCursors, String key, String cursor) {

--- a/server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/BoardsFacadeServiceTest.java
@@ -201,6 +201,7 @@ class BoardsFacadeServiceTest {
             assertThat(event.tenantId()).isEqualTo("tenant-default");
             assertThat(event.contextId()).isEqualTo("workspace-default");
             assertThat(event.payload()).containsEntry("supportSafe", true);
+            assertThat(event.payload().get("mappingRef").toString()).startsWith("provider-mapping://boards/task/");
         });
     }
 
@@ -291,9 +292,34 @@ class BoardsFacadeServiceTest {
         assertThat(response.syncMetadata().userWriteAudited()).isTrue();
         assertThat(response.syncMetadata().contextScoped()).isTrue();
         assertThat(response.syncMetadata().supportSafe()).isTrue();
+        assertThat(response.syncMetadata().mappingRefs()).isEmpty();
+        assertThat(response.syncMetadata().replacementPreviewState()).isEqualTo("coming_later");
         assertThat(response.projects()).isEmpty();
         assertThat(response.boards()).isEmpty();
         assertThat(response.tasks()).isEmpty();
+    }
+
+    @Test
+    void workspaceReturnsCanonicalMappingRefsForBoardObjects() {
+        BoardsFacadeService service = new BoardsFacadeService(
+                new BoardsRuntimeGuard(true),
+                new LocalWorkspaceBoardsRepository(),
+                request -> ContextAuthorizationDecision.allow("test allow"),
+                contextAuthorizationProperties(),
+                workspaceCapabilityService());
+
+        var response = service.workspace(jwt());
+
+        assertThat(response.syncMetadata().mappingRefs())
+                .containsKeys("local-project-1", "local-board-1", "local-task-contract");
+        assertThat(response.syncMetadata().mappingRefs().get("local-project-1")).startsWith("provider-mapping://boards/project/");
+        assertThat(response.syncMetadata().mappingRefs().get("local-board-1")).startsWith("provider-mapping://boards/board/");
+        assertThat(response.syncMetadata().mappingRefs().get("local-task-contract")).startsWith("provider-mapping://boards/task/");
+        assertThat(response.syncMetadata().mappingRefs().values()).allSatisfy(ref -> {
+            assertThat(ref).startsWith("provider-mapping://boards/");
+            assertThat(ref).doesNotContain("https://").doesNotContain("token").doesNotContain("secret");
+        });
+        assertThat(response.syncMetadata().replacementPreviewState()).isEqualTo("coming_later");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Exposes explicit provider-mapping refs in Boards workspace sync metadata for canonical projects, boards, and tasks.
- Adds support-safe `mappingRef` evidence to audited Boards task mutations, matching the Files/Calendar parity pattern without exposing provider-native ids.
- Marks Boards replacement preview state as `coming_later` so the slice stays honest about no production migration/apply claim.

## Scope and user impact

- Server Boards facade response/audit parity only.
- Members/admins keep provider-neutral Boards semantics; no provider setup or migration readiness is claimed.

## Spec / acceptance link

- Issue: Fixes #791
- Repo spec or spec note: `docs/non-chat-domain-facade-contract.md`; `tools/fixtures/domain_facades/boards_facade_slice_contract.json`
- Acceptance scenario / mapping marker when product behavior changed: Boards facade mapping refs and audit payload assertions in `BoardsFacadeServiceTest`
- Product-core questions intentionally left unresolved: no production provider replacement/apply; preview remains `coming_later`.

## Branch, target lane, and release path

- Target lane: main exception — Sprint 32 implementation slice continuing the current protected-main PR train from `origin/main`.
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [ ] none
- [x] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

- Release note: Boards facade now returns support-safe mapping refs and audit evidence for canonical board/task parity.

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- None.

## Accessibility and localization

- Not UI-facing; no localization impact.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: `BoardsSyncMetadataResponse` adds provider-neutral mapping refs and preview state for #791 parity.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented

Fallback review evidence: independent Architecture/Security/QA red-team reviewed #791 live code and flagged explicit mapping refs plus preview/lossy/conflict proof as the main remaining acceptance risk. This PR addresses the mapping-ref/preview-state portion while keeping migration/apply claims bounded.

## Checks run

- [ ] `git diff --check`
- [ ] `./gradlew specCorpusConformance`
- [ ] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant for server facade metadata/audit slice.

Additional focused checks run:
- `cd server && ./gradlew test --tests com.massimotter.weave.backend.service.BoardsFacadeServiceTest --console=plain` — PASS
- `python3 tools/boards_facade_slice_contract_test.py` — PASS
- `./gradlew acceptanceContract releaseEvidenceCheck --console=plain` — PASS
- `./gradlew serverCi --console=plain` — PASS

## Notes for reviewers

- This is intentionally not a full Boards provider replacement/migration slice.
- `replacementPreviewState` is `coming_later` to preserve release-claim hygiene until a future non-mutating preview/lossy/conflict endpoint is implemented.
