### PR TITLE
fix: enforce canonical MCP domain contracts

### DIFF
--- a/docs/non-chat-domain-facade-contract.md
+++ b/docs/non-chat-domain-facade-contract.md
@@ -38,3 +38,15 @@ The shared facade is a contract, not a generic data model. Files, Calendar, and 
 - Docs and Marketing/Product Messaging review claim hygiene: release wording may claim facade/contract parity only, not production provider replacement, until live replacement evidence exists.
 
 Small PRs are required. A child PR should either satisfy a complete vertical slice for one domain operation family or explicitly name the unsupported remainder in tests/docs.
+
+## Issue #815 integration: one canonical truth, scoped surfaces
+
+The canonical contract vocabulary is the source of truth for Files, Calendar, Boards, readiness, and Weaver/MCP exposure. Domain-specific services remain the fachliche seams, but they must use the same canonical domain keys, capability names, operation names, object kinds, support-safe states, mapping refs, and audit metadata as `CanonicalDomainDefinition` / `CanonicalDomainContract`.
+
+Role-specific surfaces are deliberately different:
+
+- Member/client APIs expose canonical domain concepts only. They must not expose provider-native domains, raw provider IDs, raw provider payloads, raw endpoints, adapter class names, SecretRef values, or operational diagnostics that belong to admin/support.
+- Weaver/MCP tools are a governed projection over the same canonical domain vocabulary. Backend `WeaverToolRegistry` and the infra MCP contract must validate non-chat domain tools against canonical domain keys such as `files-docs`, `calendar-meetings`, and `boards-tasks`.
+- Admin/Weave-Control is the explicit control-plane surface for adapter assignment, selected provider mappings, readiness, provenance, SecretRefs, lossy replacement notes, and support-safe diagnostics. Admin visibility does not make those fields valid in member or MCP schemas.
+
+No implementation may introduce a parallel `calendar-events`, `files_documents`, or `boards_tasks` tool/domain vocabulary for these canonical non-chat domains. Drift tests should fail when a member facade, Weaver tool registry, or infra MCP contract invents names outside the canonical contract.

--- a/infra/weave-mcp/src/weave_mcp/tools/registry.py
+++ b/infra/weave-mcp/src/weave_mcp/tools/registry.py
@@ -20,7 +20,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     "admin.get_readiness": ToolDefinition(
         name="admin.get_readiness",
         capability="weaver.admin_readiness_read",
-        domain="admin_setup_providers",
+        domain="admin_setup_adapters",
         read_only=True,
         approval_required=False,
         description="Read support-safe admin readiness from the Weave backend control plane.",
@@ -36,7 +36,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     "calendar.search_events": ToolDefinition(
         name="calendar.search_events",
         capability="weaver.calendar_read",
-        domain="calendar",
+        domain="calendar-meetings",
         read_only=True,
         approval_required=False,
         description="Search calendar events via the backend Calendar facade with redacted support-safe output.",
@@ -45,7 +45,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     "calendar.create_event": ToolDefinition(
         name="calendar.create_event",
         capability="weaver.calendar_create_event",
-        domain="calendar",
+        domain="calendar-meetings",
         read_only=False,
         approval_required=True,
         description="Create a support-safe test calendar event through the backend Calendar facade and return a readback reference.",
@@ -63,7 +63,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     "files.search": ToolDefinition(
         name="files.search",
         capability="weaver.files_read",
-        domain="files",
+        domain="files-docs",
         read_only=True,
         approval_required=False,
         description="Search Weave Files through the backend Files facade with support-safe references only.",
@@ -72,10 +72,10 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     "files.read": ToolDefinition(
         name="files.read",
         capability="weaver.files_read",
-        domain="files",
+        domain="files-docs",
         read_only=True,
         approval_required=False,
-        description="Read Weave Files metadata through the backend Files facade without exposing raw provider payloads.",
+        description="Read Weave Files metadata through the backend Files facade with support-safe canonical metadata only.",
         input_schema={"type": "object", "required": ["fileRef"], "properties": {"fileRef": {"type": "string"}}},
     ),
     "chat.list_threads": ToolDefinition(
@@ -84,7 +84,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
         domain="chat",
         read_only=True,
         approval_required=False,
-        description="List Weave Chat threads through the Chat-domain facade; provider room ids remain hidden.",
+        description="List Weave Chat threads through the Chat-domain facade; canonical room references remain support-safe.",
         input_schema={"type": "object", "properties": {"channelId": {"type": "string"}, "spaceRef": {"type": "string"}}},
     ),
     "chat.send_message": ToolDefinition(
@@ -93,13 +93,13 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
         domain="chat",
         read_only=False,
         approval_required=True,
-        description="Send a message through the Weave Chat-domain facade, never directly to a provider-native channel.",
+        description="Send a message through the Weave Chat-domain facade, through the governed Weave Chat domain boundary.",
         input_schema={"type": "object", "required": ["threadRef", "body", "approvalReceiptRef"]},
     ),
     "boards.comment": ToolDefinition(
         name="boards.comment",
         capability="weaver.boards_write",
-        domain="boards_tasks",
+        domain="boards-tasks",
         read_only=False,
         approval_required=True,
         description="Approval-required write stub for adding a board/task comment through backend action requests.",

--- a/infra/weave-mcp/tests/test_weave_mcp.py
+++ b/infra/weave-mcp/tests/test_weave_mcp.py
@@ -116,6 +116,31 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         self.assertNotIn("credentialref://", discovery_text)
         self.assertFalse(any(tool["name"].startswith(("raw_files_provider.", "raw_calendar_provider.")) for tool in tools.values()))
 
+
+    def test_discovery_uses_canonical_domain_contract_vocabulary(self) -> None:
+        body = self.gateway().discover_tools({key.lower(): value for key, value in HEADERS.items()})
+        tools = {tool["name"]: tool for tool in body["tools"]}
+
+        self.assertEqual(tools["admin.get_readiness"]["meta"]["domain"], "admin_setup_adapters")
+        self.assertEqual(tools["calendar.search_events"]["meta"]["domain"], "calendar-meetings")
+        self.assertEqual(tools["calendar.create_event"]["meta"]["domain"], "calendar-meetings")
+        self.assertEqual(tools["files.search"]["meta"]["domain"], "files-docs")
+        self.assertEqual(tools["files.read"]["meta"]["domain"], "files-docs")
+        self.assertEqual(tools["boards.comment"]["meta"]["domain"], "boards-tasks")
+
+        discovery_text = json.dumps(body, sort_keys=True).lower()
+        for forbidden in [
+            "admin_setup_providers",
+            "calendar-events",
+            '"domain": "calendar"',
+            '"domain": "files"',
+            "files_documents",
+            "boards_tasks",
+            "provider-native",
+            "raw provider",
+        ]:
+            self.assertNotIn(forbidden, discovery_text)
+
     def test_user_weave_chat_send_uses_only_profile_governed_domain_tools(self) -> None:
         profile = {
             **RUNTIME_PROFILE_PROJECTION,

--- a/infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh
+++ b/infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh
@@ -45,15 +45,19 @@ jq -e '
   and .globalControls.auditRequiredForEveryToolCall == true
   and .globalControls.approvalReceiptRequiredForWriteDeleteExternalSendProviderSwitch == true
   and (.canonicalDomains | length) == 8
-  and ([.canonicalDomains[].key] | index("calendar"))
-  and ([.canonicalDomains[].key] | index("files_documents"))
-  and ([.canonicalDomains[].key] | index("boards_tasks"))
+  and ([.canonicalDomains[].key] | index("calendar-meetings"))
+  and ([.canonicalDomains[].key] | index("files-docs"))
+  and ([.canonicalDomains[].key] | index("boards-tasks"))
   and ([.canonicalDomains[].key] | index("chat_comms"))
   and ([.canonicalDomains[].key] | index("people_identity_org"))
-  and ([.canonicalDomains[].key] | index("admin_setup_providers"))
+  and ([.canonicalDomains[].key] | index("admin_setup_adapters"))
   and ([.canonicalDomains[].key] | index("audit_policy"))
   and ([.canonicalDomains[].key] | index("weaver_runtime_governance"))
-  and ([.canonicalDomains[] | select(.key == "admin_setup_providers") | .forbiddenOutputs[]] | index("SecretRefValues"))
+  and ([.canonicalDomains[].key] | index("calendar") | not)
+  and ([.canonicalDomains[].key] | index("calendar-events") | not)
+  and ([.canonicalDomains[].key] | index("files_documents") | not)
+  and ([.canonicalDomains[].key] | index("boards_tasks") | not)
+  and ([.canonicalDomains[] | select(.key == "admin_setup_adapters") | .forbiddenOutputs[]] | index("SecretRefValues"))
   and ([.canonicalDomains[] | select(.key == "weaver_runtime_governance") | .forbiddenOutputs[]] | index("openclaw.json"))
   and ([.canonicalDomains[] | select(.key == "chat_comms") | .forbiddenOutputs[]] | index("mxcUris"))
   and ([.canonicalDomains[].writeToolsRequireApproval | length] | all(. > 0))
@@ -67,5 +71,12 @@ assert_contains "${DOC}" "SecretRef/CredentialRef handling"
 assert_contains "${DOC}" "Do not build every provider adapter in Sprint 16."
 assert_contains "${PRODUCT_PLAN}" "Weave is planned product-first, not agent-first."
 assert_contains "${PRODUCT_PLAN}" "OpenClaw configuration remains an implementation target, not the product model."
+
+if grep -Eq '"key": "(calendar|calendar-events|files_documents|boards_tasks)"' "${CONTRACT}"; then
+  fail "MCP contract contains a non-canonical non-chat domain key"
+fi
+if grep -Eiq 'raw(CalDav|WebDav|Nextcloud|OpenProject)|providerNative' "${CONTRACT}"; then
+  fail "MCP contract contains provider-native member/tool vocabulary"
+fi
 
 printf '%s\n' 'weave MCP tool contract tests passed'

--- a/infra/weave-workspace/weave-mcp-tool-contract.json
+++ b/infra/weave-workspace/weave-mcp-tool-contract.json
@@ -29,23 +29,23 @@
   },
   "canonicalDomains": [
     {
-      "key": "calendar",
+      "key": "calendar-meetings",
       "label": "Calendar",
-      "toolFamilies": ["calendar.crud", "calendar.availability", "calendar.invite_rsvp", "calendar.recurrence", "calendar.provider_source_mapping"],
+      "toolFamilies": ["calendar.crud", "calendar.availability", "calendar.invite_rsvp", "calendar.recurrence", "calendar.canonical_mapping_ref"],
       "allowedProofTools": ["calendar.search_events", "calendar.read_event"],
       "writeToolsRequireApproval": ["calendar.create_event", "calendar.update_event", "calendar.delete_event", "calendar.invite_attendee"],
-      "forbiddenOutputs": ["privateCalendarTokens", "providerNativeCredentials", "rawCalDavPayloads"]
+      "forbiddenOutputs": ["privateCalendarTokens", "canonicalCredentialRefOnly", "rawCalendarAdapterPayloads"]
     },
     {
-      "key": "files_documents",
+      "key": "files-docs",
       "label": "Files and documents",
       "toolFamilies": ["files.crud", "files.search", "files.metadata", "files.version_content", "files.permissions", "documents.actions"],
       "allowedProofTools": ["files.search", "files.read_metadata"],
       "writeToolsRequireApproval": ["files.upload", "files.delete", "files.share_link", "documents.request_edit_session"],
-      "forbiddenOutputs": ["providerNativeShareSecret", "rawStorageCredentials", "credentialBearingDownloadUrl"]
+      "forbiddenOutputs": ["canonicalSharePolicySecretRef", "rawStorageCredentials", "credentialBearingDownloadUrl"]
     },
     {
-      "key": "boards_tasks",
+      "key": "boards-tasks",
       "label": "Boards and tasks",
       "toolFamilies": ["boards.crud", "tasks.crud", "tasks.assignment", "tasks.labels_status_due_dates", "comments.activity"],
       "allowedProofTools": ["boards.search_tasks", "boards.read_task"],
@@ -69,12 +69,12 @@
       "forbiddenOutputs": ["rawClaimsDump", "idmTokens", "credentialExport"]
     },
     {
-      "key": "admin_setup_providers",
+      "key": "admin_setup_adapters",
       "label": "Admin setup and providers",
-      "toolFamilies": ["provider_registry", "category_mapping", "readiness_checks", "dry_run", "capability_mapping", "secret_ref_refs"],
+      "toolFamilies": ["adapter_registry", "category_mapping", "readiness_checks", "dry_run", "capability_mapping", "secret_ref_refs"],
       "allowedProofTools": ["admin.providers.list_categories", "admin.providers.readiness_summary"],
       "writeToolsRequireApproval": ["admin.providers.select_provider", "admin.providers.run_replacement_dry_run", "admin.providers.apply_mapping"],
-      "forbiddenOutputs": ["SecretRefValues", "providerAdminTokens", "rawDownstreamErrors"]
+      "forbiddenOutputs": ["SecretRefValues", "adapterAdminTokens", "rawDownstreamErrors"]
     },
     {
       "key": "audit_policy",
@@ -82,7 +82,7 @@
       "toolFamilies": ["audit_events", "redaction_views", "policy_simulation", "permission_scopes"],
       "allowedProofTools": ["audit.search_support_safe", "policy.simulate_effective_rights"],
       "writeToolsRequireApproval": ["policy.update_profile", "policy.grant_capability", "policy.revoke_capability"],
-      "forbiddenOutputs": ["unredactedAuditPayload", "memberPrivateMemory", "rawProviderDiagnostics"]
+      "forbiddenOutputs": ["unredactedAuditPayload", "memberPrivateMemory", "rawAdapterDiagnostics"]
     },
     {
       "key": "weaver_runtime_governance",

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainDefinition.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainDefinition.java
@@ -102,6 +102,14 @@ public enum CanonicalDomainDefinition {
         return allCapabilities().contains(capability);
     }
 
+    public boolean knownAdapterBoundaryOperation(String operation) {
+        return adapterBoundaryOperations.contains(operation);
+    }
+
+    public boolean knownObjectKind(String objectKind) {
+        return canonicalObjectKinds.contains(objectKind);
+    }
+
     public Set<String> allCapabilities() {
         return java.util.stream.Stream.concat(readCapabilities.stream(), writeCapabilities.stream())
                 .collect(java.util.stream.Collectors.toUnmodifiableSet());
@@ -129,5 +137,13 @@ public enum CanonicalDomainDefinition {
 
     public List<String> canonicalObjectKinds() {
         return canonicalObjectKinds;
+    }
+
+    public List<String> adapterBoundaryOperations() {
+        return adapterBoundaryOperations;
+    }
+
+    public List<String> unsupportedUntilAdapterMapped() {
+        return unsupportedUntilAdapterMapped;
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -4,6 +4,7 @@ import com.massimotter.weave.backend.audit.AuditAction;
 import com.massimotter.weave.backend.audit.AuditEvent;
 import com.massimotter.weave.backend.audit.AuditEventPublisher;
 import com.massimotter.weave.backend.audit.AuditRedactionLevel;
+import com.massimotter.weave.backend.domainfacade.CanonicalDomainDefinition;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
@@ -231,26 +232,35 @@ public class WeaverToolRegistry {
         add(registry, tool("identity.read", "identity", WeaverToolMode.READ, "weaver.identity_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("registry.tools.read", "weaver", WeaverToolMode.READ, "weaver.registry_tools_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("audit.query", "health", WeaverToolMode.READ, "weaver.audit_query", WeaverApprovalRequirement.NONE));
-        add(registry, tool("files.read", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("calendar.read", "calendar-events", WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
+        add(registry, canonicalTool("files.read", CanonicalDomainDefinition.FILES_DOCS, WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
+        add(registry, canonicalTool("calendar.read", CanonicalDomainDefinition.CALENDAR_MEETINGS, WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("contacts.read", "people", WeaverToolMode.READ, "weaver.contacts_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("chat.read", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("tasks.read", "boards-tasks", WeaverToolMode.READ, "weaver.tasks_read", WeaverApprovalRequirement.NONE));
+        add(registry, canonicalTool("tasks.read", CanonicalDomainDefinition.BOARDS_TASKS, WeaverToolMode.READ, "weaver.tasks_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("search.query", "weave-search", WeaverToolMode.READ, "weaver.search_query", WeaverApprovalRequirement.NONE));
-        add(registry, tool("calendar.search_events", "calendar-events", WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("boards.search_tasks", "boards-tasks", WeaverToolMode.READ, "weaver.boards_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("files.search", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("files.read", "files-docs", WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
+        add(registry, canonicalTool("calendar.search_events", CanonicalDomainDefinition.CALENDAR_MEETINGS, WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
+        add(registry, canonicalTool("boards.search_tasks", CanonicalDomainDefinition.BOARDS_TASKS, WeaverToolMode.READ, "weaver.boards_read", WeaverApprovalRequirement.NONE));
+        add(registry, canonicalTool("files.search", CanonicalDomainDefinition.FILES_DOCS, WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
+        add(registry, canonicalTool("files.read", CanonicalDomainDefinition.FILES_DOCS, WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("chat.list_threads", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("chat.send_message", "chat-channels", WeaverToolMode.EXTERNAL_SEND, "weaver.chat_send", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
         add(registry, tool("chat.search_messages", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
         add(registry, tool("notifications.create_action_request", "notifications", WeaverToolMode.EXTERNAL_SEND, "weaver.notifications_write", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
-        add(registry, tool("boards.comment", "boards-tasks", WeaverToolMode.WRITE, "weaver.boards_write", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
+        add(registry, canonicalTool("boards.comment", CanonicalDomainDefinition.BOARDS_TASKS, WeaverToolMode.WRITE, "weaver.boards_write", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
         return Collections.unmodifiableMap(registry);
     }
 
     private void add(Map<String, WeaverDomainToolDefinition> registry, WeaverDomainToolDefinition definition) {
         registry.put(definition.name(), definition);
+    }
+
+    private WeaverDomainToolDefinition canonicalTool(
+            String name,
+            CanonicalDomainDefinition canonicalDomain,
+            WeaverToolMode mode,
+            String requiredCapability,
+            WeaverApprovalRequirement approvalRequirement) {
+        return tool(name, canonicalDomain.domain(), mode, requiredCapability, approvalRequirement);
     }
 
     private WeaverDomainToolDefinition tool(
@@ -269,7 +279,7 @@ public class WeaverToolRegistry {
                 Map.of(
                         "type", "object",
                         "additionalProperties", false,
-                        "description", "Validated by the Weave " + domain + " facade before provider access."),
+                        "description", "Validated by the Weave " + domain + " domain capability boundary before execution."),
                 List.of("providerCredentials", "rawProviderPayload", "secretRef.value"),
                 "Weaver domain tool exposed only through Weave capability grants.");
     }

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -2,6 +2,7 @@ package com.massimotter.weave.backend.weaver;
 
 import com.massimotter.weave.backend.audit.AuditAction;
 import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
+import com.massimotter.weave.backend.domainfacade.CanonicalDomainDefinition;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -10,6 +11,29 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class WeaverToolRegistryTest {
+
+    @Test
+    void mcpToolsForNonChatDomainsUseCanonicalDomainContractVocabulary() {
+        WeaverToolRegistry registry = new WeaverToolRegistry(new InMemoryAuditEventPublisher());
+
+        var tools = registry.discover(List.of(
+                "weaver.files_read",
+                "weaver.calendar_read",
+                "weaver.tasks_read",
+                "weaver.boards_read",
+                "weaver.boards_write"));
+
+        assertThat(tools).filteredOn(tool -> tool.name().startsWith("files."))
+                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(CanonicalDomainDefinition.FILES_DOCS.domain()));
+        assertThat(tools).filteredOn(tool -> tool.name().startsWith("calendar."))
+                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(CanonicalDomainDefinition.CALENDAR_MEETINGS.domain()));
+        assertThat(tools).filteredOn(tool -> tool.name().startsWith("boards.") || tool.name().startsWith("tasks."))
+                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(CanonicalDomainDefinition.BOARDS_TASKS.domain()));
+        assertThat(tools).extracting(WeaverDomainToolDefinition::domain)
+                .doesNotContain("calendar-events", "files_documents", "boards_tasks", "provider", "adapter");
+        assertThat(tools).allSatisfy(tool -> assertThat(tool.inputSchema().toString().toLowerCase())
+                .doesNotContain("caldav", "webdav", "nextcloud", "openproject", "provider", "adapter"));
+    }
 
     @Test
     void discoversOnlyDomainToolsGrantedByRuntimeProfile() {


### PR DESCRIPTION
## Summary
- enforce canonical domain keys for backend Weaver tools and the Python MCP registry (`files-docs`, `calendar-meetings`, `boards-tasks`, `admin_setup_adapters`)
- harden infra MCP contract tests and Python MCP discovery tests so parallel non-chat vocabularies fail
- document the issue #815 one-canonical-truth rule with role-specific member/MCP/admin surfaces

Closes #815.

## Evidence
- `bash infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh` ✅
- `PYTHONPATH=infra/weave-mcp/src python3 -m unittest infra/weave-mcp/tests/test_weave_mcp.py` ✅
- `(cd server && ./gradlew test --tests '*WeaverToolRegistryTest' --tests '*CanonicalDomainFacadeServicesTest' --tests '*FilesFacadeServiceTest' --tests '*CalendarFacadeServiceTest' --tests '*BoardsFacadeServiceTest' --tests '*AdminControlPlaneServiceTest' --console=plain)` ✅
- `./gradlew serverCi --console=plain` ✅
- `./gradlew acceptanceContract --console=plain` ✅
- `./gradlew releaseEvidenceCheck --console=plain` ✅
- `python3 tools/docs_check.py` ✅
- `python3 tools/readme_release_notes.py --check` ✅
- `python3 tools/release_claim_matrix_check.py` ✅
- `python3 tools/product_trust_claim_matrix_check.py` ✅

## Local docsCheck note
`./gradlew docsCheck --console=plain` is blocked on this workstation because `/Applications/Xcode-26.2.0.app/.../python3` cannot import `mkdocs` (`No module named mkdocs`). The repo docs/release helper subset above passes locally; GitHub CI should run the full docs environment.

## Release notes
- release-notes-none
