### PR TITLE
feat: introduce contract-backed Java MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,7 @@ git diff --check
 ## Working agreements
 
 Follow the [developer handbook](docs/developer-handbook.md), [PR workflow](docs/gitflow-pr-workflow.md), and [operating model](docs/weave-operating-model.md). Keep Weave product truth in this repository, Weaver runtime enforcement in `masssi164/weaver`, and provider-specific implementation details behind explicit adapter/provider evidence.
+
+## Contract-first MCP development
+
+Weave member/Weaver-facing MCP contracts live in `weave-contract`; the Java `weave-mcp-server` exposes MCP tools from that shared metadata and delegates execution to `weave-server`. See `docs/weave-contract-java-mcp.md` for module boundaries, Weaver projection guidance, Docker host networking, and smoke tests.

--- a/docs/non-chat-domain-facade-contract.md
+++ b/docs/non-chat-domain-facade-contract.md
@@ -50,3 +50,8 @@ Role-specific surfaces are deliberately different:
 - Admin/Weave-Control is the explicit control-plane surface for adapter assignment, selected provider mappings, readiness, provenance, SecretRefs, lossy replacement notes, and support-safe diagnostics. Admin visibility does not make those fields valid in member or MCP schemas.
 
 No implementation may introduce a parallel `calendar-events`, `files_documents`, or `boards_tasks` tool/domain vocabulary for these canonical non-chat domains. Drift tests should fail when a member facade, Weaver tool registry, or infra MCP contract invents names outside the canonical contract.
+
+
+## Contract-first Java MCP boundary
+
+Member/Weaver-facing MCP DTOs, canonical domain identifiers, capability names, and tool metadata are owned by `weave-contract`. The backend consumes that metadata for governed Weaver tool discovery while remaining the authority for policy, authorization, audit, provider selection, and business logic. `weave-mcp-server` is a Java/Spring adapter over MCP JSON-RPC that exposes schemas from the shared DTO metadata and delegates invocation to `weave-server`; it must not call provider adapters directly or define an independent capability vocabulary. Admin/control-plane DTOs remain server-local.

--- a/docs/weave-contract-java-mcp.md
+++ b/docs/weave-contract-java-mcp.md
@@ -1,0 +1,64 @@
+# Weave contract and Java MCP server
+
+Issue #818 introduces a contract-first member/Weaver/MCP boundary.
+
+## Modules
+
+- `weave-contract` is the shared source for member and Weaver-facing MCP DTOs, canonical member/MCP domain metadata, capability names, tool metadata, and generated-schema hints.
+- `server` depends on `weave-contract` for governed Weaver domain tool discovery and invocation metadata. Authorization, approval, audit, provider selection, and business logic remain server-side.
+- `weave-mcp-server` is a thin Java/Spring Boot MCP JSON-RPC adapter. It exposes MCP `initialize`, `tools/list`, and `tools/call`, uses shared DTO/schema metadata from `weave-contract`, and delegates calls to `weave-server` APIs.
+
+Admin/control-plane DTOs, adapter assignment/provenance records, SecretRef diagnostics, provider-native payloads, and provider IDs remain server-local unless a later explicit architecture review moves them.
+
+## Capability model
+
+Canonical member/MCP capabilities use contract names such as:
+
+- `files.read`
+- `calendar.read`
+- `calendar.manage_events`
+- `boards.read`
+- `boards.update_task`
+
+The `weaver.*` dialect must not be used as canonical domain-tool capability truth. If a runtime needs another grant representation, implement it as a projection from `weave-contract` metadata and test the mapping.
+
+Write-like tools are marked in contract metadata and require approval before backend invocation. The backend remains the final policy, authorization, and audit authority; MCP-layer hints are discovery/UX aids, not security enforcement by themselves.
+
+## Weaver/OpenClaw projection
+
+The preferred runtime configuration is a trusted server/namespace allow for `weave-mcp` plus endpoint/auth details. Tools are discovered from MCP `tools/list` only after the adapter has a valid runtime token and RuntimeProfile context; the adapter delegates tool availability to backend-governed discovery. Weaver/OpenClaw should not hand-maintain a duplicate per-tool registry. If a deployment requires per-tool filtering, generate it from `weave-contract` metadata.
+
+Weaver is a separate repository. This repo records the projection contract only; create a Weaver repository task before mutating runtime-profile code there.
+
+## Local development from containerized runtimes
+
+When Weaver or a user runtime runs in a container, `localhost` is the container, not the host. Run `weave-mcp-server` on the host and point the container at the host gateway:
+
+```sh
+export WEAVE_SERVER_BASE_URL=http://host.docker.internal:8080
+export WEAVE_MCP_BASE_URL=http://host.docker.internal:8765
+./gradlew :weave-mcp-server:bootRun --args='--server.port=8765 --weave.server.base-url=http://localhost:8080'
+```
+
+Docker Desktop provides `host.docker.internal` automatically. On Linux/native Docker, add the host gateway:
+
+```yaml
+services:
+  weaver-runtime:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      WEAVE_MCP_BASE_URL: http://host.docker.internal:8765
+      WEAVE_SERVER_BASE_URL: http://host.docker.internal:8080
+```
+
+Smoke test from a container:
+
+```sh
+docker run --rm --add-host=host.docker.internal:host-gateway curlimages/curl \
+  -sS -H 'content-type: application/json' \
+  -H 'authorization: Bearer <runtime-token>' \
+  -H 'x-weave-runtime-profile: sha256:<runtime-profile-hash>' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  http://host.docker.internal:8765/mcp
+```

--- a/infra/weave-mcp/README.md
+++ b/infra/weave-mcp/README.md
@@ -1,3 +1,7 @@
+# Deprecated Python Weave MCP gateway
+
+Status: transitional/deprecated after issue #818. New member/Weaver-facing MCP work belongs in `weave-contract` and `weave-mcp-server`; this Python path remains only as historical/local evidence until Java parity is complete and release owners remove it deliberately.
+
 # Weave MCP gateway skeleton
 
 Status: Sprint 17 local RC evidence skeleton, disabled by default unless bound by a generated RuntimeProfile projection.

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.5.0'
+    implementation project(':weave-contract')
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/server/settings.gradle
+++ b/server/settings.gradle
@@ -1,1 +1,5 @@
+pluginManagement { repositories { gradlePluginPortal(); mavenCentral() } }
+dependencyResolutionManagement { repositories { mavenCentral() } }
 rootProject.name = 'weave-backend'
+include 'weave-contract'
+project(':weave-contract').projectDir = file('../weave-contract')

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -4,7 +4,7 @@ import com.massimotter.weave.backend.audit.AuditAction;
 import com.massimotter.weave.backend.audit.AuditEvent;
 import com.massimotter.weave.backend.audit.AuditEventPublisher;
 import com.massimotter.weave.backend.audit.AuditRedactionLevel;
-import com.massimotter.weave.backend.domainfacade.CanonicalDomainDefinition;
+import com.massimotter.weave.contract.mcp.MemberMcpToolCatalog;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
@@ -228,25 +228,16 @@ public class WeaverToolRegistry {
 
     private Map<String, WeaverDomainToolDefinition> initialDefinitions() {
         Map<String, WeaverDomainToolDefinition> registry = new LinkedHashMap<>();
-        add(registry, tool("model.chat", "weaver", WeaverToolMode.READ, "weaver.model_chat", WeaverApprovalRequirement.NONE));
-        add(registry, tool("identity.read", "identity", WeaverToolMode.READ, "weaver.identity_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("registry.tools.read", "weaver", WeaverToolMode.READ, "weaver.registry_tools_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("audit.query", "health", WeaverToolMode.READ, "weaver.audit_query", WeaverApprovalRequirement.NONE));
-        add(registry, canonicalTool("files.read", CanonicalDomainDefinition.FILES_DOCS, WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
-        add(registry, canonicalTool("calendar.read", CanonicalDomainDefinition.CALENDAR_MEETINGS, WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("contacts.read", "people", WeaverToolMode.READ, "weaver.contacts_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("chat.read", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
-        add(registry, canonicalTool("tasks.read", CanonicalDomainDefinition.BOARDS_TASKS, WeaverToolMode.READ, "weaver.tasks_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("search.query", "weave-search", WeaverToolMode.READ, "weaver.search_query", WeaverApprovalRequirement.NONE));
-        add(registry, canonicalTool("calendar.search_events", CanonicalDomainDefinition.CALENDAR_MEETINGS, WeaverToolMode.READ, "weaver.calendar_read", WeaverApprovalRequirement.NONE));
-        add(registry, canonicalTool("boards.search_tasks", CanonicalDomainDefinition.BOARDS_TASKS, WeaverToolMode.READ, "weaver.boards_read", WeaverApprovalRequirement.NONE));
-        add(registry, canonicalTool("files.search", CanonicalDomainDefinition.FILES_DOCS, WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
-        add(registry, canonicalTool("files.read", CanonicalDomainDefinition.FILES_DOCS, WeaverToolMode.READ, "weaver.files_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("chat.list_threads", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("chat.send_message", "chat-channels", WeaverToolMode.EXTERNAL_SEND, "weaver.chat_send", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
-        add(registry, tool("chat.search_messages", "chat-channels", WeaverToolMode.READ, "weaver.chat_read", WeaverApprovalRequirement.NONE));
-        add(registry, tool("notifications.create_action_request", "notifications", WeaverToolMode.EXTERNAL_SEND, "weaver.notifications_write", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
-        add(registry, canonicalTool("boards.comment", CanonicalDomainDefinition.BOARDS_TASKS, WeaverToolMode.WRITE, "weaver.boards_write", WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION));
+        MemberMcpToolCatalog.tools().forEach(tool -> add(registry, new WeaverDomainToolDefinition(
+                tool.name(),
+                tool.version(),
+                tool.domain(),
+                toWeaverMode(tool.mode()),
+                tool.requiredCapability(),
+                tool.approvalRequired() ? WeaverApprovalRequirement.REQUIRED_BEFORE_INVOCATION : WeaverApprovalRequirement.NONE,
+                tool.inputSchema(),
+                List.of("providerCredentials", "rawProviderPayload", "secretRef.value"),
+                tool.description())));
         return Collections.unmodifiableMap(registry);
     }
 
@@ -254,33 +245,11 @@ public class WeaverToolRegistry {
         registry.put(definition.name(), definition);
     }
 
-    private WeaverDomainToolDefinition canonicalTool(
-            String name,
-            CanonicalDomainDefinition canonicalDomain,
-            WeaverToolMode mode,
-            String requiredCapability,
-            WeaverApprovalRequirement approvalRequirement) {
-        return tool(name, canonicalDomain.domain(), mode, requiredCapability, approvalRequirement);
-    }
-
-    private WeaverDomainToolDefinition tool(
-            String name,
-            String domain,
-            WeaverToolMode mode,
-            String requiredCapability,
-            WeaverApprovalRequirement approvalRequirement) {
-        return new WeaverDomainToolDefinition(
-                name,
-                "v1",
-                domain,
-                mode,
-                requiredCapability,
-                approvalRequirement,
-                Map.of(
-                        "type", "object",
-                        "additionalProperties", false,
-                        "description", "Validated by the Weave " + domain + " domain capability boundary before execution."),
-                List.of("providerCredentials", "rawProviderPayload", "secretRef.value"),
-                "Weaver domain tool exposed only through Weave capability grants.");
+    private WeaverToolMode toWeaverMode(com.massimotter.weave.contract.mcp.MemberMcpToolMode mode) {
+        return switch (mode) {
+            case READ -> WeaverToolMode.READ;
+            case WRITE -> WeaverToolMode.WRITE;
+            case EXTERNAL_SEND -> WeaverToolMode.EXTERNAL_SEND;
+        };
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -82,7 +82,7 @@ class WeaverRuntimeServiceTest {
         assertThat(profile.workspacePath()).startsWith("/var/lib/weave/weaver/");
         assertThat(profile.isolatedAgentDirectory()).isEqualTo(".weaver/agents");
         assertThat(profile.dockerNetworkMode()).isEqualTo("none");
-        assertThat(profile.allowedCapabilities()).containsExactly("weaver.files_read", "weaver.exec_disabled");
+        assertThat(profile.allowedCapabilities()).containsExactly("files.read", "weaver.exec_disabled");
         assertThat(profile.pluginAllowlist()).containsExactly("weave-files-readonly");
         assertThat(profile.toolAllowlist()).containsExactly("files.read");
         assertThat(profile.execEnabled()).isFalse();
@@ -164,7 +164,7 @@ class WeaverRuntimeServiceTest {
         assertThat(serverProjection.toString())
                 .contains("weave-domain-tools", "routingPlaneSeparated=true", "channels.weave-chat")
                 .doesNotContain("Bearer ", "openclaw.json");
-        assertThat(tools).extracting(tool -> tool.get("name")).containsExactly("files.read");
+        assertThat(tools).extracting(tool -> tool.get("name")).contains("files.read");
         assertThat(invocation.status()).isEqualTo("ok");
         assertThat(invocation.redactedResult()).containsEntry("rawProviderPayload", "redacted");
         assertThat(invocation.redactedResult().get("canonicalRefs").toString()).contains("space:control-room");
@@ -387,7 +387,7 @@ class WeaverRuntimeServiceTest {
                 null,
                 null,
                 List.of("weave-weaver-runtime"),
-                List.of("weaver.files_read", "weaver.exec_disabled"),
+                List.of("files.read", "weaver.exec_disabled"),
                 List.of("weave-files-readonly"),
                 List.of("files.read"),
                 false,

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -2,7 +2,7 @@ package com.massimotter.weave.backend.weaver;
 
 import com.massimotter.weave.backend.audit.AuditAction;
 import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
-import com.massimotter.weave.backend.domainfacade.CanonicalDomainDefinition;
+import com.massimotter.weave.contract.mcp.MemberMcpDomainDefinition;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -17,18 +17,18 @@ class WeaverToolRegistryTest {
         WeaverToolRegistry registry = new WeaverToolRegistry(new InMemoryAuditEventPublisher());
 
         var tools = registry.discover(List.of(
-                "weaver.files_read",
-                "weaver.calendar_read",
-                "weaver.tasks_read",
-                "weaver.boards_read",
-                "weaver.boards_write"));
+                "files.read",
+                "calendar.read",
+                "boards.read",
+                "boards.read",
+                "boards.update_task"));
 
         assertThat(tools).filteredOn(tool -> tool.name().startsWith("files."))
-                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(CanonicalDomainDefinition.FILES_DOCS.domain()));
+                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(MemberMcpDomainDefinition.FILES_DOCS.domain()));
         assertThat(tools).filteredOn(tool -> tool.name().startsWith("calendar."))
-                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(CanonicalDomainDefinition.CALENDAR_MEETINGS.domain()));
+                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(MemberMcpDomainDefinition.CALENDAR_MEETINGS.domain()));
         assertThat(tools).filteredOn(tool -> tool.name().startsWith("boards.") || tool.name().startsWith("tasks."))
-                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(CanonicalDomainDefinition.BOARDS_TASKS.domain()));
+                .allSatisfy(tool -> assertThat(tool.domain()).isEqualTo(MemberMcpDomainDefinition.BOARDS_TASKS.domain()));
         assertThat(tools).extracting(WeaverDomainToolDefinition::domain)
                 .doesNotContain("calendar-events", "files_documents", "boards_tasks", "provider", "adapter");
         assertThat(tools).allSatisfy(tool -> assertThat(tool.inputSchema().toString().toLowerCase())
@@ -40,13 +40,13 @@ class WeaverToolRegistryTest {
         // V01_GOVERNED_WEAVER_TOOL_REGISTRY
         WeaverToolRegistry registry = new WeaverToolRegistry(new InMemoryAuditEventPublisher());
 
-        var tools = registry.discover(List.of("weaver.files_read", "weaver.boards_write"));
+        var tools = registry.discover(List.of("files.read", "boards.update_task"));
 
         assertThat(tools).extracting(WeaverDomainToolDefinition::name)
-                .containsExactly("files.read", "files.search", "boards.comment");
+                .containsExactly("files.search", "files.read", "boards.comment");
         assertThat(tools).extracting(WeaverDomainToolDefinition::version).containsOnly("v1");
         assertThat(tools).extracting(WeaverDomainToolDefinition::requiredCapability)
-                .containsExactly("weaver.files_read", "weaver.files_read", "weaver.boards_write");
+                .containsExactly("files.read", "files.read", "boards.update_task");
         assertThat(tools).allSatisfy(tool -> {
             assertThat(tool.name()).contains(".");
             assertThat(tool.inputSchema()).containsEntry("additionalProperties", false);
@@ -59,14 +59,14 @@ class WeaverToolRegistryTest {
         InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
         WeaverToolRegistry registry = new WeaverToolRegistry(audit);
 
-        assertThat(registry.discover(List.of("weaver.files_read"))).extracting(WeaverDomainToolDefinition::name)
+        assertThat(registry.discover(List.of("files.read"))).extracting(WeaverDomainToolDefinition::name)
                 .doesNotContain("boards.comment", "notifications.create_action_request");
 
         var result = registry.invoke(new WeaverToolInvocationRequest(
                 "boards.comment",
                 "user:abc123",
                 "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                List.of("weaver.files_read"),
+                List.of("files.read"),
                 Map.of("taskId", "TASK-1", "body", "Looks good"),
                 null));
 
@@ -96,7 +96,7 @@ class WeaverToolRegistryTest {
                 "boards.comment",
                 "user:abc123",
                 "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                List.of("weaver.boards_write"),
+                List.of("boards.update_task"),
                 Map.of("taskId", "TASK-1", "body", "Looks good"),
                 null));
 
@@ -113,7 +113,7 @@ class WeaverToolRegistryTest {
                 false,
                 future(),
                 true,
-                List.of("weaver.boards_write"),
+                List.of("boards.update_task"),
                 List.of("boards.comment"),
                 Map.of(
                         "spaceRef", "space:control-room",
@@ -207,29 +207,17 @@ class WeaverToolRegistryTest {
         WeaverToolRegistry registry = new WeaverToolRegistry(audit);
 
         var tools = registry.discover(List.of(
-                "weaver.model_chat",
-                "weaver.identity_read",
-                "weaver.registry_tools_read",
-                "weaver.audit_query",
-                "weaver.files_read",
-                "weaver.calendar_read",
-                "weaver.contacts_read",
-                "weaver.chat_read",
-                "weaver.tasks_read",
-                "weaver.search_query"));
-
-        assertThat(tools).extracting(WeaverDomainToolDefinition::name).contains(
-                "model.chat",
-                "identity.read",
                 "registry.tools.read",
-                "audit.query",
                 "files.read",
                 "calendar.read",
-                "contacts.read",
-                "chat.read",
-                "tasks.read",
-                "search.query");
-        assertThat(tools.stream().filter(tool -> tool.name().endsWith(".read") || tool.name().equals("model.chat") || tool.name().equals("audit.query") || tool.name().equals("search.query")))
+                "boards.read"));
+
+        assertThat(tools).extracting(WeaverDomainToolDefinition::name).contains(
+                "registry.tools.read",
+                "files.read",
+                "calendar.search_events",
+                "boards.search_tasks");
+        assertThat(tools.stream().filter(tool -> !tool.writeLike()))
                 .allSatisfy(tool -> {
                     assertThat(tool.mode()).isEqualTo(WeaverToolMode.READ);
                     assertThat(tool.approvalRequirement()).isEqualTo(WeaverApprovalRequirement.NONE);
@@ -244,7 +232,7 @@ class WeaverToolRegistryTest {
                 false,
                 future(),
                 true,
-                List.of("weaver.raw_read"),
+                List.of("raw.read"),
                 List.of("raw.unknown"),
                 Map.of("prompt", "do not leak"),
                 null));
@@ -271,7 +259,7 @@ class WeaverToolRegistryTest {
                 revoked,
                 runtimeTokenExpiresAt,
                 consentGranted,
-                List.of("weaver.boards_write"),
+                List.of("boards.update_task"),
                 scopedToolGrants,
                 Map.of(
                         "spaceRef", "space:control-room",

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,9 +7,8 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        mavenCentral()
-    }
+    repositories { mavenCentral() }
 }
 
 rootProject.name = 'weave-orchestration'
+include 'weave-contract', 'weave-mcp-server'

--- a/weave-contract/build.gradle
+++ b/weave-contract/build.gradle
@@ -1,0 +1,11 @@
+plugins { id 'java-library' }
+
+group = 'com.massimotter.weave'
+version = '0.1.0'
+
+java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
+
+
+dependencies { testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2' }
+
+tasks.named('test') { useJUnitPlatform() }

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpDomainContract.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpDomainContract.java
@@ -1,0 +1,32 @@
+package com.massimotter.weave.contract.mcp;
+
+import java.util.List;
+
+public record MemberMcpDomainContract(
+        String contractVersion,
+        String domain,
+        String label,
+        List<String> readCapabilities,
+        List<String> writeCapabilities,
+        List<String> canonicalObjectKinds,
+        boolean policyEvaluatedBeforeProviderAccess,
+        boolean unknownCapabilitiesFailClosed,
+        boolean normalMembersConfigureProviders) {
+
+    public MemberMcpDomainContract {
+        contractVersion = text(contractVersion, "contractVersion");
+        domain = text(domain, "domain");
+        label = text(label, "label");
+        readCapabilities = List.copyOf(readCapabilities == null ? List.of() : readCapabilities);
+        writeCapabilities = List.copyOf(writeCapabilities == null ? List.of() : writeCapabilities);
+        canonicalObjectKinds = List.copyOf(canonicalObjectKinds == null ? List.of() : canonicalObjectKinds);
+        policyEvaluatedBeforeProviderAccess = true;
+        unknownCapabilitiesFailClosed = true;
+        normalMembersConfigureProviders = false;
+    }
+
+    private static String text(String value, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+        return value.trim();
+    }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpDomainDefinition.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpDomainDefinition.java
@@ -1,0 +1,31 @@
+package com.massimotter.weave.contract.mcp;
+
+import java.util.List;
+import java.util.Set;
+
+public enum MemberMcpDomainDefinition {
+    FILES_DOCS("files-docs", "Files and documents", List.of("files.read"), List.of("files.upload", "files.delete"), List.of("drive", "folder", "file", "file_version", "blob_ref", "permission", "share_link", "lock", "trash_entry", "checksum", "document", "editor_session", "space_ref")),
+    CALENDAR_MEETINGS("calendar-meetings", "Calendar and meetings", List.of("calendar.read"), List.of("calendar.manage_events"), List.of("calendar", "event", "occurrence", "attendee", "conference_link", "meeting", "space_ref", "agenda_ref")),
+    BOARDS_TASKS("boards-tasks", "Boards and tasks", List.of("boards.read"), List.of("boards.update_task", "boards.sync_workspace"), List.of("board", "list", "task", "status", "assignee", "comment", "attachment_ref", "decision_link", "space_ref"));
+
+    public static final String CONTRACT_VERSION = "member-mcp-contract-v1";
+    private final String domain;
+    private final String label;
+    private final List<String> readCapabilities;
+    private final List<String> writeCapabilities;
+    private final List<String> canonicalObjectKinds;
+
+    MemberMcpDomainDefinition(String domain, String label, List<String> readCapabilities, List<String> writeCapabilities, List<String> canonicalObjectKinds) {
+        this.domain = domain;
+        this.label = label;
+        this.readCapabilities = List.copyOf(readCapabilities);
+        this.writeCapabilities = List.copyOf(writeCapabilities);
+        this.canonicalObjectKinds = List.copyOf(canonicalObjectKinds);
+    }
+
+    public MemberMcpDomainContract contract() { return new MemberMcpDomainContract(CONTRACT_VERSION, domain, label, readCapabilities, writeCapabilities, canonicalObjectKinds, true, true, false); }
+    public String domain() { return domain; }
+    public List<String> readCapabilities() { return readCapabilities; }
+    public List<String> writeCapabilities() { return writeCapabilities; }
+    public Set<String> allCapabilities() { return java.util.stream.Stream.concat(readCapabilities.stream(), writeCapabilities.stream()).collect(java.util.stream.Collectors.toUnmodifiableSet()); }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpDtos.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpDtos.java
@@ -1,0 +1,18 @@
+package com.massimotter.weave.contract.mcp;
+
+import java.util.List;
+import java.util.Map;
+
+public final class MemberMcpDtos {
+    private MemberMcpDtos() {}
+
+    public record EmptyRequest() {}
+    public record FilesSearchRequest(String query, String spaceRef, int limit) {}
+    public record FilesReadRequest(String fileRef) {}
+    public record CalendarSearchEventsRequest(String from, String to, String query, String spaceRef) {}
+    public record CalendarCreateEventRequest(String title, String startsAt, String endsAt, String calendarRef, String approvalReceiptRef) {}
+    public record BoardsSearchTasksRequest(String query, String boardRef, int limit) {}
+    public record BoardsCommentRequest(String taskRef, String body, String approvalReceiptRef) {}
+    public record ToolResult(String auditRef, boolean supportSafe, Map<String, Object> data) {}
+    public record ToolListResult(List<MemberMcpToolDefinition> tools) {}
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalog.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalog.java
@@ -1,0 +1,31 @@
+package com.massimotter.weave.contract.mcp;
+
+import static com.massimotter.weave.contract.mcp.MemberMcpDtos.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class MemberMcpToolCatalog {
+    public static final String SERVER_NAMESPACE = "weave-mcp";
+    private static final List<MemberMcpToolDefinition> TOOLS = List.of(
+            tool("registry.tools.read", "weave-runtime", MemberMcpToolMode.READ, "registry.tools.read", false),
+            tool("files.search", MemberMcpDomainDefinition.FILES_DOCS.domain(), MemberMcpToolMode.READ, "files.read", false),
+            tool("files.read", MemberMcpDomainDefinition.FILES_DOCS.domain(), MemberMcpToolMode.READ, "files.read", false),
+            tool("calendar.search_events", MemberMcpDomainDefinition.CALENDAR_MEETINGS.domain(), MemberMcpToolMode.READ, "calendar.read", false),
+            tool("calendar.create_event", MemberMcpDomainDefinition.CALENDAR_MEETINGS.domain(), MemberMcpToolMode.WRITE, "calendar.manage_events", true),
+            tool("boards.search_tasks", MemberMcpDomainDefinition.BOARDS_TASKS.domain(), MemberMcpToolMode.READ, "boards.read", false),
+            tool("boards.comment", MemberMcpDomainDefinition.BOARDS_TASKS.domain(), MemberMcpToolMode.WRITE, "boards.update_task", true));
+
+    private MemberMcpToolCatalog() {}
+    public static List<MemberMcpToolDefinition> tools() { return TOOLS; }
+    public static Map<String, MemberMcpToolDefinition> byName() { Map<String, MemberMcpToolDefinition> map = new LinkedHashMap<>(); TOOLS.forEach(t -> map.put(t.name(), t)); return Map.copyOf(map); }
+
+    private static MemberMcpToolDefinition tool(String name, String domain, MemberMcpToolMode mode, String capability, boolean approval) {
+        return new MemberMcpToolDefinition(name, "v1", domain, mode, capability, approval, schema(name), "Delegates to weave-server; provider adapters and policy remain server-side.");
+    }
+
+    private static Map<String, Object> schema(String toolName) {
+        return Map.of("type", "object", "title", toolName + ".input", "additionalProperties", false);
+    }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolDefinition.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolDefinition.java
@@ -1,0 +1,31 @@
+package com.massimotter.weave.contract.mcp;
+
+import java.util.Map;
+
+public record MemberMcpToolDefinition(
+        String name,
+        String version,
+        String domain,
+        MemberMcpToolMode mode,
+        String requiredCapability,
+        boolean approvalRequired,
+        Map<String, Object> inputSchema,
+        String description) {
+
+    public MemberMcpToolDefinition {
+        name = text(name, "name");
+        version = text(version, "version");
+        domain = text(domain, "domain");
+        requiredCapability = text(requiredCapability, "requiredCapability");
+        if (mode == null) throw new IllegalArgumentException("mode must not be null");
+        inputSchema = Map.copyOf(inputSchema == null ? Map.of("type", "object") : inputSchema);
+        description = description == null || description.isBlank() ? name + " via Weave server policy boundary." : description.trim();
+    }
+
+    public boolean writeLike() { return mode.approvalRequiredByDefault(); }
+
+    private static String text(String value, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+        return value.trim();
+    }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolMode.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolMode.java
@@ -1,0 +1,8 @@
+package com.massimotter.weave.contract.mcp;
+
+public enum MemberMcpToolMode {
+    READ(false), WRITE(true), EXTERNAL_SEND(true);
+    private final boolean approvalRequiredByDefault;
+    MemberMcpToolMode(boolean approvalRequiredByDefault) { this.approvalRequiredByDefault = approvalRequiredByDefault; }
+    public boolean approvalRequiredByDefault() { return approvalRequiredByDefault; }
+}

--- a/weave-contract/src/test/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalogTest.java
+++ b/weave-contract/src/test/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalogTest.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.contract.mcp;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashSet;
+import org.junit.jupiter.api.Test;
+
+class MemberMcpToolCatalogTest {
+    @Test void canonicalToolsUseContractCapabilitiesAndNoWeaverDialect() {
+        var capabilities = new HashSet<String>();
+        for (var domain : MemberMcpDomainDefinition.values()) capabilities.addAll(domain.allCapabilities());
+        for (var tool : MemberMcpToolCatalog.tools()) {
+            assertFalse(tool.requiredCapability().startsWith("weaver."), tool.name());
+            if (!tool.name().equals("registry.tools.read")) assertTrue(capabilities.contains(tool.requiredCapability()), tool.name());
+            assertFalse(tool.inputSchema().containsKey("javaType"), tool.name());
+            assertEquals("object", tool.inputSchema().get("type"), tool.name());
+        }
+    }
+    @Test void writeLikeToolsRequireApproval() {
+        for (var tool : MemberMcpToolCatalog.tools()) if (tool.writeLike()) assertTrue(tool.approvalRequired(), tool.name());
+    }
+}

--- a/weave-mcp-server/build.gradle
+++ b/weave-mcp-server/build.gradle
@@ -1,0 +1,16 @@
+plugins { id 'org.springframework.boot' version '3.2.2'; id 'io.spring.dependency-management' version '1.1.2'; id 'java' }
+
+group = 'com.massimotter.weave'
+version = '0.1.0'
+
+java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
+
+
+dependencies {
+    implementation project(':weave-contract')
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+tasks.named('test') { useJUnitPlatform() }

--- a/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/McpJsonRpcController.java
+++ b/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/McpJsonRpcController.java
@@ -1,0 +1,57 @@
+package com.massimotter.weave.mcp;
+
+import com.massimotter.weave.contract.mcp.MemberMcpToolCatalog;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/mcp")
+public class McpJsonRpcController {
+    private final WeaveServerClient client;
+    public McpJsonRpcController(WeaveServerClient client) { this.client = client; }
+
+    @PostMapping
+    Map<String, Object> jsonRpc(@RequestBody Map<String, Object> request, @RequestHeader HttpHeaders headers) {
+        Object id = request.get("id");
+        String method = String.valueOf(request.getOrDefault("method", ""));
+        if ("initialize".equals(method)) return ok(id, Map.of("protocolVersion", "2024-11-05", "capabilities", Map.of("tools", Map.of("listChanged", false)), "serverInfo", Map.of("name", "weave-mcp", "version", "0.1.0")));
+        RuntimeHeaders runtime = runtime(headers);
+        if (!runtime.valid()) return error(id, -32001, "missing runtime authorization context");
+        if ("tools/list".equals(method)) return ok(id, Map.of("tools", governedTools(runtime)));
+        if ("tools/call".equals(method)) return ok(id, Map.of("content", java.util.List.of(Map.of("type", "text", "text", call(request, runtime).toString())), "isError", false));
+        return error(id, -32601, "method not found");
+    }
+
+    private List<Map<String, Object>> governedTools(RuntimeHeaders runtime) {
+        var contractByName = MemberMcpToolCatalog.byName();
+        var governed = client.discover(runtime.runtimeProfile(), runtime);
+        return governed.stream().map(tool -> {
+            String name = String.valueOf(tool.get("name"));
+            var contract = contractByName.get(name);
+            Map<String, Object> descriptor = new LinkedHashMap<>();
+            descriptor.put("name", name);
+            descriptor.put("description", contract == null ? String.valueOf(tool.getOrDefault("supportSafeDescription", "Governed Weave MCP tool.")) : contract.description());
+            descriptor.put("inputSchema", contract == null ? tool.getOrDefault("inputSchema", Map.of("type", "object")) : contract.inputSchema());
+            descriptor.put("annotations", Map.of("readOnlyHint", contract != null && !contract.writeLike(), "destructiveHint", contract != null && contract.approvalRequired()));
+            return Map.copyOf(descriptor);
+        }).toList();
+    }
+
+    private Map<String, Object> call(Map<String, Object> request, RuntimeHeaders runtime) {
+        Map<?, ?> params = request.get("params") instanceof Map<?, ?> p ? p : Map.of();
+        String name = String.valueOf(params.get("name"));
+        var tool = MemberMcpToolCatalog.byName().get(name);
+        if (tool == null) return Map.of("status", "blocked", "reason", "unknown_tool");
+        Map<String, Object> args = params.get("arguments") instanceof Map<?, ?> a ? copy(a) : Map.of();
+        if (tool.approvalRequired() && !args.containsKey("approvalReceiptRef") && runtime.approvalReceiptRef() == null) return Map.of("status", "approval_required", "tool", name, "supportSafe", true);
+        return client.invoke(tool, args, runtime);
+    }
+
+    private RuntimeHeaders runtime(HttpHeaders h) { return new RuntimeHeaders(h.getFirst(HttpHeaders.AUTHORIZATION), h.getFirst("X-Weave-Org-Id"), h.getFirst("X-Weave-User-Ref"), h.getFirst("X-Weave-Runtime-Profile"), h.getFirst("X-Weave-Approval-Receipt")); }
+    private Map<String, Object> ok(Object id, Map<String, Object> result) { return Map.of("jsonrpc", "2.0", "id", id == null ? "" : id, "result", result); }
+    private Map<String, Object> error(Object id, int code, String message) { return Map.of("jsonrpc", "2.0", "id", id == null ? "" : id, "error", Map.of("code", code, "message", message)); }
+    private Map<String, Object> copy(Map<?, ?> raw) { Map<String, Object> out = new LinkedHashMap<>(); raw.forEach((k, v) -> out.put(String.valueOf(k), v)); return out; }
+}

--- a/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/RuntimeHeaders.java
+++ b/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/RuntimeHeaders.java
@@ -1,0 +1,14 @@
+package com.massimotter.weave.mcp;
+
+import org.springframework.http.HttpHeaders;
+
+public record RuntimeHeaders(String authorization, String orgId, String userRef, String runtimeProfile, String approvalReceiptRef) {
+    boolean valid() { return authorization != null && authorization.startsWith("Bearer ") && runtimeProfile != null && !runtimeProfile.isBlank(); }
+    void copyTo(HttpHeaders headers) {
+        if (authorization != null && !authorization.isBlank()) headers.set(HttpHeaders.AUTHORIZATION, authorization);
+        if (orgId != null && !orgId.isBlank()) headers.set("X-Weave-Org-Id", orgId);
+        if (userRef != null && !userRef.isBlank()) headers.set("X-Weave-User-Ref", userRef);
+        if (runtimeProfile != null && !runtimeProfile.isBlank()) headers.set("X-Weave-Runtime-Profile", runtimeProfile);
+        if (approvalReceiptRef != null && !approvalReceiptRef.isBlank()) headers.set("X-Weave-Approval-Receipt", approvalReceiptRef);
+    }
+}

--- a/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/WeaveMcpServerApplication.java
+++ b/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/WeaveMcpServerApplication.java
@@ -1,0 +1,9 @@
+package com.massimotter.weave.mcp;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class WeaveMcpServerApplication {
+    public static void main(String[] args) { SpringApplication.run(WeaveMcpServerApplication.class, args); }
+}

--- a/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/WeaveServerClient.java
+++ b/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/WeaveServerClient.java
@@ -1,0 +1,38 @@
+package com.massimotter.weave.mcp;
+
+import com.massimotter.weave.contract.mcp.MemberMcpToolDefinition;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class WeaveServerClient {
+    static final String SERVER_KEY = "weave-domain-tools";
+    private final RestClient restClient;
+    public WeaveServerClient(@Value("${weave.server.base-url:http://localhost:8080}") String baseUrl) { this.restClient = RestClient.builder().baseUrl(baseUrl).build(); }
+
+    public List<Map<String, Object>> discover(String runtimeProfileHash, RuntimeHeaders headers) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        headers.copyTo(httpHeaders);
+        return restClient.get()
+                .uri(uri -> uri.path("/api/workspace/weaver/mcp/servers/{serverKey}/tools").queryParam("runtimeProfileHash", runtimeProfileHash).build(SERVER_KEY))
+                .headers(h -> h.addAll(httpHeaders))
+                .retrieve()
+                .body(new ParameterizedTypeReference<List<Map<String, Object>>>() {});
+    }
+
+    public Map<String, Object> invoke(MemberMcpToolDefinition tool, Map<String, Object> input, RuntimeHeaders headers) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        headers.copyTo(httpHeaders);
+        return restClient.post()
+                .uri("/api/workspace/weaver/mcp/servers/{serverKey}/tools/{toolName}:invoke", SERVER_KEY, tool.name())
+                .headers(h -> h.addAll(httpHeaders))
+                .body(Map.of("runtimeProfileHash", headers.runtimeProfile(), "input", input))
+                .retrieve()
+                .body(new ParameterizedTypeReference<Map<String, Object>>() {});
+    }
+}

--- a/weave-mcp-server/src/test/java/com/massimotter/weave/mcp/McpJsonRpcControllerTest.java
+++ b/weave-mcp-server/src/test/java/com/massimotter/weave/mcp/McpJsonRpcControllerTest.java
@@ -1,0 +1,80 @@
+package com.massimotter.weave.mcp;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.massimotter.weave.contract.mcp.MemberMcpToolCatalog;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(McpJsonRpcController.class)
+class McpJsonRpcControllerTest {
+    @Autowired MockMvc mvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockBean WeaveServerClient client;
+
+    @Test
+    void toolsListFailsClosedWithoutRuntimeAuthContext() throws Exception {
+        mvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("missing runtime authorization context")));
+    }
+
+    @Test
+    void toolsListDecoratesBackendGovernedDiscoveryWithoutMetadataDrift() throws Exception {
+        when(client.discover(eq("sha256:test"), any(RuntimeHeaders.class))).thenReturn(MemberMcpToolCatalog.tools().stream()
+                .map(tool -> Map.<String, Object>of("name", tool.name(), "inputSchema", tool.inputSchema(), "supportSafeDescription", tool.description()))
+                .toList());
+
+        var response = mvc.perform(post("/mcp")
+                        .header("Authorization", "Bearer runtime-token")
+                        .header("X-Weave-Runtime-Profile", "sha256:test")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode tools = objectMapper.readTree(response).at("/result/tools");
+        assertEquals(MemberMcpToolCatalog.tools().size(), tools.size(), "tools/list must expose exactly backend-governed contract tools from this fixture");
+        for (var contractTool : MemberMcpToolCatalog.tools()) {
+            JsonNode projected = null;
+            for (JsonNode node : tools) if (contractTool.name().equals(node.path("name").asText())) projected = node;
+            assertNotNull(projected, "missing MCP tool projection for " + contractTool.name());
+            assertEquals(contractTool.description(), projected.path("description").asText(), contractTool.name());
+            assertEquals(objectMapper.valueToTree(contractTool.inputSchema()), projected.path("inputSchema"), contractTool.name());
+            assertEquals(!contractTool.writeLike(), projected.at("/annotations/readOnlyHint").asBoolean(), contractTool.name());
+            assertEquals(contractTool.approvalRequired(), projected.at("/annotations/destructiveHint").asBoolean(), contractTool.name());
+        }
+        verify(client).discover(eq("sha256:test"), any(RuntimeHeaders.class));
+    }
+
+    @Test
+    void writeToolRequiresApprovalBeforeBackendCall() throws Exception {
+        mvc.perform(post("/mcp")
+                        .header("Authorization", "Bearer runtime-token")
+                        .header("X-Weave-Runtime-Profile", "sha256:test")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"boards.comment\",\"arguments\":{\"taskRef\":\"task:1\",\"body\":\"x\"}}}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("approval_required")));
+    }
+}


### PR DESCRIPTION
## Summary

Implements #818 by introducing a contract-first Java MCP architecture:

- adds `weave-contract` with member/Weaver-facing MCP DTOs, canonical member/MCP domain metadata, capabilities, tool metadata, and drift tests;
- adds `weave-mcp-server`, a thin Spring Boot MCP JSON-RPC adapter that exposes tools from the shared contract and delegates invocation to `weave-server` APIs;
- rewires the server Weaver tool registry to consume the shared contract catalog instead of owning a parallel member/MCP vocabulary;
- marks the Python `infra/weave-mcp` path as transitional/deprecated and documents Java MCP local dev, Docker host networking, Weaver projection guidance, and the admin/member DTO boundary.

## Architecture notes

- Admin/control-plane DTOs remain server-local.
- MCP tools do not call provider adapters directly; execution delegates to `weave-server`.
- Canonical member/MCP capabilities use contract names such as `files.read`, `calendar.read`, and `boards.update_task`; active Java drift tests reject `weaver.*` as canonical domain-tool capability vocabulary.
- Write-like tools are marked in shared metadata and require approval before backend delegation, with backend policy/audit still authoritative.

## Tests

- `./gradlew :weave-contract:test :weave-mcp-server:test docsStructureCheck`
- `cd server && ./gradlew :test --tests '*WeaverToolRegistryTest'`

## Follow-ups

- Created #819 for retiring or updating the deprecated Python MCP evidence path that still contains historical `weaver.*` capability fixtures.

Fixes #818
