### PR TITLE
fix: retire Python MCP weaver capability dialect

### DIFF
--- a/infra/weave-mcp/README.md
+++ b/infra/weave-mcp/README.md
@@ -1,6 +1,6 @@
 # Deprecated Python Weave MCP gateway
 
-Status: transitional/deprecated after issue #818. New member/Weaver-facing MCP work belongs in `weave-contract` and `weave-mcp-server`; this Python path remains only as historical/local evidence until Java parity is complete and release owners remove it deliberately.
+Status: transitional/deprecated after issue #818. New member/Weaver-facing MCP work belongs in `weave-contract` and `weave-mcp-server`; this Python path remains only as historical/local evidence until Java parity is complete and release owners remove it deliberately. The historical `weaver.*` capability dialect is retired here too: local fixtures must use the Java contract capability vocabulary (`files.read`, `calendar.read`, `calendar.manage_events`, `boards.update_task`, and related domain grants) so this deprecated path cannot drift into a second canonical MCP contract.
 
 # Weave MCP gateway skeleton
 

--- a/infra/weave-mcp/src/weave_mcp/tools/registry.py
+++ b/infra/weave-mcp/src/weave_mcp/tools/registry.py
@@ -19,7 +19,7 @@ Handler = Callable[[RuntimeContext, dict[str, Any], WeaveBackendClient], dict[st
 TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     "admin.get_readiness": ToolDefinition(
         name="admin.get_readiness",
-        capability="weaver.admin_readiness_read",
+        capability="registry.tools.read",
         domain="admin_setup_adapters",
         read_only=True,
         approval_required=False,
@@ -27,7 +27,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     ),
     "weaver.get_runtime_profile_projection": ToolDefinition(
         name="weaver.get_runtime_profile_projection",
-        capability="weaver.runtime_profile_read",
+        capability="registry.tools.read",
         domain="weaver_runtime_governance",
         read_only=True,
         approval_required=False,
@@ -35,7 +35,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     ),
     "calendar.search_events": ToolDefinition(
         name="calendar.search_events",
-        capability="weaver.calendar_read",
+        capability="calendar.read",
         domain="calendar-meetings",
         read_only=True,
         approval_required=False,
@@ -44,7 +44,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     ),
     "calendar.create_event": ToolDefinition(
         name="calendar.create_event",
-        capability="weaver.calendar_create_event",
+        capability="calendar.manage_events",
         domain="calendar-meetings",
         read_only=False,
         approval_required=True,
@@ -62,7 +62,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     ),
     "files.search": ToolDefinition(
         name="files.search",
-        capability="weaver.files_read",
+        capability="files.read",
         domain="files-docs",
         read_only=True,
         approval_required=False,
@@ -71,7 +71,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     ),
     "files.read": ToolDefinition(
         name="files.read",
-        capability="weaver.files_read",
+        capability="files.read",
         domain="files-docs",
         read_only=True,
         approval_required=False,
@@ -80,7 +80,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     ),
     "chat.list_threads": ToolDefinition(
         name="chat.list_threads",
-        capability="weaver.chat_read",
+        capability="chat.read",
         domain="chat",
         read_only=True,
         approval_required=False,
@@ -89,7 +89,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     ),
     "chat.send_message": ToolDefinition(
         name="chat.send_message",
-        capability="weaver.chat_send",
+        capability="chat.send",
         domain="chat",
         read_only=False,
         approval_required=True,
@@ -98,7 +98,7 @@ TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     ),
     "boards.comment": ToolDefinition(
         name="boards.comment",
-        capability="weaver.boards_write",
+        capability="boards.update_task",
         domain="boards-tasks",
         read_only=False,
         approval_required=True,

--- a/infra/weave-mcp/tests/test_weave_mcp.py
+++ b/infra/weave-mcp/tests/test_weave_mcp.py
@@ -37,14 +37,13 @@ RUNTIME_PROFILE_PROJECTION = {
     "runtimeTokenRef": "credentialref://weave/runtime/short-lived/local-rc-evidence",
     "runtimeTokenExpiresAt": future_iso(10),
     "capabilityGrants": [
-        "weaver.admin_readiness_read",
-        "weaver.runtime_profile_read",
-        "weaver.calendar_read",
-        "weaver.calendar_create_event",
-        "weaver.files_read",
-        "weaver.chat_read",
-        "weaver.chat_send",
-        "weaver.boards_write",
+        "registry.tools.read",
+        "calendar.read",
+        "calendar.manage_events",
+        "files.read",
+        "chat.read",
+        "chat.send",
+        "boards.update_task",
     ],
     "allowedTools": [
         "admin.get_readiness",
@@ -117,6 +116,43 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         self.assertFalse(any(tool["name"].startswith(("raw_files_provider.", "raw_calendar_provider.")) for tool in tools.values()))
 
 
+    def test_transitional_python_fixture_rejects_deprecated_weaver_capability_dialect(self) -> None:
+        profile = {
+            **RUNTIME_PROFILE_PROJECTION,
+            "allowedTools": ["files.read", "calendar.search_events", "boards.comment"],
+            "capabilityGrants": ["weaver.files_read", "weaver.calendar_read", "weaver.boards_write"],
+        }
+        headers = {key.lower(): value for key, value in {**HEADERS, "X-Weave-Runtime-Profile-Projection": encoded_projection(profile)}.items()}
+
+        discovered = self.gateway().discover_tools(headers)
+        self.assertEqual(discovered["tools"], [])
+
+        with self.assertRaises(McpDenied) as denied:
+            self.gateway().invoke_tool(headers, {"tool": "files.read", "input": {"fileRef": "file://weave/support-safe/one"}})
+        self.assertEqual(denied.exception.reason, "capability-not-granted")
+
+    def test_transitional_python_fixture_uses_java_contract_capability_vocabulary(self) -> None:
+        body = self.gateway().discover_tools({key.lower(): value for key, value in HEADERS.items()})
+        discovery_text = json.dumps(body, sort_keys=True)
+
+        for deprecated in [
+            "weaver.admin_readiness_read",
+            "weaver.runtime_profile_read",
+            "weaver.calendar_read",
+            "weaver.calendar_create_event",
+            "weaver.files_read",
+            "weaver.chat_read",
+            "weaver.chat_send",
+            "weaver.boards_write",
+        ]:
+            self.assertNotIn(deprecated, discovery_text)
+
+        tools = {tool["name"]: tool for tool in body["tools"]}
+        self.assertEqual(tools["files.read"]["meta"]["capability"], "files.read")
+        self.assertEqual(tools["calendar.search_events"]["meta"]["capability"], "calendar.read")
+        self.assertEqual(tools["calendar.create_event"]["meta"]["capability"], "calendar.manage_events")
+        self.assertEqual(tools["boards.comment"]["meta"]["capability"], "boards.update_task")
+
     def test_discovery_uses_canonical_domain_contract_vocabulary(self) -> None:
         body = self.gateway().discover_tools({key.lower(): value for key, value in HEADERS.items()})
         tools = {tool["name"]: tool for tool in body["tools"]}
@@ -145,7 +181,7 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         profile = {
             **RUNTIME_PROFILE_PROJECTION,
             "allowedTools": ["chat.list_threads", "chat.send_message", "calendar.search_events", "files.search"],
-            "capabilityGrants": ["weaver.chat_read", "weaver.chat_send", "weaver.calendar_read", "weaver.files_read"],
+            "capabilityGrants": ["chat.read", "chat.send", "calendar.read", "files.read"],
         }
         headers = {key.lower(): value for key, value in {**HEADERS, "X-Weave-Runtime-Profile-Projection": encoded_projection(profile)}.items()}
 
@@ -183,9 +219,9 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         self.assertNotIn("Hello Weaver", json.dumps(sent, sort_keys=True))
 
     def test_discovery_uses_runtime_profile_projection_not_caller_grant_headers(self) -> None:
-        profile = {**RUNTIME_PROFILE_PROJECTION, "allowedTools": ["calendar.search_events"], "capabilityGrants": ["weaver.calendar_read"]}
+        profile = {**RUNTIME_PROFILE_PROJECTION, "allowedTools": ["calendar.search_events"], "capabilityGrants": ["calendar.read"]}
         headers = {key.lower(): value for key, value in {**HEADERS, "X-Weave-Runtime-Profile-Projection": encoded_projection(profile)}.items()}
-        headers["x-weave-capabilities"] = "weaver.boards_write,weaver.admin_readiness_read"
+        headers["x-weave-capabilities"] = "boards.update_task,registry.tools.read"
 
         body = self.gateway().discover_tools(headers)
         tools = {tool["name"]: tool for tool in body["tools"]}


### PR DESCRIPTION
## Summary

Retires the deprecated `weaver.*` capability dialect from the transitional Python MCP evidence path now that the Java `weave-contract` MCP catalog is split out.

## Changes

- Replaces Python MCP tool capability requirements with Java contract vocabulary (`files.read`, `calendar.read`, `calendar.manage_events`, `boards.update_task`, etc.).
- Updates RuntimeProfile fixtures so discovery/invocation no longer treats historical `weaver.*` grants as valid MCP capability vocabulary.
- Adds regression coverage proving old `weaver.*` grants do not enable active tools and documents the deprecated Python path boundary.

## Testing

- ✅ `bash infra/weave-workspace/tests/weave-mcp-server-test.sh`
- ✅ `git diff --check`
- ⚠️ `./gradlew --no-daemon :weave-contract:test --tests "*MemberMcp*" :server:test --tests "*WeaverToolRegistryTest"` could not run locally because this host has no Java Runtime installed (`Unable to locate a Java Runtime`).

Fixes #819
