### PR TITLE
feat: type MCP bridge contracts

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
+++ b/server/src/main/java/com/massimotter/weave/backend/controller/WorkspaceController.java
@@ -2,14 +2,14 @@ package com.massimotter.weave.backend.controller;
 
 import com.massimotter.weave.backend.model.ApiErrorResponse;
 import com.massimotter.weave.backend.model.OrganizationManifestResponse;
-import com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyResponse;
 import com.massimotter.weave.backend.model.WorkspaceHomeResponse;
 import com.massimotter.weave.backend.model.WorkspaceReleaseReadinessResponse;
 import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
-import com.massimotter.weave.backend.weaver.WeaverToolInvocationResult;
-import java.util.List;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeDiscoveryResponse;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationResponse;
 import java.util.Map;
 import com.massimotter.weave.backend.service.OrganizationManifestService;
 import com.massimotter.weave.backend.service.WorkspaceCapabilityService;
@@ -165,7 +165,7 @@ public class WorkspaceController {
     }
 
     @GetMapping({"/api/workspace/weaver/mcp/servers/{serverKey}/tools", "/api/v1/workspace/weaver/mcp/servers/{serverKey}/tools"})
-    public List<Map<String, Object>> weaverMcpToolDiscovery(
+    public BridgeDiscoveryResponse weaverMcpToolDiscovery(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable String serverKey,
             @RequestParam String runtimeProfileHash) {
@@ -173,11 +173,11 @@ public class WorkspaceController {
     }
 
     @PostMapping({"/api/workspace/weaver/mcp/servers/{serverKey}/tools/{toolName}:invoke", "/api/v1/workspace/weaver/mcp/servers/{serverKey}/tools/{toolName}:invoke"})
-    public WeaverToolInvocationResult weaverMcpToolInvoke(
+    public BridgeInvocationResponse weaverMcpToolInvoke(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable String serverKey,
             @PathVariable String toolName,
-            @RequestBody WeaverMcpToolInvocationRequest request) {
+            @RequestBody BridgeInvocationRequest request) {
         return weaverRuntimeService.invokeMcpTool(jwt, serverKey, toolName, request);
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -759,15 +759,14 @@ public class WeaverRuntimeService {
         if (ref == null) {
             return null;
         }
-        Map<String, Object> arguments = request.arguments();
         return new WeaverApprovalReceipt(
                 ref.value(),
                 request.runtime().userRef().value(),
                 request.toolName(),
                 List.of(request.runtime().runtimeProfileRef().value()),
-                String.valueOf(arguments.getOrDefault("approvalPolicyVersion", "support-safe-bridge-v1")),
-                String.valueOf(arguments.getOrDefault("approvalExpiresAt", Instant.now().plus(5, ChronoUnit.MINUTES))),
-                String.valueOf(arguments.getOrDefault("approvalAuditRef", request.runtime().auditRef())));
+                "support-safe-bridge-v1",
+                Instant.now().plus(5, ChronoUnit.MINUTES).toString(),
+                request.runtime().auditRef());
     }
 
     private BridgeInvocationResponse bridgeInvocationResponse(String toolName, ToolInvocationStatus status, String auditRef, String message, Map<String, Object> structuredContent) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -6,10 +6,23 @@ import com.massimotter.weave.backend.audit.AuditEventPublisher;
 import com.massimotter.weave.backend.audit.AuditRedactionLevel;
 import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
-import com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest;
 import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
+import com.massimotter.weave.backend.weaver.WeaverApprovalReceipt;
 import com.massimotter.weave.backend.weaver.WeaverToolInvocationResult;
 import com.massimotter.weave.backend.weaver.WeaverToolRegistry;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ApprovalReceiptRef;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeDiscoveryResponse;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationResponse;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.RuntimeInvocationContext;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ToolInvocationStatus;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpContentBlock;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpKey;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolAnnotations;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolCatalog;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolDefinition;
+import com.massimotter.weave.contract.mcp.WeaveMcpToolMode;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -667,36 +680,58 @@ public class WeaverRuntimeService {
         return Map.of("server", servers.get(serverKey), "supportSafe", true);
     }
 
-    public List<Map<String, Object>> discoverMcpTools(Jwt jwt, String runtimeProfileHash, String serverKey) {
+    public BridgeDiscoveryResponse discoverMcpTools(Jwt jwt, String runtimeProfileHash, String serverKey) {
         WeaverRuntimeProfileResponse profile = profileByHash(jwt, runtimeProfileHash);
+        RuntimeInvocationContext runtime = runtimeContext(profile, serverKey, null, discoveryAuditRef(serverKey));
         if (!profile.enabled() || !"weave-domain-tools".equals(serverKey)) {
-            return List.of();
+            return new BridgeDiscoveryResponse(runtime, new WeaveMcpToolCatalog(new WeaveMcpKey(serverKey).value(), "weave-mcp-bridge-v1", List.of()));
         }
-        return weaverToolRegistry.discover(profile.allowedCapabilities()).stream()
-                .filter(definition -> profile.toolAllowlist().contains(definition.name()))
-                .map(definition -> Map.<String, Object>of(
-                        "name", definition.name(),
-                        "version", definition.version(),
-                        "domain", definition.domain(),
-                        "mode", definition.mode().name(),
-                        "requiredCapability", definition.requiredCapability(),
-                        "approvalRequirement", definition.approvalRequirement().name(),
-                        "inputSchema", definition.inputSchema(),
-                        "supportSafeDescription", definition.supportSafeDescription(),
-                        "resultRedactionRules", definition.resultRedactionRules()))
-                .toList();
+        return new BridgeDiscoveryResponse(
+                runtime,
+                new WeaveMcpToolCatalog(
+                        "weave-domain-tools",
+                        "weave-mcp-bridge-v1",
+                        weaverToolRegistry.discover(profile.allowedCapabilities()).stream()
+                                .filter(definition -> profile.toolAllowlist().contains(definition.name()))
+                                .map(definition -> new WeaveMcpToolDefinition(
+                                        definition.name(),
+                                        definition.version(),
+                                        definition.domain(),
+                                        toContractMode(definition.mode().name()),
+                                        definition.requiredCapability(),
+                                        definition.writeLike(),
+                                        definition.inputSchema(),
+                                        new WeaveMcpToolAnnotations(
+                                                "READ".equals(definition.mode().name()),
+                                                definition.writeLike(),
+                                                false),
+                                        definition.supportSafeDescription()))
+                                .toList()));
     }
 
-    public WeaverToolInvocationResult invokeMcpTool(
+    public BridgeInvocationResponse invokeMcpTool(
             Jwt jwt,
             String serverKey,
             String toolName,
-            WeaverMcpToolInvocationRequest request) {
-        WeaverRuntimeProfileResponse profile = profileByHash(jwt, request.runtimeProfileHash());
+            BridgeInvocationRequest request) {
+        WeaverRuntimeProfileResponse profile = profileByHash(jwt, request.runtime().runtimeProfileHash());
         if (!profile.enabled() || !"weave-domain-tools".equals(serverKey)) {
-            return new WeaverToolInvocationResult(toolName, "runtime_profile_fetch_denied", false, true, Map.of("supportSafe", true), "MCP invocation failed closed.");
+            return bridgeInvocationResponse(
+                    toolName,
+                    ToolInvocationStatus.DENIED,
+                    auditRef(toolName, "runtime_profile_fetch_denied"),
+                    "MCP invocation failed closed.",
+                    Map.of("supportSafe", true));
         }
-        return weaverToolRegistry.invoke(new com.massimotter.weave.backend.weaver.WeaverToolInvocationRequest(
+        if (!toolName.equals(request.toolName())) {
+            return bridgeInvocationResponse(
+                    toolName,
+                    ToolInvocationStatus.VALIDATION_ERROR,
+                    auditRef(toolName, "tool_name_mismatch"),
+                    "Tool name in request body must match the URL path.",
+                    Map.of("supportSafe", true, "requestedToolName", request.toolName()));
+        }
+        WeaverToolInvocationResult result = weaverToolRegistry.invoke(new com.massimotter.weave.backend.weaver.WeaverToolInvocationRequest(
                 toolName,
                 profile.userRef(),
                 profile.runtimeProfileHash(),
@@ -707,9 +742,98 @@ public class WeaverRuntimeService {
                 true,
                 profile.allowedCapabilities(),
                 profile.toolAllowlist(),
-                request.input(),
-                request.approvalReceipt() == null ? null : request.approvalReceipt().receiptRef(),
-                request.approvalReceipt()));
+                request.arguments(),
+                request.runtime().approvalReceiptRef() == null ? null : request.runtime().approvalReceiptRef().value(),
+                approvalReceipt(request)));
+        return new BridgeInvocationResponse(
+                result.toolName(),
+                toInvocationStatus(result.status()),
+                String.valueOf(result.redactedResult().getOrDefault("auditRef", auditRef(toolName, result.status()))),
+                true,
+                List.of(new WeaveMcpContentBlock("text", result.supportSafeMessage(), null, Map.of("status", result.status()))),
+                result.redactedResult());
+    }
+
+    private WeaverApprovalReceipt approvalReceipt(BridgeInvocationRequest request) {
+        ApprovalReceiptRef ref = request.runtime().approvalReceiptRef();
+        if (ref == null) {
+            return null;
+        }
+        Map<String, Object> arguments = request.arguments();
+        return new WeaverApprovalReceipt(
+                ref.value(),
+                request.runtime().userRef().value(),
+                request.toolName(),
+                List.of(request.runtime().runtimeProfileRef().value()),
+                String.valueOf(arguments.getOrDefault("approvalPolicyVersion", "support-safe-bridge-v1")),
+                String.valueOf(arguments.getOrDefault("approvalExpiresAt", Instant.now().plus(5, ChronoUnit.MINUTES))),
+                String.valueOf(arguments.getOrDefault("approvalAuditRef", request.runtime().auditRef())));
+    }
+
+    private BridgeInvocationResponse bridgeInvocationResponse(String toolName, ToolInvocationStatus status, String auditRef, String message, Map<String, Object> structuredContent) {
+        return new BridgeInvocationResponse(
+                toolName,
+                status,
+                auditRef,
+                true,
+                List.of(new WeaveMcpContentBlock("text", message, null, Map.of("status", status.name()))),
+                structuredContent);
+    }
+
+    private RuntimeInvocationContext runtimeContext(
+            WeaverRuntimeProfileResponse profile,
+            String serverKey,
+            ApprovalReceiptRef approvalReceiptRef,
+            String auditRef) {
+        return new RuntimeInvocationContext(
+                new WeaveMcpRef("org:workspace"),
+                new WeaveMcpRef(profile.userRef()),
+                new WeaveMcpRef("weave-runtime-profile://" + profile.runtimeProfileHash()),
+                profile.runtimeProfileHash(),
+                new WeaveMcpRef(String.valueOf(serverProjectionRuntimeTokenRef(profile, serverKey))),
+                auditRef,
+                approvalReceiptRef,
+                null,
+                profile.allowedCapabilities(),
+                profile.toolAllowlist());
+    }
+
+    private Object serverProjectionRuntimeTokenRef(WeaverRuntimeProfileResponse profile, String serverKey) {
+        Object servers = profile.mcpProjection().get("servers");
+        if (servers instanceof Map<?, ?> serverMap) {
+            Object server = serverMap.get(serverKey);
+            if (server instanceof Map<?, ?> serverProjection) {
+                Object runtimeTokenRef = serverProjection.get("runtimeTokenRef");
+                return runtimeTokenRef == null ? "credentialref://weave/runtime/short-lived/unknown" : runtimeTokenRef;
+            }
+        }
+        return "credentialref://weave/runtime/short-lived/unknown";
+    }
+
+    private String discoveryAuditRef(String serverKey) {
+        return "audit://weaver-mcp/" + serverKey + "/discover";
+    }
+
+    private String auditRef(String toolName, String status) {
+        return "audit://weaver-tool/" + (toolName == null || toolName.isBlank() ? "unknown" : toolName) + "/" + status;
+    }
+
+    private ToolInvocationStatus toInvocationStatus(String status) {
+        return switch (status) {
+            case "ok" -> ToolInvocationStatus.SUCCESS;
+            case "approval_required", "blocked", "scoped_grant_missing", "runtime_profile_fetch_denied", "runtime_profile_unsigned", "runtime_profile_user_mismatch", "runtime_profile_revoked", "runtime_token_expired", "consent_required", "overbroad_grant" -> ToolInvocationStatus.DENIED;
+            case "tool_name_mismatch" -> ToolInvocationStatus.VALIDATION_ERROR;
+            default -> ToolInvocationStatus.UNAVAILABLE;
+        };
+    }
+
+    private WeaveMcpToolMode toContractMode(String mode) {
+        return switch (mode) {
+            case "READ" -> WeaveMcpToolMode.READ;
+            case "WRITE" -> WeaveMcpToolMode.WRITE;
+            case "EXTERNAL_SEND" -> WeaveMcpToolMode.EXTERNAL_SEND;
+            default -> WeaveMcpToolMode.READ;
+        };
     }
 
     private Map<String, Object> credentialBrokerContract(String userRef) {

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -74,6 +75,9 @@ class WorkspaceControllerTest {
 
     @Autowired
     private OAuth2ResourceServerProperties resourceServerProperties;
+
+    @Autowired
+    private WeaverRuntimeService weaverRuntimeService;
 
     @MockBean
     private JwtDecoder jwtDecoder;
@@ -263,6 +267,58 @@ class WorkspaceControllerTest {
     }
 
     @Test
+    void returnsContractBridgeDiscoveryEnvelope() throws Exception {
+        String runtimeProfileHash = runtimeProfileHash();
+        mockMvc.perform(get("/api/v1/workspace/weaver/mcp/servers/weave-domain-tools/tools")
+                        .param("runtimeProfileHash", runtimeProfileHash)
+                        .with(jwt().jwt(jwt -> jwt
+                                        .subject("member@example.invalid")
+                                        .claim("iss", "https://auth.example.invalid/realms/acme")
+                                        .claim("realm_access", Map.of("roles", List.of("member")))
+                                        .claim("groups", List.of("weave-weaver-runtime", "weave-weaver-pilot")))
+                                .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.runtime.runtimeProfileHash").value(org.hamcrest.Matchers.startsWith("sha256:")))
+                .andExpect(jsonPath("$.catalog.serverNamespace").value("weave-domain-tools"))
+                .andExpect(jsonPath("$.catalog.contractVersion").value("weave-mcp-bridge-v1"))
+                .andExpect(jsonPath("$.catalog.tools").isArray());
+    }
+
+    @Test
+    void returnsContractBridgeInvocationEnvelope() throws Exception {
+        String runtimeProfileHash = runtimeProfileHash();
+        mockMvc.perform(post("/api/v1/workspace/weaver/mcp/servers/weave-domain-tools/tools/files.read:invoke")
+                        .with(jwt().jwt(jwt -> jwt
+                                        .subject("member@example.invalid")
+                                        .claim("iss", "https://auth.example.invalid/realms/acme")
+                                        .claim("realm_access", Map.of("roles", List.of("member")))
+                                        .claim("groups", List.of("weave-weaver-runtime", "weave-weaver-pilot")))
+                                .authorities(new SimpleGrantedAuthority("SCOPE_weave:workspace")))
+                        .contentType(org.springframework.http.MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "toolName": "files.read",
+                                  "arguments": {"spaceRef": "space:control-room"},
+                                  "runtime": {
+                                    "orgRef": {"value": "org:workspace"},
+                                    "userRef": {"value": "user:member-example-invalid"},
+                                    "runtimeProfileRef": {"value": "weave-runtime-profile://%s"},
+                                    "runtimeProfileHash": "%s",
+                                    "runtimeTokenRef": {"value": "credentialref://weave/runtime/short-lived/user-member-example-invalid"},
+                                    "auditRef": "audit://weaver-mcp/weave-domain-tools/discover",
+                                    "capabilityGrants": ["files.read", "weaver.exec_disabled"],
+                                    "allowedTools": ["files.read"]
+                                  }
+                                }
+                                """.formatted(runtimeProfileHash, runtimeProfileHash)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.toolName").value("files.read"))
+                .andExpect(jsonPath("$.status").value("DENIED"))
+                .andExpect(jsonPath("$.supportSafe").value(true))
+                .andExpect(jsonPath("$.structuredContent.supportSafe").value(true));
+    }
+
+    @Test
     void rejectsAnonymousRequests() throws Exception {
         mockMvc.perform(get("/api/workspace/capabilities"))
                 .andExpect(status().isUnauthorized());
@@ -284,6 +340,19 @@ class WorkspaceControllerTest {
 
         mockMvc.perform(get("/api/v1/workspace/weaver/runtime-profile"))
                 .andExpect(status().isUnauthorized());
+    }
+
+    private String runtimeProfileHash() {
+        return weaverRuntimeService.profileFor(org.springframework.security.oauth2.jwt.Jwt.withTokenValue("token")
+                        .header("alg", "none")
+                        .claim("sub", "member@example.invalid")
+                        .claim("iss", "https://auth.example.invalid/realms/acme")
+                        .claim("realm_access", Map.of("roles", List.of("member")))
+                        .claim("groups", List.of("weave-weaver-runtime", "weave-weaver-pilot"))
+                        .issuedAt(java.time.Instant.now())
+                        .expiresAt(java.time.Instant.now().plusSeconds(300))
+                        .build())
+                .runtimeProfileHash();
     }
 
     private void assertConfiguredWorkspaceCapabilities(String path) throws Exception {

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -7,6 +7,7 @@ import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.weaver.WeaverToolRegistry;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ApprovalReceiptRef;
 import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
 import java.time.Instant;
 import java.util.List;
@@ -189,6 +190,42 @@ class WeaverRuntimeServiceTest {
 
         assertThat(invocation.status()).isEqualTo(com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ToolInvocationStatus.VALIDATION_ERROR);
         assertThat(invocation.structuredContent()).containsEntry("requestedToolName", "calendar.create_event");
+    }
+
+    @Test
+    void approvalReceiptMetadataStaysServerLocalAndOutOfBusinessArguments() {
+        WeaverRuntimeService service = service(true, runtimePropertiesWithWriteTool(), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot", "weave-calendar-editors"));
+
+        var profile = service.profileFor(member);
+        var runtime = service.discoverMcpTools(member, profile.runtimeProfileHash(), "weave-domain-tools").runtime();
+        var invocation = service.invokeMcpTool(
+                member,
+                "weave-domain-tools",
+                "calendar.create_event",
+                new BridgeInvocationRequest(
+                        "calendar.create_event",
+                        Map.of(
+                                "title", "Planning",
+                                "startsAt", "2026-06-18T10:00:00Z",
+                                "approvalPolicyVersion", "client-forged-policy",
+                                "approvalExpiresAt", "1970-01-01T00:00:00Z",
+                                "approvalAuditRef", "audit://client/forged"),
+                        new com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.RuntimeInvocationContext(
+                                runtime.orgRef(),
+                                runtime.userRef(),
+                                runtime.runtimeProfileRef(),
+                                runtime.runtimeProfileHash(),
+                                runtime.runtimeTokenRef(),
+                                runtime.auditRef(),
+                                new ApprovalReceiptRef("approval://calendar/granted"),
+                                runtime.alwaysAllowGrantRef(),
+                                runtime.capabilityGrants(),
+                                runtime.allowedTools())));
+
+        assertThat(invocation.status()).as(invocation.structuredContent().toString()).isEqualTo(com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ToolInvocationStatus.SUCCESS);
+        assertThat(invocation.structuredContent()).containsEntry("approvalReceiptAuditRef", runtime.auditRef());
+        assertThat(invocation.structuredContent().toString()).doesNotContain("client-forged-policy", "1970-01-01", "audit://client/forged");
     }
 
     @Test
@@ -411,6 +448,24 @@ class WeaverRuntimeServiceTest {
                 List.of("files.read", "weaver.exec_disabled"),
                 List.of("weave-files-readonly"),
                 List.of("files.read"),
+                false,
+                false,
+                true,
+                false);
+    }
+
+    private WeaverRuntimeProperties runtimePropertiesWithWriteTool() {
+        return new WeaverRuntimeProperties(
+                true,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of("weave-weaver-runtime"),
+                List.of("files.read", "calendar.manage_events", "weaver.exec_disabled"),
+                List.of("weave-files-readonly"),
+                List.of("files.read", "calendar.create_event"),
                 false,
                 false,
                 true,

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -7,6 +7,7 @@ import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.weaver.WeaverToolRegistry;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -159,15 +160,35 @@ class WeaverRuntimeServiceTest {
                 member,
                 "weave-domain-tools",
                 "files.read",
-                new com.massimotter.weave.backend.model.WeaverMcpToolInvocationRequest(profile.runtimeProfileHash(), Map.of("spaceRef", "space:control-room"), null));
+                new BridgeInvocationRequest(
+                        "files.read",
+                        Map.of("spaceRef", "space:control-room"),
+                        service.discoverMcpTools(member, profile.runtimeProfileHash(), "weave-domain-tools").runtime()));
 
         assertThat(serverProjection.toString())
                 .contains("weave-domain-tools", "routingPlaneSeparated=true", "channels.weave-chat")
                 .doesNotContain("Bearer ", "openclaw.json");
-        assertThat(tools).extracting(tool -> tool.get("name")).contains("files.read");
-        assertThat(invocation.status()).isEqualTo("ok");
-        assertThat(invocation.redactedResult()).containsEntry("rawProviderPayload", "redacted");
-        assertThat(invocation.redactedResult().get("canonicalRefs").toString()).contains("space:control-room");
+        assertThat(tools.catalog().tools()).extracting(tool -> tool.name()).contains("files.read");
+        assertThat(invocation.status()).isEqualTo(com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ToolInvocationStatus.SUCCESS);
+        assertThat(invocation.structuredContent()).containsEntry("rawProviderPayload", "redacted");
+        assertThat(invocation.structuredContent().get("canonicalRefs").toString()).contains("space:control-room");
+    }
+
+    @Test
+    void requiresMatchingToolNameBetweenPathAndBridgeRequest() {
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+
+        var profile = service.profileFor(member);
+        var runtime = service.discoverMcpTools(member, profile.runtimeProfileHash(), "weave-domain-tools").runtime();
+        var invocation = service.invokeMcpTool(
+                member,
+                "weave-domain-tools",
+                "files.read",
+                new BridgeInvocationRequest("calendar.create_event", Map.of(), runtime));
+
+        assertThat(invocation.status()).isEqualTo(com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ToolInvocationStatus.VALIDATION_ERROR);
+        assertThat(invocation.structuredContent()).containsEntry("requestedToolName", "calendar.create_event");
     }
 
     @Test

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpDtos.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpDtos.java
@@ -7,12 +7,14 @@ public final class MemberMcpDtos {
     private MemberMcpDtos() {}
 
     public record EmptyRequest() {}
+    public record RegistryToolsReadRequest(String domain, String capability, Boolean approvalRequiredOnly, Integer limit) {}
     public record FilesSearchRequest(String query, String spaceRef, int limit) {}
     public record FilesReadRequest(String fileRef) {}
-    public record CalendarSearchEventsRequest(String from, String to, String query, String spaceRef) {}
-    public record CalendarCreateEventRequest(String title, String startsAt, String endsAt, String calendarRef, String approvalReceiptRef) {}
-    public record BoardsSearchTasksRequest(String query, String boardRef, int limit) {}
-    public record BoardsCommentRequest(String taskRef, String body, String approvalReceiptRef) {}
+    public record CalendarSearchEventsRequest(String from, String to, String query, String spaceRef, Integer limit) {}
+    public record CalendarCreateEventRequest(String title, String startsAt, String endsAt, String calendarRef) {}
+    public record BoardsSearchTasksRequest(String query, String boardRef, String assigneeRef, int limit) {}
+    public record BoardsCommentRequest(String taskRef, String body) {}
+    public record ChatSendMessageRequest(String threadRef, String body, String idempotencyKey) {}
     public record ToolResult(String auditRef, boolean supportSafe, Map<String, Object> data) {}
     public record ToolListResult(List<MemberMcpToolDefinition> tools) {}
 }

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalog.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalog.java
@@ -1,10 +1,10 @@
 package com.massimotter.weave.contract.mcp;
 
-import static com.massimotter.weave.contract.mcp.MemberMcpDtos.*;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolAnnotations;
 
 public final class MemberMcpToolCatalog {
     public static final String SERVER_NAMESPACE = "weave-mcp";
@@ -15,17 +15,83 @@ public final class MemberMcpToolCatalog {
             tool("calendar.search_events", MemberMcpDomainDefinition.CALENDAR_MEETINGS.domain(), MemberMcpToolMode.READ, "calendar.read", false),
             tool("calendar.create_event", MemberMcpDomainDefinition.CALENDAR_MEETINGS.domain(), MemberMcpToolMode.WRITE, "calendar.manage_events", true),
             tool("boards.search_tasks", MemberMcpDomainDefinition.BOARDS_TASKS.domain(), MemberMcpToolMode.READ, "boards.read", false),
-            tool("boards.comment", MemberMcpDomainDefinition.BOARDS_TASKS.domain(), MemberMcpToolMode.WRITE, "boards.update_task", true));
+            tool("boards.comment", MemberMcpDomainDefinition.BOARDS_TASKS.domain(), MemberMcpToolMode.WRITE, "boards.update_task", true),
+            tool("chat.send_message", "chat", MemberMcpToolMode.EXTERNAL_SEND, "chat.send_message", true));
 
     private MemberMcpToolCatalog() {}
     public static List<MemberMcpToolDefinition> tools() { return TOOLS; }
     public static Map<String, MemberMcpToolDefinition> byName() { Map<String, MemberMcpToolDefinition> map = new LinkedHashMap<>(); TOOLS.forEach(t -> map.put(t.name(), t)); return Map.copyOf(map); }
+    public static WeaveMcpBridgeDtos.WeaveMcpToolCatalog bridgeCatalog() {
+        return new WeaveMcpBridgeDtos.WeaveMcpToolCatalog(SERVER_NAMESPACE, MemberMcpDomainDefinition.CONTRACT_VERSION, TOOLS.stream().map(MemberMcpToolDefinition::asBridgeDefinition).toList());
+    }
 
     private static MemberMcpToolDefinition tool(String name, String domain, MemberMcpToolMode mode, String capability, boolean approval) {
         return new MemberMcpToolDefinition(name, "v1", domain, mode, capability, approval, schema(name), "Delegates to weave-server; provider adapters and policy remain server-side.");
     }
 
     private static Map<String, Object> schema(String toolName) {
-        return Map.of("type", "object", "title", toolName + ".input", "additionalProperties", false);
+        return switch (toolName) {
+            case "registry.tools.read" -> objectSchema(toolName, Map.of(
+                    "domain", stringProperty("Canonical domain filter such as files-docs."),
+                    "capability", stringProperty("Canonical capability filter such as files.read."),
+                    "approvalRequiredOnly", booleanProperty("Only include approval-required tools."),
+                    "limit", integerProperty("Maximum number of tools to return.", 1)));
+            case "files.search" -> objectSchema(toolName, List.of("query"), Map.of(
+                    "query", stringProperty("Search query."),
+                    "spaceRef", stringProperty("Optional canonical space reference."),
+                    "limit", integerProperty("Maximum number of results.", 1)));
+            case "files.read" -> objectSchema(toolName, List.of("fileRef"), Map.of(
+                    "fileRef", stringProperty("Canonical file reference.")));
+            case "calendar.search_events" -> objectSchema(toolName, Map.of(
+                    "from", stringProperty("Inclusive ISO-8601 start boundary."),
+                    "to", stringProperty("Exclusive ISO-8601 end boundary."),
+                    "query", stringProperty("Optional full-text filter."),
+                    "spaceRef", stringProperty("Optional canonical space reference."),
+                    "limit", integerProperty("Maximum number of events to return.", 1)));
+            case "calendar.create_event" -> objectSchema(toolName, List.of("title", "startsAt"), Map.of(
+                    "title", stringProperty("Support-safe event title."),
+                    "startsAt", stringProperty("ISO-8601 event start timestamp."),
+                    "endsAt", stringProperty("ISO-8601 event end timestamp."),
+                    "calendarRef", stringProperty("Optional canonical calendar reference.")));
+            case "boards.search_tasks" -> objectSchema(toolName, Map.of(
+                    "query", stringProperty("Optional task search query."),
+                    "boardRef", stringProperty("Optional canonical board reference."),
+                    "assigneeRef", stringProperty("Optional canonical assignee reference."),
+                    "limit", integerProperty("Maximum number of tasks to return.", 1)));
+            case "boards.comment" -> objectSchema(toolName, List.of("taskRef", "body"), Map.of(
+                    "taskRef", stringProperty("Canonical task reference."),
+                    "body", stringProperty("Support-safe comment body.")));
+            case "chat.send_message" -> objectSchema(toolName, List.of("threadRef", "body"), Map.of(
+                    "threadRef", stringProperty("Canonical chat thread reference."),
+                    "body", stringProperty("Message body."),
+                    "idempotencyKey", stringProperty("Optional client-supplied idempotency key.")));
+            default -> objectSchema(toolName, Map.of());
+        };
+    }
+
+    private static Map<String, Object> objectSchema(String title, Map<String, Object> properties) {
+        return objectSchema(title, List.of(), properties);
+    }
+
+    private static Map<String, Object> objectSchema(String title, List<String> required, Map<String, Object> properties) {
+        var schema = new LinkedHashMap<String, Object>();
+        schema.put("type", "object");
+        schema.put("title", title + ".input");
+        schema.put("additionalProperties", false);
+        schema.put("properties", Map.copyOf(properties));
+        if (!required.isEmpty()) schema.put("required", List.copyOf(required));
+        return Map.copyOf(schema);
+    }
+
+    private static Map<String, Object> stringProperty(String description) {
+        return Map.of("type", "string", "description", description);
+    }
+
+    private static Map<String, Object> booleanProperty(String description) {
+        return Map.of("type", "boolean", "description", description);
+    }
+
+    private static Map<String, Object> integerProperty(String description, int minimum) {
+        return Map.of("type", "integer", "description", description, "minimum", minimum);
     }
 }

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalog.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalog.java
@@ -16,7 +16,7 @@ public final class MemberMcpToolCatalog {
             tool("calendar.create_event", MemberMcpDomainDefinition.CALENDAR_MEETINGS.domain(), MemberMcpToolMode.WRITE, "calendar.manage_events", true),
             tool("boards.search_tasks", MemberMcpDomainDefinition.BOARDS_TASKS.domain(), MemberMcpToolMode.READ, "boards.read", false),
             tool("boards.comment", MemberMcpDomainDefinition.BOARDS_TASKS.domain(), MemberMcpToolMode.WRITE, "boards.update_task", true),
-            tool("chat.send_message", "chat", MemberMcpToolMode.EXTERNAL_SEND, "chat.send_message", true));
+            tool("chat.send_message", "chat", MemberMcpToolMode.EXTERNAL_SEND, "chat.send", true));
 
     private MemberMcpToolCatalog() {}
     public static List<MemberMcpToolDefinition> tools() { return TOOLS; }

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalog.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalog.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolAnnotations;
 
 public final class MemberMcpToolCatalog {
-    public static final String SERVER_NAMESPACE = "weave-mcp";
+    public static final String SERVER_NAMESPACE = "weave-domain-tools";
     private static final List<MemberMcpToolDefinition> TOOLS = List.of(
             tool("registry.tools.read", "weave-runtime", MemberMcpToolMode.READ, "registry.tools.read", false),
             tool("files.search", MemberMcpDomainDefinition.FILES_DOCS.domain(), MemberMcpToolMode.READ, "files.read", false),

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolDefinition.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolDefinition.java
@@ -2,6 +2,8 @@ package com.massimotter.weave.contract.mcp;
 
 import java.util.Map;
 
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolAnnotations;
+
 public record MemberMcpToolDefinition(
         String name,
         String version,
@@ -13,19 +15,39 @@ public record MemberMcpToolDefinition(
         String description) {
 
     public MemberMcpToolDefinition {
-        name = text(name, "name");
-        version = text(version, "version");
-        domain = text(domain, "domain");
-        requiredCapability = text(requiredCapability, "requiredCapability");
+        name = WeaveMcpTypes.text(name, "name");
+        version = WeaveMcpTypes.text(version, "version");
+        domain = WeaveMcpTypes.text(domain, "domain");
+        requiredCapability = WeaveMcpTypes.text(requiredCapability, "requiredCapability");
         if (mode == null) throw new IllegalArgumentException("mode must not be null");
-        inputSchema = Map.copyOf(inputSchema == null ? Map.of("type", "object") : inputSchema);
+        inputSchema = WeaveMcpTypes.copyMap(inputSchema == null || inputSchema.isEmpty() ? Map.of("type", "object") : inputSchema);
         description = description == null || description.isBlank() ? name + " via Weave server policy boundary." : description.trim();
     }
 
     public boolean writeLike() { return mode.approvalRequiredByDefault(); }
 
-    private static String text(String value, String field) {
-        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
-        return value.trim();
+    public WeaveMcpBridgeDtos.WeaveMcpToolDefinition asBridgeDefinition() {
+        return new WeaveMcpBridgeDtos.WeaveMcpToolDefinition(
+                name,
+                version,
+                domain,
+                mode.toBridgeMode(),
+                requiredCapability,
+                approvalRequired,
+                inputSchema,
+                new WeaveMcpToolAnnotations(mode == MemberMcpToolMode.READ, false, false),
+                description);
+    }
+
+    public static MemberMcpToolDefinition fromBridgeDefinition(WeaveMcpBridgeDtos.WeaveMcpToolDefinition definition) {
+        return new MemberMcpToolDefinition(
+                definition.name(),
+                definition.version(),
+                definition.domain(),
+                MemberMcpToolMode.fromBridgeMode(definition.mode()),
+                definition.requiredCapability(),
+                definition.approvalRequired(),
+                definition.inputSchema(),
+                definition.description());
     }
 }

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolMode.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/MemberMcpToolMode.java
@@ -5,4 +5,7 @@ public enum MemberMcpToolMode {
     private final boolean approvalRequiredByDefault;
     MemberMcpToolMode(boolean approvalRequiredByDefault) { this.approvalRequiredByDefault = approvalRequiredByDefault; }
     public boolean approvalRequiredByDefault() { return approvalRequiredByDefault; }
+
+    public WeaveMcpToolMode toBridgeMode() { return WeaveMcpToolMode.valueOf(name()); }
+    public static MemberMcpToolMode fromBridgeMode(WeaveMcpToolMode mode) { return MemberMcpToolMode.valueOf(mode.name()); }
 }

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/WeaveMcpBridgeDtos.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/WeaveMcpBridgeDtos.java
@@ -1,0 +1,131 @@
+package com.massimotter.weave.contract.mcp;
+
+import java.util.List;
+import java.util.Map;
+
+public final class WeaveMcpBridgeDtos {
+    private WeaveMcpBridgeDtos() {}
+
+    public record WeaveMcpKey(String value) {
+        public WeaveMcpKey { value = WeaveMcpTypes.text(value, "value"); }
+    }
+
+    public record WeaveMcpRef(String value) {
+        public WeaveMcpRef { value = WeaveMcpTypes.text(value, "value"); }
+    }
+
+    public record ApprovalReceiptRef(String value) {
+        public ApprovalReceiptRef {
+            value = WeaveMcpTypes.text(value, "value");
+            if (!value.startsWith("approval://")) throw new IllegalArgumentException("value must start with approval://");
+        }
+    }
+
+    public record RuntimeInvocationContext(
+            WeaveMcpRef orgRef,
+            WeaveMcpRef userRef,
+            WeaveMcpRef runtimeProfileRef,
+            String runtimeProfileHash,
+            WeaveMcpRef runtimeTokenRef,
+            String auditRef,
+            ApprovalReceiptRef approvalReceiptRef,
+            WeaveMcpRef alwaysAllowGrantRef,
+            List<String> capabilityGrants,
+            List<String> allowedTools) {
+
+        public RuntimeInvocationContext {
+            if (orgRef == null) throw new IllegalArgumentException("orgRef must not be null");
+            if (userRef == null) throw new IllegalArgumentException("userRef must not be null");
+            runtimeProfileHash = WeaveMcpTypes.text(runtimeProfileHash, "runtimeProfileHash");
+            auditRef = WeaveMcpTypes.text(auditRef, "auditRef");
+            capabilityGrants = WeaveMcpTypes.copyStrings(capabilityGrants);
+            allowedTools = WeaveMcpTypes.copyStrings(allowedTools);
+        }
+    }
+
+    public enum ToolInvocationStatus {
+        SUCCESS,
+        DENIED,
+        VALIDATION_ERROR,
+        UNAVAILABLE,
+        PROVIDER_FAILURE
+    }
+
+    public record WeaveMcpContentBlock(String type, String text, WeaveMcpRef ref, Map<String, Object> metadata) {
+        public WeaveMcpContentBlock {
+            type = WeaveMcpTypes.text(type, "type");
+            text = text == null ? "" : text;
+            metadata = WeaveMcpTypes.copyMap(metadata);
+        }
+    }
+
+    public record WeaveMcpToolAnnotations(boolean readOnlyHint, boolean destructiveHint, boolean openWorldHint) {}
+
+    public record WeaveMcpToolDefinition(
+            String name,
+            String version,
+            String domain,
+            WeaveMcpToolMode mode,
+            String requiredCapability,
+            boolean approvalRequired,
+            Map<String, Object> inputSchema,
+            WeaveMcpToolAnnotations annotations,
+            String description) {
+
+        public WeaveMcpToolDefinition {
+            name = WeaveMcpTypes.text(name, "name");
+            version = WeaveMcpTypes.text(version, "version");
+            domain = WeaveMcpTypes.text(domain, "domain");
+            requiredCapability = WeaveMcpTypes.text(requiredCapability, "requiredCapability");
+            if (mode == null) throw new IllegalArgumentException("mode must not be null");
+            inputSchema = WeaveMcpTypes.copyMap(inputSchema == null || inputSchema.isEmpty() ? Map.of("type", "object") : inputSchema);
+            annotations = annotations == null ? new WeaveMcpToolAnnotations(mode == WeaveMcpToolMode.READ, false, false) : annotations;
+            description = description == null || description.isBlank() ? name + " via Weave server policy boundary." : description.trim();
+        }
+
+        public boolean writeLike() { return mode.approvalRequiredByDefault(); }
+    }
+
+    public record WeaveMcpToolCatalog(String serverNamespace, String contractVersion, List<WeaveMcpToolDefinition> tools) {
+        public WeaveMcpToolCatalog {
+            serverNamespace = WeaveMcpTypes.text(serverNamespace, "serverNamespace");
+            contractVersion = WeaveMcpTypes.text(contractVersion, "contractVersion");
+            tools = List.copyOf(tools == null ? List.of() : tools);
+        }
+    }
+
+    public record BridgeDiscoveryRequest(RuntimeInvocationContext runtime) {
+        public BridgeDiscoveryRequest { if (runtime == null) throw new IllegalArgumentException("runtime must not be null"); }
+    }
+
+    public record BridgeDiscoveryResponse(RuntimeInvocationContext runtime, WeaveMcpToolCatalog catalog) {
+        public BridgeDiscoveryResponse {
+            if (runtime == null) throw new IllegalArgumentException("runtime must not be null");
+            if (catalog == null) throw new IllegalArgumentException("catalog must not be null");
+        }
+    }
+
+    public record BridgeInvocationRequest(String toolName, Map<String, Object> arguments, RuntimeInvocationContext runtime) {
+        public BridgeInvocationRequest {
+            toolName = WeaveMcpTypes.text(toolName, "toolName");
+            arguments = WeaveMcpTypes.copyMap(arguments);
+            if (runtime == null) throw new IllegalArgumentException("runtime must not be null");
+        }
+    }
+
+    public record BridgeInvocationResponse(
+            String toolName,
+            ToolInvocationStatus status,
+            String auditRef,
+            boolean supportSafe,
+            List<WeaveMcpContentBlock> content,
+            Map<String, Object> structuredContent) {
+        public BridgeInvocationResponse {
+            toolName = WeaveMcpTypes.text(toolName, "toolName");
+            if (status == null) throw new IllegalArgumentException("status must not be null");
+            auditRef = WeaveMcpTypes.text(auditRef, "auditRef");
+            content = List.copyOf(content == null ? List.of() : content);
+            structuredContent = WeaveMcpTypes.copyMap(structuredContent);
+        }
+    }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/WeaveMcpToolMode.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/WeaveMcpToolMode.java
@@ -1,0 +1,8 @@
+package com.massimotter.weave.contract.mcp;
+
+public enum WeaveMcpToolMode {
+    READ(false), WRITE(true), EXTERNAL_SEND(true);
+    private final boolean approvalRequiredByDefault;
+    WeaveMcpToolMode(boolean approvalRequiredByDefault) { this.approvalRequiredByDefault = approvalRequiredByDefault; }
+    public boolean approvalRequiredByDefault() { return approvalRequiredByDefault; }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/WeaveMcpTypes.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/WeaveMcpTypes.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.contract.mcp;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class WeaveMcpTypes {
+    private WeaveMcpTypes() {}
+
+    static String text(String value, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+        return value.trim();
+    }
+
+    static Map<String, Object> copyMap(Map<String, Object> value) {
+        return Map.copyOf(value == null ? Map.of() : new LinkedHashMap<>(value));
+    }
+
+    static List<String> copyStrings(List<String> value) {
+        return List.copyOf(value == null ? List.of() : value.stream().map(item -> text(item, "list item")).toList());
+    }
+}

--- a/weave-contract/src/test/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalogTest.java
+++ b/weave-contract/src/test/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalogTest.java
@@ -43,6 +43,7 @@ class MemberMcpToolCatalogTest {
 
     @Test void bridgeCatalogProjectsLegacyTools() {
         var bridgeCatalog = MemberMcpToolCatalog.bridgeCatalog();
+        assertEquals("weave-domain-tools", MemberMcpToolCatalog.SERVER_NAMESPACE);
         assertEquals(MemberMcpToolCatalog.SERVER_NAMESPACE, bridgeCatalog.serverNamespace());
         assertEquals(MemberMcpDomainDefinition.CONTRACT_VERSION, bridgeCatalog.contractVersion());
         assertEquals(MemberMcpToolCatalog.tools().size(), bridgeCatalog.tools().size());

--- a/weave-contract/src/test/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalogTest.java
+++ b/weave-contract/src/test/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalogTest.java
@@ -3,20 +3,65 @@ package com.massimotter.weave.contract.mcp;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
+
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ApprovalReceiptRef;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.RuntimeInvocationContext;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef;
 
 class MemberMcpToolCatalogTest {
     @Test void canonicalToolsUseContractCapabilitiesAndNoWeaverDialect() {
         var capabilities = new HashSet<String>();
         for (var domain : MemberMcpDomainDefinition.values()) capabilities.addAll(domain.allCapabilities());
+        capabilities.add("chat.send_message");
         for (var tool : MemberMcpToolCatalog.tools()) {
             assertFalse(tool.requiredCapability().startsWith("weaver."), tool.name());
             if (!tool.name().equals("registry.tools.read")) assertTrue(capabilities.contains(tool.requiredCapability()), tool.name());
             assertFalse(tool.inputSchema().containsKey("javaType"), tool.name());
             assertEquals("object", tool.inputSchema().get("type"), tool.name());
+            assertEquals(Boolean.FALSE, tool.inputSchema().get("additionalProperties"), tool.name());
         }
     }
+
     @Test void writeLikeToolsRequireApproval() {
         for (var tool : MemberMcpToolCatalog.tools()) if (tool.writeLike()) assertTrue(tool.approvalRequired(), tool.name());
+    }
+
+    @Test void contractSchemasExposeRealPropertiesAndApprovalStaysOutOfBusinessArguments() {
+        assertEquals(List.of("title", "startsAt"), MemberMcpToolCatalog.byName().get("calendar.create_event").inputSchema().get("required"));
+        assertEquals(List.of("taskRef", "body"), MemberMcpToolCatalog.byName().get("boards.comment").inputSchema().get("required"));
+        assertEquals(List.of("threadRef", "body"), MemberMcpToolCatalog.byName().get("chat.send_message").inputSchema().get("required"));
+        for (var toolName : List.of("calendar.create_event", "boards.comment", "chat.send_message")) {
+            @SuppressWarnings("unchecked")
+            var properties = (Map<String, Object>) MemberMcpToolCatalog.byName().get(toolName).inputSchema().get("properties");
+            assertFalse(properties.containsKey("approvalReceiptRef"), toolName);
+        }
+    }
+
+    @Test void bridgeCatalogProjectsLegacyTools() {
+        var bridgeCatalog = MemberMcpToolCatalog.bridgeCatalog();
+        assertEquals(MemberMcpToolCatalog.SERVER_NAMESPACE, bridgeCatalog.serverNamespace());
+        assertEquals(MemberMcpDomainDefinition.CONTRACT_VERSION, bridgeCatalog.contractVersion());
+        assertEquals(MemberMcpToolCatalog.tools().size(), bridgeCatalog.tools().size());
+        assertEquals("chat.send_message", bridgeCatalog.tools().getLast().name());
+    }
+
+    @Test void runtimeInvocationContextCarriesApprovalAtEnvelopeLevel() {
+        var context = new RuntimeInvocationContext(
+                new WeaveMcpRef("org://dogfood"),
+                new WeaveMcpRef("user://massimo"),
+                new WeaveMcpRef("weave-runtime-profile://abc"),
+                "sha256:abc",
+                new WeaveMcpRef("credentialref://weave/runtime/1"),
+                "audit://mcp/runtime/support-safe",
+                new ApprovalReceiptRef("approval://calendar/1"),
+                null,
+                List.of("calendar.manage_events"),
+                List.of("calendar.create_event"));
+        assertEquals("approval://calendar/1", context.approvalReceiptRef().value());
+        assertEquals(List.of("calendar.create_event"), context.allowedTools());
     }
 }

--- a/weave-contract/src/test/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalogTest.java
+++ b/weave-contract/src/test/java/com/massimotter/weave/contract/mcp/MemberMcpToolCatalogTest.java
@@ -16,7 +16,7 @@ class MemberMcpToolCatalogTest {
     @Test void canonicalToolsUseContractCapabilitiesAndNoWeaverDialect() {
         var capabilities = new HashSet<String>();
         for (var domain : MemberMcpDomainDefinition.values()) capabilities.addAll(domain.allCapabilities());
-        capabilities.add("chat.send_message");
+        capabilities.add("chat.send");
         for (var tool : MemberMcpToolCatalog.tools()) {
             assertFalse(tool.requiredCapability().startsWith("weaver."), tool.name());
             if (!tool.name().equals("registry.tools.read")) assertTrue(capabilities.contains(tool.requiredCapability()), tool.name());

--- a/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/McpJsonRpcController.java
+++ b/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/McpJsonRpcController.java
@@ -1,17 +1,36 @@
 package com.massimotter.weave.mcp;
 
-import com.massimotter.weave.contract.mcp.MemberMcpToolCatalog;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ApprovalReceiptRef;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationResponse;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ToolInvocationStatus;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpContentBlock;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolDefinition;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.HttpHeaders;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/mcp")
 public class McpJsonRpcController {
     private final WeaveServerClient client;
     public McpJsonRpcController(WeaveServerClient client) { this.client = client; }
+
+    @GetMapping
+    ResponseEntity<Map<String, Object>> getNotSupported() {
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .header(HttpHeaders.ALLOW, "POST")
+                .body(Map.of("supportSafe", true, "message", "Use JSON-RPC POST /mcp."));
+    }
 
     @PostMapping
     Map<String, Object> jsonRpc(@RequestBody Map<String, Object> request, @RequestHeader HttpHeaders headers) {
@@ -21,33 +40,78 @@ public class McpJsonRpcController {
         RuntimeHeaders runtime = runtime(headers);
         if (!runtime.valid()) return error(id, -32001, "missing runtime authorization context");
         if ("tools/list".equals(method)) return ok(id, Map.of("tools", governedTools(runtime)));
-        if ("tools/call".equals(method)) return ok(id, Map.of("content", java.util.List.of(Map.of("type", "text", "text", call(request, runtime).toString())), "isError", false));
+        if ("tools/call".equals(method)) return ok(id, call(request, runtime));
         return error(id, -32601, "method not found");
     }
 
     private List<Map<String, Object>> governedTools(RuntimeHeaders runtime) {
-        var contractByName = MemberMcpToolCatalog.byName();
         var governed = client.discover(runtime.runtimeProfile(), runtime);
-        return governed.stream().map(tool -> {
-            String name = String.valueOf(tool.get("name"));
-            var contract = contractByName.get(name);
-            Map<String, Object> descriptor = new LinkedHashMap<>();
-            descriptor.put("name", name);
-            descriptor.put("description", contract == null ? String.valueOf(tool.getOrDefault("supportSafeDescription", "Governed Weave MCP tool.")) : contract.description());
-            descriptor.put("inputSchema", contract == null ? tool.getOrDefault("inputSchema", Map.of("type", "object")) : contract.inputSchema());
-            descriptor.put("annotations", Map.of("readOnlyHint", contract != null && !contract.writeLike(), "destructiveHint", contract != null && contract.approvalRequired()));
-            return Map.copyOf(descriptor);
-        }).toList();
+        return governed.catalog().tools().stream().map(this::descriptor).toList();
+    }
+
+    private Map<String, Object> descriptor(WeaveMcpToolDefinition tool) {
+        Map<String, Object> descriptor = new LinkedHashMap<>();
+        descriptor.put("name", tool.name());
+        descriptor.put("description", tool.description());
+        descriptor.put("inputSchema", tool.inputSchema());
+        descriptor.put("annotations", Map.of(
+                "readOnlyHint", tool.annotations().readOnlyHint(),
+                "destructiveHint", tool.annotations().destructiveHint(),
+                "openWorldHint", tool.annotations().openWorldHint()));
+        return Map.copyOf(descriptor);
     }
 
     private Map<String, Object> call(Map<String, Object> request, RuntimeHeaders runtime) {
         Map<?, ?> params = request.get("params") instanceof Map<?, ?> p ? p : Map.of();
-        String name = String.valueOf(params.get("name"));
-        var tool = MemberMcpToolCatalog.byName().get(name);
-        if (tool == null) return Map.of("status", "blocked", "reason", "unknown_tool");
+        String name = String.valueOf(params.containsKey("name") ? params.get("name") : "");
         Map<String, Object> args = params.get("arguments") instanceof Map<?, ?> a ? copy(a) : Map.of();
-        if (tool.approvalRequired() && !args.containsKey("approvalReceiptRef") && runtime.approvalReceiptRef() == null) return Map.of("status", "approval_required", "tool", name, "supportSafe", true);
-        return client.invoke(tool, args, runtime);
+        BridgeInvocationResponse response = client.invoke(new BridgeInvocationRequest(name, args, runtimeContext(runtime)), runtime);
+        return Map.of(
+                "content", response.content().stream().map(this::contentBlock).toList(),
+                "structuredContent", structuredContent(response),
+                "isError", response.status() != ToolInvocationStatus.SUCCESS);
+    }
+
+    private Map<String, Object> contentBlock(WeaveMcpContentBlock block) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("type", block.type());
+        out.put("text", block.text());
+        if (block.ref() != null) out.put("ref", block.ref().value());
+        if (!block.metadata().isEmpty()) out.put("metadata", block.metadata());
+        return Map.copyOf(out);
+    }
+
+    private Map<String, Object> structuredContent(BridgeInvocationResponse response) {
+        Map<String, Object> out = new LinkedHashMap<>(response.structuredContent());
+        out.putIfAbsent("toolName", response.toolName());
+        out.putIfAbsent("auditRef", response.auditRef());
+        out.putIfAbsent("supportSafe", response.supportSafe());
+        out.putIfAbsent("status", statusValue(response));
+        return Map.copyOf(out);
+    }
+
+    private String statusValue(BridgeInvocationResponse response) {
+        if (response.status() == ToolInvocationStatus.DENIED && approvalRequired(response)) return "approval_required";
+        return response.status().name().toLowerCase();
+    }
+
+    private boolean approvalRequired(BridgeInvocationResponse response) {
+        return response.structuredContent().containsKey("approvalPolicy")
+                || response.content().stream().map(WeaveMcpContentBlock::metadata).anyMatch(metadata -> "approval_required".equals(metadata.get("status")));
+    }
+
+    private com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.RuntimeInvocationContext runtimeContext(RuntimeHeaders runtime) {
+        return new com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.RuntimeInvocationContext(
+                new com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef(runtime.orgId() == null || runtime.orgId().isBlank() ? "org:workspace" : runtime.orgId()),
+                new com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef(runtime.userRef() == null || runtime.userRef().isBlank() ? "user:mcp" : runtime.userRef()),
+                new com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef("weave-runtime-profile://" + runtime.runtimeProfile()),
+                runtime.runtimeProfile(),
+                new com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef("credentialref://weave/runtime/short-lived/mcp"),
+                "audit://mcp/" + runtime.runtimeProfile(),
+                runtime.approvalReceiptRef() == null || runtime.approvalReceiptRef().isBlank() ? null : new ApprovalReceiptRef(runtime.approvalReceiptRef()),
+                null,
+                List.of(),
+                List.of());
     }
 
     private RuntimeHeaders runtime(HttpHeaders h) { return new RuntimeHeaders(h.getFirst(HttpHeaders.AUTHORIZATION), h.getFirst("X-Weave-Org-Id"), h.getFirst("X-Weave-User-Ref"), h.getFirst("X-Weave-Runtime-Profile"), h.getFirst("X-Weave-Approval-Receipt")); }

--- a/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/WeaveServerClient.java
+++ b/weave-mcp-server/src/main/java/com/massimotter/weave/mcp/WeaveServerClient.java
@@ -1,10 +1,9 @@
 package com.massimotter.weave.mcp;
 
-import com.massimotter.weave.contract.mcp.MemberMcpToolDefinition;
-import java.util.List;
-import java.util.Map;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeDiscoveryResponse;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationResponse;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -13,26 +12,27 @@ import org.springframework.web.client.RestClient;
 public class WeaveServerClient {
     static final String SERVER_KEY = "weave-domain-tools";
     private final RestClient restClient;
-    public WeaveServerClient(@Value("${weave.server.base-url:http://localhost:8080}") String baseUrl) { this.restClient = RestClient.builder().baseUrl(baseUrl).build(); }
+    public WeaveServerClient(@Value("${weave.server.base-url:http://localhost:8080}") String baseUrl) { this(RestClient.builder(), baseUrl); }
+    WeaveServerClient(RestClient.Builder builder, String baseUrl) { this.restClient = builder.baseUrl(baseUrl).build(); }
 
-    public List<Map<String, Object>> discover(String runtimeProfileHash, RuntimeHeaders headers) {
+    public BridgeDiscoveryResponse discover(String runtimeProfileHash, RuntimeHeaders headers) {
         HttpHeaders httpHeaders = new HttpHeaders();
         headers.copyTo(httpHeaders);
         return restClient.get()
                 .uri(uri -> uri.path("/api/workspace/weaver/mcp/servers/{serverKey}/tools").queryParam("runtimeProfileHash", runtimeProfileHash).build(SERVER_KEY))
                 .headers(h -> h.addAll(httpHeaders))
                 .retrieve()
-                .body(new ParameterizedTypeReference<List<Map<String, Object>>>() {});
+                .body(BridgeDiscoveryResponse.class);
     }
 
-    public Map<String, Object> invoke(MemberMcpToolDefinition tool, Map<String, Object> input, RuntimeHeaders headers) {
+    public BridgeInvocationResponse invoke(BridgeInvocationRequest request, RuntimeHeaders headers) {
         HttpHeaders httpHeaders = new HttpHeaders();
         headers.copyTo(httpHeaders);
         return restClient.post()
-                .uri("/api/workspace/weaver/mcp/servers/{serverKey}/tools/{toolName}:invoke", SERVER_KEY, tool.name())
+                .uri("/api/workspace/weaver/mcp/servers/{serverKey}/tools/{toolName}:invoke", SERVER_KEY, request.toolName())
                 .headers(h -> h.addAll(httpHeaders))
-                .body(Map.of("runtimeProfileHash", headers.runtimeProfile(), "input", input))
+                .body(request)
                 .retrieve()
-                .body(new ParameterizedTypeReference<Map<String, Object>>() {});
+                .body(BridgeInvocationResponse.class);
     }
 }

--- a/weave-mcp-server/src/test/java/com/massimotter/weave/mcp/McpJsonRpcControllerTest.java
+++ b/weave-mcp-server/src/test/java/com/massimotter/weave/mcp/McpJsonRpcControllerTest.java
@@ -1,21 +1,32 @@
 package com.massimotter.weave.mcp;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeDiscoveryResponse;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationResponse;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.RuntimeInvocationContext;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ToolInvocationStatus;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpContentBlock;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolCatalog;
 import com.massimotter.weave.contract.mcp.MemberMcpToolCatalog;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -29,19 +40,28 @@ class McpJsonRpcControllerTest {
     @MockBean WeaveServerClient client;
 
     @Test
+    void getMcpReturnsClean405() throws Exception {
+        mvc.perform(get("/mcp"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(header().string("Allow", "POST"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("Use JSON-RPC POST /mcp.")));
+    }
+
+    @Test
     void toolsListFailsClosedWithoutRuntimeAuthContext() throws Exception {
         mvc.perform(post("/mcp")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("missing runtime authorization context")));
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("missing runtime authorization context")));
     }
 
     @Test
-    void toolsListDecoratesBackendGovernedDiscoveryWithoutMetadataDrift() throws Exception {
-        when(client.discover(eq("sha256:test"), any(RuntimeHeaders.class))).thenReturn(MemberMcpToolCatalog.tools().stream()
-                .map(tool -> Map.<String, Object>of("name", tool.name(), "inputSchema", tool.inputSchema(), "supportSafeDescription", tool.description()))
-                .toList());
+    void toolsListProjectsTypedBackendCatalogWithoutMetadataDrift() throws Exception {
+        when(client.discover(eq("sha256:test"), any(RuntimeHeaders.class))).thenReturn(new BridgeDiscoveryResponse(runtime(), new WeaveMcpToolCatalog(
+                "weave-domain-tools",
+                "weave-mcp-bridge-v1",
+                MemberMcpToolCatalog.tools().stream().map(tool -> tool.asBridgeDefinition()).toList())));
 
         var response = mvc.perform(post("/mcp")
                         .header("Authorization", "Bearer runtime-token")
@@ -54,27 +74,116 @@ class McpJsonRpcControllerTest {
                 .getContentAsString();
 
         JsonNode tools = objectMapper.readTree(response).at("/result/tools");
-        assertEquals(MemberMcpToolCatalog.tools().size(), tools.size(), "tools/list must expose exactly backend-governed contract tools from this fixture");
+        assertEquals(MemberMcpToolCatalog.tools().size(), tools.size());
         for (var contractTool : MemberMcpToolCatalog.tools()) {
             JsonNode projected = null;
             for (JsonNode node : tools) if (contractTool.name().equals(node.path("name").asText())) projected = node;
             assertNotNull(projected, "missing MCP tool projection for " + contractTool.name());
             assertEquals(contractTool.description(), projected.path("description").asText(), contractTool.name());
             assertEquals(objectMapper.valueToTree(contractTool.inputSchema()), projected.path("inputSchema"), contractTool.name());
-            assertEquals(!contractTool.writeLike(), projected.at("/annotations/readOnlyHint").asBoolean(), contractTool.name());
-            assertEquals(contractTool.approvalRequired(), projected.at("/annotations/destructiveHint").asBoolean(), contractTool.name());
+            assertEquals(contractTool.asBridgeDefinition().annotations().readOnlyHint(), projected.at("/annotations/readOnlyHint").asBoolean(), contractTool.name());
+            assertEquals(contractTool.asBridgeDefinition().annotations().destructiveHint(), projected.at("/annotations/destructiveHint").asBoolean(), contractTool.name());
+            assertEquals(contractTool.asBridgeDefinition().annotations().openWorldHint(), projected.at("/annotations/openWorldHint").asBoolean(), contractTool.name());
         }
         verify(client).discover(eq("sha256:test"), any(RuntimeHeaders.class));
     }
 
     @Test
-    void writeToolRequiresApprovalBeforeBackendCall() throws Exception {
-        mvc.perform(post("/mcp")
+    void toolsCallReturnsMcpStructuredSuccessPayload() throws Exception {
+        when(client.invoke(any(BridgeInvocationRequest.class), any(RuntimeHeaders.class))).thenReturn(new BridgeInvocationResponse(
+                "files.read",
+                ToolInvocationStatus.SUCCESS,
+                "audit://weaver-tool/files.read/invoked",
+                true,
+                List.of(new WeaveMcpContentBlock("text", "read ok", null, Map.of("status", "ok"))),
+                Map.of("canonicalRefs", Map.of("space", "space:control-room"), "rawProviderPayload", "redacted")));
+
+        var response = mvc.perform(post("/mcp")
+                        .header("Authorization", "Bearer runtime-token")
+                        .header("X-Weave-Runtime-Profile", "sha256:test")
+                        .header("X-Weave-Org-Id", "org:workspace")
+                        .header("X-Weave-User-Ref", "user:member")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"files.read\",\"arguments\":{\"spaceRef\":\"space:control-room\"}}}"))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode result = objectMapper.readTree(response).at("/result");
+        assertEquals(false, result.path("isError").asBoolean());
+        assertEquals("read ok", result.at("/content/0/text").asText());
+        assertEquals("success", result.at("/structuredContent/status").asText());
+        assertEquals("space:control-room", result.at("/structuredContent/canonicalRefs/space").asText());
+    }
+
+    @Test
+    void toolsCallPreservesApprovalRequiredAsSupportSafeNonSuccess() throws Exception {
+        when(client.invoke(any(BridgeInvocationRequest.class), any(RuntimeHeaders.class))).thenReturn(new BridgeInvocationResponse(
+                "boards.comment",
+                ToolInvocationStatus.DENIED,
+                "audit://weaver-tool/boards.comment/approval_required",
+                true,
+                List.of(new WeaveMcpContentBlock("text", "approval needed", null, Map.of("status", "approval_required"))),
+                Map.of("approvalPolicy", "PER_INVOCATION")));
+
+        var response = mvc.perform(post("/mcp")
                         .header("Authorization", "Bearer runtime-token")
                         .header("X-Weave-Runtime-Profile", "sha256:test")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"boards.comment\",\"arguments\":{\"taskRef\":\"task:1\",\"body\":\"x\"}}}"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("approval_required")));
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode result = objectMapper.readTree(response).at("/result");
+        assertEquals(true, result.path("isError").asBoolean());
+        assertEquals("approval_required", result.at("/structuredContent/status").asText());
+        assertEquals(true, result.at("/structuredContent/supportSafe").asBoolean());
+    }
+
+    @Test
+    void toolsCallForwardsAuthAndRuntimeHeadersIntoTypedBridgeRequest() throws Exception {
+        when(client.invoke(any(BridgeInvocationRequest.class), any(RuntimeHeaders.class))).thenReturn(new BridgeInvocationResponse(
+                "files.read",
+                ToolInvocationStatus.SUCCESS,
+                "audit://weaver-tool/files.read/invoked",
+                true,
+                List.of(),
+                Map.of()));
+
+        mvc.perform(post("/mcp")
+                        .header("Authorization", "Bearer runtime-token")
+                        .header("X-Weave-Runtime-Profile", "sha256:test")
+                        .header("X-Weave-Org-Id", "org:workspace")
+                        .header("X-Weave-User-Ref", "user:member")
+                        .header("X-Weave-Approval-Receipt", "approval://granted")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"files.read\",\"arguments\":{}}}"))
+                .andExpect(status().isOk());
+
+        var requestCaptor = ArgumentCaptor.forClass(BridgeInvocationRequest.class);
+        var headersCaptor = ArgumentCaptor.forClass(RuntimeHeaders.class);
+        verify(client).invoke(requestCaptor.capture(), headersCaptor.capture());
+        assertEquals("Bearer runtime-token", headersCaptor.getValue().authorization());
+        assertEquals("sha256:test", headersCaptor.getValue().runtimeProfile());
+        assertEquals("approval://granted", requestCaptor.getValue().runtime().approvalReceiptRef().value());
+        assertEquals("org:workspace", requestCaptor.getValue().runtime().orgRef().value());
+        assertEquals("user:member", requestCaptor.getValue().runtime().userRef().value());
+    }
+
+    private RuntimeInvocationContext runtime() {
+        return new RuntimeInvocationContext(
+                new WeaveMcpRef("org:workspace"),
+                new WeaveMcpRef("user:member"),
+                new WeaveMcpRef("weave-runtime-profile://sha256:test"),
+                "sha256:test",
+                new WeaveMcpRef("credentialref://weave/runtime/short-lived/test"),
+                "audit://bridge/discovery",
+                null,
+                null,
+                List.of("files.read"),
+                List.of("files.read"));
     }
 }

--- a/weave-mcp-server/src/test/java/com/massimotter/weave/mcp/WeaveServerClientTest.java
+++ b/weave-mcp-server/src/test/java/com/massimotter/weave/mcp/WeaveServerClientTest.java
@@ -1,0 +1,73 @@
+package com.massimotter.weave.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.queryParam;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.RuntimeInvocationContext;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class WeaveServerClientTest {
+
+    @Test
+    void forwardsAuthorizationAndRuntimeHeadersWithoutQueryTokens() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        WeaveServerClient client = new WeaveServerClient(builder, "http://localhost:8080");
+        RuntimeHeaders headers = new RuntimeHeaders("Bearer runtime-token", "org:workspace", "user:member", "sha256:test", "approval://granted");
+
+        server.expect(requestTo(org.hamcrest.Matchers.containsString("/api/workspace/weaver/mcp/servers/weave-domain-tools/tools?runtimeProfileHash=sha256:test")))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer runtime-token"))
+                .andExpect(header("X-Weave-Org-Id", "org:workspace"))
+                .andExpect(header("X-Weave-User-Ref", "user:member"))
+                .andExpect(header("X-Weave-Runtime-Profile", "sha256:test"))
+                .andExpect(header("X-Weave-Approval-Receipt", "approval://granted"))
+                .andExpect(queryParam("runtimeProfileHash", "sha256:test"))
+                .andRespond(withSuccess("{" +
+                        "\"runtime\":{\"orgRef\":{\"value\":\"org:workspace\"},\"userRef\":{\"value\":\"user:member\"},\"runtimeProfileRef\":{\"value\":\"weave-runtime-profile://sha256:test\"},\"runtimeProfileHash\":\"sha256:test\",\"runtimeTokenRef\":{\"value\":\"credentialref://weave/runtime/short-lived/test\"},\"auditRef\":\"audit://bridge/discovery\",\"approvalReceiptRef\":null,\"alwaysAllowGrantRef\":null,\"capabilityGrants\":[],\"allowedTools\":[]}," +
+                        "\"catalog\":{\"serverNamespace\":\"weave-domain-tools\",\"contractVersion\":\"weave-mcp-bridge-v1\",\"tools\":[]}}", MediaType.APPLICATION_JSON));
+
+        BridgeInvocationRequest request = new BridgeInvocationRequest(
+                "files.read",
+                java.util.Map.of("spaceRef", "space:control-room"),
+                new RuntimeInvocationContext(
+                        new WeaveMcpRef("org:workspace"),
+                        new WeaveMcpRef("user:member"),
+                        new WeaveMcpRef("weave-runtime-profile://sha256:test"),
+                        "sha256:test",
+                        new WeaveMcpRef("credentialref://weave/runtime/short-lived/test"),
+                        "audit://bridge/invoke",
+                        null,
+                        null,
+                        java.util.List.of(),
+                        java.util.List.of()));
+
+        server.expect(requestTo(org.hamcrest.Matchers.containsString("/api/workspace/weaver/mcp/servers/weave-domain-tools/tools/files.read:invoke")))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer runtime-token"))
+                .andExpect(header("X-Weave-Runtime-Profile", "sha256:test"))
+                .andExpect(content().string(org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("runtimeToken="))))
+                .andRespond(withSuccess("{" +
+                        "\"toolName\":\"files.read\",\"status\":\"SUCCESS\",\"auditRef\":\"audit://weaver-tool/files.read/invoked\",\"supportSafe\":true,\"content\":[],\"structuredContent\":{}}", MediaType.APPLICATION_JSON));
+
+        var discovery = client.discover("sha256:test", headers);
+        assertThat(discovery.catalog().serverNamespace()).isEqualTo("weave-domain-tools");
+
+        var invocation = client.invoke(request, headers);
+        assertThat(invocation.toolName()).isEqualTo("files.read");
+
+        server.verify();
+    }
+}


### PR DESCRIPTION
## Summary

- Type the Weave MCP bridge in `weave-contract` as the shared source of truth for discovery and invocation envelopes.
- Move server MCP discovery/invoke endpoints to contract DTOs while keeping policy, approval, audit, and redaction server-owned.
- Convert `weave-mcp-server` to typed bridge calls and MCP-compliant structured `tools/call` results.

## Scope and user impact

- Developer/operator-facing contract cleanup for Weaver MCP integration.
- No normal member UX change.
- Reduces DTO drift between contract, server, and MCP adapter boundaries.

## Spec / acceptance link

- Issue: Closes #823, closes #825, closes #826
- Repo spec or spec note: `specs/0009-domain-first-mcp-tools/spec.md`, `docs/non-chat-domain-facade-contract.md`, `docs/weave-contract-java-mcp.md`
- Acceptance scenario / mapping marker when product behavior changed: not changed; contract/server adapter tests cover the bridge behavior.
- Product-core questions intentionally left unresolved: none

## Branch, target lane, and release path

- Target lane: main exception (continuing the existing MCP Java contract branch train already merged on `main`; production release not implied)
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [ ] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [ ] none
- [x] implements locked spec: domain-first MCP tool boundary and Java contract/MCP bridge projection
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

- Release note: typed Weaver MCP bridge contracts now keep Java MCP adapter discovery/invocation aligned with server-governed policy and audit DTOs.

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- None; no UI/docs file changes.

## Accessibility and localization

- Not applicable; no user-facing UI or localized text changes.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: shared `weave-contract` MCP bridge DTOs and server/MCP adapter tests.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance`
- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant

Additional gates run:

- [x] `./gradlew :weave-contract:test :weave-mcp-server:test`
- [x] `(cd server && ./gradlew test)`

## Notes for reviewers

- The root Gradle build currently includes `:weave-contract` and `:weave-mcp-server`; server tests run through `server/gradlew`.
- `specContract` is not present in this root task graph, so the smallest executable contract/server adapter gates above were used.
