### PR TITLE
feat(admin): add Beta readiness control preview

### DIFF
--- a/admin-console/src/App.test.tsx
+++ b/admin-console/src/App.test.tsx
@@ -316,6 +316,20 @@ describe("Admin Console MVP", () => {
     expect(
       screen.getByLabelText(/domain readiness dashboard/i),
     ).toHaveTextContent(/member preview: degraded/i);
+    expect(
+      screen.getByRole("heading", {
+        name: /beta setup and control readiness preview/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/beta setup and control readiness checklist/i),
+    ).toHaveTextContent(/idm and rbac posture: ready/i);
+    expect(
+      screen.getByLabelText(/beta setup and control readiness checklist/i),
+    ).toHaveTextContent(/weaver availability: coming_later/i);
+    expect(
+      screen.getByLabelText(/beta setup and control readiness checklist/i),
+    ).toHaveTextContent(/raw provider diagnostics exposed: no/i);
     expect(screen.getByText(/rc claim control/i)).toBeInTheDocument();
     expect(
       screen.getByLabelText(/rc go-live evidence and release claim gates/i),

--- a/admin-console/src/App.tsx
+++ b/admin-console/src/App.tsx
@@ -977,6 +977,54 @@ export default function App({
                 </CardContent>
               </Card>
 
+              <Card
+                component="section"
+                aria-labelledby="beta-readiness-preview-heading"
+              >
+                <CardContent>
+                  <Typography
+                    id="beta-readiness-preview-heading"
+                    variant="h2"
+                    sx={{ fontSize: "1.35rem", mb: 2 }}
+                  >
+                    Beta setup and control readiness preview
+                  </Typography>
+                  <Typography sx={{ mb: 2 }}>
+                    This Admin Console preview ties IDM/RBAC, provider adapters,
+                    Weaver eligibility, and evidence posture into one
+                    screen-reader-friendly checklist before members are invited.
+                    It is support-safe: admins see action labels and evidence
+                    refs, not raw provider payloads or secrets.
+                  </Typography>
+                  <List aria-label="Beta setup and control readiness checklist">
+                    <ListItem alignItems="flex-start">
+                      <ListItemText
+                        primary={`IDM and RBAC posture: ${readableState(controlPlane.identityProviderReadiness.overallState)}`}
+                        secondary={`Backend-owned identity facade: ${controlPlane.identityProviderReadiness.backendOwnedFacade ? "yes" : "no"}; member identity-provider setup controls: ${controlPlane.identityProviderReadiness.memberClientMayConfigureIdentityProvider ? "exposed" : "blocked"}.`}
+                      />
+                    </ListItem>
+                    <ListItem alignItems="flex-start">
+                      <ListItemText
+                        primary={`Provider adapter posture: ${controlPlane.providerCategories.map((category) => `${category.label} ${readableState(category.state)}`).join("; ")}`}
+                        secondary="Each provider category includes member impact, policy state, dry-run/apply gates, evidence freshness, and the next safe operator action."
+                      />
+                    </ListItem>
+                    <ListItem alignItems="flex-start">
+                      <ListItemText
+                        primary={`Weaver availability: ${controlPlane.weaverEligibilityPreview.memberStateWhenEligible}`}
+                        secondary={`Explicit policy enabled: ${controlPlane.weaverEligibilityPreview.policyEnabled ? "yes" : "no"}; required groups: ${controlPlane.weaverEligibilityPreview.requiredGroups.join(", ") || "none"}; fail-closed without group: ${controlPlane.weaverEligibilityPreview.memberStateWithoutGroup}.`}
+                      />
+                    </ListItem>
+                    <ListItem alignItems="flex-start">
+                      <ListItemText
+                        primary={`Evidence posture: ${readableState(controlPlane.goLiveReadiness.state)}`}
+                        secondary={`Support-safe go-live evidence: ${controlPlane.goLiveReadiness.supportSafe ? "yes" : "no"}; raw provider diagnostics exposed: ${controlPlane.goLiveReadiness.rawProviderDiagnosticsExposed ? "yes" : "no"}; blockers: ${controlPlane.goLiveReadiness.blockers.join(", ") || "none"}.`}
+                      />
+                    </ListItem>
+                  </List>
+                </CardContent>
+              </Card>
+
               {canInspectReadiness ? (
                 <Card component="section" aria-labelledby="go-live-heading">
                   <CardContent>


### PR DESCRIPTION
## Summary
- Add a dedicated Admin Console Beta setup/control readiness preview tying IDM/RBAC, provider adapter posture, Weaver eligibility, and evidence posture into one accessible checklist.
- Keep the preview support-safe: action labels and evidence posture only, no raw provider payloads, secrets, or member-side provider setup controls.
- Extend Admin Console tests to verify the screen-reader-labelled Beta checklist, Weaver fail-closed state, and redacted diagnostics posture.

## Issue
Closes #832
Integrates with #792 by surfacing the backend-owned identity readiness contract rather than duplicating IDM/RBAC setup.
References #794 and #795 via the existing Weaver RuntimeProfile projection/revocation posture.

## Gates
- [x] `./gradlew adminCi --console=plain`
- [ ] `./gradlew serverCi --console=plain` (not run; no server files changed)

## Release notes
Feature: Admin Console Beta readiness preview for setup/control, provider posture, Weaver availability, and support-safe evidence.
