### PR TITLE
feat(weaver): route approvals through runtime

### DIFF
--- a/docs/evidence/weaver-approval-runtime-boundary-issue-833.md
+++ b/docs/evidence/weaver-approval-runtime-boundary-issue-833.md
@@ -1,0 +1,23 @@
+# Weaver runtime approval boundary evidence (#833)
+
+Status: Sprint 32 Beta-equivalent boundary proof.
+
+## Boundary
+
+- **User OpenClaw/Weaver runtime** owns human approval UX for approval-required tool actions. Native OpenClaw-style runtime semantics are represented as allow-once, deny, and timeout/closed outcomes in the user runtime context.
+- **Weave server** owns policy, capability grants, risk class, support-safe receipt metadata, audit correlation, and fail-closed validation. It does not present a server-owned approval dialog and does not decide user approval.
+- **MCP tool invocation** is a governed projection over Weave domain tools. The MCP layer carries support-safe approval receipt references and parameter summaries only; it must not expose provider payloads, secrets, raw OpenClaw config, or credential-bearing data.
+
+## Proof slice
+
+`server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java` proves:
+
+- `boards.comment` is a write-like Weaver action and returns `approval_required` with `approvalAuthority=user_openclaw_runtime`, `approvalSurface=openclaw_native_or_beta_equivalent_runtime_ux`, and `serverApprovalDecision=false` until a valid runtime receipt exists.
+- A valid runtime approval receipt permits invocation through the Weave domain capability boundary and records only support-safe audit refs.
+- Runtime deny and timeout markers fail closed as `approval_denied` and `approval_timeout` without provider access.
+- Read-only `calendar.search_events` invokes without approval to avoid approval fatigue.
+- Audit/evidence excludes raw provider payloads, secrets, bearer tokens, private prompts, and credential values.
+
+## Claim boundary
+
+This is not a server approval oracle and not a broad always-allow model. Persistent approval, if added later, must be scoped, revokable, expiring where appropriate, and tied to current profile/policy/tool-contract versions.

--- a/docs/governed-weaver-runtime-security-contract.md
+++ b/docs/governed-weaver-runtime-security-contract.md
@@ -84,7 +84,7 @@ Discovery filters by the generated runtime profile's grants. Invocation addition
 
 ## OpenClaw fork and supply-chain posture
 
-Weave treats OpenClaw as runtime substrate. Weave owns policy, grants, profiles, audit, approval receipts, and domain tools.
+Weave treats OpenClaw as runtime substrate. Weave owns policy, grants, profiles, audit, approval receipts, and domain tools. The human approval interaction for a user's runtime remains in the user's OpenClaw/Weaver runtime surface. Server responses may return `approval_required`, `approval_denied`, or `approval_timeout` plus support-safe metadata, but the server must not become a central approval UI or approval decision-maker for the user's container.
 
 Release evidence must capture:
 

--- a/infra/weave-workspace/weave-mcp-tool-contract.json
+++ b/infra/weave-workspace/weave-mcp-tool-contract.json
@@ -25,7 +25,10 @@
     "credentialBearingUrlsReturned": false,
     "authorizationSource": "Generated Weave RuntimeProfile projection carrying the capability-policy intersection; caller-supplied capability headers are ignored",
     "auditRequiredForEveryToolCall": true,
-    "approvalReceiptRequiredForWriteDeleteExternalSendProviderSwitch": true
+    "approvalReceiptRequiredForWriteDeleteExternalSendProviderSwitch": true,
+    "approvalAuthority": "user_openclaw_runtime_for_member_tool_actions",
+    "serverApprovalOracleAllowed": false,
+    "approvalFatigueControl": "approval receipts are required only for write/delete/external-send/provider-switch/admin-risk actions; read-only granted tools do not prompt by default"
   },
   "canonicalDomains": [
     {

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverApprovalReceipt.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverApprovalReceipt.java
@@ -23,10 +23,12 @@ public record WeaverApprovalReceipt(
         auditRef = safe(auditRef);
     }
 
-    public boolean validFor(String actorRef, String action) {
+    public boolean validFor(String actorRef, String action, List<String> requiredScopeRefs) {
+        List<String> safeRequiredScopeRefs = List.copyOf(requiredScopeRefs == null ? List.of() : requiredScopeRefs);
         return !receiptRef.isBlank()
                 && this.actorRef.equals(actorRef)
                 && this.action.equals(action)
+                && scopeRefs.containsAll(safeRequiredScopeRefs)
                 && !policyVersion.isBlank()
                 && auditRef.startsWith("audit://")
                 && expiresInFuture();

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -65,17 +65,20 @@ public class WeaverToolRegistry {
                         "auditRef", auditRef(request.toolName(), terminalApprovalStatus)));
                 return blocked(request.toolName(), terminalApprovalStatus, "Weaver action failed closed after the user runtime did not approve it.");
             }
-            if (approvalReceipt == null || !approvalReceipt.validFor(request.userRef(), request.toolName())) {
-                audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), "approval_required", Map.of(
+            List<String> requiredScopeRefs = canonicalScopeRefs(request.input());
+            if (approvalReceipt == null || !approvalReceipt.validFor(request.userRef(), request.toolName(), requiredScopeRefs)) {
+                String status = approvalReceipt == null ? "approval_required" : "approval_scope_mismatch";
+                audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), status, Map.of(
                         "domain", definition.domain(),
                         "approvalAuthority", "user_openclaw_runtime",
                         "approvalReceiptValidated", false,
                         "serverApprovalDecision", false,
-                        "auditRef", auditRef(request.toolName(), "approval_required")));
+                        "canonicalRefs", requiredScopeRefs,
+                        "auditRef", auditRef(request.toolName(), status)));
                 return new WeaverToolInvocationResult(
                         request.toolName(),
-                        "approval_required",
-                        true,
+                        status,
+                        approvalReceipt == null,
                         true,
                         Map.of(
                                 "approvalPolicy", definition.approvalRequirement().name(),
@@ -85,8 +88,11 @@ public class WeaverToolRegistry {
                                 "approvalPromptInputs", List.of("toolName", "domain", "mode", "canonicalRefs", "supportSafeParameterSummary"),
                                 "approvalPromptForbiddenInputs", List.of("rawProviderPayload", "secretRef.value", "providerCredentials", "privatePrompt"),
                                 "approvalReceiptValidated", false,
-                                "auditRef", auditRef(request.toolName(), "approval_required")),
-                        "This action requires a valid approval receipt before Weaver may continue.");
+                                "canonicalRefs", requiredScopeRefs,
+                                "auditRef", auditRef(request.toolName(), status)),
+                        approvalReceipt == null
+                                ? "This action requires a valid approval receipt before Weaver may continue."
+                                : "Approval receipt scope does not match the Weaver tool invocation.");
             }
             approvalReceiptValidated = true;
         }
@@ -194,6 +200,14 @@ public class WeaverToolRegistry {
         copyCanonicalRef(input, refs, "decisionRef", "decision");
         copyCanonicalRef(input, refs, "boardTaskRef", "boardTask");
         return Map.copyOf(refs);
+    }
+
+    private List<String> canonicalScopeRefs(Map<String, Object> input) {
+        return canonicalRefs(input).values().stream()
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .sorted()
+                .toList();
     }
 
     private void copyCanonicalRef(Map<String, Object> input, Map<String, Object> refs, String inputKey, String outputKey) {

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -55,10 +55,22 @@ public class WeaverToolRegistry {
         boolean approvalReceiptValidated = false;
         if (definition.writeLike()) {
             WeaverApprovalReceipt approvalReceipt = request.approvalReceipt();
+            String terminalApprovalStatus = terminalApprovalStatus(request.approvalReceiptRef(), approvalReceipt);
+            if (terminalApprovalStatus != null) {
+                audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), terminalApprovalStatus, Map.of(
+                        "domain", definition.domain(),
+                        "approvalAuthority", "user_openclaw_runtime",
+                        "approvalReceiptValidated", false,
+                        "serverApprovalDecision", false,
+                        "auditRef", auditRef(request.toolName(), terminalApprovalStatus)));
+                return blocked(request.toolName(), terminalApprovalStatus, "Weaver action failed closed after the user runtime did not approve it.");
+            }
             if (approvalReceipt == null || !approvalReceipt.validFor(request.userRef(), request.toolName())) {
                 audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), "approval_required", Map.of(
                         "domain", definition.domain(),
+                        "approvalAuthority", "user_openclaw_runtime",
                         "approvalReceiptValidated", false,
+                        "serverApprovalDecision", false,
                         "auditRef", auditRef(request.toolName(), "approval_required")));
                 return new WeaverToolInvocationResult(
                         request.toolName(),
@@ -67,6 +79,11 @@ public class WeaverToolRegistry {
                         true,
                         Map.of(
                                 "approvalPolicy", definition.approvalRequirement().name(),
+                                "approvalAuthority", "user_openclaw_runtime",
+                                "approvalSurface", "openclaw_native_or_beta_equivalent_runtime_ux",
+                                "serverApprovalDecision", false,
+                                "approvalPromptInputs", List.of("toolName", "domain", "mode", "canonicalRefs", "supportSafeParameterSummary"),
+                                "approvalPromptForbiddenInputs", List.of("rawProviderPayload", "secretRef.value", "providerCredentials", "privatePrompt"),
                                 "approvalReceiptValidated", false,
                                 "auditRef", auditRef(request.toolName(), "approval_required")),
                         "This action requires a valid approval receipt before Weaver may continue.");
@@ -77,6 +94,8 @@ public class WeaverToolRegistry {
                 "domain", definition.domain(),
                 "mode", definition.mode().name(),
                 "consentGranted", true,
+                "approvalAuthority", definition.writeLike() ? "user_openclaw_runtime" : "not_required",
+                "serverApprovalDecision", false,
                 "approvalReceiptRef", request.approvalReceiptRef() == null ? "none" : request.approvalReceiptRef(),
                 "approvalReceiptAuditRef", request.approvalReceipt() == null ? "none" : request.approvalReceipt().auditRef(),
                 "approvalReceiptPolicyVersion", request.approvalReceipt() == null ? "none" : request.approvalReceipt().policyVersion(),
@@ -92,9 +111,25 @@ public class WeaverToolRegistry {
                         "result", "support-safe-placeholder",
                         "canonicalRefs", canonicalRefs(request.input()),
                         "approvalReceiptAuditRef", request.approvalReceipt() == null ? "none" : request.approvalReceipt().auditRef(),
+                        "approvalAuthority", definition.writeLike() ? "user_openclaw_runtime" : "not_required",
                         "rawProviderPayload", "redacted",
                         "auditRef", auditRef(request.toolName(), "invoked")),
                 "Tool invocation went through a Weave domain capability boundary; raw provider APIs are not exposed.");
+    }
+
+    private String terminalApprovalStatus(String approvalReceiptRef, WeaverApprovalReceipt approvalReceipt) {
+        String marker = approvalReceipt != null ? approvalReceipt.receiptRef() : approvalReceiptRef;
+        if (marker == null) {
+            return null;
+        }
+        String normalized = marker.strip().toLowerCase();
+        if (normalized.contains("denied") || normalized.contains("deny")) {
+            return "approval_denied";
+        }
+        if (normalized.contains("timeout") || normalized.contains("expired")) {
+            return "approval_timeout";
+        }
+        return null;
     }
 
     private String governanceDenial(WeaverToolInvocationRequest request, WeaverDomainToolDefinition definition) {

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -109,7 +109,7 @@ class WeaverToolRegistryTest {
                         "approval:abc123",
                         "user:abc123",
                         "boards.comment",
-                        List.of("board-task:WEAVE-601"),
+                        List.of("space:control-room", "decision:governed-weaver", "board-task:WEAVE-601"),
                         "policy:test",
                         future(),
                         "audit://weaver-approval/test")));
@@ -130,6 +130,51 @@ class WeaverToolRegistryTest {
                 .containsEntry("approvalReceiptValidated", true)
                 .containsEntry("approvalReceiptAuditRef", "audit://weaver-approval/test")
                 .containsEntry("approvalReceiptPolicyVersion", "policy:test");
+    }
+
+    @Test
+    void mismatchedApprovalReceiptScopeFailsClosedBeforeInvocation() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverToolRegistry registry = new WeaverToolRegistry(audit);
+
+        var result = registry.invoke(new WeaverToolInvocationRequest(
+                "boards.comment",
+                "user:abc123",
+                "sha256:scope-mismatch000000000000000000000000000000000000000000000000",
+                "user:abc123",
+                signature(),
+                false,
+                future(),
+                true,
+                List.of("weaver.boards_write"),
+                List.of("boards.comment"),
+                Map.of(
+                        "spaceRef", "space:control-room",
+                        "decisionRef", "decision:governed-weaver",
+                        "boardTaskRef", "board-task:WEAVE-602",
+                        "body", "Looks good"),
+                "approval:abc123",
+                new WeaverApprovalReceipt(
+                        "approval:abc123",
+                        "user:abc123",
+                        "boards.comment",
+                        List.of("space:control-room", "decision:governed-weaver", "board-task:WEAVE-601"),
+                        "policy:test",
+                        future(),
+                        "audit://weaver-approval/test")));
+
+        assertThat(result.status()).isEqualTo("approval_scope_mismatch");
+        assertThat(result.approvalRequired()).isFalse();
+        assertThat(result.redactedResult()).containsEntry("approvalReceiptValidated", false);
+        assertThat(result.redactedResult().get("canonicalRefs").toString())
+                .contains("space:control-room", "decision:governed-weaver", "board-task:WEAVE-602")
+                .doesNotContain("WEAVE-601");
+        assertThat(audit.events()).hasSize(1);
+        assertThat(audit.events().get(0).payload())
+                .containsEntry("status", "approval_scope_mismatch")
+                .containsEntry("approvalReceiptValidated", false)
+                .containsEntry("serverApprovalDecision", false);
+        assertThat(audit.events().get(0).payload().toString()).doesNotContain("Looks good", "provider payload", "secret");
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -78,7 +78,15 @@ class WeaverToolRegistryTest {
 
         assertThat(missingApproval.status()).isEqualTo("approval_required");
         assertThat(missingApproval.approvalRequired()).isTrue();
-        assertThat(missingApproval.redactedResult()).containsEntry("approvalPolicy", "REQUIRED_BEFORE_INVOCATION");
+        assertThat(missingApproval.redactedResult())
+                .containsEntry("approvalPolicy", "REQUIRED_BEFORE_INVOCATION")
+                .containsEntry("approvalAuthority", "user_openclaw_runtime")
+                .containsEntry("approvalSurface", "openclaw_native_or_beta_equivalent_runtime_ux")
+                .containsEntry("serverApprovalDecision", false);
+        assertThat(missingApproval.redactedResult().get("approvalPromptInputs").toString())
+                .contains("supportSafeParameterSummary")
+                .doesNotContain("rawProviderPayload", "secretRef.value");
+
 
         var approved = registry.invoke(new WeaverToolInvocationRequest(
                 "boards.comment",
@@ -110,6 +118,7 @@ class WeaverToolRegistryTest {
         assertThat(approved.approvalRequired()).isFalse();
         assertThat(approved.redactedResult()).containsEntry("rawProviderPayload", "redacted");
         assertThat(approved.redactedResult()).containsEntry("approvalReceiptAuditRef", "audit://weaver-approval/test");
+        assertThat(approved.redactedResult()).containsEntry("approvalAuthority", "user_openclaw_runtime");
         assertThat(approved.redactedResult().get("canonicalRefs").toString())
                 .contains("space:control-room", "decision:governed-weaver", "board-task:WEAVE-601")
                 .doesNotContain("Looks good", "providerRoom", "matrix");
@@ -121,6 +130,56 @@ class WeaverToolRegistryTest {
                 .containsEntry("approvalReceiptValidated", true)
                 .containsEntry("approvalReceiptAuditRef", "audit://weaver-approval/test")
                 .containsEntry("approvalReceiptPolicyVersion", "policy:test");
+    }
+
+    @Test
+    void runtimeDeniedOrTimedOutApprovalFailsClosedWithoutServerDecision() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverToolRegistry registry = new WeaverToolRegistry(audit);
+
+        var denied = registry.invoke(new WeaverToolInvocationRequest(
+                "boards.comment",
+                "user:abc123",
+                "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                List.of("weaver.boards_write"),
+                Map.of("boardTaskRef", "board-task:WEAVE-833", "body", "provider payload must stay out"),
+                "approval:denied:user-runtime"));
+        var timedOut = registry.invoke(new WeaverToolInvocationRequest(
+                "boards.comment",
+                "user:abc123",
+                "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                List.of("weaver.boards_write"),
+                Map.of("boardTaskRef", "board-task:WEAVE-833", "body", "provider payload must stay out"),
+                "approval:timeout:user-runtime"));
+
+        assertThat(denied.status()).isEqualTo("approval_denied");
+        assertThat(timedOut.status()).isEqualTo("approval_timeout");
+        assertThat(denied.approvalRequired()).isFalse();
+        assertThat(timedOut.approvalRequired()).isFalse();
+        assertThat(audit.events()).hasSize(2);
+        assertThat(audit.events()).allSatisfy(event -> assertThat(event.payload())
+                .containsEntry("approvalAuthority", "user_openclaw_runtime")
+                .containsEntry("serverApprovalDecision", false)
+                .containsEntry("supportSafe", true));
+        assertThat(audit.events().toString()).doesNotContain("provider payload", "secret", "Bearer ");
+    }
+
+    @Test
+    void readOnlyToolsDoNotRequestApprovalToAvoidApprovalFatigue() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverToolRegistry registry = new WeaverToolRegistry(audit);
+
+        var result = registry.invoke(new WeaverToolInvocationRequest(
+                "calendar.search_events",
+                "user:abc123",
+                "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                List.of("weaver.calendar_read"),
+                Map.of("query", "today"),
+                null));
+
+        assertThat(result.status()).isEqualTo("ok");
+        assertThat(result.approvalRequired()).isFalse();
+        assertThat(result.redactedResult()).containsEntry("approvalAuthority", "not_required");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements the Sprint 32 #833 approval boundary: approval-required Weaver actions now route approval state through the user's OpenClaw/Weaver runtime semantics while the server remains the policy/capability/audit metadata validator, not an approval oracle.

## Linked issue

Fixes #833
Depends on #771, #794, #795 for the broader runtime proof/trust posture.

## Target lane

dev

## Changes

- Adds runtime-approval metadata for write-like Weaver tool actions (`approvalAuthority=user_openclaw_runtime`, Beta-equivalent approval surface, `serverApprovalDecision=false`).
- Fails closed for runtime deny/timeout markers with support-safe audit metadata and no provider access.
- Keeps read-only granted tools approval-free to avoid approval fatigue.
- Documents the OpenClaw runtime vs Weave server vs MCP invocation boundary and adds issue #833 evidence notes.
- Updates MCP tool contract controls to forbid a server approval oracle and name runtime approval authority.

## Spec / contract impact

- Updates governed Weaver runtime security contract and MCP tool contract metadata.
- Adds support-safe evidence doc: `docs/evidence/weaver-approval-runtime-boundary-issue-833.md`.

## User/admin/operator impact

- Weaver users get approval UX in their runtime surface for consequential actions only.
- Admin/operator evidence remains support-safe and redacted.
- No raw provider payloads, secrets, private prompts, or OpenClaw config are exposed.

## Checks run

- `./gradlew serverCi --console=plain` ✅
- `./gradlew acceptanceContract --console=plain` ✅
- `infra/weave-workspace/tests/weave-mcp-tool-contract-test.sh` ✅
- `cd infra/weave-mcp && python3 -m pytest -q` ⚠️ blocked locally: `No module named pytest`

## Release notes

- `release-notes-feature` — adds governed Weaver approval boundary behavior/evidence.

## Risks / follow-ups

- This is a Beta-equivalent runtime UX proof, not a full live OpenClaw UI integration claim.
- Broader live model/tool loop and profile signing/revocation claims remain tied to #771, #794, and #795.
