### PR TITLE
feat(client): add bounded Weaver beta helper flow

### DIFF
--- a/client/lib/features/chat/presentation/chat_screen.dart
+++ b/client/lib/features/chat/presentation/chat_screen.dart
@@ -9,6 +9,8 @@ import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 import 'package:weave/features/chat/domain/entities/chat_failure.dart';
 import 'package:weave/features/chat/presentation/chat_room_screen.dart';
 import 'package:weave/features/chat/presentation/providers/chat_provider.dart';
+import 'package:weave/features/agents/domain/entities/agent_capability_policy.dart';
+import 'package:weave/features/agents/presentation/providers/agent_capability_policy_provider.dart';
 import 'package:weave/features/chat/presentation/providers/chat_security_provider.dart';
 import 'package:weave/features/chat/presentation/widgets/chat_security_banner.dart';
 import 'package:weave/features/onboarding/domain/entities/first_run_status.dart';
@@ -384,7 +386,7 @@ class _ChatErrorState extends StatelessWidget {
   }
 }
 
-class _ChatOverviewSliver extends StatelessWidget {
+class _ChatOverviewSliver extends ConsumerWidget {
   const _ChatOverviewSliver({
     required this.conversations,
     required this.onOpenConversation,
@@ -394,9 +396,18 @@ class _ChatOverviewSliver extends StatelessWidget {
   final ValueChanged<ChatConversation> onOpenConversation;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
     final overview = ChatOverview.fromConversations(conversations);
+    final weaverPolicy = ref
+        .watch(agentCapabilityPolicyProvider)
+        .when(
+          data: (value) => value,
+          error: (_, _) =>
+              AgentCapabilityPolicy.failClosed(canManageCapabilities: false),
+          loading: () =>
+              AgentCapabilityPolicy.failClosed(canManageCapabilities: false),
+        );
 
     return SliverToBoxAdapter(
       child: Padding(
@@ -471,6 +482,8 @@ class _ChatOverviewSliver extends StatelessWidget {
               conversations: overview.aiChats,
               onOpenConversation: onOpenConversation,
             ),
+            const SizedBox(height: 20),
+            _WeaverBetaCard(policy: weaverPolicy),
           ],
         ),
       ),
@@ -618,6 +631,168 @@ class _ChatHomeMetricChip extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _WeaverBetaCard extends StatelessWidget {
+  const _WeaverBetaCard({required this.policy});
+
+  final AgentCapabilityPolicy policy;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final personalAssistant = policy.stateFor(
+      AgentCapability.personalAssistant,
+    );
+    final channelAgent = policy.stateFor(AgentCapability.channelAgent);
+    final personalStatus = _statusFor(l10n, personalAssistant);
+    final channelStatus = _statusFor(l10n, channelAgent);
+    final canStart = personalAssistant.canStart;
+    final semanticLabel = l10n.chatWeaverBetaSemanticLabel(
+      personalStatus.label,
+      channelStatus.label,
+      canStart
+          ? l10n.chatWeaverBetaConnectedState
+          : l10n.chatWeaverBetaUnconnectedState,
+    );
+
+    return Semantics(
+      container: true,
+      liveRegion: true,
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: Card(
+          elevation: 0,
+          color: theme.colorScheme.surfaceContainerHighest,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+            side: BorderSide(color: theme.colorScheme.outlineVariant),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(
+                      Icons.auto_awesome_outlined,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            l10n.chatWeaverBetaTitle,
+                            style: theme.textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            l10n.chatWeaverBetaDescription,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    _WeaverStateChip(
+                      label: canStart
+                          ? l10n.chatWeaverBetaConnectedState
+                          : l10n.chatWeaverBetaUnconnectedState,
+                      icon: canStart ? Icons.link : Icons.link_off,
+                    ),
+                    _WeaverStateChip(
+                      label: personalStatus.label,
+                      icon: personalStatus.icon,
+                    ),
+                    _WeaverStateChip(
+                      label: channelStatus.label,
+                      icon: channelStatus.icon,
+                    ),
+                    _WeaverStateChip(
+                      label: l10n.chatWeaverBetaApprovalRequiredState,
+                      icon: Icons.verified_user_outlined,
+                    ),
+                    _WeaverStateChip(
+                      label: l10n.chatWeaverBetaDeniedFailedState,
+                      icon: Icons.report_gmailerrorred_outlined,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  l10n.chatWeaverBetaSupportSafeResult,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  _WeaverStatus _statusFor(AppLocalizations l10n, AgentCapabilityState state) {
+    if (state.canStart) {
+      return _WeaverStatus(
+        l10n.chatWeaverBetaEnabledState,
+        Icons.check_circle_outline,
+      );
+    }
+    return switch (state.availability) {
+      AgentCapabilityAvailability.disabledByPolicy => _WeaverStatus(
+        l10n.chatWeaverBetaDisabledState,
+        Icons.policy_outlined,
+      ),
+      AgentCapabilityAvailability.adminSetupRequired => _WeaverStatus(
+        l10n.chatWeaverBetaCapabilityUnavailableState,
+        Icons.info_outline,
+      ),
+      AgentCapabilityAvailability.blocked => _WeaverStatus(
+        l10n.chatWeaverBetaDeniedFailedState,
+        Icons.report_gmailerrorred_outlined,
+      ),
+    };
+  }
+}
+
+class _WeaverStatus {
+  const _WeaverStatus(this.label, this.icon);
+
+  final String label;
+  final IconData icon;
+}
+
+class _WeaverStateChip extends StatelessWidget {
+  const _WeaverStateChip({required this.label, required this.icon});
+
+  final String label;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Chip(
+      avatar: Icon(icon, size: 18),
+      label: Text(label),
+      backgroundColor: theme.colorScheme.surface,
+      side: BorderSide(color: theme.colorScheme.outlineVariant),
     );
   }
 }

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -1078,7 +1078,6 @@
   "@agentCapabilityPolicyLoading": {
     "description": "Loading message for AI agent capability policy settings section"
   },
-
   "weaverMemberTitle": "Mein Weaver",
   "@weaverMemberTitle": {
     "description": "Title for the governed member Weaver settings entry point"
@@ -1272,5 +1271,60 @@
   "connectorPreviewTileSemanticLabel": "{name}. Status {statusLabel}. {summary} {auditSummary} {actionsState}; die App verarbeitet kein Provider-Geheimnis.",
   "channelWorkspaceStatusDisabledByPolicy": "disabled_by_policy",
   "channelWorkspaceStatusDegraded": "degraded",
-  "agentCapabilityAvailabilityDisabledByPolicy": "Durch Policy deaktiviert"
+  "agentCapabilityAvailabilityDisabledByPolicy": "Durch Policy deaktiviert",
+  "chatWeaverBetaTitle": "Weaver Beta helper",
+  "@chatWeaverBetaTitle": {
+    "description": "Title for the bounded Weaver helper card in chat home"
+  },
+  "chatWeaverBetaDescription": "Weaver stays inside this Weave workspace and can only use approved capabilities. Members see approved Weave actions, not internal runtime catalogs.",
+  "@chatWeaverBetaDescription": {
+    "description": "Description for bounded Weaver helper card"
+  },
+  "chatWeaverBetaConnectedState": "Connected",
+  "@chatWeaverBetaConnectedState": {
+    "description": "Weaver connection state label"
+  },
+  "chatWeaverBetaUnconnectedState": "Unconnected",
+  "@chatWeaverBetaUnconnectedState": {
+    "description": "Weaver connection state label"
+  },
+  "chatWeaverBetaEnabledState": "Weaver enabled",
+  "@chatWeaverBetaEnabledState": {
+    "description": "Weaver enabled state label"
+  },
+  "chatWeaverBetaDisabledState": "Weaver disabled",
+  "@chatWeaverBetaDisabledState": {
+    "description": "Weaver disabled state label"
+  },
+  "chatWeaverBetaCapabilityUnavailableState": "Capability unavailable",
+  "@chatWeaverBetaCapabilityUnavailableState": {
+    "description": "Weaver capability unavailable state label"
+  },
+  "chatWeaverBetaApprovalRequiredState": "Approval required for sensitive actions",
+  "@chatWeaverBetaApprovalRequiredState": {
+    "description": "Weaver approval state label"
+  },
+  "chatWeaverBetaDeniedFailedState": "Denied or failed safely",
+  "@chatWeaverBetaDeniedFailedState": {
+    "description": "Weaver denied/failed state label"
+  },
+  "chatWeaverBetaSupportSafeResult": "Results show a summary, status, and audit reference only; secrets and raw provider payloads stay out of the member view.",
+  "@chatWeaverBetaSupportSafeResult": {
+    "description": "Support-safe result note for Weaver helper"
+  },
+  "chatWeaverBetaSemanticLabel": "Weaver Beta helper. Personal helper: {personalState}. Channel helper: {channelState}. Workspace connection: {connectionState}. Results are support-safe and do not expose secrets or raw provider payloads.",
+  "@chatWeaverBetaSemanticLabel": {
+    "description": "Accessibility label for Weaver helper card",
+    "placeholders": {
+      "personalState": {
+        "type": "String"
+      },
+      "channelState": {
+        "type": "String"
+      },
+      "connectionState": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -4061,7 +4061,6 @@
   "@agentCapabilityPolicyLoading": {
     "description": "Loading message for AI agent capability policy settings section"
   },
-
   "weaverMemberTitle": "Mein Weaver",
   "@weaverMemberTitle": {
     "description": "Title for the governed member Weaver settings entry point"
@@ -4584,5 +4583,60 @@
   "agentCapabilityAvailabilityDisabledByPolicy": "Disabled by policy",
   "@agentCapabilityAvailabilityDisabledByPolicy": {
     "description": "Availability chip for an agent capability disabled by workspace policy"
+  },
+  "chatWeaverBetaTitle": "Weaver Beta helper",
+  "@chatWeaverBetaTitle": {
+    "description": "Title for the bounded Weaver helper card in chat home"
+  },
+  "chatWeaverBetaDescription": "Weaver stays inside this Weave workspace and can only use approved capabilities. Members see approved Weave actions, not internal runtime catalogs.",
+  "@chatWeaverBetaDescription": {
+    "description": "Description for bounded Weaver helper card"
+  },
+  "chatWeaverBetaConnectedState": "Connected",
+  "@chatWeaverBetaConnectedState": {
+    "description": "Weaver connection state label"
+  },
+  "chatWeaverBetaUnconnectedState": "Unconnected",
+  "@chatWeaverBetaUnconnectedState": {
+    "description": "Weaver connection state label"
+  },
+  "chatWeaverBetaEnabledState": "Weaver enabled",
+  "@chatWeaverBetaEnabledState": {
+    "description": "Weaver enabled state label"
+  },
+  "chatWeaverBetaDisabledState": "Weaver disabled",
+  "@chatWeaverBetaDisabledState": {
+    "description": "Weaver disabled state label"
+  },
+  "chatWeaverBetaCapabilityUnavailableState": "Capability unavailable",
+  "@chatWeaverBetaCapabilityUnavailableState": {
+    "description": "Weaver capability unavailable state label"
+  },
+  "chatWeaverBetaApprovalRequiredState": "Approval required for sensitive actions",
+  "@chatWeaverBetaApprovalRequiredState": {
+    "description": "Weaver approval state label"
+  },
+  "chatWeaverBetaDeniedFailedState": "Denied or failed safely",
+  "@chatWeaverBetaDeniedFailedState": {
+    "description": "Weaver denied/failed state label"
+  },
+  "chatWeaverBetaSupportSafeResult": "Results show a summary, status, and audit reference only; secrets and raw provider payloads stay out of the member view.",
+  "@chatWeaverBetaSupportSafeResult": {
+    "description": "Support-safe result note for Weaver helper"
+  },
+  "chatWeaverBetaSemanticLabel": "Weaver Beta helper. Personal helper: {personalState}. Channel helper: {channelState}. Workspace connection: {connectionState}. Results are support-safe and do not expose secrets or raw provider payloads.",
+  "@chatWeaverBetaSemanticLabel": {
+    "description": "Accessibility label for Weaver helper card",
+    "placeholders": {
+      "personalState": {
+        "type": "String"
+      },
+      "channelState": {
+        "type": "String"
+      },
+      "connectionState": {
+        "type": "String"
+      }
+    }
   }
 }

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -6214,6 +6214,76 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Disabled by policy'**
   String get agentCapabilityAvailabilityDisabledByPolicy;
+
+  /// Title for the bounded Weaver helper card in chat home
+  ///
+  /// In en, this message translates to:
+  /// **'Weaver Beta helper'**
+  String get chatWeaverBetaTitle;
+
+  /// Description for bounded Weaver helper card
+  ///
+  /// In en, this message translates to:
+  /// **'Weaver stays inside this Weave workspace and can only use approved capabilities. Members see approved Weave actions, not internal runtime catalogs.'**
+  String get chatWeaverBetaDescription;
+
+  /// Weaver connection state label
+  ///
+  /// In en, this message translates to:
+  /// **'Connected'**
+  String get chatWeaverBetaConnectedState;
+
+  /// Weaver connection state label
+  ///
+  /// In en, this message translates to:
+  /// **'Unconnected'**
+  String get chatWeaverBetaUnconnectedState;
+
+  /// Weaver enabled state label
+  ///
+  /// In en, this message translates to:
+  /// **'Weaver enabled'**
+  String get chatWeaverBetaEnabledState;
+
+  /// Weaver disabled state label
+  ///
+  /// In en, this message translates to:
+  /// **'Weaver disabled'**
+  String get chatWeaverBetaDisabledState;
+
+  /// Weaver capability unavailable state label
+  ///
+  /// In en, this message translates to:
+  /// **'Capability unavailable'**
+  String get chatWeaverBetaCapabilityUnavailableState;
+
+  /// Weaver approval state label
+  ///
+  /// In en, this message translates to:
+  /// **'Approval required for sensitive actions'**
+  String get chatWeaverBetaApprovalRequiredState;
+
+  /// Weaver denied/failed state label
+  ///
+  /// In en, this message translates to:
+  /// **'Denied or failed safely'**
+  String get chatWeaverBetaDeniedFailedState;
+
+  /// Support-safe result note for Weaver helper
+  ///
+  /// In en, this message translates to:
+  /// **'Results show a summary, status, and audit reference only; secrets and raw provider payloads stay out of the member view.'**
+  String get chatWeaverBetaSupportSafeResult;
+
+  /// Accessibility label for Weaver helper card
+  ///
+  /// In en, this message translates to:
+  /// **'Weaver Beta helper. Personal helper: {personalState}. Channel helper: {channelState}. Workspace connection: {connectionState}. Results are support-safe and do not expose secrets or raw provider payloads.'**
+  String chatWeaverBetaSemanticLabel(
+    String personalState,
+    String channelState,
+    String connectionState,
+  );
 }
 
 class _AppLocalizationsDelegate

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -3867,4 +3867,47 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get agentCapabilityAvailabilityDisabledByPolicy =>
       'Durch Policy deaktiviert';
+
+  @override
+  String get chatWeaverBetaTitle => 'Weaver Beta helper';
+
+  @override
+  String get chatWeaverBetaDescription =>
+      'Weaver stays inside this Weave workspace and can only use approved capabilities. Members see approved Weave actions, not internal runtime catalogs.';
+
+  @override
+  String get chatWeaverBetaConnectedState => 'Connected';
+
+  @override
+  String get chatWeaverBetaUnconnectedState => 'Unconnected';
+
+  @override
+  String get chatWeaverBetaEnabledState => 'Weaver enabled';
+
+  @override
+  String get chatWeaverBetaDisabledState => 'Weaver disabled';
+
+  @override
+  String get chatWeaverBetaCapabilityUnavailableState =>
+      'Capability unavailable';
+
+  @override
+  String get chatWeaverBetaApprovalRequiredState =>
+      'Approval required for sensitive actions';
+
+  @override
+  String get chatWeaverBetaDeniedFailedState => 'Denied or failed safely';
+
+  @override
+  String get chatWeaverBetaSupportSafeResult =>
+      'Results show a summary, status, and audit reference only; secrets and raw provider payloads stay out of the member view.';
+
+  @override
+  String chatWeaverBetaSemanticLabel(
+    String personalState,
+    String channelState,
+    String connectionState,
+  ) {
+    return 'Weaver Beta helper. Personal helper: $personalState. Channel helper: $channelState. Workspace connection: $connectionState. Results are support-safe and do not expose secrets or raw provider payloads.';
+  }
 }

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -3817,4 +3817,47 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get agentCapabilityAvailabilityDisabledByPolicy =>
       'Disabled by policy';
+
+  @override
+  String get chatWeaverBetaTitle => 'Weaver Beta helper';
+
+  @override
+  String get chatWeaverBetaDescription =>
+      'Weaver stays inside this Weave workspace and can only use approved capabilities. Members see approved Weave actions, not internal runtime catalogs.';
+
+  @override
+  String get chatWeaverBetaConnectedState => 'Connected';
+
+  @override
+  String get chatWeaverBetaUnconnectedState => 'Unconnected';
+
+  @override
+  String get chatWeaverBetaEnabledState => 'Weaver enabled';
+
+  @override
+  String get chatWeaverBetaDisabledState => 'Weaver disabled';
+
+  @override
+  String get chatWeaverBetaCapabilityUnavailableState =>
+      'Capability unavailable';
+
+  @override
+  String get chatWeaverBetaApprovalRequiredState =>
+      'Approval required for sensitive actions';
+
+  @override
+  String get chatWeaverBetaDeniedFailedState => 'Denied or failed safely';
+
+  @override
+  String get chatWeaverBetaSupportSafeResult =>
+      'Results show a summary, status, and audit reference only; secrets and raw provider payloads stay out of the member view.';
+
+  @override
+  String chatWeaverBetaSemanticLabel(
+    String personalState,
+    String channelState,
+    String connectionState,
+  ) {
+    return 'Weaver Beta helper. Personal helper: $personalState. Channel helper: $channelState. Workspace connection: $connectionState. Results are support-safe and do not expose secrets or raw provider payloads.';
+  }
 }

--- a/client/test/features/chat/chat_screen_test.dart
+++ b/client/test/features/chat/chat_screen_test.dart
@@ -1,10 +1,13 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
+
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:weave/core/theme/app_theme.dart';
+import 'package:weave/features/agents/domain/entities/agent_capability_policy.dart';
+import 'package:weave/features/agents/presentation/providers/agent_capability_policy_provider.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
 import 'package:weave/features/app/presentation/providers/workspace_invalidation_provider.dart';
 import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
@@ -838,6 +841,76 @@ void main() {
       await tester.pumpAndSettle();
 
       await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+    });
+
+    testWidgets('renders bounded Weaver Beta helper states accessibly', (
+      tester,
+    ) async {
+      final repository = FakeChatRepository(
+        loadConversationsHandler: () async => const <ChatConversation>[
+          ChatConversation(
+            id: '!ai:home.internal',
+            title: 'Weaver notes',
+            previewType: ChatConversationPreviewType.text,
+            previewText: 'Structured result ready',
+            unreadCount: 0,
+            isInvite: false,
+            isDirectMessage: false,
+          ),
+        ],
+      );
+      final securityRepository = buildSecurityRepository();
+      await tester.pumpWidget(
+        createTestApp(
+          const ChatScreen(),
+          overrides: [
+            chatRepositoryProvider.overrideWithValue(repository),
+            chatSecurityRepositoryProvider.overrideWithValue(
+              securityRepository,
+            ),
+            firstRunStatusProvider.overrideWith((ref) async => null),
+            agentCapabilityPolicyProvider.overrideWithValue(
+              const AsyncData(
+                AgentCapabilityPolicy(
+                  canManageCapabilities: false,
+                  capabilities: <AgentCapabilityState>[
+                    AgentCapabilityState(
+                      capability: AgentCapability.personalAssistant,
+                      enablement: AgentCapabilityEnablement.enabled,
+                      availability:
+                          AgentCapabilityAvailability.adminSetupRequired,
+                    ),
+                    AgentCapabilityState(
+                      capability: AgentCapability.channelAgent,
+                      enablement: AgentCapabilityEnablement.disabled,
+                      availability:
+                          AgentCapabilityAvailability.disabledByPolicy,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Weaver Beta helper'), findsOneWidget);
+      expect(find.text('Connected'), findsOneWidget);
+      expect(find.text('Weaver enabled'), findsOneWidget);
+      expect(find.text('Weaver disabled'), findsOneWidget);
+      expect(
+        find.text('Approval required for sensitive actions'),
+        findsOneWidget,
+      );
+      expect(find.text('Denied or failed safely'), findsOneWidget);
+      expect(find.textContaining('raw provider payloads'), findsOneWidget);
+      expect(find.textContaining('MCP'), findsNothing);
+      expect(find.textContaining('tool catalog'), findsNothing);
+      expect(
+        find.bySemanticsLabel(RegExp('Results are support-safe')),
+        findsOneWidget,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- Adds a member-facing Weaver Beta helper card inside the Client chat workspace.
- Derives bounded helper states from capability policy and workspace connection state without exposing provider setup or raw runtime catalogs.
- Adds localized support-safe result copy and widget coverage for the deterministic member journey.

## Scope and user impact

- Members see Weaver as part of the Weave Client workspace, with clear connected/unconnected, enabled/disabled, unavailable, approval-required, and denied/failed states.
- Support guidance states that results are structured and safe to share without secrets or raw provider payloads.

## Spec / acceptance link

- Issue: Closes #834; depends on #786, #787, #771 context.
- Repo spec / Spec Kit package: pinned corpus via `specs/weave-specs.lock.json`; Client implementation evidence only.
- Plan/tasks/traceability: Sprint 32 member Client + governed Weaver hardening.
- Mapped Gherkin feature/scenario when product behavior changed: deterministic widget journey in `client/test/features/chat/chat_screen_test.dart`.
- Evidence mode / reality level: `offline-spec` / `contract_only` widget evidence.
- Product-core questions intentionally left unresolved: none.

Quality Reset rule: this PR describes offline widget/contract evidence only and does not claim live-runtime or release-ready validation.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

Choose one and explain when needed.

- [ ] none
- [x] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

Use exactly one form.

- Release note: Add the bounded Weaver Beta helper flow to the member Client chat workspace.

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- No docs or screenshot assets changed.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: support-safe copy explicitly avoids secrets and raw provider payloads; no raw provider or MCP catalog surface added.
- Accessibility/localization impact: localized EN/DE strings added; semantic label covers Weaver state and support-safe result guidance.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [x] No public API/auth/topology/spec contract change
- [ ] Contract/spec change documented:
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: Client/member UX + accessibility reviewer for Sprint 32.
- If Copilot is unavailable/insufficient, matching reviewer used:

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [x] `flutter pub get` (via Flutter/Gradle gates)
- [x] `flutter gen-l10n`
- [x] `dart run build_runner build --delete-conflicting-outputs` (via `./gradlew clientCi`)
- [x] `dart format --output=none --set-exit-if-changed .` (via `./gradlew clientCi`)
- [x] `flutter analyze --fatal-infos`
- [x] `flutter test` (via `./gradlew clientCi`; targeted chat tests also passed)
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant; member Client widget flow only.

## Notes for reviewers

- Review for claim hygiene first: this PR intentionally keeps Weaver inside the Client workspace and avoids provider setup/raw runtime catalog language.
