### PR TITLE
test: map Sprint 32 Beta path evidence

### DIFF
--- a/client/test/live_stack_feature_mapping_test.dart
+++ b/client/test/live_stack_feature_mapping_test.dart
@@ -270,6 +270,7 @@ void main() {
         'Weaver memory is isolated per user',
         'Weaver uses domain-first tools with approval receipts',
         'Weaver automation heartbeat fails closed with support-safe audit and fallback',
+        'Admin prepares readiness, enables Weaver, and a member uses governed Weaver in a workspace',
       ]),
     );
   });

--- a/docs/evidence/sprint-32-beta-path-evidence.md
+++ b/docs/evidence/sprint-32-beta-path-evidence.md
@@ -1,0 +1,48 @@
+# Sprint 32 Beta path evidence (#835)
+
+Status: deterministic offline evidence for the Sprint 32 Admin + User + Weaver Beta path. This file does not claim production release, unrestricted Weaver availability, or completed credentialed live-stack proof.
+
+## Coherent story
+
+1. Admin prepares and validates organization/provider/category readiness before member go-live. Readiness stays category-first for identity, chat, files, calendar, boards/tasks, meetings, admin health, and Weaver.
+2. Admin enables Weaver only for an eligible user/group scope through policy. Weaver remains disabled by default, and approved capabilities are user-rights plus organization-whitelisted capabilities.
+3. User opens the Client in workspace context and uses Weaver from that workspace rather than from raw provider setup.
+4. Weaver follows the governed runtime/tool path: runtime profile from organization policy, tool registry boundary, runtime receipt for approval-required write-like actions, and support-safe audit refs.
+5. Result language is canonical and support-safe: `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, or `coming_later`; provider-specific detail appears only as sanitized support references.
+6. Adapter-continuity dry-run proves preserved/lossy/blocked/rollback/member-impact accounting and does not make an unqualified no-data-loss claim.
+7. Audit/evidence is inspectable without secrets or raw provider payloads.
+
+## Evidence map
+
+| Acceptance slice | Marker | Evidence |
+| --- | --- | --- |
+| Admin prepares/validates readiness | `BETA_ADMIN_READINESS_RESULT` | `release/provider-lab/weaver-runtime/sprint-32-beta-path-evidence.fixture.json` story step `admin_readiness` |
+| Admin enables Weaver for eligible scope | `BETA_WEAVER_ENABLEMENT_RESULT` | same fixture story step `admin_weaver_enablement` |
+| User uses Weaver in workspace context | `BETA_MEMBER_WORKSPACE_RESULT` | same fixture story step `member_workspace_weaver_use`; supporting client flow from PR #841 |
+| Governed Weaver runtime/tool path | `BETA_GOVERNED_RUNTIME_RESULT` | same fixture story step `governed_runtime_tool_path`; `docs/evidence/weaver-approval-runtime-boundary-issue-833.md`; `release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json` |
+| Adapter-continuity dry-run | `BETA_ADAPTER_CONTINUITY_RESULT` | same fixture story step `adapter_continuity_dry_run`; `docs/evidence/sprint-32-adapter-continuity-dry-run.md` |
+| Support-safe audit/evidence | `BETA_AUDIT_EVIDENCE_RESULT` | same fixture story step `audit_evidence_inspection` |
+
+## Live-stack gate
+
+The PR-safe artifact marks live runtime execution as `blocked_environment_unavailable` because no credentialed live stack was available in this implementation session. Local DNS is not treated as the blocker. Before RC promotion, the same scenario must be rerun against the intended runtime/container topology and attached as sanitized live-stack evidence.
+
+## Support-safety boundary
+
+No secrets, raw provider payloads, raw Weaver prompts, endpoint URLs, room IDs, event IDs, usernames, or member content are recorded. Evidence uses support-safe references and deterministic fixture assertions only.
+
+## Accessibility smoke
+
+The deterministic smoke covers critical state copy and keyboard/screen-reader-friendly state boundaries for:
+
+- Admin readiness and Weaver enablement states.
+- Member workspace Weaver helper states.
+
+This is supporting smoke evidence only; it is not a replacement for release-owner manual assistive-technology signoff where that gate applies.
+
+## Local verification
+
+```sh
+python3 e2e/tests/sprint32_beta_path_check.py
+./gradlew acceptanceContract
+```

--- a/e2e/features/sprint_32_beta_path.feature
+++ b/e2e/features/sprint_32_beta_path.feature
@@ -1,0 +1,17 @@
+Feature: Sprint 32 Admin User Weaver Beta path
+
+  Sprint 32 proves one coherent Beta evaluator story across Admin readiness,
+  eligible Weaver enablement, member workspace use, governed runtime/tool
+  execution, adapter-continuity accounting, and support-safe audit evidence.
+
+  @sprint32-beta-admin-user-weaver-path
+  Scenario: Admin prepares readiness, enables Weaver, and a member uses governed Weaver in a workspace
+    Given the Admin has category readiness evidence for organization, identity, chat, files, calendar, boards, meetings, health, and Weaver
+    And the Admin has a support-safe adapter-continuity dry-run with preserved, lossy, blocked, rollback, and member-impact accounting
+    When the Admin enables Weaver for an eligible policy scope
+    And the User opens the Client in a workspace context
+    And the User asks Weaver for workspace help through the governed runtime/tool path
+    Then the result uses canonical support-safe capability language
+    And approval-required Weaver tool actions are controlled by the user runtime receipt boundary
+    And audit and evidence refs are inspectable without secrets, raw provider payloads, raw Weaver prompts, or user content
+    And the live-stack gate is blocked only when the credentialed runtime environment is unavailable

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -4110,6 +4110,39 @@
           ]
         }
       ]
+    },
+    {
+      "tag": "@sprint32-beta-admin-user-weaver-path",
+      "scenario": "Admin prepares readiness, enables Weaver, and a member uses governed Weaver in a workspace",
+      "feature": "e2e/features/sprint_32_beta_path.feature",
+      "executableTest": "e2e/tests/sprint32_beta_path_check.py",
+      "evidenceMarkers": [
+        "BETA_ADMIN_READINESS_RESULT",
+        "BETA_WEAVER_ENABLEMENT_RESULT",
+        "BETA_MEMBER_WORKSPACE_RESULT",
+        "BETA_GOVERNED_RUNTIME_RESULT",
+        "BETA_ADAPTER_CONTINUITY_RESULT",
+        "BETA_AUDIT_EVIDENCE_RESULT"
+      ],
+      "evidenceMode": "offline-spec",
+      "additionalEvidence": [
+        {
+          "path": "docs/evidence/sprint-32-beta-path-evidence.md",
+          "fragments": [
+            "Admin prepares and validates organization/provider/category readiness",
+            "User opens the Client in workspace context and uses Weaver",
+            "No secrets, raw provider payloads, raw Weaver prompts, endpoint URLs, room IDs, event IDs, usernames, or member content are recorded"
+          ]
+        },
+        {
+          "path": "release/provider-lab/weaver-runtime/sprint-32-beta-path-evidence.fixture.json",
+          "fragments": [
+            "weave-beta-admin-user-weaver-path-evidence",
+            "blocked_environment_unavailable",
+            "BETA_GOVERNED_RUNTIME_RESULT"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/e2e/suites/scenario_catalog.json
+++ b/e2e/suites/scenario_catalog.json
@@ -3072,6 +3072,37 @@
         "heartbeat scope enforcement",
         "safe fallback audit"
       ]
+    },
+    {
+      "tag": "@sprint32-beta-admin-user-weaver-path",
+      "domains": [
+        "identity-idm",
+        "chat",
+        "files",
+        "calendar",
+        "boards-tasks",
+        "meetings-calls",
+        "admin-health-ops",
+        "weaver-governed-pa",
+        "provider-portability",
+        "decisions-evidence"
+      ],
+      "assertionFocus": [
+        "coherent Beta evaluator path",
+        "Admin readiness and Weaver enablement",
+        "member workspace Weaver use",
+        "governed runtime/tool execution",
+        "adapter-continuity accounting",
+        "support-safe audit evidence"
+      ],
+      "suiteId": "product-e2e-scenario-layer",
+      "personas": [
+        "admin",
+        "member",
+        "weaver_user",
+        "operator"
+      ],
+      "testLevel": "offline-contract"
     }
   ]
 }

--- a/e2e/tests/sprint32_beta_path_check.py
+++ b/e2e/tests/sprint32_beta_path_check.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate Sprint 32 Admin + User + Weaver Beta path evidence."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "release/provider-lab/weaver-runtime/sprint-32-beta-path-evidence.fixture.json"
+DOC = ROOT / "docs/evidence/sprint-32-beta-path-evidence.md"
+
+# Evidence markers used by e2e/scenario_mappings.json.
+BETA_ADMIN_READINESS_RESULT = "admin readiness marker"
+BETA_WEAVER_ENABLEMENT_RESULT = "admin Weaver enablement marker"
+BETA_MEMBER_WORKSPACE_RESULT = "member workspace Weaver marker"
+BETA_GOVERNED_RUNTIME_RESULT = "governed runtime/tool marker"
+BETA_ADAPTER_CONTINUITY_RESULT = "adapter continuity dry-run marker"
+BETA_AUDIT_EVIDENCE_RESULT = "audit evidence marker"
+
+REQUIRED_MARKERS = {
+    "BETA_ADMIN_READINESS_RESULT",
+    "BETA_WEAVER_ENABLEMENT_RESULT",
+    "BETA_MEMBER_WORKSPACE_RESULT",
+    "BETA_GOVERNED_RUNTIME_RESULT",
+    "BETA_ADAPTER_CONTINUITY_RESULT",
+    "BETA_AUDIT_EVIDENCE_RESULT",
+}
+REQUIRED_STEPS = {
+    "admin_readiness",
+    "admin_weaver_enablement",
+    "member_workspace_weaver_use",
+    "governed_runtime_tool_path",
+    "adapter_continuity_dry_run",
+    "audit_evidence_inspection",
+}
+FORBIDDEN_SUBSTRINGS = (
+    "secret=",
+    "token=",
+    "bearer ",
+    "mxc://",
+    "https://matrix.",
+    "https://auth.",
+    "rawProviderPayload",
+    "rawWeaverPrompt",
+)
+
+
+def fail(message: str) -> None:
+    print(f"sprint32-beta-path-check: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        fail(f"missing {path.relative_to(ROOT)}")
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path.relative_to(ROOT)}: {exc}")
+    if not isinstance(data, dict):
+        fail(f"{path.relative_to(ROOT)} must be an object")
+    return data
+
+
+def main() -> int:
+    data = load_json(FIXTURE)
+    if data.get("schemaVersion") != "sprint32.beta-path-evidence.v1":
+        fail("unexpected schemaVersion")
+    if data.get("issue") != 835:
+        fail("fixture must be bound to issue 835")
+
+    support = data.get("supportSafety")
+    if not isinstance(support, dict):
+        fail("supportSafety must be an object")
+    for key in ("containsSecrets", "containsRawProviderPayloads", "containsRawWeaverPrompts", "containsEndpointUrls"):
+        if support.get(key) is not False:
+            fail(f"supportSafety.{key} must be false")
+
+    story = data.get("story")
+    if not isinstance(story, list):
+        fail("story must be a list")
+    steps = {item.get("step") for item in story if isinstance(item, dict)}
+    missing_steps = REQUIRED_STEPS - steps
+    if missing_steps:
+        fail("missing story steps: " + ", ".join(sorted(missing_steps)))
+
+    markers = {item.get("evidenceMarker") for item in story if isinstance(item, dict)}
+    missing_markers = REQUIRED_MARKERS - markers
+    if missing_markers:
+        fail("missing markers: " + ", ".join(sorted(missing_markers)))
+
+    for item in story:
+        if not isinstance(item, dict):
+            fail("each story item must be an object")
+        assertions = item.get("assertions")
+        if not isinstance(assertions, list) or len(assertions) < 2:
+            fail(f"{item.get('step')} needs at least two assertions")
+        if item.get("status") != "passed_offline_contract":
+            fail(f"{item.get('step')} must be passed_offline_contract")
+
+    gate = data.get("liveStackGate")
+    if not isinstance(gate, dict):
+        fail("liveStackGate must be an object")
+    if gate.get("status") != "blocked_environment_unavailable":
+        fail("liveStackGate must state the exact environment blocker for this PR-safe run")
+    if gate.get("requiredBeforeRcPromotion") is not True:
+        fail("live stack evidence must remain required before RC promotion")
+
+    text = FIXTURE.read_text().lower()
+    for forbidden in FORBIDDEN_SUBSTRINGS:
+        if forbidden in text:
+            fail(f"support-unsafe substring found: {forbidden}")
+
+    doc_text = DOC.read_text() if DOC.exists() else ""
+    for fragment in (
+        "Admin prepares and validates organization/provider/category readiness",
+        "User opens the Client in workspace context and uses Weaver",
+        "No secrets, raw provider payloads, raw Weaver prompts, endpoint URLs, room IDs, event IDs, usernames, or member content are recorded",
+    ):
+        if fragment not in doc_text:
+            fail(f"missing documentation fragment: {fragment}")
+
+    print("sprint32-beta-path-check: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/release/provider-lab/weaver-runtime/sprint-32-beta-path-evidence.fixture.json
+++ b/release/provider-lab/weaver-runtime/sprint-32-beta-path-evidence.fixture.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": "sprint32.beta-path-evidence.v1",
+  "artifactKind": "weave-beta-admin-user-weaver-path-evidence",
+  "issue": 835,
+  "claimBoundary": "deterministic offline evidence for the coherent Beta path; live-stack runtime evidence is still required before release-candidate promotion if no credentialed stack artifact is attached",
+  "supportSafety": {
+    "containsSecrets": false,
+    "containsRawProviderPayloads": false,
+    "containsRawWeaverPrompts": false,
+    "containsEndpointUrls": false,
+    "redactedFields": [
+      "subjectRef",
+      "workspaceRef",
+      "providerDiagnosticRef",
+      "auditCorrelationRef"
+    ]
+  },
+  "story": [
+    {
+      "step": "admin_readiness",
+      "persona": "admin",
+      "evidenceMarker": "BETA_ADMIN_READINESS_RESULT",
+      "assertions": [
+        "organization readiness is validated before member go-live",
+        "identity, chat, files, calendar, boards/tasks, meetings, admin health, and Weaver categories use provider-neutral readiness states",
+        "provider diagnostics are referenced only through support-safe refs"
+      ],
+      "status": "passed_offline_contract"
+    },
+    {
+      "step": "admin_weaver_enablement",
+      "persona": "admin",
+      "evidenceMarker": "BETA_WEAVER_ENABLEMENT_RESULT",
+      "assertions": [
+        "Weaver remains disabled by default",
+        "eligible scope is enabled by policy profile rather than raw runtime configuration",
+        "approved capabilities are user-rights organization-whitelisted"
+      ],
+      "status": "passed_offline_contract"
+    },
+    {
+      "step": "member_workspace_weaver_use",
+      "persona": "member",
+      "evidenceMarker": "BETA_MEMBER_WORKSPACE_RESULT",
+      "assertions": [
+        "member opens a workspace context before invoking Weaver",
+        "member sees canonical capability state language",
+        "Weaver answer avoids provider names unless required for support-safe diagnostics"
+      ],
+      "status": "passed_offline_contract"
+    },
+    {
+      "step": "governed_runtime_tool_path",
+      "persona": "weaver_user",
+      "evidenceMarker": "BETA_GOVERNED_RUNTIME_RESULT",
+      "assertions": [
+        "runtime profile is derived from organization policy and user rights",
+        "MCP/tool execution records approval authority and runtime receipt when required",
+        "server does not silently approve write-like Weaver actions"
+      ],
+      "status": "passed_offline_contract"
+    },
+    {
+      "step": "adapter_continuity_dry_run",
+      "persona": "operator",
+      "evidenceMarker": "BETA_ADAPTER_CONTINUITY_RESULT",
+      "assertions": [
+        "dry-run records preserved, lossy, blocked, rollback, and member-impact categories",
+        "no lossless or no-data-loss claim is made unless every mapped record is accounted for",
+        "dry-run evidence links to adapter-continuity issue evidence without raw payloads"
+      ],
+      "status": "passed_offline_contract"
+    },
+    {
+      "step": "audit_evidence_inspection",
+      "persona": "operator",
+      "evidenceMarker": "BETA_AUDIT_EVIDENCE_RESULT",
+      "assertions": [
+        "audit trail is inspectable by support-safe refs",
+        "evidence excludes secrets, raw provider payloads, raw Weaver prompts, and user content",
+        "live-stack gate is explicitly marked blocked only when environment is unavailable"
+      ],
+      "status": "passed_offline_contract"
+    }
+  ],
+  "accessibilitySmoke": [
+    {
+      "surface": "admin readiness and Weaver enablement",
+      "coverage": "keyboard labels and blocked/available state copy are covered by deterministic Admin evidence references",
+      "status": "supporting_offline_smoke"
+    },
+    {
+      "surface": "member workspace Weaver helper",
+      "coverage": "bounded Weaver helper copy and disabled/available states are covered by client widget evidence references",
+      "status": "supporting_offline_smoke"
+    }
+  ],
+  "linkedEvidence": [
+    "docs/evidence/sprint-32-beta-path-evidence.md",
+    "docs/evidence/sprint-32-adapter-continuity-dry-run.md",
+    "docs/evidence/weaver-approval-runtime-boundary-issue-833.md",
+    "release/provider-lab/weaver-runtime/sprint-32-governed-foundation.fixture.json",
+    "release/provider-lab/weaver-runtime/sprint-32-weaver-mcp-tool-execution.fixture.json"
+  ],
+  "liveStackGate": {
+    "status": "blocked_environment_unavailable",
+    "blockedReason": "No credentialed live stack was available to this offline PR-safe evidence run; local DNS is not treated as the blocker.",
+    "requiredBeforeRcPromotion": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a Sprint 32 Gherkin scenario for the complete Admin + User + Weaver Beta evaluator path.
- Maps the scenario to deterministic offline evidence markers, a support-safe fixture, and an executable evidence check.
- Documents the live-stack gate as blocked by unavailable credentialed runtime environment, not local DNS.

## Scope and user impact

- Evidence/acceptance only; no product runtime code changes.
- Gives reviewers a deterministic acceptance map for issue #835 across Admin readiness, Weaver enablement, member workspace use, governed runtime/tool path, adapter-continuity, and audit evidence.

## Spec / acceptance link

- Issue: Fixes #835
- Repo spec / Spec Kit package: pinned corpus via `specs/weave-specs.lock.json`; Sprint 32 implementation evidence from merged PRs #837, #838, #839, #840, #841.
- Plan/tasks/traceability: `docs/evidence/sprint-32-beta-path-evidence.md`, `release/provider-lab/weaver-runtime/sprint-32-beta-path-evidence.fixture.json`
- Mapped Gherkin feature/scenario when product behavior changed: `e2e/features/sprint_32_beta_path.feature` / `@sprint32-beta-admin-user-weaver-path`
- Evidence mode / reality level: `offline-spec` / `contract_only`; live-stack gate remains blocked until credentialed runtime evidence is attached before RC promotion.
- Product-core questions intentionally left unresolved: none.

Quality Reset rule: this PR does not describe fixture evidence as live-runtime, release_ready, customer-ready, or production evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [ ] none
- [ ] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [x] changes evidence only

## Release note

- Release note: none — reason: acceptance/evidence mapping only, no runtime product behavior change.

## Release notes label

- [ ] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [x] `release-notes-skip`

## Screenshots or docs impact

- Adds support-safe evidence documentation only; no screenshots.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: fixture check rejects common secret/raw payload substrings and records no endpoints, raw provider payloads, raw Weaver prompts, or member content.
- Accessibility/localization impact: deterministic accessibility smoke is documented for Admin readiness/Weaver enablement and member workspace Weaver helper states; no UI strings changed.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [x] No public API/auth/topology/spec contract change
- [ ] Contract/spec change documented:
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: QA/evidence acceptance mapping for Sprint 32 issue #835.
- If Copilot is unavailable/insufficient, matching reviewer used: fallback self-review against acceptance-contract output and support-safety fixture check in this PR body.

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [x] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed (via `./gradlew acceptanceContract`)
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): skipped/blocked — no credentialed live-stack runtime environment available in this implementation session; local DNS is not the blocker.

Additional related gate:

- [x] `python3 e2e/tests/sprint32_beta_path_check.py`

## Notes for reviewers

- Review claim hygiene first: this is offline deterministic evidence only, with explicit live-stack follow-up before RC promotion.
- Approval semantics distinguish user runtime receipt authority from server/product permissions.
