### PR TITLE
feat(server): govern local Qwen MCP tool calls

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/config/WeaverPaChatProperties.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/WeaverPaChatProperties.java
@@ -12,7 +12,7 @@ public record WeaverPaChatProperties(
 
     public WeaverPaChatProperties {
         bridgeUrl = hasText(bridgeUrl) ? bridgeUrl.trim() : "";
-        timeout = timeout == null ? Duration.ofSeconds(10) : timeout;
+        timeout = timeout == null ? Duration.ofSeconds(120) : timeout;
         runtimeTokenRef = hasText(runtimeTokenRef) ? runtimeTokenRef.trim() : "credentialref://weave/channels/weave-chat/runtime-token";
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
@@ -67,6 +67,9 @@ public class ChatFacadeService {
     private static final String DEFAULT_MODEL_PROVIDER_KEY = "lmstudio";
     private static final String WEAVER_CHAT_PROVIDER_REF = "provider:chat:selected-by-admin";
     private static final String WEAVER_LMSTUDIO_MODEL_REF = "lmstudio/qwen/qwen3.5-9b";
+    private static final String WEAVER_RUNTIME_PROFILE_VERSION = "weaver-runtime-profile:v1";
+    private static final String WEAVER_RUNTIME_PROFILE_HASH = "runtime-profile:qwen-mcp-weave-chat";
+    private static final String WEAVER_MCP_SERVER_ID = "mcp-weave-domain-tools";
 
     private final WorkspaceCapabilityProperties workspaceCapabilityProperties;
     private final WorkspaceCapabilityService workspaceCapabilityService;
@@ -286,6 +289,14 @@ public class ChatFacadeService {
         responseEvidence.put("lmStudioResponseReceived", assistantEvidence.get("lmStudioResponseReceived"));
         responseEvidence.put("assistantMessageId", assistantMessage.id());
         responseEvidence.put("modelRef", assistantEvidence.get("modelRef"));
+        copySupportSafeEvidence(assistantEvidence, responseEvidence, "runtimeProfileHash");
+        copySupportSafeEvidence(assistantEvidence, responseEvidence, "runtimeProfileVersion");
+        copySupportSafeEvidence(assistantEvidence, responseEvidence, "mcpServerId");
+        copySupportSafeEvidence(assistantEvidence, responseEvidence, "toolId");
+        copySupportSafeEvidence(assistantEvidence, responseEvidence, "auditRef");
+        copySupportSafeEvidence(assistantEvidence, responseEvidence, "approvalState");
+        copySupportSafeEvidence(assistantEvidence, responseEvidence, "denyState");
+        copySupportSafeEvidence(assistantEvidence, responseEvidence, "toolResultFedBackToModel");
         responseEvidence.put("supportSafe", assistantEvidence.getOrDefault("supportSafe", true));
         return new ChatMessageResponse(
                 userMessage.id(),
@@ -317,6 +328,11 @@ public class ChatFacadeService {
                     Map.of(
                             "contextId", conversation.contextId(),
                             "chatProviderRef", WEAVER_CHAT_PROVIDER_REF,
+                            "runtimeProfileHash", WEAVER_RUNTIME_PROFILE_HASH,
+                            "runtimeProfileVersion", WEAVER_RUNTIME_PROFILE_VERSION,
+                            "mcpServerId", WEAVER_MCP_SERVER_ID,
+                            "offeredToolIds", List.of("calendar.search_events", "chat.search_messages"),
+                            "toolPolicy", "domain-first-read-only-fail-closed",
                             "supportSafe", true,
                             "rawProviderContentIncluded", false)));
         } catch (WeaverPaChatUnavailableException exception) {
@@ -339,12 +355,22 @@ public class ChatFacadeService {
         evidence.put("weaverReceived", result.weaverReceived());
         evidence.put("lmStudioResponseReceived", result.lmStudioResponseReceived());
         evidence.put("auditRef", result.auditRef());
+        evidence.put("runtimeProfileHash", WEAVER_RUNTIME_PROFILE_HASH);
+        evidence.put("runtimeProfileVersion", WEAVER_RUNTIME_PROFILE_VERSION);
+        evidence.put("mcpServerId", WEAVER_MCP_SERVER_ID);
         evidence.put("supportSafe", true);
         evidence.put("rawProviderDiagnosticsExposed", false);
         copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "source");
         copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "liveCall");
         copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "approvedReplyTool");
         copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "unsafeExecTool");
+        copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "runtimeProfileHash");
+        copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "runtimeProfileVersion");
+        copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "mcpServerId");
+        copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "toolId");
+        copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "approvalState");
+        copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "denyState");
+        copySupportSafeEvidence(result.supportSafeEvidence(), evidence, "toolResultFedBackToModel");
         ChatMessageResponse assistantMessage = new ChatMessageResponse(
                 "msg-" + UUID.randomUUID(),
                 conversation.id(),

--- a/server/src/main/java/com/massimotter/weave/backend/service/HttpWeaverPaChatClient.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/HttpWeaverPaChatClient.java
@@ -4,6 +4,7 @@ import com.massimotter.weave.backend.config.WeaverPaChatProperties;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
@@ -16,7 +17,9 @@ public class HttpWeaverPaChatClient implements WeaverPaChatClient {
 
     @Autowired
     public HttpWeaverPaChatClient(WeaverPaChatProperties properties) {
-        this(properties, RestClient.builder().build());
+        this(properties, RestClient.builder()
+                .requestFactory(requestFactory(properties))
+                .build());
     }
 
     HttpWeaverPaChatClient(WeaverPaChatProperties properties, RestClient restClient) {
@@ -75,6 +78,15 @@ public class HttpWeaverPaChatClient implements WeaverPaChatClient {
                 hasText(response.providerRef()) ? response.providerRef() : "provider:model:lmstudio",
                 auditRef,
                 evidence);
+    }
+
+    private static SimpleClientHttpRequestFactory requestFactory(WeaverPaChatProperties properties) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        if (properties != null && properties.timeout() != null) {
+            requestFactory.setConnectTimeout(properties.timeout());
+            requestFactory.setReadTimeout(properties.timeout());
+        }
+        return requestFactory;
     }
 
     private static boolean hasText(String value) {

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridge.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridge.java
@@ -26,12 +26,15 @@ public class LocalQwenMcpToolBridge {
 
     public QwenMcpToolTurn execute(QwenMcpToolRequest request) {
         List<WeaverDomainToolDefinition> offeredTools = offeredTools(request.grantedCapabilities());
-        boolean offered = offeredTools.stream().anyMatch(definition -> definition.name().equals(request.toolName()));
-        if (!offered) {
+        WeaverDomainToolDefinition offeredTool = offeredTools.stream()
+                .filter(definition -> definition.name().equals(request.toolName()))
+                .findFirst()
+                .orElse(null);
+        if (offeredTool == null) {
             return denied(request, "tool_not_offered", "Local Qwen requested a tool that is not in the governed read-only MCP offer.");
         }
-        if (request.input().keySet().stream().anyMatch(LocalQwenMcpToolBridge::overbroadArgument)) {
-            return denied(request, "overbroad_args", "Local Qwen requested overbroad or provider-shaped arguments; invocation failed closed.");
+        if (!inputAllowedBySchema(offeredTool, request.input()) || containsProviderShapedArgument(request.input())) {
+            return denied(request, "overbroad_args", "Local Qwen requested unknown, overbroad, or provider-shaped arguments; invocation failed closed.");
         }
         WeaverToolInvocationResult result = toolRegistry.invoke(new WeaverToolInvocationRequest(
                 request.toolName(),
@@ -94,18 +97,51 @@ public class LocalQwenMcpToolBridge {
         return toolName.substring(0, toolName.indexOf('.'));
     }
 
-    private static boolean overbroadArgument(String key) {
-        if (key == null) {
+    private static boolean inputAllowedBySchema(WeaverDomainToolDefinition definition, Map<String, Object> input) {
+        Object additionalProperties = definition.inputSchema().get("additionalProperties");
+        if (!Boolean.FALSE.equals(additionalProperties)) {
+            return true;
+        }
+        Object properties = definition.inputSchema().get("properties");
+        if (!(properties instanceof Map<?, ?> allowedProperties)) {
+            return input.isEmpty();
+        }
+        return input.keySet().stream().allMatch(allowedProperties::containsKey);
+    }
+
+    private static boolean containsProviderShapedArgument(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (providerShapedKey(entry.getKey()) || containsProviderShapedArgument(entry.getValue())) {
+                    return true;
+                }
+            }
+        } else if (value instanceof Iterable<?> iterable) {
+            for (Object item : iterable) {
+                if (containsProviderShapedArgument(item)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean providerShapedKey(Object key) {
+        if (!(key instanceof String stringKey)) {
             return false;
         }
-        String normalized = key.strip().toLowerCase();
+        String normalized = stringKey.strip().toLowerCase();
         return normalized.equals("providerpayload")
                 || normalized.equals("rawproviderpayload")
+                || normalized.equals("providerurl")
                 || normalized.equals("secret")
+                || normalized.equals("secrettoken")
+                || normalized.equals("accesstoken")
                 || normalized.equals("token")
                 || normalized.equals("all")
                 || normalized.equals("*")
-                || normalized.startsWith("provider");
+                || normalized.startsWith("provider")
+                || normalized.contains("token");
     }
 
     public record QwenMcpToolRequest(

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridge.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridge.java
@@ -1,0 +1,150 @@
+package com.massimotter.weave.backend.weaver;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LocalQwenMcpToolBridge {
+
+    public static final String MCP_SERVER_ID = "mcp-weave-domain-tools";
+    public static final String RUNTIME_PROFILE_VERSION = "weaver-runtime-profile:v1";
+
+    private final WeaverToolRegistry toolRegistry;
+
+    public LocalQwenMcpToolBridge(WeaverToolRegistry toolRegistry) {
+        this.toolRegistry = toolRegistry;
+    }
+
+    public List<WeaverDomainToolDefinition> offeredTools(List<String> grantedCapabilities) {
+        return toolRegistry.discover(grantedCapabilities).stream()
+                .filter(definition -> !definition.writeLike())
+                .toList();
+    }
+
+    public QwenMcpToolTurn execute(QwenMcpToolRequest request) {
+        List<WeaverDomainToolDefinition> offeredTools = offeredTools(request.grantedCapabilities());
+        boolean offered = offeredTools.stream().anyMatch(definition -> definition.name().equals(request.toolName()));
+        if (!offered) {
+            return denied(request, "tool_not_offered", "Local Qwen requested a tool that is not in the governed read-only MCP offer.");
+        }
+        if (request.input().keySet().stream().anyMatch(LocalQwenMcpToolBridge::overbroadArgument)) {
+            return denied(request, "overbroad_args", "Local Qwen requested overbroad or provider-shaped arguments; invocation failed closed.");
+        }
+        WeaverToolInvocationResult result = toolRegistry.invoke(new WeaverToolInvocationRequest(
+                request.toolName(),
+                request.userRef(),
+                request.runtimeProfileHash(),
+                request.runtimeProfileUserRef(),
+                request.runtimeProfileSignature(),
+                request.runtimeProfileRevoked(),
+                request.runtimeTokenExpiresAt(),
+                request.consentGranted(),
+                request.grantedCapabilities(),
+                request.scopedToolGrants(),
+                request.input(),
+                null));
+        Map<String, Object> evidence = baseEvidence(request, result.status());
+        evidence.put("toolCallReceived", true);
+        evidence.put("toolOffered", true);
+        evidence.put("toolResultFedBackToModel", "ok".equals(result.status()));
+        evidence.put("auditRef", result.redactedResult().getOrDefault("auditRef", "audit://weaver-tool/" + request.toolName() + "/" + result.status()));
+        evidence.put("approvalState", result.approvalRequired() ? "required" : "not_required");
+        evidence.put("denyState", "ok".equals(result.status()) ? "allowed" : result.status());
+        evidence.put("rawProviderPayloadIncluded", false);
+        evidence.put("visibleThinkingTreatedAsAuthority", false);
+        return new QwenMcpToolTurn("ok".equals(result.status()), result.status(), result.supportSafeMessage(), Map.copyOf(evidence), result.redactedResult());
+    }
+
+    private QwenMcpToolTurn denied(QwenMcpToolRequest request, String status, String message) {
+        Map<String, Object> evidence = baseEvidence(request, status);
+        evidence.put("toolCallReceived", true);
+        evidence.put("toolResultFedBackToModel", false);
+        evidence.put("approvalState", "denied");
+        evidence.put("denyState", status);
+        evidence.put("rawProviderPayloadIncluded", false);
+        evidence.put("visibleThinkingTreatedAsAuthority", false);
+        return new QwenMcpToolTurn(false, status, message, Map.copyOf(evidence), Map.of("auditRef", evidence.get("auditRef")));
+    }
+
+    private Map<String, Object> baseEvidence(QwenMcpToolRequest request, String decision) {
+        Map<String, Object> evidence = new LinkedHashMap<>();
+        evidence.put("channelId", request.channelId());
+        evidence.put("modelRef", request.modelRef());
+        evidence.put("runtimeProfileHash", request.runtimeProfileHash());
+        evidence.put("runtimeProfileVersion", request.runtimeProfileVersion());
+        evidence.put("mcpServerId", MCP_SERVER_ID);
+        evidence.put("toolId", request.toolName());
+        evidence.put("tool", request.toolName());
+        evidence.put("domain", domainOf(request.toolName()));
+        evidence.put("providerRef", "provider:domain-facade");
+        evidence.put("credentialRef", "credentialref://weave/runtime/short-lived");
+        evidence.put("decision", decision);
+        evidence.put("auditRef", "audit://weaver-tool/" + (request.toolName() == null ? "unknown" : request.toolName()) + "/" + decision);
+        evidence.put("supportSafe", true);
+        return evidence;
+    }
+
+    private static String domainOf(String toolName) {
+        if (toolName == null || !toolName.contains(".")) {
+            return "weaver-runtime";
+        }
+        return toolName.substring(0, toolName.indexOf('.'));
+    }
+
+    private static boolean overbroadArgument(String key) {
+        if (key == null) {
+            return false;
+        }
+        String normalized = key.strip().toLowerCase();
+        return normalized.equals("providerpayload")
+                || normalized.equals("rawproviderpayload")
+                || normalized.equals("secret")
+                || normalized.equals("token")
+                || normalized.equals("all")
+                || normalized.equals("*")
+                || normalized.startsWith("provider");
+    }
+
+    public record QwenMcpToolRequest(
+            String channelId,
+            String modelRef,
+            String toolName,
+            String userRef,
+            String runtimeProfileHash,
+            String runtimeProfileVersion,
+            String runtimeProfileUserRef,
+            String runtimeProfileSignature,
+            boolean runtimeProfileRevoked,
+            String runtimeTokenExpiresAt,
+            boolean consentGranted,
+            List<String> grantedCapabilities,
+            List<String> scopedToolGrants,
+            Map<String, Object> input) {
+        public QwenMcpToolRequest {
+            channelId = channelId == null || channelId.isBlank() ? "channels.weave-chat" : channelId;
+            modelRef = modelRef == null || modelRef.isBlank() ? "lmstudio/qwen/qwen3.5-9b" : modelRef;
+            runtimeProfileVersion = runtimeProfileVersion == null || runtimeProfileVersion.isBlank()
+                    ? RUNTIME_PROFILE_VERSION
+                    : runtimeProfileVersion;
+            runtimeProfileUserRef = runtimeProfileUserRef == null || runtimeProfileUserRef.isBlank() ? userRef : runtimeProfileUserRef;
+            runtimeProfileSignature = runtimeProfileSignature == null ? "" : runtimeProfileSignature;
+            runtimeTokenExpiresAt = runtimeTokenExpiresAt == null || runtimeTokenExpiresAt.isBlank()
+                    ? Instant.now().plusSeconds(120).toString()
+                    : runtimeTokenExpiresAt;
+            grantedCapabilities = List.copyOf(grantedCapabilities == null ? List.of() : grantedCapabilities);
+            scopedToolGrants = List.copyOf(scopedToolGrants == null ? List.of() : scopedToolGrants);
+            input = Map.copyOf(input == null ? Map.of() : input);
+        }
+    }
+
+    public record QwenMcpToolTurn(
+            boolean allowed,
+            String decision,
+            String modelVisibleToolResult,
+            Map<String, Object> supportSafeEvidence,
+            Map<String, Object> toolResult) {
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridge.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridge.java
@@ -98,15 +98,44 @@ public class LocalQwenMcpToolBridge {
     }
 
     private static boolean inputAllowedBySchema(WeaverDomainToolDefinition definition, Map<String, Object> input) {
-        Object additionalProperties = definition.inputSchema().get("additionalProperties");
-        if (!Boolean.FALSE.equals(additionalProperties)) {
+        return valueAllowedBySchema(definition.inputSchema(), input);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean valueAllowedBySchema(Map<String, Object> schema, Object value) {
+        Object type = schema.get("type");
+        if ("object".equals(type)) {
+            if (!(value instanceof Map<?, ?> map)) {
+                return false;
+            }
+            Object properties = schema.get("properties");
+            Map<?, ?> allowedProperties = properties instanceof Map<?, ?> propertyMap ? propertyMap : Map.of();
+            if (Boolean.FALSE.equals(schema.get("additionalProperties"))
+                    && !map.keySet().stream().allMatch(allowedProperties::containsKey)) {
+                return false;
+            }
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                Object nestedSchema = allowedProperties.get(entry.getKey());
+                if (nestedSchema instanceof Map<?, ?> nestedSchemaMap
+                        && !valueAllowedBySchema((Map<String, Object>) nestedSchemaMap, entry.getValue())) {
+                    return false;
+                }
+            }
             return true;
         }
-        Object properties = definition.inputSchema().get("properties");
-        if (!(properties instanceof Map<?, ?> allowedProperties)) {
-            return input.isEmpty();
+        if ("string".equals(type)) {
+            return value instanceof String;
         }
-        return input.keySet().stream().allMatch(allowedProperties::containsKey);
+        if ("integer".equals(type)) {
+            return value instanceof Integer || value instanceof Long;
+        }
+        if ("number".equals(type)) {
+            return value instanceof Number;
+        }
+        if ("boolean".equals(type)) {
+            return value instanceof Boolean;
+        }
+        return true;
     }
 
     private static boolean containsProviderShapedArgument(Object value) {
@@ -132,15 +161,21 @@ public class LocalQwenMcpToolBridge {
         }
         String normalized = stringKey.strip().toLowerCase();
         return normalized.equals("providerpayload")
+                || normalized.equals("rawpayload")
                 || normalized.equals("rawproviderpayload")
                 || normalized.equals("providerurl")
                 || normalized.equals("secret")
+                || normalized.equals("secretref")
+                || normalized.equals("secretref.value")
                 || normalized.equals("secrettoken")
                 || normalized.equals("accesstoken")
+                || normalized.equals("access_token")
                 || normalized.equals("token")
                 || normalized.equals("all")
                 || normalized.equals("*")
                 || normalized.startsWith("provider")
+                || normalized.startsWith("secret")
+                || normalized.contains("payload")
                 || normalized.contains("token");
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -282,6 +282,10 @@ public class WeaverToolRegistry {
                 Map.of(
                         "type", "object",
                         "additionalProperties", false,
+                        "properties", Map.of(
+                                "spaceRef", Map.of("type", "string"),
+                                "query", Map.of("type", "string"),
+                                "limit", Map.of("type", "integer", "minimum", 1, "maximum", 50)),
                         "description", "Validated by the Weave " + domain + " facade before provider access."),
                 List.of("providerCredentials", "rawProviderPayload", "secretRef.value"),
                 "Weaver domain tool exposed only through Weave capability grants.");

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -131,7 +131,8 @@ weave:
       # Weaver/LM Studio success evidence.
       enabled: ${WEAVE_WEAVER_PA_CHAT_ENABLED:false}
       bridge-url: ${WEAVE_WEAVER_PA_CHAT_BRIDGE_URL:}
-      timeout: ${WEAVE_WEAVER_PA_CHAT_TIMEOUT:10s}
+      # Local LM Studio/Qwen tool-call turns can be much slower than cloud chat completions.
+      timeout: ${WEAVE_WEAVER_PA_CHAT_TIMEOUT:120s}
       runtime-token-ref: ${WEAVE_WEAVER_PA_CHAT_RUNTIME_TOKEN_REF:credentialref://weave/channels/weave-chat/runtime-token}
   boards:
     runtime-enabled: ${WEAVE_BOARDS_RUNTIME_ENABLED:${WEAVE_BOARDS_WORKSPACE_RUNTIME_ENABLED:false}}

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
@@ -60,6 +60,9 @@ class ChatFacadeServiceTest {
                     assertThat(message.deliveryEvidence())
                             .containsEntry("channelId", "channels.weave-chat")
                             .containsEntry("modelRef", "lmstudio/qwen/qwen3.5-9b")
+                            .containsEntry("runtimeProfileHash", "runtime-profile:qwen-mcp-weave-chat")
+                            .containsEntry("runtimeProfileVersion", "weaver-runtime-profile:v1")
+                            .containsEntry("mcpServerId", "mcp-weave-domain-tools")
                             .containsEntry("rawProviderDiagnosticsExposed", false);
                 });
         assertThat(auditPublisher.events())
@@ -156,6 +159,10 @@ class ChatFacadeServiceTest {
         assertThat(capturedRequest.get().providerRef()).isEqualTo("provider:model:custom-lmstudio");
         assertThat(capturedRequest.get().supportSafeContext())
                 .containsEntry("chatProviderRef", "provider:chat:selected-by-admin")
+                .containsEntry("runtimeProfileHash", "runtime-profile:qwen-mcp-weave-chat")
+                .containsEntry("runtimeProfileVersion", "weaver-runtime-profile:v1")
+                .containsEntry("mcpServerId", "mcp-weave-domain-tools")
+                .containsEntry("toolPolicy", "domain-first-read-only-fail-closed")
                 .containsEntry("rawProviderContentIncluded", false);
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridgeTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridgeTest.java
@@ -1,0 +1,131 @@
+package com.massimotter.weave.backend.weaver;
+
+import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalQwenMcpToolBridgeTest {
+
+    @Test
+    void localQwenReadOnlyToolCallExecutesThroughGovernedDomainToolPlane() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));
+
+        var turn = bridge.execute(request("calendar.search_events", false, Map.of("spaceRef", "space:default")));
+
+        assertThat(turn.allowed()).isTrue();
+        assertThat(turn.decision()).isEqualTo("ok");
+        assertThat(turn.supportSafeEvidence())
+                .containsEntry("channelId", "channels.weave-chat")
+                .containsEntry("modelRef", "lmstudio/qwen/qwen3.5-9b")
+                .containsEntry("runtimeProfileHash", "rph-qwen-tool-test")
+                .containsEntry("runtimeProfileVersion", "weaver-runtime-profile:v1")
+                .containsEntry("mcpServerId", "mcp-weave-domain-tools")
+                .containsEntry("toolId", "calendar.search_events")
+                .containsEntry("approvalState", "not_required")
+                .containsEntry("toolCallReceived", true)
+                .containsEntry("toolResultFedBackToModel", true)
+                .containsEntry("supportSafe", true)
+                .containsEntry("rawProviderPayloadIncluded", false)
+                .containsEntry("visibleThinkingTreatedAsAuthority", false);
+        assertThat(turn.toolResult())
+                .containsEntry("rawProviderPayload", "redacted")
+                .containsKey("auditRef");
+        assertThat(auditPublisher.events()).hasSize(1);
+        assertThat(auditPublisher.events().get(0).payload())
+                .containsEntry("runtimeProfileHash", "rph-qwen-tool-test")
+                .containsEntry("tool", "calendar.search_events")
+                .containsEntry("decision", "invoked")
+                .containsEntry("providerRef", "provider:domain-facade")
+                .containsEntry("credentialRef", "credentialref://weave/runtime/short-lived");
+        assertThat(auditPublisher.events().toString())
+                .doesNotContain("Bearer", "access_token", "rawProviderPayload={", "secret.value");
+    }
+
+    @Test
+    void unknownToolIsDeniedBeforeInvocation() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));
+
+        var turn = bridge.execute(request("provider.native_dump", false, Map.of("spaceRef", "space:default")));
+
+        assertThat(turn.allowed()).isFalse();
+        assertThat(turn.decision()).isEqualTo("tool_not_offered");
+        assertThat(turn.supportSafeEvidence())
+                .containsEntry("denyState", "tool_not_offered")
+                .containsEntry("toolResultFedBackToModel", false);
+        assertThat(auditPublisher.events()).isEmpty();
+    }
+
+    @Test
+    void overbroadArgsAreDeniedBeforeInvocation() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));
+
+        var turn = bridge.execute(request("calendar.search_events", false, Map.of("providerPayload", "dump everything")));
+
+        assertThat(turn.allowed()).isFalse();
+        assertThat(turn.decision()).isEqualTo("overbroad_args");
+        assertThat(turn.supportSafeEvidence())
+                .containsEntry("denyState", "overbroad_args")
+                .containsEntry("rawProviderPayloadIncluded", false);
+        assertThat(auditPublisher.events()).isEmpty();
+    }
+
+    @Test
+    void revokedRuntimeProfileIsDeniedByToolRegistryPolicyGuard() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));
+
+        var turn = bridge.execute(request("calendar.search_events", true, Map.of("spaceRef", "space:default")));
+
+        assertThat(turn.allowed()).isFalse();
+        assertThat(turn.decision()).isEqualTo("runtime_profile_revoked");
+        assertThat(turn.supportSafeEvidence())
+                .containsEntry("denyState", "runtime_profile_revoked")
+                .containsEntry("toolResultFedBackToModel", false);
+        assertThat(auditPublisher.events()).hasSize(1);
+        assertThat(auditPublisher.events().get(0).payload())
+                .containsEntry("decision", "runtime_profile_revoked")
+                .containsEntry("runtimeProfileHash", "rph-qwen-tool-test");
+    }
+
+    @Test
+    void chatSendMessageIsNotOfferedAsInboundTransportTool() {
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(new InMemoryAuditEventPublisher()));
+
+        assertThat(bridge.offeredTools(List.of("weaver.chat_read", "weaver.calendar_read")))
+                .extracting(WeaverDomainToolDefinition::name)
+                .contains("chat.search_messages", "calendar.search_events")
+                .doesNotContain("chat.send_message");
+
+        var turn = bridge.execute(request("chat.send_message", false, Map.of("spaceRef", "space:default")));
+        assertThat(turn.allowed()).isFalse();
+        assertThat(turn.decision()).isEqualTo("tool_not_offered");
+    }
+
+    private LocalQwenMcpToolBridge.QwenMcpToolRequest request(
+            String toolName,
+            boolean revoked,
+            Map<String, Object> input) {
+        return new LocalQwenMcpToolBridge.QwenMcpToolRequest(
+                "channels.weave-chat",
+                "lmstudio/qwen/qwen3.5-9b",
+                toolName,
+                "user:123",
+                "rph-qwen-tool-test",
+                "weaver-runtime-profile:v1",
+                "user:123",
+                "weave-signature:v1:test-support-safe",
+                revoked,
+                Instant.now().plusSeconds(300).toString(),
+                true,
+                List.of("weaver.calendar_read", "weaver.chat_read"),
+                List.of(toolName),
+                input);
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridgeTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridgeTest.java
@@ -118,6 +118,44 @@ class LocalQwenMcpToolBridgeTest {
     }
 
     @Test
+    void nestedSecretRefUnderAllowedTopLevelArgIsDeniedBeforeInvocation() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));
+
+        var turn = bridge.execute(request("calendar.search_events", false, Map.of(
+                "query", Map.of("secretRef", Map.of("value", "secret://calendar/provider-token")))));
+
+        assertThat(turn.allowed()).isFalse();
+        assertThat(turn.decision()).isEqualTo("overbroad_args");
+        assertThat(turn.supportSafeEvidence())
+                .containsEntry("denyState", "overbroad_args")
+                .containsEntry("toolResultFedBackToModel", false)
+                .containsEntry("rawProviderPayloadIncluded", false);
+        assertThat(turn.supportSafeEvidence().toString())
+                .doesNotContain("secret://calendar/provider-token", "secretRef");
+        assertThat(auditPublisher.events()).isEmpty();
+    }
+
+    @Test
+    void nestedRawPayloadUnderAllowedTopLevelArgIsDeniedBeforeInvocation() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));
+
+        var turn = bridge.execute(request("calendar.search_events", false, Map.of(
+                "query", Map.of("rawPayload", Map.of("provider", "calendar", "body", "raw dump")))));
+
+        assertThat(turn.allowed()).isFalse();
+        assertThat(turn.decision()).isEqualTo("overbroad_args");
+        assertThat(turn.supportSafeEvidence())
+                .containsEntry("denyState", "overbroad_args")
+                .containsEntry("toolResultFedBackToModel", false)
+                .containsEntry("rawProviderPayloadIncluded", false);
+        assertThat(turn.supportSafeEvidence().toString())
+                .doesNotContain("raw dump", "rawPayload");
+        assertThat(auditPublisher.events()).isEmpty();
+    }
+
+    @Test
     void revokedRuntimeProfileIsDeniedByToolRegistryPolicyGuard() {
         InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
         LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridgeTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/LocalQwenMcpToolBridgeTest.java
@@ -73,6 +73,47 @@ class LocalQwenMcpToolBridgeTest {
         assertThat(turn.supportSafeEvidence())
                 .containsEntry("denyState", "overbroad_args")
                 .containsEntry("rawProviderPayloadIncluded", false);
+        assertThat(turn.supportSafeEvidence().toString())
+                .doesNotContain("dump everything", "providerPayload");
+        assertThat(auditPublisher.events()).isEmpty();
+    }
+
+    @Test
+    void unexpectedArgsAreDeniedBeforeInvocation() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));
+
+        var turn = bridge.execute(request("calendar.search_events", false, Map.of("spaceRef", "space:default", "unexpected", "value")));
+
+        assertThat(turn.allowed()).isFalse();
+        assertThat(turn.decision()).isEqualTo("overbroad_args");
+        assertThat(turn.supportSafeEvidence())
+                .containsEntry("denyState", "overbroad_args")
+                .containsEntry("toolResultFedBackToModel", false)
+                .containsEntry("rawProviderPayloadIncluded", false);
+        assertThat(turn.supportSafeEvidence().toString()).doesNotContain("unexpected", "value");
+        assertThat(auditPublisher.events()).isEmpty();
+    }
+
+    @Test
+    void nestedProviderAndSecretShapedArgsAreDeniedBeforeInvocation() {
+        InMemoryAuditEventPublisher auditPublisher = new InMemoryAuditEventPublisher();
+        LocalQwenMcpToolBridge bridge = new LocalQwenMcpToolBridge(new WeaverToolRegistry(auditPublisher));
+
+        var turn = bridge.execute(request("calendar.search_events", false, Map.of(
+                "spaceRef", "space:default",
+                "query", Map.of(
+                        "providerUrl", "https://svc-user:svc-pass@calendar.weave.test?access_token=raw",
+                        "tokenLike", "Bearer raw"))));
+
+        assertThat(turn.allowed()).isFalse();
+        assertThat(turn.decision()).isEqualTo("overbroad_args");
+        assertThat(turn.supportSafeEvidence())
+                .containsEntry("denyState", "overbroad_args")
+                .containsEntry("toolResultFedBackToModel", false)
+                .containsEntry("rawProviderPayloadIncluded", false);
+        assertThat(turn.supportSafeEvidence().toString())
+                .doesNotContain("calendar.weave.test", "access_token", "Bearer raw", "providerUrl", "tokenLike");
         assertThat(auditPublisher.events()).isEmpty();
     }
 


### PR DESCRIPTION
## Summary

- Add a server-side local-Qwen MCP tool bridge that offers only safe/read-only Weave domain tools and executes requested tool calls through `WeaverToolRegistry` policy enforcement.
- Carry support-safe Qwen/MCP evidence through the PA Weaver chat response path: channel id, model ref, RuntimeProfile hash/version, MCP server id, tool id, audit ref, approval/deny state, and model tool-result feedback state.
- Make the PA Weaver bridge timeout explicit for local LM Studio/Qwen latency and apply it to the HTTP client.

## Scope and user impact

- Scope: server Weaver/chat path and tests only.
- User impact: governed PA Weaver turns can prove local-Qwen tool-call selection and fail-closed MCP/domain tool execution without exposing raw provider payloads, secrets, visible-thinking output, or operator-local runtime configuration.

## Spec / acceptance link

- Issue: Closes #771
- Repo spec / Spec Kit package: `specs/0007-governed-weaver-runtime/spec.md`, `specs/0009-domain-first-mcp-tools/spec.md`, `specs/0011-weaver-governed-pa-target/spec.md`
- Plan/tasks/traceability: Sprint 32 local Qwen / Weaver MCP vertical slice after #768 and #764/#769/#770.
- Mapped Gherkin feature/scenario when product behavior changed: existing Weaver RuntimeProfile / governed PA target acceptance mappings; no new Gherkin scenario added in this slice.
- Evidence mode / reality level: `offline-spec` / `contract_only`; live LM Studio runtime evidence is not claimed by this PR.
- Product-core questions intentionally left unresolved: none.

Quality Reset rule: this PR does not claim live-runtime, release-ready, or customer-ready evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [ ] none
- [x] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

- Release note: Added governed local-Qwen MCP tool-call enforcement for PA Weaver chat evidence.

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- None.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: fail-closed policy guard for unknown tools, overbroad/provider-shaped args, revoked RuntimeProfiles, unsigned/mismatched profiles, expired runtime tokens, and missing consent. Tool evidence is support-safe and redacts raw provider payloads.
- Accessibility/localization impact: none; server-only.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: issue #771 acceptance implemented in server-side contract tests; no public API shape change.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: server Weaver/MCP governance path.
- If Copilot is unavailable/insufficient, matching reviewer used: GitHub rejected `copilot` reviewer resolution; fallback review pending by integrator.

## Checks run

- [ ] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not run; this PR is contract-only/offline server evidence.
- [x] `./gradlew serverCi`

## Notes for reviewers

- Review for claim hygiene first: this is contract-only/offline evidence, not a live LM Studio runtime proof.
- Local Qwen/helper model output is not treated as authority; only the validated tool call and governed tool result are used.

