### PR TITLE
feat(server): define non-chat domain facade operation gate

### DIFF
--- a/docs/non-chat-domain-facade-contract.md
+++ b/docs/non-chat-domain-facade-contract.md
@@ -1,0 +1,52 @@
+# Non-chat domain facade contract
+
+Sprint 32 issue #788 defines the shared implementation contract for provider-neutral Files, Calendar, and Boards facades. Chat remains the strongest existing example, but non-chat domains must not be forced into one leaky mega-abstraction.
+
+## Required boundary
+
+Implementation source: `server/src/main/java/com/massimotter/weave/backend/domainfacade/` defines the shared non-chat facade contract (`CanonicalDomainFacade`, `CanonicalDomainDefinition`) and the operation gate (`NonChatDomainFacadeOperationGuard`) that Files, Calendar, and Boards use before provider access. `CanonicalDomainFacadeServicesTest` is the server evidence gate for issue #788.
+
+Each canonical non-chat domain facade must:
+
+1. Evaluate workspace capability and policy before any provider access.
+2. Enforce Space/context authorization at the product boundary.
+3. Emit audited write/delete decisions with actor, context, domain, operation, result, and support-safe diagnostics.
+4. Return canonical object IDs and provenance/mapping references instead of provider-native IDs as the public product contract.
+5. Use support-safe failure states such as `not_configured`, `degraded`, `policy_blocked`, `unavailable`, `provider_failure`, `context_forbidden`, and `unsupported` without exposing secrets, raw provider payloads, or internal endpoints.
+6. Keep provider adapters behind server/domain seams; product callers and Weaver tools consume canonical domain APIs only.
+7. Provide dry-run or preview hooks for replacement/mapping work before any destructive apply/cutover path exists.
+
+## Domain-specific semantics stay explicit
+
+The shared facade is a contract, not a generic data model. Files, Calendar, and Boards keep their own nouns, invariants, and tests:
+
+- Files: drives, folders, files, versions, checksums, share/link policy, document sessions, and attachment refs.
+- Calendar: calendars, events, recurrence, attendees, resources, reminders, meeting join grants, artifacts, and consent/retention refs.
+- Boards: boards, lists, tasks, statuses, assignees, dependencies, labels, estimates, workflow rules, and decision/file/chat refs.
+
+## Shared operation gate
+
+The shared gate is intentionally small and not a generic mega-model:
+
+- Domain services keep their own nouns and canonical object kinds in `CanonicalDomainDefinition`.
+- `NonChatDomainFacadeOperationGuard` evaluates Weave capability policy first, then Space/context authorization, and only then allows provider access.
+- Write/delete decisions are audited through the existing support-safe audit envelope before a provider adapter may mutate state.
+- Decisions return canonical object refs and provenance/mapping refs, never provider-native public IDs.
+- Dry-run/preview operations can prove replacement or mapping behavior without destructive apply/cutover.
+
+## Child implementation order
+
+1. #789 Files: prove audited write/delete and provenance/mapping for file/folder operations.
+2. #790 Calendar: prove event/meeting authorization, audit, recurrence-safe failures, and mapping hooks.
+3. #791 Boards: prove board/task status/write parity and lossy mapping/conflict reporting.
+
+## Review and evidence gates
+
+- Architecture reviews the boundary and rejects over-generic abstraction.
+- Server/Domain reviews child domain semantics and adapter isolation.
+- Security reviews audit fields and support-safe errors.
+- QA/Evidence owns contract tests and release evidence wording.
+- DevOps/Ops reviews support bundle and deploy/readiness implications.
+- Docs and Marketing/Product Messaging review claim hygiene: release wording may claim facade/contract parity only, not production provider replacement, until live replacement evidence exists.
+
+Small PRs are required. A child PR should either satisfy a complete vertical slice for one domain operation family or explicitly name the unsupported remainder in tests/docs.

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/NonChatDomainFacadeOperationDecision.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/NonChatDomainFacadeOperationDecision.java
@@ -1,0 +1,17 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import java.util.Map;
+
+/** Canonical support-safe operation decision returned before any provider adapter may be called. */
+public record NonChatDomainFacadeOperationDecision(
+        String domain,
+        String operation,
+        boolean allowed,
+        boolean providerAccessAllowed,
+        boolean audited,
+        boolean dryRun,
+        SupportSafeFacadeError error,
+        String reason,
+        String canonicalObjectRef,
+        String provenanceRef,
+        Map<String, Object> supportSafeDiagnostics) {}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/NonChatDomainFacadeOperationGuard.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/NonChatDomainFacadeOperationGuard.java
@@ -1,0 +1,122 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.audit.AuditAction;
+import com.massimotter.weave.backend.audit.AuditEvent;
+import com.massimotter.weave.backend.audit.AuditEventPublisher;
+import com.massimotter.weave.backend.audit.AuditRedactionLevel;
+import com.massimotter.weave.backend.context.authz.ContextAuthorizationPort;
+import com.massimotter.weave.backend.context.authz.ContextAuthorizationRequest;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Shared gate for non-chat domain facades.
+ *
+ * Files, Calendar, and Boards keep domain-specific services and nouns, but they use this pattern before calling any
+ * provider adapter: capability/policy, Space authorization, audited write/delete decision, canonical mapping refs, and
+ * support-safe diagnostics.
+ */
+public final class NonChatDomainFacadeOperationGuard {
+
+    private final CanonicalDomainFacade facade;
+    private final ContextAuthorizationPort contextAuthorization;
+    private final AuditEventPublisher auditEvents;
+    private final Clock clock;
+
+    public NonChatDomainFacadeOperationGuard(
+            CanonicalDomainFacade facade,
+            ContextAuthorizationPort contextAuthorization,
+            AuditEventPublisher auditEvents,
+            Clock clock) {
+        this.facade = java.util.Objects.requireNonNull(facade, "facade must not be null");
+        this.contextAuthorization = java.util.Objects.requireNonNull(contextAuthorization, "contextAuthorization must not be null");
+        this.auditEvents = java.util.Objects.requireNonNull(auditEvents, "auditEvents must not be null");
+        this.clock = clock == null ? Clock.systemUTC() : clock;
+    }
+
+    public NonChatDomainFacadeOperationDecision decide(Jwt jwt, NonChatDomainFacadeOperationRequest request) {
+        CanonicalCapabilityDecision capability = facade.evaluateCapability(jwt, request.capability(), request.operation());
+        if (!capability.allowed()) {
+            return decision(request, false, false, false, mapCapabilityError(capability.state()), capability.reason());
+        }
+
+        var contextDecision = contextAuthorization.check(new ContextAuthorizationRequest(
+                request.tenantId(), request.contextId(), request.actorRef(), request.permission()));
+        if (!contextDecision.allowed()) {
+            return decision(request, false, false, false, SupportSafeFacadeError.CONTEXT_FORBIDDEN, "context_authorization_denied");
+        }
+
+        boolean audited = false;
+        if (request.writeOrDelete()) {
+            auditEvents.publish(new AuditEvent(
+                    request.tenantId(),
+                    request.contextId(),
+                    request.actorRef(),
+                    "domain-facade:" + facade.contract().domain(),
+                    AuditAction.CONNECTOR_WRITE_ATTEMPTED,
+                    Instant.now(clock),
+                    facade.contract().domain() + ":" + request.operation() + ":" + request.canonicalObjectRef(),
+                    AuditRedactionLevel.SUPPORT_SAFE,
+                    auditPayload(request)));
+            audited = true;
+        }
+        return decision(request, true, true, audited, null, request.dryRun() ? "dry_run_allowed" : "allowed");
+    }
+
+    private NonChatDomainFacadeOperationDecision decision(
+            NonChatDomainFacadeOperationRequest request,
+            boolean allowed,
+            boolean providerAccessAllowed,
+            boolean audited,
+            SupportSafeFacadeError error,
+            String reason) {
+        Map<String, Object> diagnostics = auditPayload(request);
+        diagnostics.put("allowed", allowed);
+        diagnostics.put("providerAccessAllowed", providerAccessAllowed);
+        diagnostics.put("audited", audited);
+        diagnostics.put("error", error == null ? "none" : error.value());
+        diagnostics.put("secretsReturned", false);
+        diagnostics.put("rawProviderPayloadsReturned", false);
+        diagnostics.put("rawProviderErrorsReturned", false);
+        diagnostics.put("diagnosticsRedacted", true);
+        return new NonChatDomainFacadeOperationDecision(
+                facade.contract().domain(),
+                request.operation(),
+                allowed,
+                providerAccessAllowed,
+                audited,
+                request.dryRun(),
+                error,
+                reason,
+                request.canonicalObjectRef(),
+                request.provenanceRef(),
+                diagnostics);
+    }
+
+    private Map<String, Object> auditPayload(NonChatDomainFacadeOperationRequest request) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("domain", facade.contract().domain());
+        payload.put("operation", request.operation());
+        payload.put("capability", request.capability());
+        payload.put("canonicalObjectRef", request.canonicalObjectRef());
+        payload.put("provenanceRef", request.provenanceRef());
+        payload.put("dryRun", request.dryRun());
+        payload.put("writeOrDelete", request.writeOrDelete());
+        payload.put("policyEvaluatedBeforeProviderAccess", true);
+        return payload;
+    }
+
+    private SupportSafeFacadeError mapCapabilityError(CanonicalMemberState state) {
+        return switch (state) {
+            case MISCONFIGURED -> SupportSafeFacadeError.NOT_CONFIGURED;
+            case DEGRADED -> SupportSafeFacadeError.DEGRADED;
+            case POLICY_BLOCKED -> SupportSafeFacadeError.POLICY_BLOCKED;
+            case UNAVAILABLE, DISABLED -> SupportSafeFacadeError.UNAVAILABLE;
+            case UNSUPPORTED -> SupportSafeFacadeError.UNSUPPORTED;
+            case READY -> SupportSafeFacadeError.PROVIDER_FAILURE;
+        };
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/NonChatDomainFacadeOperationRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/NonChatDomainFacadeOperationRequest.java
@@ -1,0 +1,43 @@
+package com.massimotter.weave.backend.domainfacade;
+
+import com.massimotter.weave.backend.context.authz.ContextPermission;
+
+/**
+ * Canonical operation gate input shared by Files, Calendar, and Boards facades.
+ *
+ * The request names Weave domain/context identifiers only. Provider-native IDs must already be mapped to canonical
+ * references before product/runtime callers reach this seam.
+ */
+public record NonChatDomainFacadeOperationRequest(
+        String tenantId,
+        String contextId,
+        String actorRef,
+        String capability,
+        String operation,
+        ContextPermission permission,
+        boolean writeOrDelete,
+        String canonicalObjectRef,
+        String provenanceRef,
+        boolean dryRun) {
+
+    public NonChatDomainFacadeOperationRequest {
+        tenantId = required("tenantId", tenantId);
+        contextId = required("contextId", contextId);
+        actorRef = required("actorRef", actorRef);
+        capability = required("capability", capability);
+        operation = required("operation", operation);
+        permission = java.util.Objects.requireNonNull(permission, "permission must not be null");
+        canonicalObjectRef = canonicalObjectRef == null || canonicalObjectRef.isBlank() ? "pending-canonical-ref" : canonicalObjectRef;
+        provenanceRef = provenanceRef == null || provenanceRef.isBlank() ? "mapping:pending" : provenanceRef;
+        if (canonicalObjectRef.startsWith("provider:") || provenanceRef.startsWith("provider:")) {
+            throw new IllegalArgumentException("public facade decisions must use canonical refs, not provider-native refs");
+        }
+    }
+
+    private static String required(String field, String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/SupportSafeFacadeError.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/SupportSafeFacadeError.java
@@ -1,0 +1,27 @@
+package com.massimotter.weave.backend.domainfacade;
+
+/**
+ * Support-safe error taxonomy for canonical non-chat facades.
+ *
+ * These values are public product states. Provider adapters may keep richer diagnostics internally, but member/runtime
+ * callers must not receive raw provider errors, secrets, endpoints, or downstream payloads.
+ */
+public enum SupportSafeFacadeError {
+    NOT_CONFIGURED("not_configured"),
+    DEGRADED("degraded"),
+    POLICY_BLOCKED("policy_blocked"),
+    UNAVAILABLE("unavailable"),
+    PROVIDER_FAILURE("provider_failure"),
+    CONTEXT_FORBIDDEN("context_forbidden"),
+    UNSUPPORTED("unsupported");
+
+    private final String value;
+
+    SupportSafeFacadeError(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/server/src/test/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeServicesTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeServicesTest.java
@@ -4,6 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
+import com.massimotter.weave.backend.context.authz.ContextAuthorizationDecision;
+import com.massimotter.weave.backend.context.authz.ContextAuthorizationPort;
+import com.massimotter.weave.backend.context.authz.ContextPermission;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
@@ -189,6 +193,80 @@ class CanonicalDomainFacadeServicesTest {
         assertThat(providerCalls).hasValue(0);
     }
 
+    @Test
+    void nonChatOperationGuardEnforcesCapabilityContextAuditAndCanonicalMappingBeforeProviderAccess() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        var guard = new NonChatDomainFacadeOperationGuard(
+                filesDocs(selectedMappings(), configuredProviders(), allowedCapabilities()),
+                allowContext(),
+                audit,
+                FIXED);
+
+        NonChatDomainFacadeOperationDecision decision = guard.decide(memberJwt(), operation("files.upload", true, false));
+
+        assertThat(decision.allowed()).isTrue();
+        assertThat(decision.providerAccessAllowed()).isTrue();
+        assertThat(decision.audited()).isTrue();
+        assertThat(decision.error()).isNull();
+        assertThat(decision.canonicalObjectRef()).isEqualTo("file:weave:space-alpha:proposal.md");
+        assertThat(decision.provenanceRef()).isEqualTo("mapping:files:space-alpha:proposal.md");
+        assertThat(decision.supportSafeDiagnostics())
+                .containsEntry("policyEvaluatedBeforeProviderAccess", true)
+                .containsEntry("secretsReturned", false)
+                .containsEntry("rawProviderPayloadsReturned", false)
+                .containsEntry("rawProviderErrorsReturned", false);
+        assertThat(audit.events()).hasSize(1);
+        assertThat(audit.events().getFirst().payload())
+                .containsEntry("domain", "files-docs")
+                .containsEntry("canonicalObjectRef", "file:weave:space-alpha:proposal.md")
+                .containsEntry("provenanceRef", "mapping:files:space-alpha:proposal.md");
+        assertThat(audit.events().getFirst().toString()).doesNotContain("https://", "Bearer ", "access_token", "provider:");
+    }
+
+    @Test
+    void nonChatOperationGuardFailsClosedForPolicyOrContextAndDoesNotAuditDeniedWrites() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        var policyGuard = new NonChatDomainFacadeOperationGuard(
+                filesDocs(selectedMappings(), configuredProviders(), blockedCapabilities()),
+                allowContext(),
+                audit,
+                FIXED);
+        var contextGuard = new NonChatDomainFacadeOperationGuard(
+                filesDocs(selectedMappings(), configuredProviders(), allowedCapabilities()),
+                denyContext(),
+                audit,
+                FIXED);
+
+        NonChatDomainFacadeOperationDecision policyDenied = policyGuard.decide(guestJwt(), operation("files.upload", true, false));
+        NonChatDomainFacadeOperationDecision contextDenied = contextGuard.decide(memberJwt(), operation("files.upload", true, false));
+
+        assertThat(policyDenied.allowed()).isFalse();
+        assertThat(policyDenied.providerAccessAllowed()).isFalse();
+        assertThat(policyDenied.error()).isEqualTo(SupportSafeFacadeError.POLICY_BLOCKED);
+        assertThat(contextDenied.allowed()).isFalse();
+        assertThat(contextDenied.providerAccessAllowed()).isFalse();
+        assertThat(contextDenied.error()).isEqualTo(SupportSafeFacadeError.CONTEXT_FORBIDDEN);
+        assertThat(audit.events()).isEmpty();
+    }
+
+    @Test
+    void nonChatOperationGuardSupportsDryRunReplacementPreviewWithoutAuditForReads() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        var guard = new NonChatDomainFacadeOperationGuard(
+                filesDocs(selectedMappings(), configuredProviders(), allowedCapabilities()),
+                allowContext(),
+                audit,
+                FIXED);
+
+        NonChatDomainFacadeOperationDecision decision = guard.decide(memberJwt(), operation("files.read", false, true));
+
+        assertThat(decision.allowed()).isTrue();
+        assertThat(decision.dryRun()).isTrue();
+        assertThat(decision.reason()).isEqualTo("dry_run_allowed");
+        assertThat(decision.audited()).isFalse();
+        assertThat(audit.events()).isEmpty();
+    }
+
     private List<CanonicalDomainFacade> services(
             ProviderSelectionRepository selections,
             List<ProviderPort> providers,
@@ -217,6 +295,28 @@ class CanonicalDomainFacadeServicesTest {
         WorkspaceCapabilityService capabilityService = capabilityService(capabilities);
         ProviderRegistry registry = new ProviderRegistry(providers, capabilityService, selections);
         return new FilesDocsDomainFacadeService(registry, selections, capabilityService, FIXED);
+    }
+
+    private ContextAuthorizationPort allowContext() {
+        return request -> ContextAuthorizationDecision.allow("test context grants " + request.permission());
+    }
+
+    private ContextAuthorizationPort denyContext() {
+        return request -> ContextAuthorizationDecision.deny("test context denies");
+    }
+
+    private NonChatDomainFacadeOperationRequest operation(String capability, boolean writeOrDelete, boolean dryRun) {
+        return new NonChatDomainFacadeOperationRequest(
+                "weave-dogfood",
+                "space-alpha",
+                "user:member-123",
+                capability,
+                writeOrDelete ? "upload_file" : "preview_file_mapping",
+                writeOrDelete ? ContextPermission.EDIT : ContextPermission.VIEW,
+                writeOrDelete,
+                "file:weave:space-alpha:proposal.md",
+                "mapping:files:space-alpha:proposal.md",
+                dryRun);
     }
 
     private WorkspaceCapabilityService capabilityService(WorkspaceCapabilitiesResponse capabilities) {


### PR DESCRIPTION
## Summary

- Defines the shared non-chat domain facade operation gate for Files, Calendar, and Boards.
- Adds support-safe error taxonomy, canonical operation decisions, audit-before-write behavior, Space/context authz checks, and dry-run mapping preview support.
- Links the implementation evidence from `docs/non-chat-domain-facade-contract.md`.

## Scope and user impact

- Server architecture/evidence only; member/runtime callers remain on canonical Weave domain seams and do not receive raw provider payloads.
- Admin/operator diagnostics remain support-safe and release claims are bounded to facade/contract parity.

## Spec / acceptance link

- Issue: Fixes #788
- Repo spec / Spec Kit package: `docs/non-chat-domain-facade-contract.md`, pinned spec corpus via `specs/weave-specs.lock.json`
- Plan/tasks/traceability: child stories #789, #790, #791 remain the per-domain vertical implementation gates
- Mapped Gherkin feature/scenario when product behavior changed: no new Gherkin; server contract tests cover the shared pattern
- Evidence mode / reality level: `offline-spec` / `contract_only`
- Product-core questions intentionally left unresolved: none

Quality Reset rule: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance before merge. `offline-spec` / `contract_only` fixture evidence must not be described as `live-runtime`, isolated E2E, `release_ready`, or customer-ready evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [ ] none
- [x] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [x] changes evidence only

## Release note

- Release note: Adds the shared server-side non-chat domain facade operation gate for Files, Calendar, and Boards.

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- Adds `docs/non-chat-domain-facade-contract.md` to link the implementation/evidence source for #788.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: strengthens support-safe diagnostics and denies provider access until capability and context checks pass.
- Accessibility/localization impact: none; server contract pattern only.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: `docs/non-chat-domain-facade-contract.md`
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: Architecture/server-domain review for non-chat facade pattern and anti-mega-facade boundary.
- If Copilot is unavailable/insufficient, matching reviewer used: pending

## Checks run

- [x] `git diff --check`
- [x] `./gradlew specCorpusConformance` when product/domain specs or projections changed (`/tmp/weave-specs` symlinked to pinned local corpus path for disposable worktree)
- [ ] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant; contract-only server evidence
- [x] `./gradlew serverCi --console=plain`

## Notes for reviewers

- Review for claim hygiene first: this PR claims facade/contract parity only, not live provider replacement or lossless migration.
- The operation guard intentionally stays small so Files, Calendar, and Boards keep domain-specific semantics.
