### PR TITLE
feat(client): make member onboarding handoff-first

### DIFF
--- a/client/lib/features/onboarding/presentation/member_handoff_screen.dart
+++ b/client/lib/features/onboarding/presentation/member_handoff_screen.dart
@@ -8,6 +8,7 @@ import 'package:weave/core/widgets/error_state.dart';
 import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/features/onboarding/domain/use_cases/consume_member_handoff.dart';
 import 'package:weave/features/server_config/presentation/providers/server_configuration_repository_provider.dart';
+import 'package:weave/l10n/generated/app_localizations.dart';
 
 final consumeMemberHandoffProvider = Provider<ConsumeMemberHandoff>((ref) {
   final httpClient = http.Client();
@@ -53,15 +54,16 @@ class _MemberHandoffScreenState extends ConsumerState<MemberHandoffScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final failure = _failure;
     if (failure != null) {
       return Scaffold(
         body: SafeArea(
           child: Center(
             child: ErrorState(
-              message: 'We could not open this Weave invite',
-              guidance: '$failure',
-              retryLabel: 'Try again',
+              message: l10n.memberHandoffErrorTitle,
+              guidance: l10n.memberHandoffErrorGuidance,
+              retryLabel: l10n.retryButton,
               onRetry: () {
                 setState(() => _failure = null);
                 _consume();
@@ -71,12 +73,12 @@ class _MemberHandoffScreenState extends ConsumerState<MemberHandoffScreen> {
         ),
       );
     }
-    return const Scaffold(
+    return Scaffold(
       body: SafeArea(
         child: Center(
           child: LoadingState(
-            message: 'Opening Weave invite',
-            hint: 'We are preparing sign-in for this workspace.',
+            message: l10n.memberHandoffLoadingTitle,
+            hint: l10n.memberHandoffLoadingHint,
           ),
         ),
       ),

--- a/client/lib/features/onboarding/presentation/setup_flow.dart
+++ b/client/lib/features/onboarding/presentation/setup_flow.dart
@@ -11,15 +11,11 @@ import 'package:weave/features/server_config/presentation/widgets/provider_categ
 import 'package:weave/features/server_config/presentation/widgets/server_configuration_form.dart';
 import 'package:weave/l10n/generated/app_localizations.dart';
 
-/// A multi-step setup flow presented after the welcome screen.
+/// Handoff-first setup presented after the welcome screen.
 ///
-/// Two steps:
-/// 1. Select provider type and issuer URL
-/// 2. Review and adjust derived service endpoints
-///
-/// Focus is moved to each step's heading when it becomes active.
-/// Back navigation works via both the system back gesture and the
-/// visible back button.
+/// Normal members are directed to invite/auth/deep-link handoff. Raw provider
+/// endpoint editing is available only after explicitly entering operator
+/// recovery mode.
 class SetupFlow extends ConsumerStatefulWidget {
   const SetupFlow({super.key});
 
@@ -29,19 +25,22 @@ class SetupFlow extends ConsumerStatefulWidget {
 
 class _SetupFlowState extends ConsumerState<SetupFlow> {
   int _currentStep = 0;
+  bool _operatorRecoveryMode = false;
   static const _totalSteps = 2;
 
+  final _memberFocusNode = FocusNode();
   final _step0FocusNode = FocusNode();
   final _step1FocusNode = FocusNode();
 
   @override
   void initState() {
     super.initState();
-    FocusUtils.requestFocusAfterFrame(_step0FocusNode);
+    FocusUtils.requestFocusAfterFrame(_memberFocusNode);
   }
 
   @override
   void dispose() {
+    _memberFocusNode.dispose();
     _step0FocusNode.dispose();
     _step1FocusNode.dispose();
     super.dispose();
@@ -62,11 +61,14 @@ class _SetupFlowState extends ConsumerState<SetupFlow> {
   }
 
   void _goBack() {
-    if (_currentStep > 0) {
-      setState(() => _currentStep--);
-      FocusUtils.requestFocusAfterFrame(_step0FocusNode);
-    } else {
+    if (!_operatorRecoveryMode) {
       context.go(AppRoutes.welcome);
+    } else if (_currentStep > 0) {
+      setState(() => _currentStep--);
+      FocusUtils.requestFocusAfterFrame(_memberFocusNode);
+    } else {
+      setState(() => _operatorRecoveryMode = false);
+      FocusUtils.requestFocusAfterFrame(_memberFocusNode);
     }
   }
 
@@ -107,7 +109,12 @@ class _SetupFlowState extends ConsumerState<SetupFlow> {
               ),
               const SizedBox(width: 12),
               Flexible(
-                child: Text(l10n.setupTitle, overflow: TextOverflow.ellipsis),
+                child: Text(
+                  _operatorRecoveryMode
+                      ? l10n.setupOperatorRecoveryTitle
+                      : l10n.setupTitle,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
             ],
           ),
@@ -120,70 +127,204 @@ class _SetupFlowState extends ConsumerState<SetupFlow> {
         body: SafeArea(
           child: Padding(
             padding: const EdgeInsets.all(24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Step indicator — announced to screen readers.
-                Semantics(
-                  label: l10n.setupStepIndicator(_currentStep + 1, _totalSteps),
-                  child: ExcludeSemantics(
-                    child: LinearProgressIndicator(
-                      value: (_currentStep + 1) / _totalSteps,
-                      borderRadius: BorderRadius.circular(4),
-                    ),
+            child: _operatorRecoveryMode
+                ? _OperatorRecoverySetup(
+                    currentStep: _currentStep,
+                    totalSteps: _totalSteps,
+                    step0FocusNode: _step0FocusNode,
+                    step1FocusNode: _step1FocusNode,
+                    onBack: _goBack,
+                    onNext: _goNext,
+                    onFinish: _finish,
+                  )
+                : _MemberHandoffSetup(
+                    focusNode: _memberFocusNode,
+                    onOpenOperatorRecovery: () {
+                      setState(() {
+                        _operatorRecoveryMode = true;
+                        _currentStep = 0;
+                      });
+                      FocusUtils.requestFocusAfterFrame(_step0FocusNode);
+                    },
                   ),
-                ),
-                const SizedBox(height: 32),
-
-                // Step content
-                Expanded(
-                  child: AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 250),
-                    child: _currentStep == 0
-                        ? _ProviderStep(
-                            key: const ValueKey('step_0'),
-                            focusNode: _step0FocusNode,
-                          )
-                        : _ServicesStep(
-                            key: const ValueKey('step_1'),
-                            focusNode: _step1FocusNode,
-                          ),
-                  ),
-                ),
-
-                // Navigation buttons
-                Row(
-                  children: [
-                    if (_currentStep > 0)
-                      Expanded(
-                        child: AccessibleButton(
-                          outlined: true,
-                          onPressed: _goBack,
-                          semanticLabel: l10n.setupBackButton,
-                          child: Text(l10n.setupBackButton),
-                        ),
-                      ),
-                    if (_currentStep > 0) const SizedBox(width: 16),
-                    Expanded(
-                      child: _currentStep < _totalSteps - 1
-                          ? AccessibleButton(
-                              onPressed: _goNext,
-                              semanticLabel: l10n.setupNextButton,
-                              child: Text(l10n.setupNextButton),
-                            )
-                          : AccessibleButton(
-                              onPressed: _finish,
-                              semanticLabel: l10n.setupFinishButton,
-                              child: Text(l10n.setupFinishButton),
-                            ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class _MemberHandoffSetup extends StatelessWidget {
+  const _MemberHandoffSetup({
+    required this.focusNode,
+    required this.onOpenOperatorRecovery,
+  });
+
+  final FocusNode focusNode;
+  final VoidCallback onOpenOperatorRecovery;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return SingleChildScrollView(
+      child: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 720),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Focus(
+                focusNode: focusNode,
+                child: Semantics(
+                  header: true,
+                  child: Text(
+                    l10n.setupMemberHandoffTitle,
+                    style: theme.textTheme.headlineSmall,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                l10n.setupMemberHandoffDescription,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 24),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Semantics(
+                        header: true,
+                        child: Text(
+                          l10n.setupMemberHandoffPrimaryAction,
+                          style: theme.textTheme.titleMedium,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(l10n.setupMemberHandoffPrimaryGuidance),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Semantics(
+                        header: true,
+                        child: Text(
+                          l10n.setupMemberHandoffAdminNoteTitle,
+                          style: theme.textTheme.titleMedium,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(l10n.setupMemberHandoffAdminNote),
+                      const SizedBox(height: 16),
+                      AccessibleButton(
+                        outlined: true,
+                        onPressed: onOpenOperatorRecovery,
+                        semanticLabel: l10n.setupOpenOperatorRecoveryButton,
+                        child: Text(l10n.setupOpenOperatorRecoveryButton),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OperatorRecoverySetup extends StatelessWidget {
+  const _OperatorRecoverySetup({
+    required this.currentStep,
+    required this.totalSteps,
+    required this.step0FocusNode,
+    required this.step1FocusNode,
+    required this.onBack,
+    required this.onNext,
+    required this.onFinish,
+  });
+
+  final int currentStep;
+  final int totalSteps;
+  final FocusNode step0FocusNode;
+  final FocusNode step1FocusNode;
+  final VoidCallback onBack;
+  final VoidCallback onNext;
+  final VoidCallback onFinish;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Semantics(
+          label: l10n.setupStepIndicator(currentStep + 1, totalSteps),
+          child: ExcludeSemantics(
+            child: LinearProgressIndicator(
+              value: (currentStep + 1) / totalSteps,
+              borderRadius: BorderRadius.circular(4),
+            ),
+          ),
+        ),
+        const SizedBox(height: 32),
+        Expanded(
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 250),
+            child: currentStep == 0
+                ? _ProviderStep(
+                    key: const ValueKey('step_0'),
+                    focusNode: step0FocusNode,
+                  )
+                : _ServicesStep(
+                    key: const ValueKey('step_1'),
+                    focusNode: step1FocusNode,
+                  ),
+          ),
+        ),
+        Row(
+          children: [
+            if (currentStep > 0)
+              Expanded(
+                child: AccessibleButton(
+                  outlined: true,
+                  onPressed: onBack,
+                  semanticLabel: l10n.setupBackButton,
+                  child: Text(l10n.setupBackButton),
+                ),
+              ),
+            if (currentStep > 0) const SizedBox(width: 16),
+            Expanded(
+              child: currentStep < totalSteps - 1
+                  ? AccessibleButton(
+                      onPressed: onNext,
+                      semanticLabel: l10n.setupNextButton,
+                      child: Text(l10n.setupNextButton),
+                    )
+                  : AccessibleButton(
+                      onPressed: onFinish,
+                      semanticLabel: l10n.setupFinishButton,
+                      child: Text(l10n.setupFinishButton),
+                    ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -2,9 +2,9 @@
   "@@locale": "de",
   "appTitle": "Weave",
   "welcomeTitle": "Willkommen bei Weave",
-  "welcomeSubtitle": "Dein einheitlicher Kollaborations-Hub — Nachrichten, Dateien und Kalender an einem Ort.",
-  "continueButton": "Los geht's",
-  "setupTitle": "Einrichtung",
+  "welcomeSubtitle": "Tritt deiner Organisation über eine Einladung oder Anmelde-Übergabe bei. Anbieter-Setup bleibt bei den Admins.",
+  "continueButton": "Organisation beitreten",
+  "setupTitle": "Weave beitreten",
   "setupProviderStepTitle": "Provider-Kategorien konfigurieren",
   "setupProviderStepDescription": "Die Admin-Einrichtung beginnt mit der Kategorie Identität/IDM und hält Chat, Dateien, Kalender, Boards/Aufgaben, Besprechungen/Anrufe, Dokumente/Zusammenarbeit und Weaver als Provider-Kategorien sichtbar, bevor Mitglieder beitreten.",
   "setupServicesStepTitle": "Dienstendpunkte prüfen",
@@ -1326,5 +1326,53 @@
         "type": "String"
       }
     }
+  },
+  "setupMemberHandoffTitle": "Über Einladung oder Organisationsanmeldung beitreten",
+  "@setupMemberHandoffTitle": {
+    "description": "Title for the normal member handoff-first setup screen"
+  },
+  "setupMemberHandoffDescription": "Öffne den Einladungslink, /join-Link oder die Organisations-Anmelde-URL, die dein Admin gesendet hat. Weave bereitet deinen Workspace aus dem Organisationsmanifest vor, ohne dass du Anbieter-Endpunkte bearbeiten musst.",
+  "@setupMemberHandoffDescription": {
+    "description": "Description for the normal member handoff-first setup screen"
+  },
+  "setupMemberHandoffPrimaryAction": "Ich habe eine Einladung oder einen Anmeldelink",
+  "@setupMemberHandoffPrimaryAction": {
+    "description": "Primary action label for handoff-first setup"
+  },
+  "setupMemberHandoffPrimaryGuidance": "Nutze den Link aus Browser, E-Mail oder Chat. Wenn er fehlt oder abgelaufen ist, bitte deinen Workspace-Admin um eine neue Einladung.",
+  "@setupMemberHandoffPrimaryGuidance": {
+    "description": "Guidance for using a member handoff link"
+  },
+  "setupMemberHandoffAdminNoteTitle": "Admins und Operatoren",
+  "@setupMemberHandoffAdminNoteTitle": {
+    "description": "Heading for operator-only setup note"
+  },
+  "setupMemberHandoffAdminNote": "Rohdaten zu Anbieter-Endpunkten werden im Admin- oder Operator-Recovery verwaltet, nicht im normalen Mitglieder-Onboarding.",
+  "@setupMemberHandoffAdminNote": {
+    "description": "Note explaining raw provider setup boundary"
+  },
+  "setupOpenOperatorRecoveryButton": "Operator-Recovery-Setup öffnen",
+  "@setupOpenOperatorRecoveryButton": {
+    "description": "Button that opens admin/operator raw endpoint recovery setup"
+  },
+  "setupOperatorRecoveryTitle": "Operator-Recovery-Setup",
+  "@setupOperatorRecoveryTitle": {
+    "description": "Title for the explicit operator recovery setup mode"
+  },
+  "memberHandoffLoadingTitle": "Weave-Einladung wird geöffnet",
+  "@memberHandoffLoadingTitle": {
+    "description": "Loading title while consuming a member handoff"
+  },
+  "memberHandoffLoadingHint": "Wir bereiten die Anmeldung für diesen Workspace vor.",
+  "@memberHandoffLoadingHint": {
+    "description": "Loading hint while consuming a member handoff"
+  },
+  "memberHandoffErrorTitle": "Diese Weave-Einladung konnte nicht geöffnet werden",
+  "@memberHandoffErrorTitle": {
+    "description": "Error title when member handoff consumption fails"
+  },
+  "memberHandoffErrorGuidance": "Die Einladung ist möglicherweise abgelaufen, unvollständig oder noch nicht bereit. Bitte deinen Workspace-Admin um eine neue Einladung oder Organisations-Anmelde-URL.",
+  "@memberHandoffErrorGuidance": {
+    "description": "Support-safe guidance when member handoff consumption fails"
   }
 }

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -8,15 +8,15 @@
   "@welcomeTitle": {
     "description": "Main heading on the welcome screen"
   },
-  "welcomeSubtitle": "Your unified collaboration hub for messaging, files, and secure self-hosted access.",
+  "welcomeSubtitle": "Join your organization through an invite or sign-in handoff. Provider setup stays with your admins.",
   "@welcomeSubtitle": {
     "description": "Subtitle text below the welcome heading"
   },
-  "continueButton": "Get Started",
+  "continueButton": "Join your organization",
   "@continueButton": {
     "description": "Label for the primary CTA on the welcome screen"
   },
-  "setupTitle": "Setup",
+  "setupTitle": "Join Weave",
   "@setupTitle": {
     "description": "Title for the setup flow screen"
   },
@@ -4638,5 +4638,53 @@
         "type": "String"
       }
     }
+  },
+  "setupMemberHandoffTitle": "Join from an invite or organization sign-in",
+  "@setupMemberHandoffTitle": {
+    "description": "Title for the normal member handoff-first setup screen"
+  },
+  "setupMemberHandoffDescription": "Open the invite link, /join link, or organization sign-in URL your admin sent you. Weave will prepare your workspace from the organization manifest without asking you to edit provider endpoints.",
+  "@setupMemberHandoffDescription": {
+    "description": "Description for the normal member handoff-first setup screen"
+  },
+  "setupMemberHandoffPrimaryAction": "I have an invite or sign-in link",
+  "@setupMemberHandoffPrimaryAction": {
+    "description": "Primary action label for handoff-first setup"
+  },
+  "setupMemberHandoffPrimaryGuidance": "Use the link from your browser, email, or chat. If it is missing or expired, ask your workspace admin for a new invite.",
+  "@setupMemberHandoffPrimaryGuidance": {
+    "description": "Guidance for using a member handoff link"
+  },
+  "setupMemberHandoffAdminNoteTitle": "Admins and operators",
+  "@setupMemberHandoffAdminNoteTitle": {
+    "description": "Heading for operator-only setup note"
+  },
+  "setupMemberHandoffAdminNote": "Raw provider endpoints are managed in admin or operator recovery, not during normal member onboarding.",
+  "@setupMemberHandoffAdminNote": {
+    "description": "Note explaining raw provider setup boundary"
+  },
+  "setupOpenOperatorRecoveryButton": "Open operator recovery setup",
+  "@setupOpenOperatorRecoveryButton": {
+    "description": "Button that opens admin/operator raw endpoint recovery setup"
+  },
+  "setupOperatorRecoveryTitle": "Operator recovery setup",
+  "@setupOperatorRecoveryTitle": {
+    "description": "Title for the explicit operator recovery setup mode"
+  },
+  "memberHandoffLoadingTitle": "Opening Weave invite",
+  "@memberHandoffLoadingTitle": {
+    "description": "Loading title while consuming a member handoff"
+  },
+  "memberHandoffLoadingHint": "We are preparing sign-in for this workspace.",
+  "@memberHandoffLoadingHint": {
+    "description": "Loading hint while consuming a member handoff"
+  },
+  "memberHandoffErrorTitle": "We could not open this Weave invite",
+  "@memberHandoffErrorTitle": {
+    "description": "Error title when member handoff consumption fails"
+  },
+  "memberHandoffErrorGuidance": "The invite may be expired, incomplete, or not ready yet. Ask your workspace admin for a fresh invite or organization sign-in link.",
+  "@memberHandoffErrorGuidance": {
+    "description": "Support-safe guidance when member handoff consumption fails"
   }
 }

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -113,19 +113,19 @@ abstract class AppLocalizations {
   /// Subtitle text below the welcome heading
   ///
   /// In en, this message translates to:
-  /// **'Your unified collaboration hub for messaging, files, and secure self-hosted access.'**
+  /// **'Join your organization through an invite or sign-in handoff. Provider setup stays with your admins.'**
   String get welcomeSubtitle;
 
   /// Label for the primary CTA on the welcome screen
   ///
   /// In en, this message translates to:
-  /// **'Get Started'**
+  /// **'Join your organization'**
   String get continueButton;
 
   /// Title for the setup flow screen
   ///
   /// In en, this message translates to:
-  /// **'Setup'**
+  /// **'Join Weave'**
   String get setupTitle;
 
   /// Title for the setup provider and issuer step
@@ -6284,6 +6284,78 @@ abstract class AppLocalizations {
     String channelState,
     String connectionState,
   );
+
+  /// Title for the normal member handoff-first setup screen
+  ///
+  /// In en, this message translates to:
+  /// **'Join from an invite or organization sign-in'**
+  String get setupMemberHandoffTitle;
+
+  /// Description for the normal member handoff-first setup screen
+  ///
+  /// In en, this message translates to:
+  /// **'Open the invite link, /join link, or organization sign-in URL your admin sent you. Weave will prepare your workspace from the organization manifest without asking you to edit provider endpoints.'**
+  String get setupMemberHandoffDescription;
+
+  /// Primary action label for handoff-first setup
+  ///
+  /// In en, this message translates to:
+  /// **'I have an invite or sign-in link'**
+  String get setupMemberHandoffPrimaryAction;
+
+  /// Guidance for using a member handoff link
+  ///
+  /// In en, this message translates to:
+  /// **'Use the link from your browser, email, or chat. If it is missing or expired, ask your workspace admin for a new invite.'**
+  String get setupMemberHandoffPrimaryGuidance;
+
+  /// Heading for operator-only setup note
+  ///
+  /// In en, this message translates to:
+  /// **'Admins and operators'**
+  String get setupMemberHandoffAdminNoteTitle;
+
+  /// Note explaining raw provider setup boundary
+  ///
+  /// In en, this message translates to:
+  /// **'Raw provider endpoints are managed in admin or operator recovery, not during normal member onboarding.'**
+  String get setupMemberHandoffAdminNote;
+
+  /// Button that opens admin/operator raw endpoint recovery setup
+  ///
+  /// In en, this message translates to:
+  /// **'Open operator recovery setup'**
+  String get setupOpenOperatorRecoveryButton;
+
+  /// Title for the explicit operator recovery setup mode
+  ///
+  /// In en, this message translates to:
+  /// **'Operator recovery setup'**
+  String get setupOperatorRecoveryTitle;
+
+  /// Loading title while consuming a member handoff
+  ///
+  /// In en, this message translates to:
+  /// **'Opening Weave invite'**
+  String get memberHandoffLoadingTitle;
+
+  /// Loading hint while consuming a member handoff
+  ///
+  /// In en, this message translates to:
+  /// **'We are preparing sign-in for this workspace.'**
+  String get memberHandoffLoadingHint;
+
+  /// Error title when member handoff consumption fails
+  ///
+  /// In en, this message translates to:
+  /// **'We could not open this Weave invite'**
+  String get memberHandoffErrorTitle;
+
+  /// Support-safe guidance when member handoff consumption fails
+  ///
+  /// In en, this message translates to:
+  /// **'The invite may be expired, incomplete, or not ready yet. Ask your workspace admin for a fresh invite or organization sign-in link.'**
+  String get memberHandoffErrorGuidance;
 }
 
 class _AppLocalizationsDelegate

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -16,13 +16,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get welcomeSubtitle =>
-      'Dein einheitlicher Kollaborations-Hub — Nachrichten, Dateien und Kalender an einem Ort.';
+      'Tritt deiner Organisation über eine Einladung oder Anmelde-Übergabe bei. Anbieter-Setup bleibt bei den Admins.';
 
   @override
-  String get continueButton => 'Los geht\'s';
+  String get continueButton => 'Organisation beitreten';
 
   @override
-  String get setupTitle => 'Einrichtung';
+  String get setupTitle => 'Weave beitreten';
 
   @override
   String get setupProviderStepTitle => 'Provider-Kategorien konfigurieren';
@@ -3910,4 +3910,49 @@ class AppLocalizationsDe extends AppLocalizations {
   ) {
     return 'Weaver Beta helper. Personal helper: $personalState. Channel helper: $channelState. Workspace connection: $connectionState. Results are support-safe and do not expose secrets or raw provider payloads.';
   }
+
+  @override
+  String get setupMemberHandoffTitle =>
+      'Über Einladung oder Organisationsanmeldung beitreten';
+
+  @override
+  String get setupMemberHandoffDescription =>
+      'Öffne den Einladungslink, /join-Link oder die Organisations-Anmelde-URL, die dein Admin gesendet hat. Weave bereitet deinen Workspace aus dem Organisationsmanifest vor, ohne dass du Anbieter-Endpunkte bearbeiten musst.';
+
+  @override
+  String get setupMemberHandoffPrimaryAction =>
+      'Ich habe eine Einladung oder einen Anmeldelink';
+
+  @override
+  String get setupMemberHandoffPrimaryGuidance =>
+      'Nutze den Link aus Browser, E-Mail oder Chat. Wenn er fehlt oder abgelaufen ist, bitte deinen Workspace-Admin um eine neue Einladung.';
+
+  @override
+  String get setupMemberHandoffAdminNoteTitle => 'Admins und Operatoren';
+
+  @override
+  String get setupMemberHandoffAdminNote =>
+      'Rohdaten zu Anbieter-Endpunkten werden im Admin- oder Operator-Recovery verwaltet, nicht im normalen Mitglieder-Onboarding.';
+
+  @override
+  String get setupOpenOperatorRecoveryButton =>
+      'Operator-Recovery-Setup öffnen';
+
+  @override
+  String get setupOperatorRecoveryTitle => 'Operator-Recovery-Setup';
+
+  @override
+  String get memberHandoffLoadingTitle => 'Weave-Einladung wird geöffnet';
+
+  @override
+  String get memberHandoffLoadingHint =>
+      'Wir bereiten die Anmeldung für diesen Workspace vor.';
+
+  @override
+  String get memberHandoffErrorTitle =>
+      'Diese Weave-Einladung konnte nicht geöffnet werden';
+
+  @override
+  String get memberHandoffErrorGuidance =>
+      'Die Einladung ist möglicherweise abgelaufen, unvollständig oder noch nicht bereit. Bitte deinen Workspace-Admin um eine neue Einladung oder Organisations-Anmelde-URL.';
 }

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -16,13 +16,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get welcomeSubtitle =>
-      'Your unified collaboration hub for messaging, files, and secure self-hosted access.';
+      'Join your organization through an invite or sign-in handoff. Provider setup stays with your admins.';
 
   @override
-  String get continueButton => 'Get Started';
+  String get continueButton => 'Join your organization';
 
   @override
-  String get setupTitle => 'Setup';
+  String get setupTitle => 'Join Weave';
 
   @override
   String get setupProviderStepTitle => 'Configure provider categories';
@@ -3860,4 +3860,47 @@ class AppLocalizationsEn extends AppLocalizations {
   ) {
     return 'Weaver Beta helper. Personal helper: $personalState. Channel helper: $channelState. Workspace connection: $connectionState. Results are support-safe and do not expose secrets or raw provider payloads.';
   }
+
+  @override
+  String get setupMemberHandoffTitle =>
+      'Join from an invite or organization sign-in';
+
+  @override
+  String get setupMemberHandoffDescription =>
+      'Open the invite link, /join link, or organization sign-in URL your admin sent you. Weave will prepare your workspace from the organization manifest without asking you to edit provider endpoints.';
+
+  @override
+  String get setupMemberHandoffPrimaryAction =>
+      'I have an invite or sign-in link';
+
+  @override
+  String get setupMemberHandoffPrimaryGuidance =>
+      'Use the link from your browser, email, or chat. If it is missing or expired, ask your workspace admin for a new invite.';
+
+  @override
+  String get setupMemberHandoffAdminNoteTitle => 'Admins and operators';
+
+  @override
+  String get setupMemberHandoffAdminNote =>
+      'Raw provider endpoints are managed in admin or operator recovery, not during normal member onboarding.';
+
+  @override
+  String get setupOpenOperatorRecoveryButton => 'Open operator recovery setup';
+
+  @override
+  String get setupOperatorRecoveryTitle => 'Operator recovery setup';
+
+  @override
+  String get memberHandoffLoadingTitle => 'Opening Weave invite';
+
+  @override
+  String get memberHandoffLoadingHint =>
+      'We are preparing sign-in for this workspace.';
+
+  @override
+  String get memberHandoffErrorTitle => 'We could not open this Weave invite';
+
+  @override
+  String get memberHandoffErrorGuidance =>
+      'The invite may be expired, incomplete, or not ready yet. Ask your workspace admin for a fresh invite or organization sign-in link.';
 }

--- a/client/test/features/onboarding/setup_flow_test.dart
+++ b/client/test/features/onboarding/setup_flow_test.dart
@@ -87,36 +87,41 @@ void main() {
       preferencesStore = InMemoryPreferencesStore();
     });
 
-    testWidgets(
-      'renders first step with identity endpoint and client id fields',
-      (tester) async {
-        await tester.pumpWidget(buildApp());
-        await tester.pumpAndSettle();
+    testWidgets('renders member handoff first without raw provider fields', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
 
-        expect(find.byType(WeaveLogo), findsOneWidget);
-        expect(find.text('Configure provider categories'), findsOneWidget);
-        expect(find.text('Provider categories'), findsOneWidget);
-        expect(find.text('Identity/IDM'), findsOneWidget);
-        expect(find.text('Documents/collaboration'), findsOneWidget);
-        expect(find.text('Weaver'), findsOneWidget);
-        expect(find.text('Identity endpoint'), findsOneWidget);
-        expect(
-          find.textContaining(
-            'Provider selection is owned by the Weave Admin Console',
-          ),
-          findsOneWidget,
-        );
-        expect(find.text('Provider type'), findsNothing);
-        expect(find.text('OIDC Client ID'), findsOneWidget);
-        expect(find.text('Next'), findsOneWidget);
-      },
-    );
+      expect(find.byType(WeaveLogo), findsOneWidget);
+      expect(
+        find.text('Join from an invite or organization sign-in'),
+        findsOneWidget,
+      );
+      expect(find.text('I have an invite or sign-in link'), findsOneWidget);
+      expect(find.text('Open operator recovery setup'), findsOneWidget);
+      expect(find.text('Configure provider categories'), findsNothing);
+      expect(find.text('Provider categories'), findsNothing);
+      expect(find.text('Identity endpoint'), findsNothing);
+      expect(find.text('Provider type'), findsNothing);
+      expect(find.text('OIDC Client ID'), findsNothing);
+      expect(find.text('OIDC Issuer URL'), findsNothing);
+      expect(find.text('Nextcloud Base URL'), findsNothing);
+    });
 
     testWidgets('derives service endpoints from the issuer host', (
       tester,
     ) async {
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Open operator recovery setup'));
+      await tester.tap(find.text('Open operator recovery setup'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Provider categories'), findsOneWidget);
+      expect(find.text('Documents/collaboration'), findsOneWidget);
+      expect(find.text('Weaver'), findsOneWidget);
 
       await tester.enterText(
         _textFieldWithLabel('OIDC Issuer URL'),
@@ -136,6 +141,10 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Open operator recovery setup'));
+      await tester.tap(find.text('Open operator recovery setup'));
       await tester.pumpAndSettle();
 
       await tester.enterText(
@@ -164,6 +173,10 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Open operator recovery setup'));
+      await tester.tap(find.text('Open operator recovery setup'));
       await tester.pumpAndSettle();
 
       await tester.enterText(

--- a/client/test/features/onboarding/welcome_screen_test.dart
+++ b/client/test/features/onboarding/welcome_screen_test.dart
@@ -22,11 +22,11 @@ void main() {
       expect(find.byType(WeaveLogo), findsOneWidget);
     });
 
-    testWidgets('renders Get Started button', (tester) async {
+    testWidgets('renders Join your organization button', (tester) async {
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();
 
-      expect(find.text('Get Started'), findsOneWidget);
+      expect(find.text('Join your organization'), findsOneWidget);
     });
 
     testWidgets('meets androidTapTargetGuideline', (tester) async {

--- a/client/test/release_1/release_golden_paths_test.dart
+++ b/client/test/release_1/release_golden_paths_test.dart
@@ -106,9 +106,13 @@ void main() {
           container.read(appBootstrapProvider).requireValue.phase,
           BootstrapPhase.needsSetup,
         );
-        expect(find.text('Get Started'), findsOneWidget);
+        expect(find.text('Join your organization'), findsOneWidget);
 
-        await tester.tap(find.text('Get Started'));
+        await tester.tap(find.text('Join your organization'));
+        await tester.pumpAndSettle();
+
+        await tester.ensureVisible(find.text('Open operator recovery setup'));
+        await tester.tap(find.text('Open operator recovery setup'));
         await tester.pumpAndSettle();
 
         await tester.enterText(


### PR DESCRIPTION
## Summary
- Makes member onboarding handoff-first instead of helper/chat-first.
- Adds localized handoff copy and generated localization accessors.
- Updates onboarding and release golden-path tests for the new member path.

Closes #786.

## Gate evidence
- Reported by the issue #786 finisher as green before PR creation.
- Branch inspection: clean working tree on `feat/issue-786-member-handoff-first`, commit `e229f7d3c0 feat(client): make member onboarding handoff-first`.

## Files changed
- `client/lib/features/onboarding/presentation/member_handoff_screen.dart`
- `client/lib/features/onboarding/presentation/setup_flow.dart`
- `client/lib/l10n/app_de.arb`
- `client/lib/l10n/app_en.arb`
- `client/lib/l10n/generated/app_localizations.dart`
- `client/lib/l10n/generated/app_localizations_de.dart`
- `client/lib/l10n/generated/app_localizations_en.dart`
- `client/test/features/onboarding/setup_flow_test.dart`
- `client/test/features/onboarding/welcome_screen_test.dart`
- `client/test/release_1/release_golden_paths_test.dart`
