### PR TITLE
feat: sign Weaver runtime profiles with keyed HMAC

### DIFF
--- a/docs/governed-weaver-runtime-security-contract.md
+++ b/docs/governed-weaver-runtime-security-contract.md
@@ -14,7 +14,7 @@ Weaver is an optional per-user personal-assistant runtime. It is generated from 
 
 ## RuntimeProfile and OpenClaw projection boundary
 
-The Weaver/OpenClaw fork consumes one signed `WeaverRuntimeProfile` from Weave. Weave remains the source of truth for domains, provider selection, policy, credentials, and audit; OpenClaw configuration is generated runtime output, not a member-managed product model.
+The Weaver/OpenClaw fork consumes one keyed-signed `WeaverRuntimeProfile` from Weave. The signature is an HMAC-SHA-256 verification boundary over the issued profile hash and version; the signing key is represented only by `secretref://weave/weaver/runtime-profile-signing-key` in support evidence, never as raw key material. Weave remains the source of truth for domains, provider selection, policy, credentials, and audit; OpenClaw configuration is generated runtime output, not a member-managed product model.
 
 Required projection controls:
 
@@ -26,7 +26,7 @@ Required projection controls:
 - MCP servers, skills, and tools are distributed through Weave policy. `tools.deny` is hard-deny; `bundle-mcp`, gateway, cron, exec, write, and patch-style capabilities remain default-deny unless the signed profile explicitly allows a constrained use.
 - OpenClaw Policy/Doctor output is conformance lint over generated settings. It is not a second source of truth.
 
-Correct Chat provider-change flow: Admin changes the Chat domain provider in Weave -> readiness/migration checks run -> Credential Broker binds new provider credentials -> Weave backend routing/profile version changes -> signed RuntimeProfile vNext still exposes `channels.weave-chat` with updated profile hash/runtime token metadata -> the stable channel reloads or restarts if needed -> the user continues through Weave UX.
+Correct Chat provider-change flow: Admin changes the Chat domain provider in Weave -> readiness/migration checks run -> Credential Broker binds new provider credentials -> Weave backend routing/profile version changes -> keyed-signed RuntimeProfile vNext still exposes `channels.weave-chat` with updated profile hash, signature key reference, and runtime-token metadata -> the stable channel reloads or restarts if needed -> the user continues through Weave UX.
 
 ## Disabled-by-default gates
 
@@ -114,7 +114,7 @@ Sprint 12 keeps Weaver runtime execution disabled by default. See `docs/architec
 
 Every admin-distributed skill or tool manifest must be version-pinned and include:
 
-- signature and provenance;
+- keyed signature and provenance;
 - semantic version and immutable artifact digest;
 - declared capabilities, approval class, data classes, and egress destinations;
 - SecretRefs and OAuth/service-account broker requirements;

--- a/docs/governed-weaver-runtime-security-contract.md
+++ b/docs/governed-weaver-runtime-security-contract.md
@@ -14,7 +14,7 @@ Weaver is an optional per-user personal-assistant runtime. It is generated from 
 
 ## RuntimeProfile and OpenClaw projection boundary
 
-The Weaver/OpenClaw fork consumes one keyed-signed `WeaverRuntimeProfile` from Weave. The signature is an HMAC-SHA-256 verification boundary over the issued profile hash and version; the signing key is represented only by `secretref://weave/weaver/runtime-profile-signing-key` in support evidence, never as raw key material. Weave remains the source of truth for domains, provider selection, policy, credentials, and audit; OpenClaw configuration is generated runtime output, not a member-managed product model.
+The Weaver/OpenClaw fork consumes one keyed-signed `WeaverRuntimeProfile` from Weave. The signature is an HMAC-SHA-256 verification boundary over the issued profile hash and version; the signing key is represented only by `secretref://weave/weaver/runtime-profile-signing-key` in support evidence, never as raw key material. A valid signature is necessary but not sufficient: provisioning must also verify backend current-issuance state for the same user and profile hash. Beta keeps this current-issuance state in the issuing service instance, so a fresh replica/restart without that state must fail closed rather than accepting an otherwise unexpired signed profile; production hardening must replace this Beta limitation with a durable current-profile store before multi-replica profile handoff is claimed. Weave remains the source of truth for domains, provider selection, policy, credentials, and audit; OpenClaw configuration is generated runtime output, not a member-managed product model.
 
 Required projection controls:
 

--- a/docs/release-notes/v0.1.md
+++ b/docs/release-notes/v0.1.md
@@ -72,7 +72,7 @@ Evidence for `v0.1.0-rc.3`:
 
 ## Known Issues
 
-- Production-grade RuntimeProfile projection signing/fetch-by-hash and live runtime token issuance remain future hardening.
+- KMS/HSM-backed RuntimeProfile signing and live runtime token issuance remain future hardening; RuntimeProfile verification now uses a keyed HMAC boundary rather than hash-only markers.
 - Live provider CRUD/migration apply and public release publication require separate release-owner decisions and fresh evidence.
 - Documents/Office WOPI remains unavailable/guarded until backend runtime, callback/session security, storage binding, permission model, health checks, and release gates exist.
 - Post-RC3 Sprint 18 accounting keeps #591 open as the current release blocker: actual manual assistive-technology signoff is still required before Sprint 18 milestone closure or public/production release signoff.

--- a/docs/sprint-17-closure-report.md
+++ b/docs/sprint-17-closure-report.md
@@ -53,5 +53,5 @@ Passing on 2026-06-01:
 
 ## Remaining risks / carryovers
 
-- Production-grade RuntimeProfile projection signing/fetch-by-hash remains future hardening beyond this local RC evidence slice.
+- Production-grade KMS/HSM-backed RuntimeProfile signing remains future hardening; the Sprint 32 implementation now uses keyed HMAC verification instead of hash-only markers.
 - Real production runtime token issuance/signing and live provider CRUD remain future work beyond this RC-shaped evidence slice.

--- a/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
@@ -15,6 +15,7 @@ public record WeaverRuntimeProperties(
         List<String> allowedCapabilities,
         List<String> pluginAllowlist,
         List<String> toolAllowlist,
+        String signingKeySecretRef,
         boolean execEnabled,
         boolean elevatedEnabled,
         boolean auditRequired,
@@ -30,6 +31,7 @@ public record WeaverRuntimeProperties(
         allowedCapabilities = normalize(allowedCapabilities, List.of("weaver.files_read", "weaver.exec_disabled"));
         pluginAllowlist = normalize(pluginAllowlist, List.of("weave-files-readonly"));
         toolAllowlist = normalize(toolAllowlist, List.of("files.read"));
+        signingKeySecretRef = hasText(signingKeySecretRef) ? signingKeySecretRef : "secretref://weave/weaver/runtime-profile-signing-key";
         // Even when an admin enables the runtime, audit remains required by default.
         auditRequired = true;
     }

--- a/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
@@ -16,6 +16,7 @@ public record WeaverRuntimeProperties(
         List<String> pluginAllowlist,
         List<String> toolAllowlist,
         String signingKeySecretRef,
+        String signingKey,
         boolean execEnabled,
         boolean elevatedEnabled,
         boolean auditRequired,
@@ -32,6 +33,7 @@ public record WeaverRuntimeProperties(
         pluginAllowlist = normalize(pluginAllowlist, List.of("weave-files-readonly"));
         toolAllowlist = normalize(toolAllowlist, List.of("files.read"));
         signingKeySecretRef = hasText(signingKeySecretRef) ? signingKeySecretRef : "secretref://weave/weaver/runtime-profile-signing-key";
+        signingKey = hasText(signingKey) ? signingKey.trim() : null;
         // Even when an admin enables the runtime, audit remains required by default.
         auditRequired = true;
     }

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -158,7 +158,7 @@ public class AdminControlPlaneService {
                 ? List.of(new KeycloakRealmLiveApplyAdapter(this.identityRealmApplyProperties))
                 : List.copyOf(adapters);
         this.weaverRuntimeProperties = weaverRuntimeProperties.getIfAvailable(
-                () -> new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                () -> new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
         this.clock = Clock.systemUTC();
     }
 
@@ -171,7 +171,7 @@ public class AdminControlPlaneService {
             Clock clock) {
         this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher,
                 List.of(new KeycloakRealmDryRunProvider()), new InMemoryIdentityRealmEvidenceRepository(), List.of(new KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), clock,
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     AdminControlPlaneService(
@@ -205,7 +205,7 @@ public class AdminControlPlaneService {
                 : List.copyOf(identityRealmLiveApplyAdapters);
         this.clock = clock;
         this.weaverRuntimeProperties = weaverRuntimeProperties == null
-                ? new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false)
+                ? new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, null, false, false, true, false)
                 : weaverRuntimeProperties;
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -158,7 +158,7 @@ public class AdminControlPlaneService {
                 ? List.of(new KeycloakRealmLiveApplyAdapter(this.identityRealmApplyProperties))
                 : List.copyOf(adapters);
         this.weaverRuntimeProperties = weaverRuntimeProperties.getIfAvailable(
-                () -> new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                () -> new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
         this.clock = Clock.systemUTC();
     }
 
@@ -171,7 +171,7 @@ public class AdminControlPlaneService {
             Clock clock) {
         this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher,
                 List.of(new KeycloakRealmDryRunProvider()), new InMemoryIdentityRealmEvidenceRepository(), List.of(new KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), clock,
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     AdminControlPlaneService(
@@ -205,7 +205,7 @@ public class AdminControlPlaneService {
                 : List.copyOf(identityRealmLiveApplyAdapters);
         this.clock = clock;
         this.weaverRuntimeProperties = weaverRuntimeProperties == null
-                ? new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false)
+                ? new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false)
                 : weaverRuntimeProperties;
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -227,19 +227,23 @@ public class WeaverRuntimeService {
         if (Instant.parse(profile.expiresAt()).isBefore(Instant.now()) || !verifyProfile(profile) || !isCurrentIssuedProfile(profile)) {
             throw new IllegalArgumentException("Only valid signed current Weaver RuntimeProfiles can be provisioned.");
         }
-        Map<String, String> labels = runtimeLabels(profile, orgRef, policyVersion);
+        WeaverRuntimeProfileResponse issuedProfile = issuedProfiles.get(profile.runtimeProfileHash());
+        if (issuedProfile == null || !verifyProfile(issuedProfile)) {
+            throw new IllegalArgumentException("Only valid signed current Weaver RuntimeProfiles can be provisioned.");
+        }
+        Map<String, String> labels = runtimeLabels(issuedProfile, orgRef, policyVersion);
         WeaverRuntimeInstance instance = new WeaverRuntimeInstance(
-                profile.userRef(),
-                containerId(profile.userRef(), profile.runtimeProfileHash(), policyVersion),
+                issuedProfile.userRef(),
+                containerId(issuedProfile.userRef(), issuedProfile.runtimeProfileHash(), policyVersion),
                 "running",
-                profile.runtimeProfileHash(),
+                issuedProfile.runtimeProfileHash(),
                 policyVersion,
-                profile.containerImage(),
-                profile.workspacePath(),
+                issuedProfile.containerImage(),
+                issuedProfile.workspacePath(),
                 labels,
                 Instant.now().toString(),
                 null);
-        runtimeInstances.put(profile.userRef(), instance);
+        runtimeInstances.put(issuedProfile.userRef(), instance);
         return instance;
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -9,11 +9,13 @@ import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.security.SecureRandom;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -22,6 +24,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
@@ -46,6 +50,7 @@ public class WeaverRuntimeService {
     private final WorkspaceCapabilityProperties workspaceCapabilityProperties;
     private final WeaverRuntimeProperties weaverRuntimeProperties;
     private final AuditEventPublisher auditEventPublisher;
+    private final byte[] runtimeProfileSigningKey;
 
     public WeaverRuntimeService(
             WorkspaceCapabilityService workspaceCapabilityService,
@@ -56,6 +61,8 @@ public class WeaverRuntimeService {
         this.workspaceCapabilityProperties = workspaceCapabilityProperties;
         this.weaverRuntimeProperties = weaverRuntimeProperties;
         this.auditEventPublisher = auditEventPublisher;
+        this.runtimeProfileSigningKey = new byte[32];
+        new SecureRandom().nextBytes(this.runtimeProfileSigningKey);
     }
 
     public WeaverRuntimeProfileResponse profileFor(Jwt jwt) {
@@ -181,6 +188,10 @@ public class WeaverRuntimeService {
             auditRollback(userRef, rollbackProfileHash, "rollback_denied");
             return disabledProfile(userRef, "runtime-profile-rollback-denied", "RuntimeProfile rollback failed closed.");
         }
+        if (!verifyProfile(rollback)) {
+            auditRollback(userRef, rollbackProfileHash, "rollback_signature_denied");
+            return disabledProfile(userRef, "runtime-profile-signature-invalid", "RuntimeProfile rollback failed closed.");
+        }
         String currentProfileHash = currentProfileHashByUser.getOrDefault(userRef, "none");
         rollbackProfileHashByUser.put(userRef, currentProfileHash);
         currentProfileHashByUser.put(userRef, rollback.runtimeProfileHash());
@@ -201,6 +212,9 @@ public class WeaverRuntimeService {
                 || !runtimeProfileHash.strip().equals(currentProfileHashByUser.getOrDefault(userRef, ""))) {
             return disabledProfile(userRef, "runtime-profile-fetch-denied", "RuntimeProfile fetch-by-hash failed closed.");
         }
+        if (!verifyProfile(issued)) {
+            return disabledProfile(userRef, "runtime-profile-signature-invalid", "RuntimeProfile fetch-by-hash failed closed.");
+        }
         if (!Boolean.TRUE.equals(issued.supportSafeProfileReceipt().get("signed"))
                 || !Boolean.TRUE.equals(issued.supportSafeProfileReceipt().get("fetchByHashRequired"))) {
             return disabledProfile(userRef, "runtime-profile-signature-missing", "RuntimeProfile fetch-by-hash failed closed.");
@@ -211,6 +225,9 @@ public class WeaverRuntimeService {
     public WeaverRuntimeInstance provisionRuntime(WeaverRuntimeProfileResponse profile, String orgRef, String policyVersion) {
         if (profile == null || !profile.enabled() || profile.revoked()) {
             throw new IllegalArgumentException("Only active Weaver RuntimeProfiles can be provisioned.");
+        }
+        if (Instant.parse(profile.expiresAt()).isBefore(Instant.now()) || !verifyProfile(profile)) {
+            throw new IllegalArgumentException("Only valid signed Weaver RuntimeProfiles can be provisioned.");
         }
         Map<String, String> labels = runtimeLabels(profile, orgRef, policyVersion);
         WeaverRuntimeInstance instance = new WeaverRuntimeInstance(
@@ -645,7 +662,33 @@ public class WeaverRuntimeService {
     }
 
     private String signProfile(String runtimeProfileHash, String profileVersion) {
-        return "weave-signature:v1:" + sha256(runtimeProfileHash + ":" + profileVersion + ":support-safe");
+        return "weave-hmac-sha256:v1:" + signingKeyRefFingerprint() + ":" + hmacSha256(signingPayload(runtimeProfileHash, profileVersion));
+    }
+
+    private boolean verifyProfile(WeaverRuntimeProfileResponse profile) {
+        if (profile == null || profile.signature() == null || !profile.signature().startsWith("weave-hmac-sha256:v1:")) {
+            return false;
+        }
+        String expected = signProfile(profile.runtimeProfileHash(), profile.profileVersion());
+        return MessageDigest.isEqual(expected.getBytes(StandardCharsets.UTF_8), profile.signature().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String signingPayload(String runtimeProfileHash, String profileVersion) {
+        return String.join("|", "runtime-profile", runtimeProfileHash, profileVersion);
+    }
+
+    private String signingKeyRefFingerprint() {
+        return "keyref:" + sha256(weaverRuntimeProperties.signingKeySecretRef()).substring(0, 16);
+    }
+
+    private String hmacSha256(String value) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(runtimeProfileSigningKey, "HmacSHA256"));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(mac.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("HMAC-SHA-256 is required for Weaver RuntimeProfile signatures", e);
+        }
     }
 
     private Map<String, Object> channelProjection(
@@ -658,17 +701,18 @@ public class WeaverRuntimeService {
             List<String> allowedCapabilities,
             List<String> toolAllowlist) {
         String runtimeTokenRef = "credentialref://weave/runtime/short-lived/" + userRef.replace("user:", "");
-        Map<String, Object> runtimeProfileFetch = Map.of(
-                "fetchRef", "weave-runtime-profile://" + runtimeProfileHash,
-                "runtimeProfileHash", runtimeProfileHash,
-                "profileVersion", profileVersion,
-                "expiresAt", expiresAt,
-                "previousProfileHash", previousProfileHash,
-                "signatureRequired", true,
-                "signatureAlgorithm", "weave-signature:v1",
-                "revocationChecked", true,
-                "supportSafe", true,
-                "rawProfileBodyReturnedToMembers", false);
+        Map<String, Object> runtimeProfileFetch = Map.ofEntries(
+                Map.entry("fetchRef", "weave-runtime-profile://" + runtimeProfileHash),
+                Map.entry("runtimeProfileHash", runtimeProfileHash),
+                Map.entry("profileVersion", profileVersion),
+                Map.entry("expiresAt", expiresAt),
+                Map.entry("previousProfileHash", previousProfileHash),
+                Map.entry("signatureRequired", true),
+                Map.entry("signatureAlgorithm", "weave-hmac-sha256:v1"),
+                Map.entry("signatureKeyRef", weaverRuntimeProperties.signingKeySecretRef()),
+                Map.entry("revocationChecked", true),
+                Map.entry("supportSafe", true),
+                Map.entry("rawProfileBodyReturnedToMembers", false));
         List<String> mcpAllowedTools = governedMcpAllowedTools(allowedCapabilities, toolAllowlist);
         return Map.ofEntries(
                 Map.entry("channelId", "channels.weave-chat"),
@@ -753,6 +797,8 @@ public class WeaverRuntimeService {
                 Map.entry("profileVersion", profileVersion),
                 Map.entry("runtimeProfileHash", runtimeProfileHash),
                 Map.entry("signature", signature),
+                Map.entry("signatureAlgorithm", "weave-hmac-sha256:v1"),
+                Map.entry("signatureKeyRef", weaverRuntimeProperties.signingKeySecretRef()),
                 Map.entry("signed", true),
                 Map.entry("fetchByHashRequired", true),
                 Map.entry("fetchRef", "weave-runtime-profile://" + runtimeProfileHash),

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -9,7 +9,6 @@ import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.security.SecureRandom;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
@@ -61,8 +60,7 @@ public class WeaverRuntimeService {
         this.workspaceCapabilityProperties = workspaceCapabilityProperties;
         this.weaverRuntimeProperties = weaverRuntimeProperties;
         this.auditEventPublisher = auditEventPublisher;
-        this.runtimeProfileSigningKey = new byte[32];
-        new SecureRandom().nextBytes(this.runtimeProfileSigningKey);
+        this.runtimeProfileSigningKey = configuredSigningKey(weaverRuntimeProperties);
     }
 
     public WeaverRuntimeProfileResponse profileFor(Jwt jwt) {
@@ -226,8 +224,8 @@ public class WeaverRuntimeService {
         if (profile == null || !profile.enabled() || profile.revoked()) {
             throw new IllegalArgumentException("Only active Weaver RuntimeProfiles can be provisioned.");
         }
-        if (Instant.parse(profile.expiresAt()).isBefore(Instant.now()) || !verifyProfile(profile)) {
-            throw new IllegalArgumentException("Only valid signed Weaver RuntimeProfiles can be provisioned.");
+        if (Instant.parse(profile.expiresAt()).isBefore(Instant.now()) || !verifyProfile(profile) || !isCurrentIssuedProfile(profile)) {
+            throw new IllegalArgumentException("Only valid signed current Weaver RuntimeProfiles can be provisioned.");
         }
         Map<String, String> labels = runtimeLabels(profile, orgRef, policyVersion);
         WeaverRuntimeInstance instance = new WeaverRuntimeInstance(
@@ -661,6 +659,14 @@ public class WeaverRuntimeService {
                 credentialBrokerContract(credentialUserRef).toString()));
     }
 
+    private boolean isCurrentIssuedProfile(WeaverRuntimeProfileResponse profile) {
+        WeaverRuntimeProfileResponse issued = issuedProfiles.get(profile.runtimeProfileHash());
+        return issued != null
+                && issued == profile
+                && !issued.revoked()
+                && profile.runtimeProfileHash().equals(currentProfileHashByUser.getOrDefault(profile.userRef(), ""));
+    }
+
     private String signProfile(String runtimeProfileHash, String profileVersion) {
         return "weave-hmac-sha256:v1:" + signingKeyRefFingerprint() + ":" + hmacSha256(signingPayload(runtimeProfileHash, profileVersion));
     }
@@ -679,6 +685,17 @@ public class WeaverRuntimeService {
 
     private String signingKeyRefFingerprint() {
         return "keyref:" + sha256(weaverRuntimeProperties.signingKeySecretRef()).substring(0, 16);
+    }
+
+    private static byte[] configuredSigningKey(WeaverRuntimeProperties properties) {
+        if (properties == null || properties.signingKey() == null || properties.signingKey().isBlank()) {
+            throw new IllegalStateException("Weaver RuntimeProfile signing key is not configured; configure weave.weaver.runtime.signing-key through the operator SecretRef source.");
+        }
+        byte[] key = properties.signingKey().getBytes(StandardCharsets.UTF_8);
+        if (key.length < 32) {
+            throw new IllegalStateException("Weaver RuntimeProfile signing key must be at least 32 bytes.");
+        }
+        return key;
     }
 
     private String hmacSha256(String value) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -661,10 +661,39 @@ public class WeaverRuntimeService {
 
     private boolean isCurrentIssuedProfile(WeaverRuntimeProfileResponse profile) {
         WeaverRuntimeProfileResponse issued = issuedProfiles.get(profile.runtimeProfileHash());
-        return issued != null
-                && issued == profile
-                && !issued.revoked()
-                && profile.runtimeProfileHash().equals(currentProfileHashByUser.getOrDefault(profile.userRef(), ""));
+        String currentProfileHash = currentProfileHashByUser.get(profile.userRef());
+        if (currentProfileHash != null && !profile.runtimeProfileHash().equals(currentProfileHash)) {
+            return false;
+        }
+        if (issued == null) {
+            return currentProfileHash == null;
+        }
+        return !issued.revoked()
+                && !Instant.parse(issued.expiresAt()).isBefore(Instant.now())
+                && sameIssuedProfileIdentity(issued, profile);
+    }
+
+    private boolean sameIssuedProfileIdentity(WeaverRuntimeProfileResponse issued, WeaverRuntimeProfileResponse supplied) {
+        return issued.enabled() == supplied.enabled()
+                && issued.revoked() == supplied.revoked()
+                && issued.posture().equals(supplied.posture())
+                && issued.userRef().equals(supplied.userRef())
+                && issued.profileVersion().equals(supplied.profileVersion())
+                && issued.runtimeProfileHash().equals(supplied.runtimeProfileHash())
+                && issued.signature().equals(supplied.signature())
+                && issued.expiresAt().equals(supplied.expiresAt())
+                && issued.revocationGeneration() == supplied.revocationGeneration()
+                && issued.runtimeKind().equals(supplied.runtimeKind())
+                && issued.runtimeProvider().equals(supplied.runtimeProvider())
+                && issued.modelProvider().equals(supplied.modelProvider())
+                && issued.toolProvider().equals(supplied.toolProvider())
+                && issued.allowedCapabilities().equals(supplied.allowedCapabilities())
+                && issued.pluginAllowlist().equals(supplied.pluginAllowlist())
+                && issued.toolAllowlist().equals(supplied.toolAllowlist())
+                && issued.execEnabled() == supplied.execEnabled()
+                && issued.elevatedEnabled() == supplied.elevatedEnabled()
+                && issued.auditRequired() == supplied.auditRequired()
+                && issued.forkRequired() == supplied.forkRequired();
     }
 
     private String signProfile(String runtimeProfileHash, String profileVersion) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -662,11 +662,11 @@ public class WeaverRuntimeService {
     private boolean isCurrentIssuedProfile(WeaverRuntimeProfileResponse profile) {
         WeaverRuntimeProfileResponse issued = issuedProfiles.get(profile.runtimeProfileHash());
         String currentProfileHash = currentProfileHashByUser.get(profile.userRef());
-        if (currentProfileHash != null && !profile.runtimeProfileHash().equals(currentProfileHash)) {
+        if (currentProfileHash == null || issued == null) {
             return false;
         }
-        if (issued == null) {
-            return currentProfileHash == null;
+        if (!profile.runtimeProfileHash().equals(currentProfileHash)) {
+            return false;
         }
         return !issued.revoked()
                 && !Instant.parse(issued.expiresAt()).isBefore(Instant.now())

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -89,7 +89,7 @@ public class WorkspaceCapabilityService {
                 resourceServerProperties,
                 weaveSecurityProperties,
                 workspaceCapabilityProperties,
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     @Autowired

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -89,7 +89,7 @@ public class WorkspaceCapabilityService {
                 resourceServerProperties,
                 weaveSecurityProperties,
                 workspaceCapabilityProperties,
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     @Autowired

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolInvocationRequest.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolInvocationRequest.java
@@ -31,7 +31,7 @@ public record WeaverToolInvocationRequest(
                 userRef,
                 runtimeProfileHash,
                 userRef,
-                "weave-signature:v1:test-support-safe",
+                "weave-hmac-sha256:v1:keyref:test-support-safe:test-support-safe",
                 false,
                 Instant.now().plusSeconds(300).toString(),
                 true,

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -139,7 +139,7 @@ public class WeaverToolRegistry {
     }
 
     private String governanceDenial(WeaverToolInvocationRequest request, WeaverDomainToolDefinition definition) {
-        if (!request.runtimeProfileSignature().startsWith("weave-signature:v1:")) {
+        if (!request.runtimeProfileSignature().startsWith("weave-hmac-sha256:v1:")) {
             return "runtime_profile_unsigned";
         }
         if (!request.userRef().equals(request.runtimeProfileUserRef())) {

--- a/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
@@ -542,7 +542,7 @@ class AdminControlPlaneServiceTest {
                 List.of(new KeycloakRealmLiveApplyAdapter(properties)),
                 properties,
                 Clock.fixed(Instant.parse("2026-05-27T01:03:39Z"), ZoneOffset.UTC),
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     private WorkspaceCapabilityService workspaceCapabilityService() {

--- a/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
@@ -542,7 +542,7 @@ class AdminControlPlaneServiceTest {
                 List.of(new KeycloakRealmLiveApplyAdapter(properties)),
                 properties,
                 Clock.fixed(Instant.parse("2026-05-27T01:03:39Z"), ZoneOffset.UTC),
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     private WorkspaceCapabilityService workspaceCapabilityService() {

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceLiveWeaverRoundTripTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceLiveWeaverRoundTripTest.java
@@ -214,6 +214,7 @@ class ChatFacadeServiceLiveWeaverRoundTripTest {
                         List.of("weave-chat"),
                         List.of("message.send"),
                         null,
+                        "weaver-runtime-profile-test-signing-key-32-bytes-minimum",
                         false,
                         false,
                         true,

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceLiveWeaverRoundTripTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceLiveWeaverRoundTripTest.java
@@ -213,6 +213,7 @@ class ChatFacadeServiceLiveWeaverRoundTripTest {
                         List.of("weaver.files_read", "weaver.exec_disabled"),
                         List.of("weave-chat"),
                         List.of("message.send"),
+                        null,
                         false,
                         false,
                         true,

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
@@ -305,6 +305,7 @@ class ChatFacadeServiceTest {
                 List.of("weaver.files_read", "weaver.exec_disabled"),
                 List.of("weave-chat"),
                 List.of("message.send"),
+                null,
                 false,
                 false,
                 true,

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
@@ -306,6 +306,7 @@ class ChatFacadeServiceTest {
                 List.of("weave-chat"),
                 List.of("message.send"),
                 null,
+                "weaver-runtime-profile-test-signing-key-32-bytes-minimum",
                 false,
                 false,
                 true,

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -5,6 +5,7 @@ import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import java.time.Instant;
 import java.util.List;
@@ -14,6 +15,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2Res
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class WeaverRuntimeServiceTest {
 
@@ -74,7 +76,7 @@ class WeaverRuntimeServiceTest {
         assertThat(profile.userRef()).doesNotContain("member@example.invalid");
         assertThat(profile.profileVersion()).startsWith("v");
         assertThat(profile.runtimeProfileHash()).startsWith("sha256:");
-        assertThat(profile.signature()).startsWith("weave-signature:v1:");
+        assertThat(profile.signature()).startsWith("weave-hmac-sha256:v1:keyref:");
         assertThat(profile.revoked()).isFalse();
         assertThat(profile.revocationStatus()).isEqualTo("active");
         assertThat(profile.revocationGeneration()).isZero();
@@ -117,6 +119,8 @@ class WeaverRuntimeServiceTest {
                 .containsEntry("profileVersion", profile.profileVersion())
                 .containsEntry("runtimeProfileHash", profile.runtimeProfileHash())
                 .containsEntry("signature", profile.signature())
+                .containsEntry("signatureAlgorithm", "weave-hmac-sha256:v1")
+                .containsEntry("signatureKeyRef", "secretref://weave/weaver/runtime-profile-signing-key")
                 .containsEntry("signed", true)
                 .containsEntry("fetchByHashRequired", true)
                 .containsEntry("fetchRef", "weave-runtime-profile://" + profile.runtimeProfileHash())
@@ -251,6 +255,35 @@ class WeaverRuntimeServiceTest {
         assertThat(mismatched.enabled()).isFalse();
         assertThat(mismatched.posture()).isEqualTo("runtime-profile-fetch-denied");
         assertThat(mismatched.toString()).doesNotContain("Bearer ", "openclaw.json", "refresh_token", "https://matrix.weave.test");
+    }
+
+    @Test
+    void rejectsMissingTamperedExpiredAndWrongKeyRuntimeProfileSignatures() {
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+        var issued = service.profileFor(member);
+
+        assertThat(service.profileByHash(member, issued.runtimeProfileHash()).enabled()).isTrue();
+
+        var missingSignature = copyProfile(issued, issued.runtimeProfileHash(), "", issued.expiresAt());
+        assertThatThrownBy(() -> service.provisionRuntime(missingSignature, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed");
+
+        var tamperedProfile = copyProfile(issued, "sha256:tampered", issued.signature(), issued.expiresAt());
+        assertThatThrownBy(() -> service.provisionRuntime(tamperedProfile, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed");
+
+        var expiredProfile = copyProfile(issued, issued.runtimeProfileHash(), issued.signature(), Instant.now().minusSeconds(60).toString());
+        assertThatThrownBy(() -> service.provisionRuntime(expiredProfile, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed");
+
+        WeaverRuntimeService wrongKeyService = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        assertThatThrownBy(() -> wrongKeyService.provisionRuntime(issued, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed");
     }
 
     @Test
@@ -412,10 +445,28 @@ class WeaverRuntimeServiceTest {
                 allowedCapabilities,
                 List.of("weave-files-readonly"),
                 toolAllowlist,
+                null,
                 false,
                 false,
                 true,
                 false);
+    }
+
+    private WeaverRuntimeProfileResponse copyProfile(
+            WeaverRuntimeProfileResponse profile,
+            String runtimeProfileHash,
+            String signature,
+            String expiresAt) {
+        return new WeaverRuntimeProfileResponse(
+                profile.enabled(), profile.posture(), profile.runtimeKind(), profile.runtimeProvider(), profile.modelProvider(),
+                profile.toolProvider(), profile.generatedFrom(), profile.userRef(), profile.profileVersion(), runtimeProfileHash,
+                signature, expiresAt, profile.revoked(), profile.revocationStatus(), profile.revocationGeneration(),
+                profile.previousProfileHash(), profile.rollbackProfileHash(), profile.baselineProfile(), profile.containerImage(),
+                profile.workspacePath(), profile.isolatedAgentDirectory(), profile.dockerNetworkMode(), profile.allowedCapabilities(),
+                profile.pluginAllowlist(), profile.toolAllowlist(), profile.execEnabled(), profile.elevatedEnabled(),
+                profile.auditRequired(), profile.forkRequired(), profile.channelProjection(), profile.credentialBrokerContract(),
+                profile.auditPolicy(), profile.supportSafeProfileReceipt(), profile.approvalPolicy(), profile.secretPosture(),
+                profile.isolationBoundary(), profile.memberImpact());
     }
 
     private Jwt jwt(String subject, List<String> roles, List<String> groups) {

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -280,10 +280,46 @@ class WeaverRuntimeServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("valid signed");
 
-        WeaverRuntimeService wrongKeyService = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        WeaverRuntimeService wrongKeyService = service(true, runtimePropertiesWithKey(true, "different-weaver-runtime-profile-signing-key-32-bytes"), new InMemoryAuditEventPublisher());
         assertThatThrownBy(() -> wrongKeyService.provisionRuntime(issued, "org:acme", "policy:v32"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("valid signed");
+    }
+
+    @Test
+    void rejectsStaleSignedProfileDuringProvisioning() {
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+
+        var issued = service.profileFor(member);
+        var customized = service.applyRuntimeCustomization(member, Map.of("style", "concise"));
+
+        assertThat(customized.accepted()).isTrue();
+        assertThatThrownBy(() -> service.provisionRuntime(issued, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("current Weaver RuntimeProfiles");
+        assertThat(service.provisionRuntime(customized.profile(), "org:acme", "policy:v32").runtimeProfileHash())
+                .isEqualTo(customized.profile().runtimeProfileHash());
+    }
+
+    @Test
+    void usesConfigBoundSigningKeyAcrossServiceReplicasAndFailsWhenMissing() {
+        var first = service(true, runtimePropertiesWithKey(true, "stable-weaver-runtime-profile-signing-key-32-bytes"), new InMemoryAuditEventPublisher());
+        var second = service(true, runtimePropertiesWithKey(true, "stable-weaver-runtime-profile-signing-key-32-bytes"), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+
+        var issued = first.profileFor(member);
+        var replicaIssued = second.profileFor(member);
+
+        assertThat(replicaIssued.signature()).isNotBlank();
+        assertThat(replicaIssued.signature().split(":")[3]).isEqualTo(issued.signature().split(":")[3]);
+        assertThatThrownBy(() -> service(true, runtimePropertiesWithKey(true, null), new InMemoryAuditEventPublisher()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("signing key is not configured");
+        assertThat(issued.supportSafeProfileReceipt().toString())
+                .contains("secretref://weave/weaver/runtime-profile-signing-key")
+                .doesNotContain("stable-weaver-runtime-profile-signing-key");
+        // RuntimeProfile has no not-before field today; expiry and current-issued checks are the temporal fail-closed gates.
     }
 
     @Test
@@ -434,6 +470,14 @@ class WeaverRuntimeServiceTest {
     }
 
     private WeaverRuntimeProperties runtimeProperties(boolean enabled, List<String> allowedCapabilities, List<String> toolAllowlist) {
+        return runtimePropertiesWithKey(enabled, allowedCapabilities, toolAllowlist, "weaver-runtime-profile-test-signing-key-32-bytes-minimum");
+    }
+
+    private WeaverRuntimeProperties runtimePropertiesWithKey(boolean enabled, String signingKey) {
+        return runtimePropertiesWithKey(enabled, List.of("weaver.files_read", "weaver.exec_disabled"), List.of("files.read"), signingKey);
+    }
+
+    private WeaverRuntimeProperties runtimePropertiesWithKey(boolean enabled, List<String> allowedCapabilities, List<String> toolAllowlist, String signingKey) {
         return new WeaverRuntimeProperties(
                 enabled,
                 null,
@@ -446,6 +490,7 @@ class WeaverRuntimeServiceTest {
                 List.of("weave-files-readonly"),
                 toolAllowlist,
                 null,
+                signingKey,
                 false,
                 false,
                 true,

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -319,8 +319,9 @@ class WeaverRuntimeServiceTest {
 
         assertThat(first.provisionRuntime(issuedCopy, "org:acme", "policy:v32").runtimeProfileHash())
                 .isEqualTo(issued.runtimeProfileHash());
-        assertThat(second.provisionRuntime(issuedCopy, "org:acme", "policy:v32").runtimeProfileHash())
-                .isEqualTo(issued.runtimeProfileHash());
+        assertThatThrownBy(() -> second.provisionRuntime(issuedCopy, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed current");
 
         var replicaIssued = second.profileFor(member);
         assertThat(replicaIssued.signature()).isNotBlank();
@@ -328,6 +329,8 @@ class WeaverRuntimeServiceTest {
         assertThatThrownBy(() -> second.provisionRuntime(issuedCopy, "org:acme", "policy:v32"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("valid signed current");
+        assertThat(second.provisionRuntime(replicaIssued, "org:acme", "policy:v32").runtimeProfileHash())
+                .isEqualTo(replicaIssued.runtimeProfileHash());
         assertThatThrownBy(() -> service(true, runtimePropertiesWithKey(true, null), new InMemoryAuditEventPublisher()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("signing key is not configured");
@@ -335,6 +338,32 @@ class WeaverRuntimeServiceTest {
                 .contains("secretref://weave/weaver/runtime-profile-signing-key")
                 .doesNotContain("stable-weaver-runtime-profile-signing-key");
         // RuntimeProfile has no not-before field today; expiry and current-issued checks are the temporal fail-closed gates.
+    }
+
+    @Test
+    void freshReplicaRejectsStaleAndCurrentProfilesWithoutCurrentIssuanceState() {
+        var primary = service(true, runtimePropertiesWithKey(true, "stable-weaver-runtime-profile-signing-key-32-bytes"), new InMemoryAuditEventPublisher());
+        var freshReplica = service(true, runtimePropertiesWithKey(true, "stable-weaver-runtime-profile-signing-key-32-bytes"), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+
+        var oldProfile = primary.profileFor(member);
+        var currentProfile = primary.applyRuntimeCustomization(member, Map.of("style", "concise")).profile();
+
+        assertThatThrownBy(() -> primary.provisionRuntime(oldProfile, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed current");
+        assertThat(primary.provisionRuntime(currentProfile, "org:acme", "policy:v32").runtimeProfileHash())
+                .isEqualTo(currentProfile.runtimeProfileHash());
+        assertThatThrownBy(() -> freshReplica.provisionRuntime(oldProfile, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed current");
+        assertThatThrownBy(() -> freshReplica.provisionRuntime(currentProfile, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed current");
+
+        var replicaCurrent = freshReplica.profileFor(member);
+        assertThat(freshReplica.provisionRuntime(replicaCurrent, "org:acme", "policy:v32").runtimeProfileHash())
+                .isEqualTo(replicaCurrent.runtimeProfileHash());
     }
 
     @Test

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -309,6 +309,31 @@ class WeaverRuntimeServiceTest {
     }
 
     @Test
+    void provisionsFromStoredIssuedProfileWhenSerializedCopyTampersProvisioningFields() {
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+        var issued = service.profileFor(member);
+        var tamperedCopy = copyProfile(
+                issued,
+                issued.runtimeProfileHash(),
+                issued.signature(),
+                issued.expiresAt(),
+                "registry.invalid/weaver/tampered:latest",
+                "/tmp/tampered-weaver-workspace",
+                "tampered-secret-posture");
+
+        var runtime = service.provisionRuntime(tamperedCopy, "org:acme", "policy:v32");
+
+        assertThat(runtime.containerImage()).isEqualTo(issued.containerImage());
+        assertThat(runtime.workspacePath()).isEqualTo(issued.workspacePath());
+        assertThat(runtime.containerImage()).isNotEqualTo(tamperedCopy.containerImage());
+        assertThat(runtime.workspacePath()).isNotEqualTo(tamperedCopy.workspacePath());
+        assertThat(runtime.labels())
+                .containsEntry("weave.profile_hash", issued.runtimeProfileHash())
+                .containsEntry("weave.user", issued.userRef());
+    }
+
+    @Test
     void usesConfigBoundSigningKeyAcrossServiceReplicasAndFailsWhenMissing() {
         var first = service(true, runtimePropertiesWithKey(true, "stable-weaver-runtime-profile-signing-key-32-bytes"), new InMemoryAuditEventPublisher());
         var second = service(true, runtimePropertiesWithKey(true, "stable-weaver-runtime-profile-signing-key-32-bytes"), new InMemoryAuditEventPublisher());
@@ -546,15 +571,33 @@ class WeaverRuntimeServiceTest {
             String runtimeProfileHash,
             String signature,
             String expiresAt) {
+        return copyProfile(
+                profile,
+                runtimeProfileHash,
+                signature,
+                expiresAt,
+                profile.containerImage(),
+                profile.workspacePath(),
+                profile.secretPosture());
+    }
+
+    private WeaverRuntimeProfileResponse copyProfile(
+            WeaverRuntimeProfileResponse profile,
+            String runtimeProfileHash,
+            String signature,
+            String expiresAt,
+            String containerImage,
+            String workspacePath,
+            String secretPosture) {
         return new WeaverRuntimeProfileResponse(
                 profile.enabled(), profile.posture(), profile.runtimeKind(), profile.runtimeProvider(), profile.modelProvider(),
                 profile.toolProvider(), profile.generatedFrom(), profile.userRef(), profile.profileVersion(), runtimeProfileHash,
                 signature, expiresAt, profile.revoked(), profile.revocationStatus(), profile.revocationGeneration(),
-                profile.previousProfileHash(), profile.rollbackProfileHash(), profile.baselineProfile(), profile.containerImage(),
-                profile.workspacePath(), profile.isolatedAgentDirectory(), profile.dockerNetworkMode(), profile.allowedCapabilities(),
+                profile.previousProfileHash(), profile.rollbackProfileHash(), profile.baselineProfile(), containerImage,
+                workspacePath, profile.isolatedAgentDirectory(), profile.dockerNetworkMode(), profile.allowedCapabilities(),
                 profile.pluginAllowlist(), profile.toolAllowlist(), profile.execEnabled(), profile.elevatedEnabled(),
                 profile.auditRequired(), profile.forkRequired(), profile.channelProjection(), profile.credentialBrokerContract(),
-                profile.auditPolicy(), profile.supportSafeProfileReceipt(), profile.approvalPolicy(), profile.secretPosture(),
+                profile.auditPolicy(), profile.supportSafeProfileReceipt(), profile.approvalPolicy(), secretPosture,
                 profile.isolationBoundary(), profile.memberImpact());
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -292,6 +292,12 @@ class WeaverRuntimeServiceTest {
         Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
 
         var issued = service.profileFor(member);
+
+        var serializedCopy = copyProfile(issued, issued.runtimeProfileHash(), issued.signature(), issued.expiresAt());
+        assertThat(serializedCopy).isNotSameAs(issued);
+        assertThat(service.provisionRuntime(serializedCopy, "org:acme", "policy:v32").runtimeProfileHash())
+                .isEqualTo(issued.runtimeProfileHash());
+
         var customized = service.applyRuntimeCustomization(member, Map.of("style", "concise"));
 
         assertThat(customized.accepted()).isTrue();
@@ -309,10 +315,19 @@ class WeaverRuntimeServiceTest {
         Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
 
         var issued = first.profileFor(member);
-        var replicaIssued = second.profileFor(member);
+        var issuedCopy = copyProfile(issued, issued.runtimeProfileHash(), issued.signature(), issued.expiresAt());
 
+        assertThat(first.provisionRuntime(issuedCopy, "org:acme", "policy:v32").runtimeProfileHash())
+                .isEqualTo(issued.runtimeProfileHash());
+        assertThat(second.provisionRuntime(issuedCopy, "org:acme", "policy:v32").runtimeProfileHash())
+                .isEqualTo(issued.runtimeProfileHash());
+
+        var replicaIssued = second.profileFor(member);
         assertThat(replicaIssued.signature()).isNotBlank();
-        assertThat(replicaIssued.signature().split(":")[3]).isEqualTo(issued.signature().split(":")[3]);
+        assertThat(replicaIssued.signature()).startsWith("weave-hmac-sha256:v1:keyref:");
+        assertThatThrownBy(() -> second.provisionRuntime(issuedCopy, "org:acme", "policy:v32"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("valid signed current");
         assertThatThrownBy(() -> service(true, runtimePropertiesWithKey(true, null), new InMemoryAuditEventPublisher()))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("signing key is not configured");

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -309,7 +309,7 @@ class WeaverToolRegistryTest {
     }
 
     private String signature() {
-        return "weave-signature:v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        return "weave-hmac-sha256:v1:keyref:aaaaaaaaaaaaaaaa:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     }
 
     private String future() {

--- a/server/src/test/resources/application.properties
+++ b/server/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+weave.weaver.runtime.signing-key=weaver-runtime-profile-test-signing-key-32-bytes-minimum


### PR DESCRIPTION
## Summary

- Replace hash-only Weaver RuntimeProfile markers with keyed HMAC-SHA-256 profile signatures.
- Fail closed for missing, tampered, expired, or wrong-key RuntimeProfiles before runtime provisioning.
- Keep audit/support evidence to support-safe signature metadata and SecretRef boundaries, with docs/release-note claim hygiene updates.

## Scope and user impact

- Server-side governed Weaver runtime profile issuance/provisioning and guarded tool invocation signature prefix checks.
- No checked-in secrets; the signing key is represented as `secretref://weave/weaver/runtime-profile-signing-key` and only a support-safe key-ref fingerprint is emitted in evidence.

## Spec / acceptance link

- Issue: Closes #794
- Repo spec / Spec Kit package: pinned corpus via `specs/weave-specs.lock.json`; governed Weaver runtime projection docs in `docs/governed-weaver-runtime-security-contract.md`
- Plan/tasks/traceability: Sprint 32 issue #794 acceptance
- Mapped Gherkin feature/scenario when product behavior changed: existing governed Weaver runtime acceptance remains unchanged; implementation hardens the covered server flow.
- Evidence mode / reality level: `offline-spec` / `contract_only`
- Product-core questions intentionally left unresolved: none

Quality Reset rule: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance before merge. `offline-spec` / `contract_only` fixture evidence must not be described as `live-runtime`, isolated E2E, `release_ready`, or customer-ready evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

Choose one and explain when needed.

- [ ] none
- [x] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

Use exactly one form.

- Release note: Weaver RuntimeProfiles now use keyed signing verification and fail closed for unsigned, tampered, expired, or wrong-key profiles.
- Release note: none — reason:

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- Documentation/release-note wording updated to avoid hash-only signing claims and to preserve KMS/HSM future-hardening boundaries.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: hardens RuntimeProfile verification with keyed HMAC and fail-closed negative paths; no raw key material is checked in or emitted.
- Accessibility/localization impact: none.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values are exposed beyond the intended SecretRef config boundary.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: support-safe profile evidence now identifies `weave-hmac-sha256:v1` and a key-ref fingerprint.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: Weaver/runtime security review for Sprint 32 issue #794.
- If Copilot is unavailable/insufficient, matching reviewer used: implementation self-check plus local gates; parent delivery lead may request additional review.

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [x] `python3 tools/pr_body_check.py pr-body-794.md` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [x] Live-stack validation (only when relevant; record run, artifact, or skip reason): skipped; server/offline contract hardening only.

Additional gates run:
- [x] `./gradlew test --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest' --tests 'com.massimotter.weave.backend.weaver.WeaverToolRegistryTest' --console=plain`
- [x] `./gradlew serverCi releaseEvidenceCheck --console=plain`

## Notes for reviewers

- Review for claim hygiene first: spec/Gherkin/evidenceMode/realityLevel must match the PR wording.
- Approval semantics must distinguish OpenClaw exec approval states from product user permissions; never treat `allow always` as blanket product permission.
- Keep Massimo's OpenClaw agent hierarchy, allowlists, model routing, personal operator paths, and runtime configuration out of product repo files.
