### PR TITLE
feat: persist Weaver runtime revocations

### DIFF
--- a/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/WeaverRuntimeProperties.java
@@ -11,6 +11,7 @@ public record WeaverRuntimeProperties(
         String workspaceRootTemplate,
         String isolatedAgentDirectory,
         String dockerNetworkMode,
+        String revocationStorePath,
         List<String> enabledGroups,
         List<String> allowedCapabilities,
         List<String> pluginAllowlist,
@@ -26,6 +27,9 @@ public record WeaverRuntimeProperties(
         workspaceRootTemplate = hasText(workspaceRootTemplate) ? workspaceRootTemplate : "/var/lib/weave/weaver/{userId}";
         isolatedAgentDirectory = hasText(isolatedAgentDirectory) ? isolatedAgentDirectory : ".weaver/agents";
         dockerNetworkMode = hasText(dockerNetworkMode) ? dockerNetworkMode : "none";
+        revocationStorePath = hasText(revocationStorePath)
+                ? revocationStorePath
+                : "/var/lib/weave/weaver/runtime-profile-revocations.json";
         enabledGroups = normalize(enabledGroups, List.of("weaver-group", "weave-weaver-runtime"));
         allowedCapabilities = normalize(allowedCapabilities, List.of("weaver.files_read", "weaver.exec_disabled"));
         pluginAllowlist = normalize(pluginAllowlist, List.of("weave-files-readonly"));

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -158,7 +158,7 @@ public class AdminControlPlaneService {
                 ? List.of(new KeycloakRealmLiveApplyAdapter(this.identityRealmApplyProperties))
                 : List.copyOf(adapters);
         this.weaverRuntimeProperties = weaverRuntimeProperties.getIfAvailable(
-                () -> new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                () -> new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
         this.clock = Clock.systemUTC();
     }
 
@@ -171,7 +171,7 @@ public class AdminControlPlaneService {
             Clock clock) {
         this(providerRegistry, workspaceCapabilityService, providerSelectionRepository, organizationBootstrapRepository, auditEventPublisher,
                 List.of(new KeycloakRealmDryRunProvider()), new InMemoryIdentityRealmEvidenceRepository(), List.of(new KeycloakRealmLiveApplyAdapter(new IdentityRealmApplyProperties())), new IdentityRealmApplyProperties(), clock,
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     AdminControlPlaneService(
@@ -205,7 +205,7 @@ public class AdminControlPlaneService {
                 : List.copyOf(identityRealmLiveApplyAdapters);
         this.clock = clock;
         this.weaverRuntimeProperties = weaverRuntimeProperties == null
-                ? new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false)
+                ? new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false)
                 : weaverRuntimeProperties;
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/service/FileBackedWeaverRuntimeRevocationStore.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/FileBackedWeaverRuntimeRevocationStore.java
@@ -1,0 +1,103 @@
+package com.massimotter.weave.backend.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+public class FileBackedWeaverRuntimeRevocationStore implements WeaverRuntimeRevocationStore {
+
+    private final Path storePath;
+    private final ObjectMapper objectMapper;
+
+    public FileBackedWeaverRuntimeRevocationStore(String storePath) {
+        this(Path.of(storePath));
+    }
+
+    FileBackedWeaverRuntimeRevocationStore(Path storePath) {
+        this.storePath = storePath;
+        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public synchronized List<RevocationRecord> recordsForUser(String userRef) {
+        return readAll().stream()
+                .filter(record -> record.userRef().equals(userRef))
+                .toList();
+    }
+
+    @Override
+    public synchronized Optional<RevocationRecord> recordForProfile(String runtimeProfileHash) {
+        return readAll().stream()
+                .filter(record -> record.runtimeProfileHash().equals(runtimeProfileHash))
+                .findFirst();
+    }
+
+    @Override
+    public synchronized void record(RevocationRecord record) {
+        List<RevocationRecord> records = new ArrayList<>(readAll());
+        records.removeIf(existing -> existing.runtimeProfileHash().equals(record.runtimeProfileHash()));
+        records.add(record);
+        writeAll(records);
+    }
+
+    private List<RevocationRecord> readAll() {
+        if (!Files.exists(storePath)) {
+            return List.of();
+        }
+        try {
+            List<Map<String, Object>> rows = objectMapper.readValue(storePath.toFile(), new TypeReference<>() {});
+            return rows.stream().map(this::fromMap).toList();
+        } catch (IOException | RuntimeException exception) {
+            throw new IllegalStateException("Weaver runtime revocation store is unavailable; refusing to trust runtime profiles.", exception);
+        }
+    }
+
+    private void writeAll(List<RevocationRecord> records) {
+        try {
+            Path parent = storePath.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            List<Map<String, Object>> rows = records.stream().map(this::toMap).toList();
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(storePath.toFile(), rows);
+        } catch (IOException exception) {
+            throw new UncheckedIOException("Weaver runtime revocation store is unavailable; refusing to trust runtime profiles.", exception);
+        }
+    }
+
+    private Map<String, Object> toMap(RevocationRecord record) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("userRef", record.userRef());
+        row.put("runtimeProfileHash", record.runtimeProfileHash());
+        row.put("signature", record.signature());
+        row.put("revocationGeneration", record.revocationGeneration());
+        row.put("reason", record.reason());
+        row.put("actor", record.actor());
+        row.put("scope", record.scope());
+        row.put("revokedAt", record.revokedAt().toString());
+        row.put("evidenceRef", record.evidenceRef());
+        return row;
+    }
+
+    private RevocationRecord fromMap(Map<String, Object> row) {
+        return new RevocationRecord(
+                String.valueOf(row.get("userRef")),
+                String.valueOf(row.get("runtimeProfileHash")),
+                String.valueOf(row.get("signature")),
+                ((Number) row.getOrDefault("revocationGeneration", 0)).intValue(),
+                String.valueOf(row.get("reason")),
+                String.valueOf(row.getOrDefault("actor", "system:weaver-runtime-policy")),
+                String.valueOf(row.getOrDefault("scope", "runtime-profile")),
+                Instant.parse(String.valueOf(row.get("revokedAt"))),
+                String.valueOf(row.get("evidenceRef")));
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeRevocationStore.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeRevocationStore.java
@@ -1,0 +1,25 @@
+package com.massimotter.weave.backend.service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface WeaverRuntimeRevocationStore {
+
+    List<RevocationRecord> recordsForUser(String userRef);
+
+    Optional<RevocationRecord> recordForProfile(String runtimeProfileHash);
+
+    void record(RevocationRecord record);
+
+    record RevocationRecord(
+            String userRef,
+            String runtimeProfileHash,
+            String signature,
+            int revocationGeneration,
+            String reason,
+            String actor,
+            String scope,
+            Instant revokedAt,
+            String evidenceRef) {}
+}

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -21,7 +21,9 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
@@ -46,16 +48,28 @@ public class WeaverRuntimeService {
     private final WorkspaceCapabilityProperties workspaceCapabilityProperties;
     private final WeaverRuntimeProperties weaverRuntimeProperties;
     private final AuditEventPublisher auditEventPublisher;
+    private final WeaverRuntimeRevocationStore revocationStore;
 
+    @Autowired
     public WeaverRuntimeService(
             WorkspaceCapabilityService workspaceCapabilityService,
             WorkspaceCapabilityProperties workspaceCapabilityProperties,
             WeaverRuntimeProperties weaverRuntimeProperties,
             AuditEventPublisher auditEventPublisher) {
+        this(workspaceCapabilityService, workspaceCapabilityProperties, weaverRuntimeProperties, auditEventPublisher, new FileBackedWeaverRuntimeRevocationStore(System.getProperty("java.io.tmpdir") + "/weave-runtime-profile-revocations.json"));
+    }
+
+    WeaverRuntimeService(
+            WorkspaceCapabilityService workspaceCapabilityService,
+            WorkspaceCapabilityProperties workspaceCapabilityProperties,
+            WeaverRuntimeProperties weaverRuntimeProperties,
+            AuditEventPublisher auditEventPublisher,
+            WeaverRuntimeRevocationStore revocationStore) {
         this.workspaceCapabilityService = workspaceCapabilityService;
         this.workspaceCapabilityProperties = workspaceCapabilityProperties;
         this.weaverRuntimeProperties = weaverRuntimeProperties;
         this.auditEventPublisher = auditEventPublisher;
+        this.revocationStore = revocationStore;
     }
 
     public WeaverRuntimeProfileResponse profileFor(Jwt jwt) {
@@ -191,6 +205,10 @@ public class WeaverRuntimeService {
 
     public WeaverRuntimeProfileResponse profileByHash(Jwt jwt, String runtimeProfileHash) {
         String userRef = supportSafeUserRef(jwt);
+        if (durableRevocationFor(runtimeProfileHash).isPresent()) {
+            auditRevocationDecision(userRef, runtimeProfileHash, "runtime-profile-fetch-revoked", "durable-revocation-store");
+            return disabledProfile(userRef, "runtime-profile-fetch-revoked", "RuntimeProfile fetch-by-hash failed closed.");
+        }
         WeaverRuntimeProfileResponse issued = issuedProfiles.get(runtimeProfileHash == null ? "" : runtimeProfileHash.strip());
         if (issued == null) {
             return disabledProfile(userRef, "runtime-profile-hash-not-issued", "RuntimeProfile fetch-by-hash failed closed.");
@@ -391,18 +409,21 @@ public class WeaverRuntimeService {
 
     private void revokeProfilesForUser(String userRef, String reason) {
         boolean revokedAny = false;
+        int nextGeneration = revocationGenerationByUser.getOrDefault(userRef, 0) + 1;
         for (Map.Entry<String, WeaverRuntimeProfileResponse> entry : issuedProfiles.entrySet()) {
             WeaverRuntimeProfileResponse issued = entry.getValue();
             if (!issued.userRef().equals(userRef) || issued.revoked()) {
                 continue;
             }
-            issuedProfiles.put(entry.getKey(), revokeProfile(issued, reason));
+            WeaverRuntimeProfileResponse revoked = revokeProfile(issued, reason);
+            issuedProfiles.put(entry.getKey(), revoked);
+            persistRevocation(revoked, reason, nextGeneration);
             revokedAny = true;
         }
         currentProfileHashByUser.remove(userRef);
         rollbackProfileHashByUser.remove(userRef);
         if (revokedAny) {
-            revocationGenerationByUser.merge(userRef, 1, Integer::sum);
+            revocationGenerationByUser.put(userRef, nextGeneration);
         }
     }
 
@@ -452,6 +473,62 @@ public class WeaverRuntimeService {
                 issued.secretPosture(),
                 issued.isolationBoundary(),
                 issued.memberImpact());
+    }
+
+    private Optional<WeaverRuntimeRevocationStore.RevocationRecord> durableRevocationFor(String runtimeProfileHash) {
+        try {
+            return revocationStore.recordForProfile(runtimeProfileHash == null ? "" : runtimeProfileHash.strip());
+        } catch (RuntimeException exception) {
+            return Optional.of(new WeaverRuntimeRevocationStore.RevocationRecord(
+                    "user:unknown",
+                    runtimeProfileHash == null ? "none" : runtimeProfileHash,
+                    "unknown",
+                    -1,
+                    "revocation-store-unavailable",
+                    "system:weaver-runtime-policy",
+                    "runtime-profile",
+                    Instant.now(),
+                    "audit:weaver-runtime-revocation-store-unavailable"));
+        }
+    }
+
+    private void persistRevocation(WeaverRuntimeProfileResponse revoked, String reason, int generation) {
+        String evidenceRef = "audit:weaver-runtime-revocation:" + revoked.runtimeProfileHash();
+        revocationStore.record(new WeaverRuntimeRevocationStore.RevocationRecord(
+                revoked.userRef(),
+                revoked.runtimeProfileHash(),
+                revoked.signature(),
+                generation,
+                reason,
+                "system:weaver-runtime-policy",
+                "runtime-profile",
+                Instant.now(),
+                evidenceRef));
+        auditRevocationDecision(revoked.userRef(), revoked.runtimeProfileHash(), reason, evidenceRef);
+    }
+
+    private void auditRevocationDecision(String userRef, String runtimeProfileHash, String reason, String evidenceRef) {
+        auditEventPublisher.publish(new AuditEvent(
+                "tenant:workspace",
+                null,
+                userRef,
+                "weaver-runtime-policy",
+                AuditAction.WEAVER_RUNTIME_PROFILE_REVOKED,
+                Instant.now(),
+                "weaver-profile:" + userRef + ":revocation",
+                AuditRedactionLevel.SUPPORT_SAFE,
+                Map.ofEntries(
+                        Map.entry("user", userRef),
+                        Map.entry("runtimeProfileHash", runtimeProfileHash == null ? "none" : runtimeProfileHash),
+                        Map.entry("profileRef", runtimeProfileHash == null ? "none" : "weave-runtime-profile://" + runtimeProfileHash),
+                        Map.entry("action", "profile.revoke"),
+                        Map.entry("domain", "weaver-runtime"),
+                        Map.entry("decision", "revoked"),
+                        Map.entry("reason", reason),
+                        Map.entry("actor", "system:weaver-runtime-policy"),
+                        Map.entry("scope", "runtime-profile"),
+                        Map.entry("evidenceRef", evidenceRef),
+                        Map.entry("supportSafe", true))));
     }
 
     private Map<String, String> runtimeLabels(WeaverRuntimeProfileResponse profile, String orgRef, String policyVersion) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java
@@ -56,7 +56,7 @@ public class WeaverRuntimeService {
             WorkspaceCapabilityProperties workspaceCapabilityProperties,
             WeaverRuntimeProperties weaverRuntimeProperties,
             AuditEventPublisher auditEventPublisher) {
-        this(workspaceCapabilityService, workspaceCapabilityProperties, weaverRuntimeProperties, auditEventPublisher, new FileBackedWeaverRuntimeRevocationStore(System.getProperty("java.io.tmpdir") + "/weave-runtime-profile-revocations.json"));
+        this(workspaceCapabilityService, workspaceCapabilityProperties, weaverRuntimeProperties, auditEventPublisher, new FileBackedWeaverRuntimeRevocationStore(weaverRuntimeProperties.revocationStorePath()));
     }
 
     WeaverRuntimeService(
@@ -95,6 +95,14 @@ public class WeaverRuntimeService {
                     userRef,
                     "policy-blocked",
                     "Your role or group policy does not allow a Weaver runtime.");
+        }
+        Optional<WeaverRuntimeRevocationStore.RevocationRecord> storeAvailability = durableRevocationReadCheck(userRef);
+        if (storeAvailability.isPresent()) {
+            auditRevocationDecision(userRef, "none", "runtime-profile-revocation-store-unavailable", storeAvailability.get().evidenceRef());
+            return disabledProfile(
+                    userRef,
+                    "runtime-profile-revocation-store-unavailable",
+                    "RuntimeProfile issuance failed closed because the durable revocation store is unavailable.");
         }
 
         List<String> allowedCapabilities = allowedCapabilities(grantedCapabilities);
@@ -229,6 +237,11 @@ public class WeaverRuntimeService {
     public WeaverRuntimeInstance provisionRuntime(WeaverRuntimeProfileResponse profile, String orgRef, String policyVersion) {
         if (profile == null || !profile.enabled() || profile.revoked()) {
             throw new IllegalArgumentException("Only active Weaver RuntimeProfiles can be provisioned.");
+        }
+        Optional<WeaverRuntimeRevocationStore.RevocationRecord> durableRevocation = durableRevocationFor(profile.runtimeProfileHash());
+        if (durableRevocation.isPresent()) {
+            auditRevocationDecision(profile.userRef(), profile.runtimeProfileHash(), "runtime-profile-provision-revoked", durableRevocation.get().evidenceRef());
+            throw new IllegalArgumentException("RuntimeProfile provision failed closed.");
         }
         Map<String, String> labels = runtimeLabels(profile, orgRef, policyVersion);
         WeaverRuntimeInstance instance = new WeaverRuntimeInstance(
@@ -479,17 +492,30 @@ public class WeaverRuntimeService {
         try {
             return revocationStore.recordForProfile(runtimeProfileHash == null ? "" : runtimeProfileHash.strip());
         } catch (RuntimeException exception) {
-            return Optional.of(new WeaverRuntimeRevocationStore.RevocationRecord(
-                    "user:unknown",
-                    runtimeProfileHash == null ? "none" : runtimeProfileHash,
-                    "unknown",
-                    -1,
-                    "revocation-store-unavailable",
-                    "system:weaver-runtime-policy",
-                    "runtime-profile",
-                    Instant.now(),
-                    "audit:weaver-runtime-revocation-store-unavailable"));
+            return Optional.of(unavailableRevocationRecord("user:unknown", runtimeProfileHash == null ? "none" : runtimeProfileHash));
         }
+    }
+
+    private Optional<WeaverRuntimeRevocationStore.RevocationRecord> durableRevocationReadCheck(String userRef) {
+        try {
+            revocationStore.recordsForUser(userRef);
+            return Optional.empty();
+        } catch (RuntimeException exception) {
+            return Optional.of(unavailableRevocationRecord(userRef, "none"));
+        }
+    }
+
+    private WeaverRuntimeRevocationStore.RevocationRecord unavailableRevocationRecord(String userRef, String runtimeProfileHash) {
+        return new WeaverRuntimeRevocationStore.RevocationRecord(
+                userRef,
+                runtimeProfileHash,
+                "unknown",
+                -1,
+                "revocation-store-unavailable",
+                "system:weaver-runtime-policy",
+                "runtime-profile",
+                Instant.now(),
+                "audit:weaver-runtime-revocation-store-unavailable");
     }
 
     private void persistRevocation(WeaverRuntimeProfileResponse revoked, String reason, int generation) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WorkspaceCapabilityService.java
@@ -89,7 +89,7 @@ public class WorkspaceCapabilityService {
                 resourceServerProperties,
                 weaveSecurityProperties,
                 workspaceCapabilityProperties,
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     @Autowired

--- a/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/AdminControlPlaneServiceTest.java
@@ -542,7 +542,7 @@ class AdminControlPlaneServiceTest {
                 List.of(new KeycloakRealmLiveApplyAdapter(properties)),
                 properties,
                 Clock.fixed(Instant.parse("2026-05-27T01:03:39Z"), ZoneOffset.UTC),
-                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, false, false, true, false));
+                new WeaverRuntimeProperties(false, null, null, null, null, null, null, null, null, null, null, false, false, true, false));
     }
 
     private WorkspaceCapabilityService workspaceCapabilityService() {

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceLiveWeaverRoundTripTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceLiveWeaverRoundTripTest.java
@@ -209,6 +209,7 @@ class ChatFacadeServiceLiveWeaverRoundTripTest {
                         "/var/lib/weave/weaver/{userId}",
                         ".weaver/agents",
                         "weave-runtime-net",
+                        null,
                         List.of("weave-weaver-runtime"),
                         List.of("weaver.files_read", "weaver.exec_disabled"),
                         List.of("weave-chat"),

--- a/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/ChatFacadeServiceTest.java
@@ -301,6 +301,7 @@ class ChatFacadeServiceTest {
                 "/var/lib/weave/weaver/{userId}",
                 ".weaver/agents",
                 "weave-runtime-net",
+                null,
                 List.of("weave-weaver-runtime"),
                 List.of("weaver.files_read", "weaver.exec_disabled"),
                 List.of("weave-chat"),

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -6,6 +6,10 @@ import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -267,7 +271,7 @@ class WeaverRuntimeServiceTest {
 
         var revokedFetch = service.profileByHash(eligible, issued.runtimeProfileHash());
         assertThat(revokedFetch.enabled()).isFalse();
-        assertThat(revokedFetch.posture()).isEqualTo("runtime-profile-fetch-denied");
+        assertThat(revokedFetch.posture()).isEqualTo("runtime-profile-fetch-revoked");
     }
 
     @Test
@@ -342,6 +346,79 @@ class WeaverRuntimeServiceTest {
     }
 
     @Test
+    void keepsRuntimeProfileRevocationDurableAcrossServiceRestart() throws IOException {
+        Path storePath = Files.createTempFile("weaver-runtime-revocation-restart", ".json");
+        Files.deleteIfExists(storePath);
+        WeaverRuntimeRevocationStore store = new FileBackedWeaverRuntimeRevocationStore(storePath);
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverRuntimeProperties runtimeProperties = runtimeProperties(true);
+        Jwt eligible = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+
+        WeaverRuntimeService beforeRestart = service(true, runtimeProperties, audit, store);
+        var active = beforeRestart.profileFor(eligible);
+        beforeRestart.profileFor(jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-pilot")));
+
+        WeaverRuntimeService afterRestart = service(true, runtimeProperties, audit, new FileBackedWeaverRuntimeRevocationStore(storePath));
+        var blocked = afterRestart.profileByHash(eligible, active.runtimeProfileHash());
+
+        assertThat(blocked.enabled()).isFalse();
+        assertThat(blocked.posture()).isEqualTo("runtime-profile-fetch-revoked");
+        assertThat(new FileBackedWeaverRuntimeRevocationStore(storePath).recordForProfile(active.runtimeProfileHash())).isPresent()
+                .get()
+                .satisfies(record -> assertThat(record)
+                        .extracting(
+                                WeaverRuntimeRevocationStore.RevocationRecord::runtimeProfileHash,
+                                WeaverRuntimeRevocationStore.RevocationRecord::signature,
+                                WeaverRuntimeRevocationStore.RevocationRecord::reason,
+                                WeaverRuntimeRevocationStore.RevocationRecord::actor,
+                                WeaverRuntimeRevocationStore.RevocationRecord::scope,
+                                WeaverRuntimeRevocationStore.RevocationRecord::evidenceRef)
+                        .containsExactly(
+                                active.runtimeProfileHash(),
+                                active.signature(),
+                                "policy-blocked",
+                                "system:weaver-runtime-policy",
+                                "runtime-profile",
+                                "audit:weaver-runtime-revocation:" + active.runtimeProfileHash()));
+        assertThat(audit.events())
+                .filteredOn(event -> event.action() == AuditAction.WEAVER_RUNTIME_PROFILE_REVOKED)
+                .anySatisfy(event -> assertThat(event.payload())
+                        .containsEntry("runtimeProfileHash", active.runtimeProfileHash())
+                        .containsEntry("actor", "system:weaver-runtime-policy")
+                        .containsEntry("scope", "runtime-profile")
+                        .containsEntry("reason", "policy-blocked")
+                        .containsEntry("supportSafe", true));
+        assertThat(audit.events().toString()).doesNotContain("member@example.invalid", "Bearer ", "openclaw.json", "refresh_token");
+    }
+
+    @Test
+    void failsClosedWhenDurableRevocationStoreIsUnavailable() {
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher(), new WeaverRuntimeRevocationStore() {
+            @Override
+            public List<RevocationRecord> recordsForUser(String userRef) {
+                throw new IllegalStateException("store unavailable");
+            }
+
+            @Override
+            public java.util.Optional<RevocationRecord> recordForProfile(String runtimeProfileHash) {
+                throw new IllegalStateException("store unavailable");
+            }
+
+            @Override
+            public void record(RevocationRecord record) {
+                throw new IllegalStateException("store unavailable");
+            }
+        });
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+        var issued = service.profileFor(member);
+
+        var blocked = service.profileByHash(member, issued.runtimeProfileHash());
+
+        assertThat(blocked.enabled()).isFalse();
+        assertThat(blocked.posture()).isEqualTo("runtime-profile-fetch-revoked");
+    }
+
+    @Test
     void blocksCrossUserWorkspaceReadsAndRedactsWeaverSupportBundle() {
         WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
         Jwt aliceJwt = jwt("alice@example.invalid", List.of("member"), List.of("weave-weaver-runtime"));
@@ -393,7 +470,39 @@ class WeaverRuntimeServiceTest {
                 new WeaveSecurityProperties("weave-app", "weave-app"),
                 capabilities,
                 runtimeProperties);
-        return new WeaverRuntimeService(capabilityService, capabilities, runtimeProperties, audit);
+        return service(workspaceWeaverEnabled, runtimeProperties, audit, revocationStore());
+    }
+
+    private WeaverRuntimeService service(
+            boolean workspaceWeaverEnabled,
+            WeaverRuntimeProperties runtimeProperties,
+            InMemoryAuditEventPublisher audit,
+            WeaverRuntimeRevocationStore revocationStore) {
+        WorkspaceCapabilityProperties capabilities = new WorkspaceCapabilityProperties(
+                new WorkspaceCapabilityProperties.Capability(true, null, null),
+                new WorkspaceCapabilityProperties.Capability(true, "https://matrix.weave.test", WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityProperties.Capability(true, "https://files.weave.test", WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityProperties.Capability(true, null, WorkspaceCapabilityReadiness.READY),
+                new WorkspaceCapabilityProperties.Capability(workspaceWeaverEnabled, null, WorkspaceCapabilityReadiness.READY));
+        OAuth2ResourceServerProperties resourceServerProperties = new OAuth2ResourceServerProperties();
+        resourceServerProperties.getJwt().setIssuerUri("https://auth.weave.test/realms/weave");
+        WorkspaceCapabilityService capabilityService = new WorkspaceCapabilityService(
+                resourceServerProperties,
+                new WeaveSecurityProperties("weave-app", "weave-app"),
+                capabilities,
+                runtimeProperties);
+        return new WeaverRuntimeService(capabilityService, capabilities, runtimeProperties, audit, revocationStore);
+    }
+
+    private WeaverRuntimeRevocationStore revocationStore() {
+        try {
+            Path path = Files.createTempFile("weave-runtime-profile-revocations", ".json");
+            Files.deleteIfExists(path);
+            return new FileBackedWeaverRuntimeRevocationStore(path);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(exception);
+        }
     }
 
     private WeaverRuntimeProperties runtimeProperties(boolean enabled) {

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2Res
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class WeaverRuntimeServiceTest {
 
@@ -393,29 +394,61 @@ class WeaverRuntimeServiceTest {
 
     @Test
     void failsClosedWhenDurableRevocationStoreIsUnavailable() {
-        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher(), new WeaverRuntimeRevocationStore() {
-            @Override
-            public List<RevocationRecord> recordsForUser(String userRef) {
-                throw new IllegalStateException("store unavailable");
-            }
-
-            @Override
-            public java.util.Optional<RevocationRecord> recordForProfile(String runtimeProfileHash) {
-                throw new IllegalStateException("store unavailable");
-            }
-
-            @Override
-            public void record(RevocationRecord record) {
-                throw new IllegalStateException("store unavailable");
-            }
-        });
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher(), unavailableRevocationStore());
         Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
-        var issued = service.profileFor(member);
+
+        var blocked = service.profileFor(member);
+
+        assertThat(blocked.enabled()).isFalse();
+        assertThat(blocked.posture()).isEqualTo("runtime-profile-revocation-store-unavailable");
+    }
+
+    @Test
+    void fetchByHashFailsClosedWhenDurableRevocationStoreIsUnavailable() {
+        WeaverRuntimeService issuer = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+        var issued = issuer.profileFor(member);
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher(), unavailableRevocationStore());
 
         var blocked = service.profileByHash(member, issued.runtimeProfileHash());
 
         assertThat(blocked.enabled()).isFalse();
         assertThat(blocked.posture()).isEqualTo("runtime-profile-fetch-revoked");
+    }
+
+    @Test
+    void provisionRuntimeFailsClosedWhenDurableRevocationStoreIsUnavailable() {
+        WeaverRuntimeService issuer = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher());
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+        var issued = issuer.profileFor(member);
+        WeaverRuntimeService service = service(true, runtimeProperties(true), new InMemoryAuditEventPublisher(), unavailableRevocationStore());
+
+        assertThatThrownBy(() -> service.provisionRuntime(issued, "org:acme", "policy:v24"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("failed closed");
+    }
+
+    @Test
+    void provisionRuntimeFailsClosedForStaleActiveObjectAfterDurableRevocation() {
+        Path storePath;
+        try {
+            storePath = Files.createTempFile("weaver-runtime-revocation-stale-active", ".json");
+            Files.deleteIfExists(storePath);
+        } catch (IOException exception) {
+            throw new UncheckedIOException(exception);
+        }
+        WeaverRuntimeProperties runtimeProperties = runtimeProperties(true);
+        Jwt eligible = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "weave-weaver-pilot"));
+        WeaverRuntimeService beforeRevocation = service(true, runtimeProperties, new InMemoryAuditEventPublisher(), new FileBackedWeaverRuntimeRevocationStore(storePath));
+        var staleActive = beforeRevocation.profileFor(eligible);
+        beforeRevocation.profileFor(jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-pilot")));
+        WeaverRuntimeService afterRevocation = service(true, runtimeProperties, new InMemoryAuditEventPublisher(), new FileBackedWeaverRuntimeRevocationStore(storePath));
+
+        assertThat(staleActive.enabled()).isTrue();
+        assertThat(staleActive.revoked()).isFalse();
+        assertThatThrownBy(() -> afterRevocation.provisionRuntime(staleActive, "org:acme", "policy:v24"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("failed closed");
     }
 
     @Test
@@ -517,6 +550,7 @@ class WeaverRuntimeServiceTest {
                 null,
                 null,
                 null,
+                null,
                 List.of("weave-weaver-runtime", "weaver-group"),
                 allowedCapabilities,
                 List.of("weave-files-readonly"),
@@ -525,6 +559,25 @@ class WeaverRuntimeServiceTest {
                 false,
                 true,
                 false);
+    }
+
+    private WeaverRuntimeRevocationStore unavailableRevocationStore() {
+        return new WeaverRuntimeRevocationStore() {
+            @Override
+            public List<RevocationRecord> recordsForUser(String userRef) {
+                throw new IllegalStateException("store unavailable");
+            }
+
+            @Override
+            public java.util.Optional<RevocationRecord> recordForProfile(String runtimeProfileHash) {
+                throw new IllegalStateException("store unavailable");
+            }
+
+            @Override
+            public void record(RevocationRecord record) {
+                throw new IllegalStateException("store unavailable");
+            }
+        };
     }
 
     private Jwt jwt(String subject, List<String> roles, List<String> groups) {


### PR DESCRIPTION
## Summary

Implements durable Weaver runtime profile revocation for Sprint 32 issue #795. Revoked profile hashes are recorded in a support-safe file-backed revocation store and checked before runtime profile fetches are trusted after a service restart.

## Changes

- Add a file-backed `WeaverRuntimeRevocationStore` with support-safe revocation records.
- Persist revocation decisions with profile hash, signature ref, actor, scope, reason, timestamp, generation, and audit evidence ref.
- Fail closed when the durable revocation store is unavailable during profile validation.
- Add restart/reload durability and unavailable-store tests for active, revoked, stale, and nonexistent runtime profile paths.

## Target lane

`dev`

## Linked issue

Fixes #795

## Release notes

`release-notes-bugfix` — fixes a governed Weaver runtime revocation durability gap.

## Spec impact

No spec corpus changes. This implements the current governed Weaver runtime/profile/audit acceptance slice.

## User/admin/operator impact

Revoked Weaver RuntimeProfiles remain blocked across the persistence boundary; audit evidence remains support-safe and does not include secrets or raw provider payloads.

## Checks run

- `./gradlew serverCi --console=plain`
- `./gradlew releaseEvidenceCheck --console=plain`

## Risks / notes

The default local file-backed store path is under the JVM temp directory unless overridden by deployment configuration; strong production claims still require an explicit durable path in the runtime environment.
