### PR TITLE
feat(client): use canonical member domain language

### DIFF
--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -45,7 +45,7 @@
   "@providerCategoryChatTitle": {
     "description": "Provider-Kategorietitel für Chat"
   },
-  "providerCategoryChatDetail": "Matrix/Chat ist die aktuelle Dogfood-Auswahl hinter der Weave-Chat-Oberfläche.",
+  "providerCategoryChatDetail": "Chat ist der aktuelle Dogfood-Dienst hinter der Weave-Chat-Oberfläche.",
   "@providerCategoryChatDetail": {
     "description": "Provider-Kategoriedetail für Chat"
   },
@@ -53,7 +53,7 @@
   "@providerCategoryFilesTitle": {
     "description": "Provider-Kategorietitel für Dateien"
   },
-  "providerCategoryFilesDetail": "Nextcloud/Files ist die aktuelle Dogfood-Speicherauswahl hinter der Weave-Datei-Fassade.",
+  "providerCategoryFilesDetail": "Dateispeicher ist der aktuelle Dogfood-Dienst hinter der Weave-Datei-Fassade.",
   "@providerCategoryFilesDetail": {
     "description": "Provider-Kategoriedetail für Dateien"
   },
@@ -61,7 +61,7 @@
   "@providerCategoryCalendarTitle": {
     "description": "Provider-Kategorietitel für Kalender"
   },
-  "providerCategoryCalendarDetail": "Nextcloud/Calendar-Anbindung ist die aktuelle Dogfood-Auswahl hinter der Weave-Kalender-Fassade.",
+  "providerCategoryCalendarDetail": "Kalender-Synchronisierung ist der aktuelle Dogfood-Dienst hinter der Weave-Kalender-Fassade.",
   "@providerCategoryCalendarDetail": {
     "description": "Provider-Kategoriedetail für Kalender"
   },
@@ -158,7 +158,7 @@
   "firstRunSignedOutSemanticLabel": "Melde dich an, um deinen Weave-Erststart-Status zu sehen. Wir brauchen eine aktive Weave-SSO-Sitzung, bevor Profil, Rolle und Modulbereitschaft geprüft werden können. Aktion: Zur Anmeldung",
   "firstRunReadyTitle": "Dein Weave-Arbeitsbereich ist bereit",
   "firstRunNeedsAttentionTitle": "Dein Weave-Arbeitsbereich wird vorbereitet",
-  "firstRunDescription": "Du hast dich einmal per Weave-SSO angemeldet. Weave prüft Profil und Zusammenarbeitsmodule; separate Matrix- oder Nextcloud-Zugangsdaten sind nicht nötig.",
+  "firstRunDescription": "Du hast dich einmal per Weave-SSO angemeldet. Weave prüft Profil und Zusammenarbeitsmodule; separate Zugangsdaten für Chat, Dateien oder Kalender sind nicht nötig.",
   "firstRunIdentitySectionTitle": "Deine Weave-Identität",
   "firstRunIdentitySectionDescription": "Dieses Profil und diese Rolle kommen nach SSO aus dem Weave-Backend-Vertrag.",
   "firstRunDisplayNameLabel": "Name",
@@ -268,7 +268,7 @@
   "filesNextcloudTitle": "Weave-Dateien",
   "filesProductTitle": "Weave-Dateien",
   "filesProductBoundaryTitle": "Weave-Produktgrenze",
-  "filesProductBoundaryBody": "Dateiaktionen nutzen die Weave-Backend-Fassade. Nextcloud bleibt Speicheranbieter sowie Admin-/Fallback-Oberfläche; rohe Anbieterpfade und Zugangsdaten gehören nicht zur normalen Dateien-UX.",
+  "filesProductBoundaryBody": "Dateiaktionen laufen über die Weave-Workspace-Dienst-Fassade. Dateispeicher bleibt Teil der Admin- und Fallback-Ebene; rohe Dienstpfade und Zugangsdaten gehören nicht zur normalen Dateien-Oberfläche.",
   "filesConnectButton": "Dateien verbinden",
   "filesReconnectButton": "Dateien neu verbinden",
   "filesDisconnectButton": "Trennen",
@@ -353,9 +353,9 @@
   "helpEmbeddedManualPermissionLabel": "Eingeschränkte Einbettung: kein breiter Skript-, Kamera-, Mikrofon- oder Provider-Zugriff",
   "helpEmbeddedManualUnavailableLabel": "Wenn gebaute Dokumentation nicht verfügbar ist, zeigt Weave diesen support-sicheren Fallback statt Dateisystem- oder Provider-Fehlern.",
   "helpWhatIsWeaveTitle": "Was Weave ist",
-  "helpWhatIsWeaveBody": "Weave ist eine Zusammenarbeits-App für Teams, die einen barrierearmen Workspace nutzen möchten, ohne Datensouveränität aufzugeben. Chat, Dateien, Kontoeinstellungen und weitere Zusammenarbeitsmodule erscheinen in Weave, während offene Dienste wie Matrix, Nextcloud, Keycloak und das Weave-Backend im Hintergrund arbeiten.",
+  "helpWhatIsWeaveBody": "Weave ist eine Zusammenarbeits-App für Teams, die einen barrierearmen Workspace nutzen möchten, ohne Datensouveränität aufzugeben. Chat, Dateien, Kontoeinstellungen und weitere Zusammenarbeitsmodule erscheinen in Weave, während offene Dienste im Hintergrund hinter Weave-Fassaden arbeiten.",
   "helpSignInTitle": "Anmelden: Grundlagen",
-  "helpSignInBody": "Nutze die Workspace-Adresse deines Admins und melde dich dann einmal mit Weave-SSO an. Für die normale Nutzung solltest du keine separaten Matrix- oder Nextcloud-Passwörter brauchen. Wenn die Anmeldung scheitert oder in einer Schleife hängt, prüfe deine Verbindung, bestätige die Serveradresse in den Einstellungen und frage einen Admin, ob deine Einladung oder dein Konto aktiv ist.",
+  "helpSignInBody": "Nutze die Workspace-Adresse deines Admins und melde dich dann einmal mit Weave-SSO an. Für die normale Nutzung solltest du keine separaten Passwörter für Chat, Dateien oder Kalender brauchen. Wenn die Anmeldung scheitert oder in einer Schleife hängt, prüfe deine Verbindung, bestätige die Serveradresse in den Einstellungen und frage einen Admin, ob deine Einladung oder dein Konto aktiv ist.",
   "helpChatTitle": "Chat",
   "helpChatBody": "Chat ist der tägliche Ort für Unterhaltungen und Nachrichten. Öffne Chat über die Hauptnavigation und wähle dann eine Unterhaltung. Weave zeigt Unterhaltungs- und Wiederherstellungszustände sichtbar an, damit du erkennst, ob Chat verbunden ist, wartet, beeinträchtigt ist oder Admin-Aufmerksamkeit braucht.",
   "helpFilesTitle": "Dateien",
@@ -367,7 +367,7 @@
   "helpTroubleshootingTitle": "Fehlersuche und Wiederherstellung",
   "helpTroubleshootingBody": "Wenn etwas nicht lädt, nutze zuerst Erneut versuchen. Wenn eine alte Chat-Raumliste oder ein alter Ordner sichtbar bleibt, bewahrt Weave deinen Kontext, während die Aktualisierung fehlschlägt. Dauerhafte Einrichtungs-, Anmelde-, Matrix-, Datei- oder Backend-Fehler solltest du deinem Admin zusammen mit der sichtbaren Meldung und der Serveradresse aus den Einstellungen melden.",
   "helpPrivacySecurityTitle": "Datenschutz und Sicherheit: Grundlagen",
-  "helpPrivacySecurityBody": "Dein Workspace kontrolliert seine eigenen Dienste und Daten. Weave nutzt SSO für den Zugriff und zeigt den Matrix-Sicherheitsstatus ehrlich an. Gehe nicht davon aus, dass Chat vollständig Ende-zu-Ende-verschlüsselt ist, solange Weave nicht meldet, dass Matrix-Verschlüsselung, Wiederherstellung und Gerätevertrauen gesund sind. Bewahre Wiederherstellungsschlüssel sicher auf und melde verlorene Geräte deinem Admin.",
+  "helpPrivacySecurityBody": "Dein Workspace kontrolliert seine eigenen Dienste und Daten. Weave nutzt SSO für den Zugriff und zeigt den Chat-Sicherheitsstatus ehrlich an. Gehe nicht davon aus, dass jeder Chat vollständig Ende-zu-Ende-verschlüsselt ist, solange Weave nicht meldet, dass verschlüsselte Räume, Wiederherstellung und Gerätevertrauen gesund sind. Bewahre Wiederherstellungsschlüssel sicher auf und melde verlorene Geräte deinem Admin.",
   "settingsShellModulesTitle": "Shell-Module",
   "settingsShellModulesDescription": "Wähle, welche Workspace-Shell-Module sichtbar bleiben. Die Navigation bleibt verfügbar, auch wenn ein Modul ausgeblendet ist.",
   "settingsShellWorkspaceStatusToggleTitle": "Workspace-Statusübersicht",
@@ -427,7 +427,7 @@
   "settingsWorkspaceInvalidationRestartSetup": "Einrichtung neu gestartet",
   "settingsWorkspaceInvalidationBackendApiBaseUrlChanged": "Backend-API-URL geändert",
   "chatSecuritySectionTitle": "Matrix-Sicherheit",
-  "chatSecuritySectionDescription": "Weave behandelt Matrix-Verschlüsselung nur dann als gesund, wenn Secret Storage, Cross-Signing, Wiederherstellung und Gerätevertrauen vollständig eingerichtet sind.",
+  "chatSecuritySectionDescription": "Weave bewertet verschlüsselte Chaträume nur dann als gesund, wenn Secret Storage, Cross-Signing, Wiederherstellung und Gerätevertrauen vollständig eingerichtet sind.",
   "chatSecurityRecoveryKeyTitle": "Diesen Matrix-Wiederherstellungsschlüssel jetzt sichern",
   "chatSecurityRecoveryKeyDescription": "Weave verlässt sich für diesen Schlüssel nicht auf app-internen Speicher, weil sicherer Speicher nach Neuinstallation, Gerätewechsel oder manchen Wiederherstellungen verschwinden kann. Bewahren Sie ihn in Ihrem Passwortmanager oder an einem anderen sicheren Ort auf.",
   "chatSecurityBannerTitle": "Matrix-Sicherheit braucht Aufmerksamkeit",
@@ -469,12 +469,12 @@
   "chatSecurityStatusReady": "Bereit",
   "chatSecurityEncryptedRoomsStatusNone": "Noch keine verschlüsselten Räume",
   "chatSecurityEncryptedRoomsStatusAttention": "Verschlüsselte Räume brauchen Aufmerksamkeit",
-  "chatSecuritySetupDescriptionSignedOut": "Öffne Chat und verbinde Matrix, bevor du die Verschlüsselung verwaltest.",
+  "chatSecuritySetupDescriptionSignedOut": "Öffne Chat und verbinde deine Chat-Sitzung, bevor du die Sicherheit verschlüsselter Räume verwaltest.",
   "chatSecuritySetupDescriptionNotInitialized": "Richte Secret Storage, Cross-Signing und Online-Schlüssel-Backup ein, bevor du verschlüsselten Räumen vertraust.",
   "chatSecuritySetupDescriptionPartiallyInitialized": "Einige Verschlüsselungsteile sind vorhanden, aber Wiederherstellung oder Cross-Signing sind noch unvollständig.",
   "chatSecuritySetupDescriptionRecoveryRequired": "Dieses Konto wurde schon eingerichtet, aber dieses Gerät benötigt den Wiederherstellungsschlüssel oder die Passphrase, um sich sicher wieder zu verbinden.",
   "chatSecuritySetupDescriptionReady": "Dieses Gerät kann die aktuelle Matrix-Kryptoidentität und Wiederherstellung verwenden.",
-  "chatSecuritySetupDescriptionUnavailable": "Matrix-Verschlüsselung ist auf dieser Plattform nicht verfügbar.",
+  "chatSecuritySetupDescriptionUnavailable": "Sicherheit für verschlüsselte Chaträume ist auf dieser Plattform nicht verfügbar.",
   "chatSecurityCurrentDeviceDescriptionVerified": "Ein anderes vertrauenswürdiges Matrix-Gerät hat diese Sitzung verifiziert.",
   "chatSecurityCurrentDeviceDescriptionUnverified": "Vergleiche Sicherheits-Emojis oder Zahlen mit einem anderen angemeldeten Matrix-Gerät.",
   "chatSecurityCurrentDeviceDescriptionBlocked": "Dieses Gerät ist blockiert oder seine Vertrauenskette ist beschädigt.",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -72,7 +72,7 @@
   "@providerCategoryChatTitle": {
     "description": "Provider category title for chat"
   },
-  "providerCategoryChatDetail": "Matrix/Chat is the current dogfood choice behind the Weave chat surface.",
+  "providerCategoryChatDetail": "Chat is the current dogfood service behind the Weave Chat surface.",
   "@providerCategoryChatDetail": {
     "description": "Provider category detail for chat"
   },
@@ -80,7 +80,7 @@
   "@providerCategoryFilesTitle": {
     "description": "Provider category title for files"
   },
-  "providerCategoryFilesDetail": "Nextcloud/Files is the current dogfood storage choice behind the Weave files facade.",
+  "providerCategoryFilesDetail": "File storage is the current dogfood service behind the Weave Files facade.",
   "@providerCategoryFilesDetail": {
     "description": "Provider category detail for files"
   },
@@ -88,7 +88,7 @@
   "@providerCategoryCalendarTitle": {
     "description": "Provider category title for calendar"
   },
-  "providerCategoryCalendarDetail": "Nextcloud/Calendar backing is the current dogfood choice behind the Weave calendar facade.",
+  "providerCategoryCalendarDetail": "Calendar sync is the current dogfood service behind the Weave Calendar facade.",
   "@providerCategoryCalendarDetail": {
     "description": "Provider category detail for calendar"
   },
@@ -373,7 +373,7 @@
   "firstRunSignedOutSemanticLabel": "Sign in to view your Weave first-run status. We need an active Weave SSO session before we can check your profile, role, and module readiness. Action: Go to sign in",
   "firstRunReadyTitle": "Your Weave workspace is ready",
   "firstRunNeedsAttentionTitle": "Your Weave workspace is being prepared",
-  "firstRunDescription": "You signed in once with Weave SSO. Weave is checking your profile and collaboration modules; no separate Matrix or Nextcloud credentials are needed.",
+  "firstRunDescription": "You signed in once with Weave SSO. Weave is checking your profile and collaboration modules; no separate Chat, Files, or Calendar credentials are needed.",
   "firstRunIdentitySectionTitle": "Your Weave identity",
   "firstRunIdentitySectionDescription": "This profile and role come from the Weave backend contract after SSO.",
   "firstRunDisplayNameLabel": "Name",
@@ -936,7 +936,7 @@
   "@filesProductBoundaryTitle": {
     "description": "Title for a Files card explaining the product/provider boundary"
   },
-  "filesProductBoundaryBody": "Files actions use the Weave backend facade. Nextcloud remains the storage provider and admin/fallback surface; raw provider paths and credentials are not part of the normal Files UX.",
+  "filesProductBoundaryBody": "Files actions use the Weave workspace service facade. File storage stays behind the admin/fallback surface; raw service paths and credentials are not part of the normal Files UX.",
   "@filesProductBoundaryBody": {
     "description": "Body for a Files card explaining the product/provider boundary"
   },
@@ -1388,7 +1388,7 @@
   "@helpWhatIsWeaveTitle": {
     "description": "Help section title explaining the product"
   },
-  "helpWhatIsWeaveBody": "Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and additional collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.",
+  "helpWhatIsWeaveBody": "Weave is a collaboration app for teams that want an accessible workspace without giving up data sovereignty. Chat, files, account settings, and other collaboration modules appear in Weave while open services work behind Weave facades in the background.",
   "@helpWhatIsWeaveBody": {
     "description": "Help copy explaining what Weave is"
   },
@@ -1396,7 +1396,7 @@
   "@helpSignInTitle": {
     "description": "Help section title for sign-in basics"
   },
-  "helpSignInBody": "Use the workspace address provided by your admin, then sign in once with Weave SSO. You should not need separate Matrix or Nextcloud passwords for normal use. If sign-in loops or fails, check your connection, confirm the server address in Settings, and ask an admin whether your invite or account is active.",
+  "helpSignInBody": "Use the workspace address from your admin, then sign in once with Weave SSO. For normal use, you should not need separate Chat, Files, or Calendar passwords. If sign-in fails or loops, check your connection, confirm the server address in Settings, and ask an admin whether your invitation or account is active.",
   "@helpSignInBody": {
     "description": "Help copy for sign-in basics and recovery"
   },
@@ -1444,7 +1444,7 @@
   "@helpPrivacySecurityTitle": {
     "description": "Help section title for privacy and security basics"
   },
-  "helpPrivacySecurityBody": "Your workspace controls its own services and data. Weave uses SSO for access and shows Matrix security status honestly. Do not assume chat is fully end-to-end encrypted unless Weave says the Matrix encryption, recovery, and device-trust gates are healthy. Keep recovery keys in a safe place and report lost devices to your admin.",
+  "helpPrivacySecurityBody": "Your workspace controls its own services and data. Weave uses SSO for access and reports the Chat security status honestly. Do not assume every chat is fully end-to-end encrypted unless Weave shows that encrypted rooms, recovery, and device trust are healthy. Keep recovery keys safe and report lost devices to your admin.",
   "@helpPrivacySecurityBody": {
     "description": "Help copy for privacy and security basics"
   },

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -209,7 +209,7 @@ abstract class AppLocalizations {
   /// Provider category detail for chat
   ///
   /// In en, this message translates to:
-  /// **'Matrix/Chat is the current dogfood choice behind the Weave chat surface.'**
+  /// **'Chat is the current dogfood service behind the Weave Chat surface.'**
   String get providerCategoryChatDetail;
 
   /// Provider category title for files
@@ -221,7 +221,7 @@ abstract class AppLocalizations {
   /// Provider category detail for files
   ///
   /// In en, this message translates to:
-  /// **'Nextcloud/Files is the current dogfood storage choice behind the Weave files facade.'**
+  /// **'File storage is the current dogfood service behind the Weave Files facade.'**
   String get providerCategoryFilesDetail;
 
   /// Provider category title for calendar
@@ -233,7 +233,7 @@ abstract class AppLocalizations {
   /// Provider category detail for calendar
   ///
   /// In en, this message translates to:
-  /// **'Nextcloud/Calendar backing is the current dogfood choice behind the Weave calendar facade.'**
+  /// **'Calendar sync is the current dogfood service behind the Weave Calendar facade.'**
   String get providerCategoryCalendarDetail;
 
   /// Provider category title for boards and tasks
@@ -662,7 +662,7 @@ abstract class AppLocalizations {
   /// No description provided for @firstRunDescription.
   ///
   /// In en, this message translates to:
-  /// **'You signed in once with Weave SSO. Weave is checking your profile and collaboration modules; no separate Matrix or Nextcloud credentials are needed.'**
+  /// **'You signed in once with Weave SSO. Weave is checking your profile and collaboration modules; no separate Chat, Files, or Calendar credentials are needed.'**
   String get firstRunDescription;
 
   /// No description provided for @firstRunIdentitySectionTitle.
@@ -1526,7 +1526,7 @@ abstract class AppLocalizations {
   /// Body for a Files card explaining the product/provider boundary
   ///
   /// In en, this message translates to:
-  /// **'Files actions use the Weave backend facade. Nextcloud remains the storage provider and admin/fallback surface; raw provider paths and credentials are not part of the normal Files UX.'**
+  /// **'Files actions use the Weave workspace service facade. File storage stays behind the admin/fallback surface; raw service paths and credentials are not part of the normal Files UX.'**
   String get filesProductBoundaryBody;
 
   /// Button label used to start the Files connection flow
@@ -2036,7 +2036,7 @@ abstract class AppLocalizations {
   /// Help copy explaining what Weave is
   ///
   /// In en, this message translates to:
-  /// **'Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and additional collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.'**
+  /// **'Weave is a collaboration app for teams that want an accessible workspace without giving up data sovereignty. Chat, files, account settings, and other collaboration modules appear in Weave while open services work behind Weave facades in the background.'**
   String get helpWhatIsWeaveBody;
 
   /// Help section title for sign-in basics
@@ -2048,7 +2048,7 @@ abstract class AppLocalizations {
   /// Help copy for sign-in basics and recovery
   ///
   /// In en, this message translates to:
-  /// **'Use the workspace address provided by your admin, then sign in once with Weave SSO. You should not need separate Matrix or Nextcloud passwords for normal use. If sign-in loops or fails, check your connection, confirm the server address in Settings, and ask an admin whether your invite or account is active.'**
+  /// **'Use the workspace address from your admin, then sign in once with Weave SSO. For normal use, you should not need separate Chat, Files, or Calendar passwords. If sign-in fails or loops, check your connection, confirm the server address in Settings, and ask an admin whether your invitation or account is active.'**
   String get helpSignInBody;
 
   /// Help section title for chat
@@ -2120,7 +2120,7 @@ abstract class AppLocalizations {
   /// Help copy for privacy and security basics
   ///
   /// In en, this message translates to:
-  /// **'Your workspace controls its own services and data. Weave uses SSO for access and shows Matrix security status honestly. Do not assume chat is fully end-to-end encrypted unless Weave says the Matrix encryption, recovery, and device-trust gates are healthy. Keep recovery keys in a safe place and report lost devices to your admin.'**
+  /// **'Your workspace controls its own services and data. Weave uses SSO for access and reports the Chat security status honestly. Do not assume every chat is fully end-to-end encrypted unless Weave shows that encrypted rooms, recovery, and device trust are healthy. Keep recovery keys safe and report lost devices to your admin.'**
   String get helpPrivacySecurityBody;
 
   /// Section title for user-configurable shell module visibility

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -72,21 +72,21 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get providerCategoryChatDetail =>
-      'Matrix/Chat ist die aktuelle Dogfood-Auswahl hinter der Weave-Chat-Oberfläche.';
+      'Chat ist der aktuelle Dogfood-Dienst hinter der Weave-Chat-Oberfläche.';
 
   @override
   String get providerCategoryFilesTitle => 'Dateien';
 
   @override
   String get providerCategoryFilesDetail =>
-      'Nextcloud/Files ist die aktuelle Dogfood-Speicherauswahl hinter der Weave-Datei-Fassade.';
+      'Dateispeicher ist der aktuelle Dogfood-Dienst hinter der Weave-Datei-Fassade.';
 
   @override
   String get providerCategoryCalendarTitle => 'Kalender';
 
   @override
   String get providerCategoryCalendarDetail =>
-      'Nextcloud/Calendar-Anbindung ist die aktuelle Dogfood-Auswahl hinter der Weave-Kalender-Fassade.';
+      'Kalender-Synchronisierung ist der aktuelle Dogfood-Dienst hinter der Weave-Kalender-Fassade.';
 
   @override
   String get providerCategoryBoardsTitle => 'Boards/Aufgaben';
@@ -335,7 +335,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get firstRunDescription =>
-      'Du hast dich einmal per Weave-SSO angemeldet. Weave prüft Profil und Zusammenarbeitsmodule; separate Matrix- oder Nextcloud-Zugangsdaten sind nicht nötig.';
+      'Du hast dich einmal per Weave-SSO angemeldet. Weave prüft Profil und Zusammenarbeitsmodule; separate Zugangsdaten für Chat, Dateien oder Kalender sind nicht nötig.';
 
   @override
   String get firstRunIdentitySectionTitle => 'Deine Weave-Identität';
@@ -886,7 +886,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get filesProductBoundaryBody =>
-      'Dateiaktionen nutzen die Weave-Backend-Fassade. Nextcloud bleibt Speicheranbieter sowie Admin-/Fallback-Oberfläche; rohe Anbieterpfade und Zugangsdaten gehören nicht zur normalen Dateien-UX.';
+      'Dateiaktionen laufen über die Weave-Workspace-Dienst-Fassade. Dateispeicher bleibt Teil der Admin- und Fallback-Ebene; rohe Dienstpfade und Zugangsdaten gehören nicht zur normalen Dateien-Oberfläche.';
 
   @override
   String get filesConnectButton => 'Dateien verbinden';
@@ -1221,14 +1221,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get helpWhatIsWeaveBody =>
-      'Weave ist eine Zusammenarbeits-App für Teams, die einen barrierearmen Workspace nutzen möchten, ohne Datensouveränität aufzugeben. Chat, Dateien, Kontoeinstellungen und weitere Zusammenarbeitsmodule erscheinen in Weave, während offene Dienste wie Matrix, Nextcloud, Keycloak und das Weave-Backend im Hintergrund arbeiten.';
+      'Weave ist eine Zusammenarbeits-App für Teams, die einen barrierearmen Workspace nutzen möchten, ohne Datensouveränität aufzugeben. Chat, Dateien, Kontoeinstellungen und weitere Zusammenarbeitsmodule erscheinen in Weave, während offene Dienste im Hintergrund hinter Weave-Fassaden arbeiten.';
 
   @override
   String get helpSignInTitle => 'Anmelden: Grundlagen';
 
   @override
   String get helpSignInBody =>
-      'Nutze die Workspace-Adresse deines Admins und melde dich dann einmal mit Weave-SSO an. Für die normale Nutzung solltest du keine separaten Matrix- oder Nextcloud-Passwörter brauchen. Wenn die Anmeldung scheitert oder in einer Schleife hängt, prüfe deine Verbindung, bestätige die Serveradresse in den Einstellungen und frage einen Admin, ob deine Einladung oder dein Konto aktiv ist.';
+      'Nutze die Workspace-Adresse deines Admins und melde dich dann einmal mit Weave-SSO an. Für die normale Nutzung solltest du keine separaten Passwörter für Chat, Dateien oder Kalender brauchen. Wenn die Anmeldung scheitert oder in einer Schleife hängt, prüfe deine Verbindung, bestätige die Serveradresse in den Einstellungen und frage einen Admin, ob deine Einladung oder dein Konto aktiv ist.';
 
   @override
   String get helpChatTitle => 'Chat';
@@ -1271,7 +1271,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get helpPrivacySecurityBody =>
-      'Dein Workspace kontrolliert seine eigenen Dienste und Daten. Weave nutzt SSO für den Zugriff und zeigt den Matrix-Sicherheitsstatus ehrlich an. Gehe nicht davon aus, dass Chat vollständig Ende-zu-Ende-verschlüsselt ist, solange Weave nicht meldet, dass Matrix-Verschlüsselung, Wiederherstellung und Gerätevertrauen gesund sind. Bewahre Wiederherstellungsschlüssel sicher auf und melde verlorene Geräte deinem Admin.';
+      'Dein Workspace kontrolliert seine eigenen Dienste und Daten. Weave nutzt SSO für den Zugriff und zeigt den Chat-Sicherheitsstatus ehrlich an. Gehe nicht davon aus, dass jeder Chat vollständig Ende-zu-Ende-verschlüsselt ist, solange Weave nicht meldet, dass verschlüsselte Räume, Wiederherstellung und Gerätevertrauen gesund sind. Bewahre Wiederherstellungsschlüssel sicher auf und melde verlorene Geräte deinem Admin.';
 
   @override
   String get settingsShellModulesTitle => 'Shell-Module';
@@ -1319,7 +1319,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chatSecuritySectionDescription =>
-      'Weave behandelt Matrix-Verschlüsselung nur dann als gesund, wenn Secret Storage, Cross-Signing, Wiederherstellung und Gerätevertrauen vollständig eingerichtet sind.';
+      'Weave bewertet verschlüsselte Chaträume nur dann als gesund, wenn Secret Storage, Cross-Signing, Wiederherstellung und Gerätevertrauen vollständig eingerichtet sind.';
 
   @override
   String get chatSecurityRecoveryKeyTitle =>
@@ -1471,7 +1471,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chatSecuritySetupDescriptionSignedOut =>
-      'Öffne Chat und verbinde Matrix, bevor du die Verschlüsselung verwaltest.';
+      'Öffne Chat und verbinde deine Chat-Sitzung, bevor du die Sicherheit verschlüsselter Räume verwaltest.';
 
   @override
   String get chatSecuritySetupDescriptionNotInitialized =>
@@ -1491,7 +1491,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get chatSecuritySetupDescriptionUnavailable =>
-      'Matrix-Verschlüsselung ist auf dieser Plattform nicht verfügbar.';
+      'Sicherheit für verschlüsselte Chaträume ist auf dieser Plattform nicht verfügbar.';
 
   @override
   String get chatSecurityCurrentDeviceDescriptionVerified =>

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -70,21 +70,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get providerCategoryChatDetail =>
-      'Matrix/Chat is the current dogfood choice behind the Weave chat surface.';
+      'Chat is the current dogfood service behind the Weave Chat surface.';
 
   @override
   String get providerCategoryFilesTitle => 'Files';
 
   @override
   String get providerCategoryFilesDetail =>
-      'Nextcloud/Files is the current dogfood storage choice behind the Weave files facade.';
+      'File storage is the current dogfood service behind the Weave Files facade.';
 
   @override
   String get providerCategoryCalendarTitle => 'Calendar';
 
   @override
   String get providerCategoryCalendarDetail =>
-      'Nextcloud/Calendar backing is the current dogfood choice behind the Weave calendar facade.';
+      'Calendar sync is the current dogfood service behind the Weave Calendar facade.';
 
   @override
   String get providerCategoryBoardsTitle => 'Boards/tasks';
@@ -330,7 +330,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get firstRunDescription =>
-      'You signed in once with Weave SSO. Weave is checking your profile and collaboration modules; no separate Matrix or Nextcloud credentials are needed.';
+      'You signed in once with Weave SSO. Weave is checking your profile and collaboration modules; no separate Chat, Files, or Calendar credentials are needed.';
 
   @override
   String get firstRunIdentitySectionTitle => 'Your Weave identity';
@@ -881,7 +881,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get filesProductBoundaryBody =>
-      'Files actions use the Weave backend facade. Nextcloud remains the storage provider and admin/fallback surface; raw provider paths and credentials are not part of the normal Files UX.';
+      'Files actions use the Weave workspace service facade. File storage stays behind the admin/fallback surface; raw service paths and credentials are not part of the normal Files UX.';
 
   @override
   String get filesConnectButton => 'Connect Files';
@@ -1213,14 +1213,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get helpWhatIsWeaveBody =>
-      'Weave is a collaboration app for teams that want one accessible workspace without giving up data sovereignty. Chat, files, account settings, and additional collaboration modules are presented through Weave while open services such as Matrix, Nextcloud, Keycloak, and the Weave backend work behind the scenes.';
+      'Weave is a collaboration app for teams that want an accessible workspace without giving up data sovereignty. Chat, files, account settings, and other collaboration modules appear in Weave while open services work behind Weave facades in the background.';
 
   @override
   String get helpSignInTitle => 'Sign in basics';
 
   @override
   String get helpSignInBody =>
-      'Use the workspace address provided by your admin, then sign in once with Weave SSO. You should not need separate Matrix or Nextcloud passwords for normal use. If sign-in loops or fails, check your connection, confirm the server address in Settings, and ask an admin whether your invite or account is active.';
+      'Use the workspace address from your admin, then sign in once with Weave SSO. For normal use, you should not need separate Chat, Files, or Calendar passwords. If sign-in fails or loops, check your connection, confirm the server address in Settings, and ask an admin whether your invitation or account is active.';
 
   @override
   String get helpChatTitle => 'Chat';
@@ -1262,7 +1262,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get helpPrivacySecurityBody =>
-      'Your workspace controls its own services and data. Weave uses SSO for access and shows Matrix security status honestly. Do not assume chat is fully end-to-end encrypted unless Weave says the Matrix encryption, recovery, and device-trust gates are healthy. Keep recovery keys in a safe place and report lost devices to your admin.';
+      'Your workspace controls its own services and data. Weave uses SSO for access and reports the Chat security status honestly. Do not assume every chat is fully end-to-end encrypted unless Weave shows that encrypted rooms, recovery, and device trust are healthy. Keep recovery keys safe and report lost devices to your admin.';
 
   @override
   String get settingsShellModulesTitle => 'Shell modules';

--- a/client/test/architecture/member_facing_domain_language_test.dart
+++ b/client/test/architecture/member_facing_domain_language_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('member-facing canonical domain language', () {
+    final en = _loadArb('lib/l10n/app_en.arb');
+    final de = _loadArb('lib/l10n/app_de.arb');
+
+    test('keeps Files and Calendar labels semantically separate', () {
+      for (final entry in <String, Map<String, Object?>>{
+        'en': en,
+        'de': de,
+      }.entries) {
+        final locale = entry.key;
+        final arb = entry.value;
+
+        expect(
+          arb['providerCategoryFilesDetail'],
+          isNot(contains(RegExp('calendar|kalender', caseSensitive: false))),
+          reason: '$locale Files detail must not conflate Calendar.',
+        );
+        expect(
+          arb['providerCategoryCalendarDetail'],
+          isNot(contains(RegExp('files|datei', caseSensitive: false))),
+          reason: '$locale Calendar detail must not conflate Files.',
+        );
+        expect(
+          arb['filesProductBoundaryBody'],
+          isNot(contains(RegExp('calendar|kalender', caseSensitive: false))),
+          reason: '$locale Files boundary copy must stay in the Files domain.',
+        );
+      }
+    });
+
+    test('describes chat encryption as contextual security state', () {
+      expect(
+        en['helpPrivacySecurityBody'],
+        allOf(
+          contains('encrypted rooms'),
+          contains('recovery'),
+          contains('device trust'),
+        ),
+      );
+      expect(
+        de['helpPrivacySecurityBody'],
+        allOf(
+          contains('verschlüsselte Räume'),
+          contains('Wiederherstellung'),
+          contains('Gerätevertrauen'),
+        ),
+      );
+      expect(
+        de['chatSecuritySectionDescription'],
+        contains('verschlüsselte Chaträume'),
+      );
+    });
+
+    test('does not use dogfood provider labels in member handbook copy', () {
+      final memberCopyKeys = <String>[
+        'firstRunDescription',
+        'filesProductBoundaryBody',
+        'helpWhatIsWeaveBody',
+        'helpSignInBody',
+        'helpPrivacySecurityBody',
+      ];
+      final forbidden = RegExp(
+        'Nextcloud|Matrix|Keycloak|OpenProject|LiveKit|Dateien und Kalender|Files and Calendar',
+        caseSensitive: false,
+      );
+
+      for (final entry in <String, Map<String, Object?>>{
+        'en': en,
+        'de': de,
+      }.entries) {
+        for (final key in memberCopyKeys) {
+          expect(
+            entry.value[key],
+            isNot(contains(forbidden)),
+            reason:
+                '${entry.key} $key must stay provider-neutral and domain-specific.',
+          );
+        }
+      }
+    });
+  });
+}
+
+Map<String, Object?> _loadArb(String path) {
+  return (jsonDecode(File(path).readAsStringSync()) as Map<String, dynamic>)
+      .cast<String, Object?>();
+}

--- a/client/test/features/files/files_screen_test.dart
+++ b/client/test/features/files/files_screen_test.dart
@@ -157,14 +157,16 @@ void main() {
       expect(find.text('Weave Files'), findsOneWidget);
       expect(find.text('Weave product boundary'), findsOneWidget);
       expect(
-        find.textContaining('Files actions use the Weave backend facade'),
+        find.textContaining(
+          'Files actions use the Weave workspace service facade',
+        ),
         findsOneWidget,
       );
       expect(find.text('https://files.home.internal'), findsNothing);
       expect(
         find.bySemanticsLabel(
           RegExp(
-            'Weave product boundary.*backend facade.*raw provider paths and credentials',
+            'Weave product boundary.*workspace service facade.*raw service paths and credentials',
             dotAll: true,
           ),
         ),

--- a/client/test/features/onboarding/first_run_screen_test.dart
+++ b/client/test/features/onboarding/first_run_screen_test.dart
@@ -37,7 +37,7 @@ void main() {
       expect(find.text('Calendar'), findsOneWidget);
       expect(find.text('Ready'), findsWidgets);
       expect(
-        find.textContaining('no separate Matrix or Nextcloud'),
+        find.textContaining('no separate Chat, Files, or Calendar credentials'),
         findsOneWidget,
       );
       expect(find.text('Owner/admin setup responsibilities'), findsNothing);

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -352,8 +352,9 @@ void main() {
       expect(find.text('Weaver'), findsOneWidget);
       expect(find.text('Disabled by default'), findsOneWidget);
       expect(find.textContaining('Keycloak/Auth'), findsOneWidget);
-      expect(find.textContaining('Matrix/Chat'), findsOneWidget);
-      expect(find.textContaining('Nextcloud/Files'), findsOneWidget);
+      expect(find.textContaining('Chat'), findsWidgets);
+      expect(find.textContaining('File storage'), findsOneWidget);
+      expect(find.textContaining('Calendar sync'), findsOneWidget);
       expect(
         find.textContaining('OpenProject Boards validation'),
         findsOneWidget,

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -304,7 +304,9 @@
           "fragments": [
             "Provider categories",
             "Keycloak/Auth",
-            "Matrix/Chat",
+            "Chat",
+            "File storage",
+            "Calendar sync",
             "Disabled by default",
             "Admin/operator readiness cockpit",
             "hides OIDC and service endpoint setup from members"


### PR DESCRIPTION
## Summary
- Replaces normal member-facing provider vocabulary with canonical Weave domain language across client copy, generated l10n, tests, release docs, e2e mappings, and generated screenshot fixtures.
- Keeps provider-specific terms only in explicit admin/operator/recovery contexts, while updating evidence mappings to the new workspace service/capability language.
- Adds a release contract to catch future member-facing raw provider vocabulary leakage.

## Evidence
- `cd client && flutter test test/live_stack_feature_mapping_test.dart -r expanded`
- `cd client && flutter test test/features/chat/presentation/widgets/chat_security_settings_section_test.dart -r expanded`
- `cd client && flutter test test/features/onboarding/setup_flow_test.dart test/release_1/release_golden_paths_test.dart test/release_1/v0_1_release_spine_contract_test.dart test/features/deck/deck_screen_test.dart test/features/boards/boards_workspace_screen_test.dart test/features/files/files_screen_test.dart test/features/settings/settings_screen_test.dart -r expanded`
- `./gradlew clientCi --console=plain`

Closes #787
