### PR TITLE
feat(contract): add canonical product domain catalog

### DIFF
--- a/weave-contract/src/main/java/com/massimotter/weave/contract/domain/ProductDomainAlias.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/domain/ProductDomainAlias.java
@@ -1,0 +1,27 @@
+package com.massimotter.weave.contract.domain;
+
+import java.util.List;
+
+public record ProductDomainAlias(
+        String key,
+        String label,
+        List<String> productDomainKeys,
+        AliasKind kind,
+        String note) {
+
+    public ProductDomainAlias {
+        key = text(key, "key");
+        label = text(label, "label");
+        productDomainKeys = List.copyOf(productDomainKeys == null ? List.of() : productDomainKeys);
+        if (productDomainKeys.isEmpty()) throw new IllegalArgumentException("productDomainKeys must not be empty");
+        if (kind == null) throw new IllegalArgumentException("kind must not be null");
+        note = text(note, "note");
+    }
+
+    public enum AliasKind { AGGREGATION_ALIAS }
+
+    private static String text(String value, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+        return value.trim();
+    }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/domain/ProductDomainCatalog.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/domain/ProductDomainCatalog.java
@@ -1,0 +1,33 @@
+package com.massimotter.weave.contract.domain;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class ProductDomainCatalog {
+    private ProductDomainCatalog() {}
+
+    private static final List<ProductDomainContract> DOMAINS = Arrays.stream(ProductDomainDefinition.values())
+            .map(ProductDomainDefinition::contract)
+            .toList();
+
+    private static final Map<String, ProductDomainContract> DOMAINS_BY_KEY = DOMAINS.stream()
+            .collect(Collectors.toUnmodifiableMap(ProductDomainContract::key, Function.identity()));
+
+    private static final List<ProductDomainAlias> ALIASES = List.of(
+            new ProductDomainAlias("files-docs", "Files and documents MCP/member grouping", List.of("files", "documents"), ProductDomainAlias.AliasKind.AGGREGATION_ALIAS, "Compatibility aggregation only; not canonical product-domain truth."),
+            new ProductDomainAlias("calendar-meetings", "Calendar and meetings MCP/member grouping", List.of("calendar", "calls"), ProductDomainAlias.AliasKind.AGGREGATION_ALIAS, "Compatibility aggregation only; not canonical product-domain truth."),
+            new ProductDomainAlias("boards-tasks", "Boards and tasks MCP/member grouping", List.of("boards"), ProductDomainAlias.AliasKind.AGGREGATION_ALIAS, "Compatibility aggregation only; not canonical product-domain truth."));
+
+    private static final Map<String, ProductDomainAlias> ALIASES_BY_KEY = ALIASES.stream()
+            .collect(Collectors.toUnmodifiableMap(ProductDomainAlias::key, Function.identity()));
+
+    public static List<ProductDomainContract> domains() { return DOMAINS; }
+    public static Map<String, ProductDomainContract> domainsByKey() { return DOMAINS_BY_KEY; }
+    public static List<ProductDomainAlias> aliases() { return ALIASES; }
+    public static Map<String, ProductDomainAlias> aliasesByKey() { return ALIASES_BY_KEY; }
+    public static boolean isCanonicalProductDomain(String key) { return DOMAINS_BY_KEY.containsKey(key); }
+    public static boolean isAggregationAlias(String key) { return ALIASES_BY_KEY.containsKey(key); }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/domain/ProductDomainContract.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/domain/ProductDomainContract.java
@@ -1,0 +1,35 @@
+package com.massimotter.weave.contract.domain;
+
+import java.util.List;
+
+public record ProductDomainContract(
+        String key,
+        String label,
+        List<String> canonicalObjectKinds,
+        List<String> readCapabilities,
+        List<String> writeCapabilities,
+        List<String> providerAdapterSlots,
+        List<String> providerCategoryHints,
+        List<String> portabilityRequirements) {
+
+    public ProductDomainContract {
+        key = text(key, "key");
+        label = text(label, "label");
+        canonicalObjectKinds = List.copyOf(canonicalObjectKinds == null ? List.of() : canonicalObjectKinds);
+        readCapabilities = List.copyOf(readCapabilities == null ? List.of() : readCapabilities);
+        writeCapabilities = List.copyOf(writeCapabilities == null ? List.of() : writeCapabilities);
+        providerAdapterSlots = List.copyOf(providerAdapterSlots == null ? List.of() : providerAdapterSlots);
+        providerCategoryHints = List.copyOf(providerCategoryHints == null ? List.of() : providerCategoryHints);
+        portabilityRequirements = List.copyOf(portabilityRequirements == null ? List.of() : portabilityRequirements);
+    }
+
+    public List<String> allCapabilities() {
+        return java.util.stream.Stream.concat(readCapabilities.stream(), writeCapabilities.stream())
+                .collect(java.util.stream.Collectors.toUnmodifiableList());
+    }
+
+    private static String text(String value, String field) {
+        if (value == null || value.isBlank()) throw new IllegalArgumentException(field + " must not be blank");
+        return value.trim();
+    }
+}

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/domain/ProductDomainDefinition.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/domain/ProductDomainDefinition.java
@@ -1,0 +1,31 @@
+package com.massimotter.weave.contract.domain;
+
+import java.util.List;
+
+public enum ProductDomainDefinition {
+    IDENTITY("identity", "Identity", List.of("organization", "user", "group", "role", "session", "credential_ref"), List.of("identity.read"), List.of("identity.manage_members", "identity.manage_roles"), List.of("identity-facade", "idm-adapter"), List.of("identity-idm", "sso", "directory"), List.of("stable_subject_refs", "external_id_redaction", "exportable_membership_graph")),
+    PEOPLE("people", "People", List.of("person", "profile", "contact", "team", "presence"), List.of("people.read"), List.of("people.update_profile", "people.manage_contacts"), List.of("people-facade", "contacts-adapter"), List.of("contacts", "directory"), List.of("portable_contact_cards", "provider_neutral_profile_refs")),
+    SPACES("spaces", "Spaces", List.of("space", "membership", "channel_ref", "permission", "announcement"), List.of("spaces.read"), List.of("spaces.manage"), List.of("spaces-facade", "workspace-adapter"), List.of("workspace", "collaboration"), List.of("portable_space_refs", "membership_policy_export")),
+    CHAT("chat", "Chat", List.of("conversation", "channel", "thread", "message", "reaction", "attachment_ref"), List.of("chat.read"), List.of("chat.send", "chat.moderate"), List.of("chat-facade", "message-adapter"), List.of("messaging", "matrix"), List.of("message_export", "thread_identity_stability", "attachment_ref_portability")),
+    FILES("files", "Files", List.of("drive", "folder", "file", "file_version", "blob_ref", "permission", "share_link", "lock", "trash_entry", "checksum"), List.of("files.read"), List.of("files.upload", "files.delete", "files.share"), List.of("files-facade", "storage-adapter"), List.of("files", "object-storage", "nextcloud"), List.of("content_export", "metadata_export", "permission_mapping")),
+    DOCUMENTS("documents", "Documents", List.of("document", "document_version", "editor_session", "comment", "template"), List.of("documents.read"), List.of("documents.edit", "documents.comment"), List.of("documents-facade", "collaboration-adapter"), List.of("documents-collaboration", "office"), List.of("document_format_export", "version_history_export", "comment_export")),
+    CALENDAR("calendar", "Calendar", List.of("calendar", "event", "occurrence", "attendee", "availability", "agenda_ref"), List.of("calendar.read"), List.of("calendar.manage_events"), List.of("calendar-facade", "calendar-adapter"), List.of("calendar", "scheduling"), List.of("ics_export", "attendee_ref_mapping", "recurrence_portability")),
+    CALLS("calls", "Calls", List.of("call", "meeting", "conference_link", "participant", "recording_ref", "transcript_ref"), List.of("calls.read"), List.of("calls.schedule", "calls.manage"), List.of("calls-facade", "media-adapter"), List.of("meetings-calls", "video", "livekit"), List.of("meeting_link_abstraction", "recording_consent_metadata", "transcript_export")),
+    BOARDS("boards", "Boards", List.of("board", "list", "task", "status", "assignee", "comment", "attachment_ref", "decision_link"), List.of("boards.read"), List.of("boards.update_task", "boards.sync_workspace"), List.of("boards-facade", "work-tracking-adapter"), List.of("boards-tasks", "project-management", "openproject"), List.of("task_export", "status_mapping", "assignee_ref_mapping")),
+    DECISIONS("decisions", "Decisions", List.of("decision", "proposal", "vote", "approval", "evidence_ref", "audit_ref"), List.of("decisions.read"), List.of("decisions.record", "decisions.approve"), List.of("decisions-facade", "evidence-adapter"), List.of("decisions-evidence", "audit"), List.of("decision_log_export", "evidence_ref_portability", "audit_chain_preservation")),
+    NOTIFICATIONS("notifications", "Notifications", List.of("notification", "subscription", "preference", "delivery", "action_request"), List.of("notifications.read"), List.of("notifications.send", "notifications.manage_preferences"), List.of("notifications-facade", "delivery-adapter"), List.of("notifications", "email", "push"), List.of("preference_export", "delivery_audit_redaction", "unsubscribe_portability"));
+
+    public static final String CONTRACT_VERSION = "product-domain-contract-v1";
+
+    private final ProductDomainContract contract;
+
+    ProductDomainDefinition(String key, String label, List<String> canonicalObjectKinds, List<String> readCapabilities,
+            List<String> writeCapabilities, List<String> providerAdapterSlots, List<String> providerCategoryHints,
+            List<String> portabilityRequirements) {
+        this.contract = new ProductDomainContract(key, label, canonicalObjectKinds, readCapabilities, writeCapabilities,
+                providerAdapterSlots, providerCategoryHints, portabilityRequirements);
+    }
+
+    public ProductDomainContract contract() { return contract; }
+    public String key() { return contract.key(); }
+}

--- a/weave-contract/src/test/java/com/massimotter/weave/contract/domain/ProductDomainCatalogTest.java
+++ b/weave-contract/src/test/java/com/massimotter/weave/contract/domain/ProductDomainCatalogTest.java
@@ -1,0 +1,59 @@
+package com.massimotter.weave.contract.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+class ProductDomainCatalogTest {
+    private static final Set<String> APPROVED_V01_PRODUCT_DOMAINS = Set.of(
+            "identity", "people", "spaces", "chat", "files", "documents", "calendar", "calls", "boards", "decisions", "notifications");
+
+    @Test void productDomainKeysMatchApprovedV01Set() {
+        var actual = ProductDomainCatalog.domains().stream().map(ProductDomainContract::key).collect(Collectors.toUnmodifiableSet());
+        assertEquals(APPROVED_V01_PRODUCT_DOMAINS, actual);
+    }
+
+    @Test void weaverAndHealthAreNotProductDomains() {
+        assertFalse(ProductDomainCatalog.isCanonicalProductDomain("weaver"));
+        assertFalse(ProductDomainCatalog.isCanonicalProductDomain("health"));
+        for (var domain : ProductDomainCatalog.domains()) {
+            assertNotEquals("weaver", domain.key());
+            assertNotEquals("health", domain.key());
+        }
+    }
+
+    @Test void groupedMcpMemberNamesAreAliasesOnlyNotProductDomains() {
+        for (var groupedName : Set.of("files-docs", "calendar-meetings", "boards-tasks")) {
+            assertFalse(ProductDomainCatalog.isCanonicalProductDomain(groupedName), groupedName);
+            assertTrue(ProductDomainCatalog.isAggregationAlias(groupedName), groupedName);
+            assertEquals(ProductDomainAlias.AliasKind.AGGREGATION_ALIAS, ProductDomainCatalog.aliasesByKey().get(groupedName).kind());
+        }
+    }
+
+    @Test void aggregationAliasesPointOnlyToExistingProductDomains() {
+        for (var alias : ProductDomainCatalog.aliases()) {
+            assertFalse(alias.productDomainKeys().isEmpty(), alias.key());
+            for (var productDomainKey : alias.productDomainKeys()) {
+                assertTrue(ProductDomainCatalog.isCanonicalProductDomain(productDomainKey), alias.key() + " -> " + productDomainKey);
+            }
+        }
+        assertEquals(Set.of("files", "documents"), Set.copyOf(ProductDomainCatalog.aliasesByKey().get("files-docs").productDomainKeys()));
+        assertEquals(Set.of("calendar", "calls"), Set.copyOf(ProductDomainCatalog.aliasesByKey().get("calendar-meetings").productDomainKeys()));
+        assertEquals(Set.of("boards"), Set.copyOf(ProductDomainCatalog.aliasesByKey().get("boards-tasks").productDomainKeys()));
+    }
+
+    @Test void eachProductDomainCarriesContractSkeleton() {
+        for (var domain : ProductDomainCatalog.domains()) {
+            assertFalse(domain.label().isBlank(), domain.key());
+            assertFalse(domain.canonicalObjectKinds().isEmpty(), domain.key());
+            assertFalse(domain.readCapabilities().isEmpty(), domain.key());
+            assertFalse(domain.writeCapabilities().isEmpty(), domain.key());
+            assertFalse(domain.providerAdapterSlots().isEmpty(), domain.key());
+            assertFalse(domain.providerCategoryHints().isEmpty(), domain.key());
+            assertFalse(domain.portabilityRequirements().isEmpty(), domain.key());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a canonical v0.1 product-domain catalog to the existing `weave-contract` module.
- Encode the approved product-domain set: `identity`, `people`, `spaces`, `chat`, `files`, `documents`, `calendar`, `calls`, `boards`, `decisions`, `notifications`.
- Keep grouped MCP/member names (`files-docs`, `calendar-meetings`, `boards-tasks`) as aggregation aliases only, not product-domain truth.
- Explicitly exclude `weaver` and `health` from canonical product domains.

## Scope and user impact

- Contract-foundation slice only; no member/admin UI behavior changes.
- Establishes stable product-domain vocabulary for later server/spec/admin/client alignment.
- Does **not** claim existing server/spec/admin/client registries are fully aligned yet.

## Spec / acceptance link

- Issue: Closes #855
- Repo spec or spec note: existing `weave-contract` foundation from PR #820/#827; product-domain baseline from Sprint 32 issue #855 and NotebookLM research notebook `9b231d70-a93b-41ee-9774-05d5a48df556`.
- Acceptance scenario / mapping marker when product behavior changed: no runtime product behavior changed; acceptance covered by `ProductDomainCatalogTest` contract guards.
- Product-core questions intentionally left unresolved: server/spec/admin/client registry migration remains a follow-up; this PR only introduces the product-domain source catalog and alias semantics.

## Branch, target lane, and release path

- Target lane: main exception
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

Main-exception reason: `weave-contract/` exists on `origin/main` from PR #820/#827 but is absent on `origin/dev`; this contract-foundation slice extends the existing mainline module rather than creating a duplicate module on dev. Follow-up lane reconciliation is required before claiming dev/server/client alignment.

## Spec impact

- [ ] none
- [x] implements locked spec: canonical v0.1 product-domain baseline for `weave-contract`
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

- Release note: add canonical v0.1 product-domain catalog to `weave-contract`, separating product-domain truth from MCP/member aggregation aliases.

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- None; no UI/docs screenshots affected.

## Accessibility and localization

- Not applicable; no user-facing UI or localized strings changed.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: `weave-contract` now exposes product-domain catalog classes plus tests for exact domain set, exclusions, alias semantics, and non-empty skeletons.
- [x] `./gradlew specContract` run for spec/product-contract changes

## Review readiness

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented

Fallback review evidence: main assistant performed semantic review against #855 and Quality Reset gates because the separate review agent timed out; Co-Leader remains owner for final Sprint 32 integration review.

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance`
- [x] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [x] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant; contract-only Java module change.

Additional gate run:

- [x] `./gradlew :weave-contract:test specContract --console=plain`

## Notes for reviewers

- Review that `ProductDomainDefinition` contains exactly the approved v0.1 product-domain keys.
- Review that `weaver` and `health` are excluded from product-domain truth.
- Review that `files-docs`, `calendar-meetings`, and `boards-tasks` are represented only as aggregation aliases.
- Do not infer full server/spec/admin/client registry alignment from this PR; that remains follow-up work.
