### PR TITLE
test: prove Weaver Chat MCP approval separation

### DIFF
--- a/docs/evidence/weaver-chat-mcp-separation-proof.md
+++ b/docs/evidence/weaver-chat-mcp-separation-proof.md
@@ -1,0 +1,72 @@
+# Weaver Chat consent and MCP approval enforcement proof
+
+Issue: #852  
+Sprint: 32  
+Scope: harnessed contract/server proof on `test/issue-852-weaver-chat-mcp-e2e`; not live customer or production-release evidence.
+
+## Governing boundary
+
+Weave keeps two planes separate:
+
+| Plane | Owner | Purpose | Support-safe ids in proof |
+| --- | --- | --- | --- |
+| Channel plane | Weave Chat / Weaver `weave-chat` channel | Member message, approval prompt, plain-language approval status, and user-facing reply/hint. | `channel:weave-chat-general`, `conversation:weaver-consent-demo`, `message:member-request-001`, `turn:weaver-852-001` |
+| Tool/MCP plane | Weave MCP server and domain tool registry | Runtime tool discovery/invocation, scoped grants, policy checks, `ApprovalReceipt` validation, and audit. | `mcp-server:weave-domain-tools`, `tool:chat.send_message`, `approval:chat-send:32:001`, `audit://weaver-tool/chat.send_message/*` |
+
+`chat.send_message` is tested only as a governed post-turn domain tool. It is not an inbound user-to-agent channel transport. The inbound user path remains the `channels.weave-chat` channel projection, and MCP server projection is marked `routingPlaneSeparated=true`.
+
+## Channel-plane UX evidence
+
+The #852 harness models the user-facing consent step as a Weave Chat approval hint/status, not an MCP prompt:
+
+- Plain-language prompt: “Send this message to `channel:weave-chat-general` in `space:control-room`?”
+- Status states: `approval required`, `approved`, `denied`, `expired`, `revoked`, `already used`, and `temporarily unavailable`.
+- Accessibility constraint: each state is asserted as text/status evidence and must not rely on color alone.
+- Correlation constraint: channel `message:*` and `turn:*` ids are distinct from `approval:*`, `mcp-server:*`, `tool:*`, and `audit://*` ids.
+
+This is harnessed evidence only. It does not claim final manual assistive-technology signoff, broad Weaver availability, or release/customer-ready accessibility.
+
+## Tool/MCP enforcement evidence
+
+Executable server tests cover the enforcement point in Weave MCP / domain tool registry:
+
+- `WeaverRuntimeServiceTest.provesWeaverChatConsentAndMcpApprovalReceiptIntegrationFailsClosed`
+- `WeaverToolRegistryTest.requiresApprovalReceiptForWriteLikeToolsBeforeInvocation`
+- `WeaverToolRegistryTest.mismatchedApprovalReceiptScopeFailsClosedBeforeInvocation`
+- `WeaverToolRegistryTest.runtimeDeniedOrTimedOutApprovalFailsClosedWithoutServerDecision`
+- `WeaverToolRegistryTest.failsClosedForServerPolicyConsentExpiryAndOverbroadGovernanceButNotRuntimeProfileMarkers`
+- `WeaverToolRegistryTest.runtimeProfileMarkersAreCorrelationOnlyAndCannotOverrideServerPolicyApproval`
+
+The approved path validates actor, action, scope refs, policy version, expiry, and `audit://` approval ref. RuntimeProfile hash/signature/revocation markers remain correlation/profile lifecycle evidence; they are not the sole security boundary for governed actions.
+
+## Integrated #852 flow matrix
+
+| Flow | Evidence | Expected side effect posture |
+| --- | --- | --- |
+| Deny / missing consent | `chat.send_message` without receipt returns `approval_required`; runtime `approval:denied:*` marker returns `approval_denied`. | No provider/domain send; support-safe audit only. |
+| Approve | Valid `ApprovalReceipt` for actor `user:*`, action `chat.send_message`, scope `space:control-room`, policy `policy:v32`, future expiry, and `audit://weaver-approval/chat-send/001` returns `ok`. | Domain tool may proceed through Weave facade; raw provider payload redacted. |
+| Expired, revoked, or policy mismatch | Expired receipt returns `approval_timeout`; revoked marker returns `approval_revoked`; policy mismatch returns `approval_receipt_invalid`; expired runtime token returns `runtime_token_expired`. | No side effect before provider access. |
+| Duplicate or retry | Reusing the same valid approval receipt returns `duplicate_approval_receipt`. | Replay blocked before provider access. |
+| MCP down / unavailable profile | Unknown/unissued runtime profile hash returns `runtime_profile_fetch_denied`. | Fail closed with support-safe result only. |
+
+## Redaction and support-safety
+
+Evidence may include support-safe refs such as `space:control-room`, `channel:weave-chat-general`, `approval:chat-send:32:001`, and `audit://weaver-tool/chat.send_message/invoked`.
+
+Evidence must not include secrets, raw provider ids, raw external payloads, prompts/private memory, tokens, credential-bearing URLs, `openclaw.json`, or provider endpoint details. Tests assert redacted results and audit payloads avoid those strings.
+
+## Proven vs not proven
+
+Proven:
+
+- Channel and MCP/tool planes are separated in profile/projection and evidence ids.
+- `chat.send_message` is governed as a post-turn domain tool, not inbound channel transport.
+- Weave MCP enforces deny, approve, expired/revoked, policy mismatch, duplicate/retry, and unavailable-profile/MCP-down fail-closed paths.
+- Approval receipt validation includes actor, action, `space:`/`channel:`/domain scope refs, policy, expiry, and audit ref.
+- Evidence is support-safe and avoids raw provider/secret/private-memory material.
+
+Not proven:
+
+- Live OpenClaw/Weaver channel plugin execution against a real provider.
+- Manual assistive-technology signoff or broad customer-ready accessibility.
+- Production cutover, broad Weaver availability, or public GA readiness.

--- a/docs/sprint-32-issue-852-delegation-plan.md
+++ b/docs/sprint-32-issue-852-delegation-plan.md
@@ -1,0 +1,67 @@
+# Sprint 32 issue #852 delegation plan
+
+Issue: #852 `test(e2e): prove Weave Chat consent UX and MCP approval enforcement integration`
+
+Base: `origin/dev`
+Branch: `test/issue-852-weaver-chat-mcp-e2e`
+
+## Acceptance derived from issue/specs
+
+Governing sources: `specs/0009-domain-first-mcp-tools/spec.md`, `docs/architecture/weaver-openclaw-profile.md`, `docs/governed-weaver-runtime-security-contract.md`, `docs/architecture/mcp-domain-tool-action-registry.md`, and `e2e/features/product_e2e_scenario_layer.feature`.
+
+The proof must show:
+
+1. Weave Chat / Weaver owns the user consent UX and accessibility-facing approval prompt/status evidence.
+2. Weave MCP owns tool policy, scoped grants, and `ApprovalReceipt` validation.
+3. `chat.send_message` is a governed domain tool only after a turn starts, not inbound user-to-agent transport.
+4. Deny, approve, expired/revoked, duplicate/retry, and MCP-down paths are covered.
+5. Deny/expired/revoked paths have no side effect; approve requires a valid explicit consent receipt for governed tools.
+6. Evidence uses support-safe correlation ids and excludes secrets, raw provider ids, raw external payloads, prompts/private memory, tokens, credential URLs, and broad customer-ready claims.
+
+## Delegation lanes
+
+### Channel plane reviewer
+
+Scope: Weave Chat consent UX / accessible prompt and status evidence only.
+
+Allowed files/globs:
+- `docs/evidence/weaver-chat-mcp-separation-proof.md`
+- `e2e/features/product_e2e_scenario_layer.feature`
+- client tests only if changed
+
+Checks:
+- Approval prompt/status is representable in plain language, not by color alone.
+- Channel ids, conversation ids, message ids, turn ids remain distinct from MCP/tool/audit ids.
+- `chat.send_message` is not described or tested as inbound user-to-agent transport.
+- Evidence does not claim release/customer-ready accessibility beyond the harnessed proof.
+
+### Tool plane reviewer
+
+Scope: Weave MCP policy / `ApprovalReceipt` enforcement only.
+
+Allowed files/globs:
+- `server/src/main/java/com/massimotter/weave/backend/weaver/**`
+- `server/src/main/java/com/massimotter/weave/backend/service/WeaverRuntimeService.java`
+- `server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java`
+- `docs/evidence/weaver-chat-mcp-separation-proof.md`
+
+Checks:
+- Governed write-like tools fail closed without valid receipt.
+- Approved path validates actor, action, policy, expiry, and audit ref.
+- Expired/revoked paths deny before provider side effects.
+- RuntimeProfile signing/revocation is not treated as the sole security boundary.
+
+### Evidence plane reviewer
+
+Scope: integrated deny/approve/expired-or-revoked/duplicate-or-retry/MCP-down proof and redaction.
+
+Allowed files/globs:
+- `server/src/test/**`
+- `e2e/**`
+- `docs/evidence/weaver-chat-mcp-separation-proof.md`
+
+Checks:
+- Tests or harnessed evidence cover deny, approve, expired-or-revoked, duplicate-or-retry, and MCP-down flows.
+- Support-safe correlation ids are stable and separated by plane.
+- No secrets, raw provider payloads, raw provider ids, prompts/private memory, tokens, or credential URLs appear.
+- The proof clearly says what is and is not proven.

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverMcpBridgeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverMcpBridgeService.java
@@ -146,10 +146,22 @@ public class WeaverMcpBridgeService {
     }
 
     private WeaverApprovalReceipt approvalReceipt(BridgeInvocationRequest request) {
-        // A receipt ref is only a correlation pointer. Until the bridge receives a
-        // server-verifiable ApprovalReceipt payload/source, it must not fabricate
-        // actor/action/scope/policy/expiry/audit bindings from that ref.
-        return null;
+        if (request.approvalReceipt() == null) {
+            return null;
+        }
+        var receipt = request.approvalReceipt();
+        if (request.runtime().approvalReceiptRef() != null
+                && !request.runtime().approvalReceiptRef().value().equals(receipt.receiptRef())) {
+            return null;
+        }
+        return new WeaverApprovalReceipt(
+                receipt.receiptRef(),
+                receipt.actorRef(),
+                receipt.action(),
+                receipt.scopeRefs(),
+                receipt.policyVersion(),
+                receipt.expiresAt(),
+                receipt.auditRef());
     }
 
     private BridgeInvocationResponse bridgeInvocationResponse(String toolName, ToolInvocationStatus status, String auditRef, String message, Map<String, Object> structuredContent) {

--- a/server/src/main/java/com/massimotter/weave/backend/service/WeaverMcpBridgeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/WeaverMcpBridgeService.java
@@ -17,8 +17,6 @@ import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ToolInvocationStatu
 import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpContentBlock;
 import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpRef;
 import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.WeaveMcpToolCatalog;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -148,18 +146,10 @@ public class WeaverMcpBridgeService {
     }
 
     private WeaverApprovalReceipt approvalReceipt(BridgeInvocationRequest request) {
-        ApprovalReceiptRef ref = request.runtime().approvalReceiptRef();
-        if (ref == null) {
-            return null;
-        }
-        return new WeaverApprovalReceipt(
-                ref.value(),
-                request.runtime().userRef().value(),
-                request.toolName(),
-                List.of(request.runtime().runtimeProfileRef().value()),
-                "support-safe-bridge-v1",
-                Instant.now().plus(5, ChronoUnit.MINUTES).toString(),
-                request.runtime().auditRef());
+        // A receipt ref is only a correlation pointer. Until the bridge receives a
+        // server-verifiable ApprovalReceipt payload/source, it must not fabricate
+        // actor/action/scope/policy/expiry/audit bindings from that ref.
+        return null;
     }
 
     private BridgeInvocationResponse bridgeInvocationResponse(String toolName, ToolInvocationStatus status, String auditRef, String message, Map<String, Object> structuredContent) {

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverApprovalReceipt.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverApprovalReceipt.java
@@ -23,13 +23,16 @@ public record WeaverApprovalReceipt(
         auditRef = safe(auditRef);
     }
 
-    public boolean validFor(String actorRef, String action, List<String> requiredScopeRefs) {
+    public boolean validFor(String actorRef, String action, List<String> requiredScopeRefs, String expectedPolicyVersion) {
         List<String> safeRequiredScopeRefs = List.copyOf(requiredScopeRefs == null ? List.of() : requiredScopeRefs);
+        String safeExpectedPolicyVersion = safe(expectedPolicyVersion).equals("unspecified") ? "policy:support-safe-bridge-v1" : safe(expectedPolicyVersion);
         return !receiptRef.isBlank()
                 && this.actorRef.equals(actorRef)
                 && this.action.equals(action)
                 && scopeRefs.containsAll(safeRequiredScopeRefs)
                 && !policyVersion.isBlank()
+                && policyVersion.startsWith("policy:")
+                && (safeExpectedPolicyVersion.isBlank() || policyVersion.equals(safeExpectedPolicyVersion))
                 && auditRef.startsWith("audit://")
                 && expiresInFuture();
     }

--- a/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
+++ b/server/src/main/java/com/massimotter/weave/backend/weaver/WeaverToolRegistry.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,6 +20,7 @@ public class WeaverToolRegistry {
 
     private final AuditEventPublisher auditEventPublisher;
     private final Map<String, WeaverDomainToolDefinition> definitions;
+    private final ConcurrentMap<String, Boolean> consumedApprovalReceipts = new ConcurrentHashMap<>();
 
     public WeaverToolRegistry(AuditEventPublisher auditEventPublisher) {
         this.auditEventPublisher = auditEventPublisher;
@@ -67,8 +70,9 @@ public class WeaverToolRegistry {
                 return blocked(request.toolName(), terminalApprovalStatus, "Weaver action failed closed after the user runtime did not approve it.");
             }
             List<String> requiredScopeRefs = canonicalScopeRefs(request.input());
-            if (approvalReceipt == null || !approvalReceipt.validFor(request.userRef(), request.toolName(), requiredScopeRefs)) {
-                String status = approvalReceipt == null ? "approval_required" : "approval_scope_mismatch";
+            String expectedPolicyVersion = expectedPolicyVersion(request.input());
+            if (approvalReceipt == null || !approvalReceipt.validFor(request.userRef(), request.toolName(), requiredScopeRefs, expectedPolicyVersion)) {
+                String status = approvalReceipt == null ? "approval_required" : "approval_receipt_invalid";
                 audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), status, Map.of(
                         "domain", definition.domain(),
                         "approvalAuthority", "user_openclaw_runtime",
@@ -91,6 +95,15 @@ public class WeaverToolRegistry {
                         approvalReceipt == null
                                 ? "This action requires a valid approval receipt before Weaver may continue."
                                 : "Approval receipt scope does not match the Weaver tool invocation.");
+            }
+            String receiptKey = request.userRef() + "|" + request.toolName() + "|" + approvalReceipt.receiptRef();
+            if (consumedApprovalReceipts.putIfAbsent(receiptKey, true) != null) {
+                audit(request.userRef(), request.runtimeProfileHash(), request.toolName(), "duplicate_approval_receipt", Map.of(
+                        "domain", definition.domain(),
+                        "approvalReceiptValidated", false,
+                        "approvalReceiptRef", approvalReceipt.receiptRef(),
+                        "auditRef", auditRef(request.toolName(), "duplicate_approval_receipt")));
+                return blocked(request.toolName(), "duplicate_approval_receipt", "Approval receipt replay was blocked before provider access.");
             }
             approvalReceiptValidated = true;
         }
@@ -153,6 +166,7 @@ public class WeaverToolRegistry {
             return "overbroad_grant";
         }
         if (definition != null && request.scopedToolGrants().stream()
+                .filter(grant -> !definition.name().equals(grant))
                 .anyMatch(grant -> grant.startsWith(definition.domain() + ".") || grant.endsWith(".*"))) {
             return "overbroad_grant";
         }
@@ -171,7 +185,18 @@ public class WeaverToolRegistry {
         if (normalized.contains("timeout") || normalized.contains("expired")) {
             return "approval_timeout";
         }
+        if (normalized.contains("revoked")) {
+            return "approval_revoked";
+        }
         return null;
+    }
+
+    private String expectedPolicyVersion(Map<String, Object> input) {
+        if (input == null) {
+            return "";
+        }
+        Object value = input.get("policyVersion");
+        return value instanceof String policyVersion ? policyVersion.strip() : "";
     }
 
     private boolean runtimeTokenExpired(String runtimeTokenExpiresAt) {
@@ -222,8 +247,15 @@ public class WeaverToolRegistry {
     private Map<String, Object> canonicalRefs(Map<String, Object> input) {
         Map<String, Object> refs = new LinkedHashMap<>();
         copyCanonicalRef(input, refs, "spaceRef", "space");
+        copyCanonicalRef(input, refs, "channelRef", "channel");
+        copyCanonicalRef(input, refs, "threadRef", "thread");
         copyCanonicalRef(input, refs, "decisionRef", "decision");
         copyCanonicalRef(input, refs, "boardTaskRef", "boardTask");
+        copyCanonicalRef(input, refs, "taskRef", "task");
+        copyCanonicalRef(input, refs, "calendarRef", "calendar");
+        copyCanonicalRef(input, refs, "eventRef", "event");
+        copyCanonicalRef(input, refs, "messageRef", "message");
+        copyCanonicalRef(input, refs, "fileRef", "file");
         return Map.copyOf(refs);
     }
 
@@ -231,7 +263,15 @@ public class WeaverToolRegistry {
         return canonicalRefs(input).values().stream()
                 .filter(String.class::isInstance)
                 .map(String.class::cast)
-                .filter(ref -> ref.startsWith("board-task:") || ref.startsWith("event:") || ref.startsWith("message:"))
+                .filter(ref -> ref.startsWith("space:")
+                        || ref.startsWith("channel:")
+                        || ref.startsWith("thread:")
+                        || ref.startsWith("board-task:")
+                        || ref.startsWith("task:")
+                        || ref.startsWith("calendar:")
+                        || ref.startsWith("event:")
+                        || ref.startsWith("message:")
+                        || ref.startsWith("file:"))
                 .sorted()
                 .toList();
     }
@@ -244,7 +284,16 @@ public class WeaverToolRegistry {
     }
 
     private boolean canonicalRef(String ref) {
-        return ref.startsWith("space:") || ref.startsWith("decision:") || ref.startsWith("board-task:");
+        return ref.startsWith("space:")
+                || ref.startsWith("channel:")
+                || ref.startsWith("thread:")
+                || ref.startsWith("decision:")
+                || ref.startsWith("board-task:")
+                || ref.startsWith("task:")
+                || ref.startsWith("calendar:")
+                || ref.startsWith("event:")
+                || ref.startsWith("message:")
+                || ref.startsWith("file:");
     }
 
     private String auditRef(String toolName, String status) {

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverMcpBridgeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverMcpBridgeServiceTest.java
@@ -8,6 +8,7 @@ import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
 import com.massimotter.weave.backend.weaver.MemberDomainToolDispatcher;
 import com.massimotter.weave.backend.weaver.WeaverToolRegistry;
 import com.massimotter.weave.contract.mcp.MemberMcpToolCatalog;
+import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ApprovalReceipt;
 import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.ApprovalReceiptRef;
 import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.BridgeInvocationRequest;
 import com.massimotter.weave.contract.mcp.WeaveMcpBridgeDtos.RuntimeInvocationContext;
@@ -122,7 +123,44 @@ class WeaverMcpBridgeServiceTest {
         verifyNoInteractions(fixture.dispatcher);
     }
 
+    @Test
+    void verifiableApprovalReceiptWithCanonicalScopeAuthorizesWriteToolDispatch() {
+        Fixture fixture = fixture();
+        var profile = fixture.runtimeService.profileFor(jwt());
+        when(fixture.dispatcher.dispatch("calendar.create_event", Map.of("title", "Planning", "calendarRef", "calendar:team", "policyVersion", "policy:support-safe-bridge-v1")))
+                .thenReturn(Map.of(
+                        "status", "ok",
+                        "supportSafe", true,
+                        "event", Map.of("id", "calendar-event:created"),
+                        "auditRef", "audit://calendar/create/support-safe",
+                        "rawProviderPayload", "redacted"));
+
+        var response = fixture.bridge.invokeMcpTool(jwt(), MemberMcpToolCatalog.SERVER_NAMESPACE, "calendar.create_event",
+                request(
+                        "calendar.create_event",
+                        profile.runtimeProfileHash(),
+                        profile.userRef(),
+                        new ApprovalReceiptRef("approval://calendar-create/1"),
+                        Map.of("title", "Planning", "calendarRef", "calendar:team", "policyVersion", "policy:support-safe-bridge-v1"),
+                        new ApprovalReceipt(
+                                "approval://calendar-create/1",
+                                profile.userRef(),
+                                "calendar.create_event",
+                                List.of("calendar:team"),
+                                "policy:support-safe-bridge-v1",
+                                Instant.now().plusSeconds(300).toString(),
+                                "audit://weaver-approval/calendar-create/1")));
+
+        assertThat(response.status()).isEqualTo(ToolInvocationStatus.SUCCESS);
+        assertThat(response.structuredContent().get("structuredContent").toString()).contains("calendar-event:created");
+        verify(fixture.dispatcher).dispatch("calendar.create_event", Map.of("title", "Planning", "calendarRef", "calendar:team", "policyVersion", "policy:support-safe-bridge-v1"));
+    }
+
     private BridgeInvocationRequest request(String toolName, String profileHash, String userRef, ApprovalReceiptRef approvalReceiptRef, Map<String, Object> arguments) {
+        return request(toolName, profileHash, userRef, approvalReceiptRef, arguments, null);
+    }
+
+    private BridgeInvocationRequest request(String toolName, String profileHash, String userRef, ApprovalReceiptRef approvalReceiptRef, Map<String, Object> arguments, ApprovalReceipt approvalReceipt) {
         return new BridgeInvocationRequest(toolName, arguments, new RuntimeInvocationContext(
                 new WeaveMcpRef("org:workspace"),
                 new WeaveMcpRef(userRef),
@@ -133,7 +171,8 @@ class WeaverMcpBridgeServiceTest {
                 approvalReceiptRef,
                 null,
                 List.of(),
-                List.of()));
+                List.of()),
+                approvalReceipt);
     }
 
     private Fixture fixture() {

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverMcpBridgeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverMcpBridgeServiceTest.java
@@ -109,23 +109,17 @@ class WeaverMcpBridgeServiceTest {
     }
 
     @Test
-    void approvedWriteToolDispatchesThroughMemberDomainFacadeBoundary() {
+    void approvalRefAloneDoesNotAuthorizeWriteToolDispatch() {
         Fixture fixture = fixture();
         var profile = fixture.runtimeService.profileFor(jwt());
-        when(fixture.dispatcher.dispatch("calendar.create_event", Map.of("title", "Planning")))
-                .thenReturn(Map.of(
-                        "status", "ok",
-                        "supportSafe", true,
-                        "event", Map.of("id", "calendar-event:created"),
-                        "auditRef", "audit://calendar/create/support-safe",
-                        "rawProviderPayload", "redacted"));
 
         var response = fixture.bridge.invokeMcpTool(jwt(), MemberMcpToolCatalog.SERVER_NAMESPACE, "calendar.create_event",
-                request("calendar.create_event", profile.runtimeProfileHash(), profile.userRef(), new ApprovalReceiptRef("approval://calendar-create/1"), Map.of("title", "Planning")));
+                request("calendar.create_event", profile.runtimeProfileHash(), profile.userRef(), new ApprovalReceiptRef("approval://calendar-create/1"), Map.of("title", "Planning", "calendarRef", "calendar:team")));
 
-        assertThat(response.status()).isEqualTo(ToolInvocationStatus.SUCCESS);
-        assertThat(response.structuredContent().get("structuredContent").toString()).contains("calendar-event:created");
-        verify(fixture.dispatcher).dispatch("calendar.create_event", Map.of("title", "Planning"));
+        assertThat(response.status()).isEqualTo(ToolInvocationStatus.DENIED);
+        assertThat(response.structuredContent()).containsEntry("approvalRequired", true);
+        assertThat(response.structuredContent().toString()).contains("approval_required");
+        verifyNoInteractions(fixture.dispatcher);
     }
 
     private BridgeInvocationRequest request(String toolName, String profileHash, String userRef, ApprovalReceiptRef approvalReceiptRef, Map<String, Object> arguments) {

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -5,7 +5,11 @@ import com.massimotter.weave.backend.audit.InMemoryAuditEventPublisher;
 import com.massimotter.weave.backend.config.WeaveSecurityProperties;
 import com.massimotter.weave.backend.config.WeaverRuntimeProperties;
 import com.massimotter.weave.backend.config.WorkspaceCapabilityProperties;
+import com.massimotter.weave.backend.model.WeaverRuntimeProfileResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityReadiness;
+import com.massimotter.weave.backend.weaver.WeaverApprovalReceipt;
+import com.massimotter.weave.backend.weaver.WeaverToolInvocationRequest;
+import com.massimotter.weave.backend.weaver.WeaverToolRegistry;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -158,6 +162,170 @@ class WeaverRuntimeServiceTest {
         assertThat(serverProjection.toString())
                 .contains("weave-domain-tools", "routingPlaneSeparated=true", "channels.weave-chat")
                 .doesNotContain("Bearer ", "openclaw.json");
+    }
+
+    @Test
+    void provesWeaverChatConsentAndMcpApprovalReceiptIntegrationFailsClosed() {
+        InMemoryAuditEventPublisher audit = new InMemoryAuditEventPublisher();
+        WeaverRuntimeService service = service(true, runtimePropertiesWithChatSendTool(), audit);
+        WeaverToolRegistry registry = new WeaverToolRegistry(audit);
+        Jwt member = jwt("member@example.invalid", List.of("member"), List.of("weave-weaver-runtime", "chat.send"));
+        var profile = service.profileFor(member);
+
+        assertThat(profile.channelProjection())
+                .containsEntry("channelId", "channels.weave-chat")
+                .containsEntry("mcpServersProjectedSeparately", true)
+                .doesNotContainKeys("chat.send_message", "inboundMcpTransport");
+        assertThat(profile.mcpProjection().toString())
+                .contains("chat.send_message", "routingPlaneSeparated=true")
+                .doesNotContain("Bearer ", "openclaw.json", "rawProviderPayload");
+
+        Map<String, String> channelConsentStatusEvidence = Map.of(
+                "messageId", "message:member-request-001",
+                "turnId", "turn:weaver-852-001",
+                "prompt", "Send this message to channel:weave-chat-general in space:control-room?",
+                "approvalRequired", "Approval required before Weaver may send this message.",
+                "approved", "Approved. Weaver may continue with the governed tool.",
+                "denied", "Denied. No message was sent.",
+                "expired", "Expired. Please review the request again.",
+                "unavailable", "Tool temporarily unavailable. No message was sent.");
+        assertThat(channelConsentStatusEvidence.values())
+                .allSatisfy(value -> assertThat(value)
+                        .isNotBlank()
+                        .doesNotContain("#00ff00", "green-only", "red-only", "Bearer ", "openclaw.json"));
+        assertThat(channelConsentStatusEvidence)
+                .containsEntry("messageId", "message:member-request-001")
+                .containsEntry("turnId", "turn:weaver-852-001");
+
+        var denied = registry.invoke(chatSendRequest(profile, Map.of(
+                        "spaceRef", "space:control-room",
+                        "channelRef", "channel:weave-chat-general"),
+                null));
+
+        assertThat(denied.status()).isEqualTo("approval_required");
+        assertThat(denied.approvalRequired()).isTrue();
+        assertThat(denied.redactedResult())
+                .containsEntry("approvalReceiptValidated", false)
+                .containsEntry("auditRef", "audit://weaver-tool/chat.send_message/approval_required");
+
+        WeaverApprovalReceipt explicitlyDeniedReceipt = new WeaverApprovalReceipt(
+                "approval:chat-send:denied",
+                profile.userRef(),
+                "chat.send_message",
+                List.of("space:control-room", "channel:weave-chat-general"),
+                "policy:v32",
+                Instant.now().plusSeconds(300).toString(),
+                "audit://weaver-approval/denied");
+        var explicitlyDenied = registry.invoke(chatSendRequest(profile, Map.of(
+                        "spaceRef", "space:control-room",
+                        "channelRef", "channel:weave-chat-general",
+                        "policyVersion", "policy:v32"),
+                explicitlyDeniedReceipt));
+        assertThat(explicitlyDenied.status()).isEqualTo("approval_denied");
+
+        WeaverApprovalReceipt revokedReceipt = new WeaverApprovalReceipt(
+                "approval:chat-send:revoked",
+                profile.userRef(),
+                "chat.send_message",
+                List.of("space:control-room", "channel:weave-chat-general"),
+                "policy:v32",
+                Instant.now().plusSeconds(300).toString(),
+                "audit://weaver-approval/revoked");
+        var revoked = registry.invoke(chatSendRequest(profile, Map.of(
+                        "spaceRef", "space:control-room",
+                        "channelRef", "channel:weave-chat-general",
+                        "policyVersion", "policy:v32"),
+                revokedReceipt));
+        assertThat(revoked.status()).isEqualTo("approval_revoked");
+
+        WeaverApprovalReceipt expiredReceipt = new WeaverApprovalReceipt(
+                "approval:chat-send:expired",
+                profile.userRef(),
+                "chat.send_message",
+                List.of("space:control-room"),
+                "policy:v32",
+                Instant.now().minusSeconds(60).toString(),
+                "audit://weaver-approval/expired");
+        var expired = registry.invoke(chatSendRequest(profile, Map.of("spaceRef", "space:control-room"), expiredReceipt));
+        assertThat(expired.status()).isEqualTo("approval_timeout");
+        assertThat(expired.redactedResult()).containsEntry("auditRef", "audit://weaver-tool/chat.send_message/approval_timeout");
+
+        WeaverApprovalReceipt policyMismatchReceipt = new WeaverApprovalReceipt(
+                "approval:chat-send:policy-mismatch",
+                profile.userRef(),
+                "chat.send_message",
+                List.of("space:control-room", "channel:weave-chat-general"),
+                "policy:v31",
+                Instant.now().plusSeconds(300).toString(),
+                "audit://weaver-approval/policy-mismatch");
+        var policyMismatch = registry.invoke(chatSendRequest(profile, Map.of(
+                        "spaceRef", "space:control-room",
+                        "channelRef", "channel:weave-chat-general",
+                        "policyVersion", "policy:v32"),
+                policyMismatchReceipt));
+        assertThat(policyMismatch.status()).isEqualTo("approval_receipt_invalid");
+
+        WeaverApprovalReceipt validReceipt = new WeaverApprovalReceipt(
+                "approval:chat-send:32:001",
+                profile.userRef(),
+                "chat.send_message",
+                List.of("space:control-room", "channel:weave-chat-general"),
+                "policy:v32",
+                Instant.now().plusSeconds(300).toString(),
+                "audit://weaver-approval/chat-send/001");
+        WeaverToolInvocationRequest approvedRequest = chatSendRequest(profile, Map.of(
+                        "spaceRef", "space:control-room",
+                        "channelRef", "channel:weave-chat-general",
+                        "policyVersion", "policy:v32"),
+                validReceipt);
+        var approved = registry.invoke(approvedRequest);
+        var duplicate = registry.invoke(approvedRequest);
+        var mcpDown = service.profileByHash(member, "sha256:mcp-down-or-profile-unavailable");
+
+        assertThat(approved.status()).isEqualTo("ok");
+        assertThat(approved.approvalRequired()).isFalse();
+        assertThat(approved.redactedResult())
+                .containsEntry("approvalReceiptAuditRef", "audit://weaver-approval/chat-send/001")
+                .containsEntry("rawProviderPayload", "redacted")
+                .containsEntry("auditRef", "audit://weaver-tool/chat.send_message/invoked");
+        assertThat(duplicate.status()).isEqualTo("duplicate_approval_receipt");
+        assertThat(duplicate.redactedResult()).containsEntry("auditRef", "audit://weaver-tool/chat.send_message/duplicate_approval_receipt");
+        assertThat(mcpDown.enabled()).isFalse();
+        assertThat(mcpDown.posture()).isEqualTo("runtime-profile-hash-not-issued");
+
+        assertThat(audit.events())
+                .filteredOn(event -> event.action() == AuditAction.WEAVER_TOOL_INVOCATION_RECORDED)
+                .extracting(event -> event.payload().get("decision"))
+                .contains(
+                        "approval_required",
+                        "approval_denied",
+                        "approval_revoked",
+                        "approval_timeout",
+                        "approval_receipt_invalid",
+                        "invoked",
+                        "duplicate_approval_receipt");
+        assertThat(audit.events().toString())
+                .doesNotContain("member@example.invalid", "Bearer ", "refresh_token", "openclaw.json", "raw-provider", "private prompt");
+    }
+
+    private WeaverToolInvocationRequest chatSendRequest(
+            WeaverRuntimeProfileResponse profile,
+            Map<String, Object> input,
+            WeaverApprovalReceipt approvalReceipt) {
+        return new WeaverToolInvocationRequest(
+                "chat.send_message",
+                profile.userRef(),
+                profile.runtimeProfileHash(),
+                profile.userRef(),
+                profile.signature(),
+                profile.revoked(),
+                String.valueOf(profile.supportSafeProfileReceipt().getOrDefault("runtimeTokenExpiresAt", "")),
+                true,
+                profile.allowedCapabilities(),
+                profile.toolAllowlist(),
+                input,
+                approvalReceipt == null ? null : approvalReceipt.receiptRef(),
+                approvalReceipt);
     }
 
     @Test
@@ -386,7 +554,7 @@ class WeaverRuntimeServiceTest {
                 false);
     }
 
-    private WeaverRuntimeProperties runtimePropertiesWithWriteTool() {
+    private WeaverRuntimeProperties runtimePropertiesWithChatSendTool() {
         return new WeaverRuntimeProperties(
                 true,
                 null,
@@ -395,9 +563,9 @@ class WeaverRuntimeServiceTest {
                 null,
                 null,
                 List.of("weave-weaver-runtime"),
-                List.of("files.read", "calendar.manage_events", "weaver.exec_disabled"),
+                List.of("files.read", "chat.send", "weaver.exec_disabled"),
                 List.of("weave-files-readonly"),
-                List.of("files.read", "calendar.create_event"),
+                List.of("files.read", "chat.send_message"),
                 false,
                 false,
                 true,

--- a/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/WeaverRuntimeServiceTest.java
@@ -188,6 +188,8 @@ class WeaverRuntimeServiceTest {
                 "approved", "Approved. Weaver may continue with the governed tool.",
                 "denied", "Denied. No message was sent.",
                 "expired", "Expired. Please review the request again.",
+                "revoked", "Revoked. Please request approval again before sending.",
+                "alreadyUsed", "Already used. This approval cannot be replayed.",
                 "unavailable", "Tool temporarily unavailable. No message was sent.");
         assertThat(channelConsentStatusEvidence.values())
                 .allSatisfy(value -> assertThat(value)
@@ -199,7 +201,7 @@ class WeaverRuntimeServiceTest {
 
         var denied = registry.invoke(chatSendRequest(profile, Map.of(
                         "spaceRef", "space:control-room",
-                        "channelRef", "channel:weave-chat-general"),
+                        "threadRef", "thread:weave-chat-general"),
                 null));
 
         assertThat(denied.status()).isEqualTo("approval_required");
@@ -212,13 +214,13 @@ class WeaverRuntimeServiceTest {
                 "approval:chat-send:denied",
                 profile.userRef(),
                 "chat.send_message",
-                List.of("space:control-room", "channel:weave-chat-general"),
+                List.of("space:control-room", "thread:weave-chat-general"),
                 "policy:v32",
                 Instant.now().plusSeconds(300).toString(),
                 "audit://weaver-approval/denied");
         var explicitlyDenied = registry.invoke(chatSendRequest(profile, Map.of(
                         "spaceRef", "space:control-room",
-                        "channelRef", "channel:weave-chat-general",
+                        "threadRef", "thread:weave-chat-general",
                         "policyVersion", "policy:v32"),
                 explicitlyDeniedReceipt));
         assertThat(explicitlyDenied.status()).isEqualTo("approval_denied");
@@ -227,13 +229,13 @@ class WeaverRuntimeServiceTest {
                 "approval:chat-send:revoked",
                 profile.userRef(),
                 "chat.send_message",
-                List.of("space:control-room", "channel:weave-chat-general"),
+                List.of("space:control-room", "thread:weave-chat-general"),
                 "policy:v32",
                 Instant.now().plusSeconds(300).toString(),
                 "audit://weaver-approval/revoked");
         var revoked = registry.invoke(chatSendRequest(profile, Map.of(
                         "spaceRef", "space:control-room",
-                        "channelRef", "channel:weave-chat-general",
+                        "threadRef", "thread:weave-chat-general",
                         "policyVersion", "policy:v32"),
                 revokedReceipt));
         assertThat(revoked.status()).isEqualTo("approval_revoked");
@@ -254,13 +256,13 @@ class WeaverRuntimeServiceTest {
                 "approval:chat-send:policy-mismatch",
                 profile.userRef(),
                 "chat.send_message",
-                List.of("space:control-room", "channel:weave-chat-general"),
+                List.of("space:control-room", "thread:weave-chat-general"),
                 "policy:v31",
                 Instant.now().plusSeconds(300).toString(),
                 "audit://weaver-approval/policy-mismatch");
         var policyMismatch = registry.invoke(chatSendRequest(profile, Map.of(
                         "spaceRef", "space:control-room",
-                        "channelRef", "channel:weave-chat-general",
+                        "threadRef", "thread:weave-chat-general",
                         "policyVersion", "policy:v32"),
                 policyMismatchReceipt));
         assertThat(policyMismatch.status()).isEqualTo("approval_receipt_invalid");
@@ -269,13 +271,13 @@ class WeaverRuntimeServiceTest {
                 "approval:chat-send:32:001",
                 profile.userRef(),
                 "chat.send_message",
-                List.of("space:control-room", "channel:weave-chat-general"),
+                List.of("space:control-room", "thread:weave-chat-general"),
                 "policy:v32",
                 Instant.now().plusSeconds(300).toString(),
                 "audit://weaver-approval/chat-send/001");
         WeaverToolInvocationRequest approvedRequest = chatSendRequest(profile, Map.of(
                         "spaceRef", "space:control-room",
-                        "channelRef", "channel:weave-chat-general",
+                        "threadRef", "thread:weave-chat-general",
                         "policyVersion", "policy:v32"),
                 validReceipt);
         var approved = registry.invoke(approvedRequest);

--- a/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/weaver/WeaverToolRegistryTest.java
@@ -125,7 +125,7 @@ class WeaverToolRegistryTest {
                         "approval:abc123",
                         "user:abc123",
                         "boards.comment",
-                        List.of("board-task:WEAVE-601"),
+                        List.of("space:control-room", "board-task:WEAVE-601"),
                         "policy:test",
                         future(),
                         "audit://weaver-approval/test")));
@@ -178,7 +178,7 @@ class WeaverToolRegistryTest {
                         future(),
                         "audit://weaver-approval/test")));
 
-        assertThat(result.status()).isEqualTo("approval_scope_mismatch");
+        assertThat(result.status()).isEqualTo("approval_receipt_invalid");
         assertThat(result.approvalRequired()).isFalse();
         assertThat(result.redactedResult()).containsEntry("approvalReceiptValidated", false);
         assertThat(result.redactedResult().get("canonicalRefs").toString())
@@ -186,7 +186,7 @@ class WeaverToolRegistryTest {
                 .doesNotContain("WEAVE-601");
         assertThat(audit.events()).hasSize(1);
         assertThat(audit.events().get(0).payload())
-                .containsEntry("status", "approval_scope_mismatch")
+                .containsEntry("status", "approval_receipt_invalid")
                 .containsEntry("approvalReceiptValidated", false)
                 .containsEntry("serverApprovalDecision", false);
         assertThat(audit.events().get(0).payload().toString()).doesNotContain("Looks good", "provider payload", "secret");

--- a/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/WeaveMcpBridgeDtos.java
+++ b/weave-contract/src/main/java/com/massimotter/weave/contract/mcp/WeaveMcpBridgeDtos.java
@@ -21,6 +21,25 @@ public final class WeaveMcpBridgeDtos {
         }
     }
 
+    public record ApprovalReceipt(
+            String receiptRef,
+            String actorRef,
+            String action,
+            List<String> scopeRefs,
+            String policyVersion,
+            String expiresAt,
+            String auditRef) {
+        public ApprovalReceipt {
+            receiptRef = WeaveMcpTypes.text(receiptRef, "receiptRef");
+            actorRef = WeaveMcpTypes.text(actorRef, "actorRef");
+            action = WeaveMcpTypes.text(action, "action");
+            scopeRefs = WeaveMcpTypes.copyStrings(scopeRefs);
+            policyVersion = WeaveMcpTypes.text(policyVersion, "policyVersion");
+            expiresAt = WeaveMcpTypes.text(expiresAt, "expiresAt");
+            auditRef = WeaveMcpTypes.text(auditRef, "auditRef");
+        }
+    }
+
     public record RuntimeInvocationContext(
             WeaveMcpRef orgRef,
             WeaveMcpRef userRef,
@@ -105,11 +124,15 @@ public final class WeaveMcpBridgeDtos {
         }
     }
 
-    public record BridgeInvocationRequest(String toolName, Map<String, Object> arguments, RuntimeInvocationContext runtime) {
+    public record BridgeInvocationRequest(String toolName, Map<String, Object> arguments, RuntimeInvocationContext runtime, ApprovalReceipt approvalReceipt) {
         public BridgeInvocationRequest {
             toolName = WeaveMcpTypes.text(toolName, "toolName");
             arguments = WeaveMcpTypes.copyMap(arguments);
             if (runtime == null) throw new IllegalArgumentException("runtime must not be null");
+        }
+
+        public BridgeInvocationRequest(String toolName, Map<String, Object> arguments, RuntimeInvocationContext runtime) {
+            this(toolName, arguments, runtime, null);
         }
     }
 


### PR DESCRIPTION
## Summary

- Add a server-verifiable MCP bridge approval receipt payload instead of treating an approval ref as authorization.
- Prove Weaver Chat channel consent states stay separate from MCP/tool enforcement, including deny, approved, expired, revoked, duplicate, and unavailable paths.
- Add bridge-level regressions that an approval ref alone fails closed and a bound receipt with canonical scope authorizes dispatch.

## Scope and user impact

- Scope: server contract DTO, MCP bridge approval hydration, Weaver runtime/tool registry tests.
- User impact: governed Weaver write tools fail closed unless approval evidence is bound to actor/action/scope/policy/expiry/audit data; no production/runtime cutover implied.

## Spec / acceptance link

- Issue: Closes #852
- Repo spec / Spec Kit package: `specs/weave-specs.lock.json`; governed Weaver runtime / MCP domain tool policy acceptance for Sprint 32.
- Plan/tasks/traceability: `docs/sprint-32-issue-852-delegation-plan.md`; `docs/evidence/weaver-chat-mcp-separation-proof.md`
- Mapped Gherkin feature/scenario when product behavior changed: existing product E2E layer; this PR adds harnessed server/contract evidence, not live provider E2E.
- Evidence mode / reality level: `offline-spec` / `contract_only`
- Product-core questions intentionally left unresolved: none

Quality Reset rule: this PR does not claim live-runtime, release-ready, customer-ready, or manual accessibility signoff evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [x] changes evidence only

## Release note

- Release note: none — contract/test evidence for Sprint 32 issue #852 only; no user-facing release note.

## Release notes label

- [x] `release-notes-skip`

## Screenshots or docs impact

- Evidence docs already describe harnessed separation proof and explicitly avoid live/customer-ready claims.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: strengthens fail-closed approval validation by requiring server-verifiable receipt fields rather than synthetic approval from a ref.
- Accessibility/localization impact: harness asserts plain-language status text for required, approved, denied, expired, revoked, duplicate/already-used, and unavailable states; no localization file changes.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: `WeaveMcpBridgeDtos.BridgeInvocationRequest` adds optional `ApprovalReceipt` while preserving the existing constructor for callers.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: server/MCP security fallback reviewer lanes documented in issue evidence.
- If Copilot is unavailable/insufficient, matching reviewer used: channel-plane, evidence-plane, architecture/security, accessibility/evidence, and final acceptance red-team agent reviews.

## Checks run

- [ ] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant — `contract_only` evidence

Additional targeted gate run:

- [x] `cd server && ./gradlew :weave-contract:test :test --tests 'com.massimotter.weave.backend.service.WeaverMcpBridgeServiceTest' --tests 'com.massimotter.weave.backend.service.WeaverRuntimeServiceTest' --tests 'com.massimotter.weave.backend.weaver.*' --console=plain`

## Notes for reviewers

- Review claim hygiene first: this is harnessed `contract_only` proof, not live OpenClaw/provider execution.
- Confirm `approvalReceiptRef` is correlation-only and `approvalReceipt` carries actor/action/scope/policy/expiry/audit bindings.
- Confirm RuntimeProfile remains correlation/profile lifecycle evidence, not the sole security boundary for governed actions.


Closes #852.
