### PR TITLE
feat(mcp): align Python MCP tools with OpenAPI route map

### DIFF
--- a/infra/weave-mcp/README.md
+++ b/infra/weave-mcp/README.md
@@ -31,7 +31,7 @@ Discovery requires runtime context headers. Policy comes from the generated Runt
 - `X-Weave-Runtime-Profile` — support-safe profile hash
 - `X-Weave-Runtime-Profile-Projection` — base64url JSON containing `runtimeProfileHash`, `enabled`, `revoked`, `serverKey`, `transport`, `credentialRef`, `capabilityGrants`, `allowedTools`, `auditRef`, and `projectionSignature` references only
 
-The Sprint 16/Sprint 32 proof tools are:
+The Sprint 16/Sprint 32 proof tools are exposed through an explicit Python route map validated against the server-owned OpenAPI artifact (`contracts/openapi/weave-openapi.json`). Route exposure is deny-by-default: adding a backend OpenAPI route does not create an MCP tool unless the reviewed `OPENAPI_ROUTE_MAP` lists the tool, method, path, and expected `operationId`. The current proof tools are:
 
 - `admin.get_readiness` (read-only)
 - `weaver.get_runtime_profile_projection` (read-only)

--- a/infra/weave-mcp/src/weave_mcp/openapi_routes.py
+++ b/infra/weave-mcp/src/weave_mcp/openapi_routes.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from .schemas.common import McpDenied
+
+
+@dataclass(frozen=True)
+class OpenApiRoute:
+    """Explicit MCP allowlist entry backed by a stable server OpenAPI operationId."""
+
+    tool_name: str
+    operation_id: str
+    method: str
+    path: str
+
+
+# Deny-by-default: only these server-owned OpenAPI operations are exposed to the
+# Python MCP adapter. Adding an OpenAPI route is intentionally not enough to make
+# it discoverable as an MCP tool; the route must be reviewed and listed here.
+OPENAPI_ROUTE_MAP: dict[str, OpenApiRoute] = {
+    "admin.get_readiness": OpenApiRoute(
+        tool_name="admin.get_readiness",
+        operation_id="getAdminControlPlane",
+        method="GET",
+        path="/api/admin/control-plane",
+    ),
+    "weaver.get_runtime_profile_projection": OpenApiRoute(
+        tool_name="weaver.get_runtime_profile_projection",
+        operation_id="weaverRuntimeProfile",
+        method="GET",
+        path="/api/workspace/weaver/runtime-profile",
+    ),
+    "calendar.search_events": OpenApiRoute(
+        tool_name="calendar.search_events",
+        operation_id="list",
+        method="GET",
+        path="/api/calendar/events",
+    ),
+    "calendar.create_event": OpenApiRoute(
+        tool_name="calendar.create_event",
+        operation_id="create",
+        method="POST",
+        path="/api/calendar/events",
+    ),
+    "boards.comment": OpenApiRoute(
+        tool_name="boards.comment",
+        operation_id="weaverMcpToolInvoke",
+        method="POST",
+        path="/api/workspace/weaver/mcp/servers/{serverKey}/tools/{toolName}:invoke",
+    ),
+}
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_OPENAPI_CONTRACT = _PROJECT_ROOT / "contracts" / "openapi" / "weave-openapi.json"
+
+
+def load_openapi_contract(path: Path = DEFAULT_OPENAPI_CONTRACT) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        contract = json.load(handle)
+    if not isinstance(contract, dict):
+        raise ValueError("OpenAPI contract must be a JSON object")
+    return contract
+
+
+def _openapi_operation(contract: Mapping[str, Any], route: OpenApiRoute) -> Mapping[str, Any]:
+    paths = contract.get("paths")
+    if not isinstance(paths, Mapping):
+        raise ValueError("OpenAPI contract is missing paths")
+    path_item = paths.get(route.path)
+    if not isinstance(path_item, Mapping):
+        raise McpDenied(f"openapi-route-missing-for-{route.tool_name}")
+    operation = path_item.get(route.method.lower())
+    if not isinstance(operation, Mapping):
+        raise McpDenied(f"openapi-method-missing-for-{route.tool_name}")
+    return operation
+
+
+def assert_route_map_matches_openapi(contract: Mapping[str, Any] | None = None) -> None:
+    """Fail closed when an allowlisted MCP route drifts from server OpenAPI."""
+
+    openapi = contract if contract is not None else load_openapi_contract()
+    seen_tools: set[str] = set()
+    for tool_name, route in OPENAPI_ROUTE_MAP.items():
+        if tool_name != route.tool_name:
+            raise McpDenied(f"openapi-route-tool-mismatch-for-{tool_name}")
+        if tool_name in seen_tools:
+            raise McpDenied(f"openapi-route-duplicate-tool-{tool_name}")
+        seen_tools.add(tool_name)
+        operation = _openapi_operation(openapi, route)
+        if operation.get("operationId") != route.operation_id:
+            raise McpDenied(f"openapi-operationid-drift-for-{tool_name}")
+
+
+def require_openapi_route(tool_name: str) -> OpenApiRoute:
+    route = OPENAPI_ROUTE_MAP.get(tool_name)
+    if route is None:
+        raise McpDenied("unknown-tool")
+    return route

--- a/infra/weave-mcp/src/weave_mcp/tools/registry.py
+++ b/infra/weave-mcp/src/weave_mcp/tools/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Callable
 
 from ..client import WeaveBackendClient
+from ..openapi_routes import assert_route_map_matches_openapi, require_openapi_route
 from ..schemas.common import (
     McpDenied,
     RuntimeContext,
@@ -15,6 +16,8 @@ from ..schemas.common import (
 from ..redaction import assert_support_safe
 
 Handler = Callable[[RuntimeContext, dict[str, Any], WeaveBackendClient], dict[str, Any]]
+
+assert_route_map_matches_openapi()
 
 TOOL_DEFINITIONS: dict[str, ToolDefinition] = {
     "admin.get_readiness": ToolDefinition(
@@ -106,13 +109,23 @@ HANDLERS: dict[str, Handler] = {
 def discover(ctx: RuntimeContext | None) -> list[dict[str, Any]]:
     grants = ctx.capability_grants if ctx is not None else frozenset()
     allowed_tools = ctx.allowed_tools if ctx is not None else frozenset()
-    return [
-        definition.discovery(definition.capability in grants and definition.name in allowed_tools)
-        for definition in TOOL_DEFINITIONS.values()
-    ]
+    discovered: list[dict[str, Any]] = []
+    for definition in TOOL_DEFINITIONS.values():
+        route = require_openapi_route(definition.name)
+        tool = definition.discovery(definition.capability in grants and definition.name in allowed_tools)
+        tool["meta"] = {
+            **tool["meta"],
+            "openApiOperationId": route.operation_id,
+            "openApiMethod": route.method,
+            "openApiPath": route.path,
+            "exposure": "explicit-openapi-route-map",
+        }
+        discovered.append(tool)
+    return discovered
 
 
 def invoke(name: str, ctx: RuntimeContext, payload: dict[str, Any], client: WeaveBackendClient) -> dict[str, Any]:
+    require_openapi_route(name)
     definition = TOOL_DEFINITIONS.get(name)
     if definition is None:
         raise McpDenied("unknown-tool")

--- a/infra/weave-mcp/tests/test_weave_mcp.py
+++ b/infra/weave-mcp/tests/test_weave_mcp.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 from weave_mcp.app import WeaveMcpGateway, serve
 from weave_mcp.config import WeaveMcpConfig
+from weave_mcp.openapi_routes import OPENAPI_ROUTE_MAP, assert_route_map_matches_openapi, load_openapi_contract, require_openapi_route
 from weave_mcp.schemas.common import McpDenied
 
 PROJECTION_HMAC_SECRET = "dev-runtime-profile-projection-secret"
@@ -97,12 +98,30 @@ class WeaveMcpGatewayTest(unittest.TestCase):
         self.assertTrue(tools["calendar.create_event"]["meta"]["approval"] == "required")
         self.assertTrue(tools["boards.comment"]["meta"]["approval"] == "required")
         self.assertTrue(all(tool["meta"]["transport"] == "streamable-http" for tool in tools.values()))
+        self.assertTrue(all(tool["meta"]["exposure"] == "explicit-openapi-route-map" for tool in tools.values()))
+        self.assertEqual(tools["calendar.search_events"]["meta"]["openApiOperationId"], "list")
+        self.assertEqual(tools["calendar.search_events"]["meta"]["openApiPath"], "/api/calendar/events")
         discovery_text = json.dumps(body, sort_keys=True).lower()
         self.assertNotIn("nextcloud", discovery_text)
         self.assertNotIn("caldav", discovery_text)
         self.assertNotIn("providerref", discovery_text)
         self.assertNotIn("credentialref://", discovery_text)
         self.assertFalse(any(tool["name"].startswith(("nextcloud.", "caldav.")) for tool in tools.values()))
+
+    def test_openapi_route_map_is_explicit_and_fails_closed_on_drift(self) -> None:
+        contract = load_openapi_contract()
+        assert_route_map_matches_openapi(contract)
+        self.assertEqual(set(OPENAPI_ROUTE_MAP), set(RUNTIME_PROFILE_PROJECTION["allowedTools"]))
+
+        drifted = json.loads(json.dumps(contract))
+        drifted["paths"]["/api/calendar/events"]["get"]["operationId"] = "renamedCalendarSearch"
+        with self.assertRaises(McpDenied) as raised:
+            assert_route_map_matches_openapi(drifted)
+        self.assertEqual(raised.exception.reason, "openapi-operationid-drift-for-calendar.search_events")
+
+        with self.assertRaises(McpDenied) as unknown:
+            require_openapi_route("calendar.raw_rest_mirror")
+        self.assertEqual(unknown.exception.reason, "unknown-tool")
 
     def test_discovery_uses_runtime_profile_projection_not_caller_grant_headers(self) -> None:
         profile = {**RUNTIME_PROFILE_PROJECTION, "allowedTools": ["calendar.search_events"], "capabilityGrants": ["weaver.calendar_read"]}


### PR DESCRIPTION
## Summary
- Add an explicit Python MCP `OPENAPI_ROUTE_MAP` backed by the server-owned OpenAPI artifact.
- Fail closed when allowlisted MCP routes drift from expected OpenAPI path/method/operationId, and keep unknown/catch-all tools denied.
- Surface support-safe OpenAPI route metadata in MCP discovery while preserving named handlers, runtime profile authorization, approval checks, and redaction.

## Issue
Closes #870

## Evidence
- `bash infra/weave-workspace/tests/weave-mcp-server-test.sh`
- `./gradlew mcpCi`
- `./gradlew checkOpenApiContractFresh contractAuthorityArchitectureCheck`
- Independent reviewer: PASS; no required fixes.

## Release notes
- release-notes-internal
