### PR TITLE
ci: add persistent test branch dogfood promotion flow

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -43,9 +43,9 @@ jobs:
       - self-hosted
       - macOS
       - ARM64
-      - weave-live
     timeout-minutes: 75
     env:
+      EXPECTED_RUNNER_NAME: weave-live-mac-mini
       WEAVE_BACKEND_IMAGE: ${{ inputs.weave_backend_image || github.event.inputs.weave_backend_image || 'weave-backend:live-stack-ci' }}
       WEAVE_MCP_SERVER_IMAGE: ${{ inputs.weave_mcp_server_image || github.event.inputs.weave_mcp_server_image || 'weave-mcp-server:live-stack-ci' }}
       WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
@@ -84,6 +84,15 @@ jobs:
         shell: bash
 
     steps:
+      - name: Verify dedicated live runner
+        run: |
+          set -euo pipefail
+          echo "runner=${RUNNER_NAME:-unknown}"
+          if [[ "${RUNNER_NAME:-}" != "${EXPECTED_RUNNER_NAME}" ]]; then
+            echo "::error::Live Stack E2E must run only on ${EXPECTED_RUNNER_NAME}; got ${RUNNER_NAME:-unknown}." >&2
+            exit 1
+          fi
+
       - name: Check out weave
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/main-promotion-gate.yml
+++ b/.github/workflows/main-promotion-gate.yml
@@ -1,0 +1,72 @@
+name: Main Promotion Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: "Commit SHA that should be eligible for main promotion"
+        required: true
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  verify-dev-test-promotion:
+    name: Verify dev → test evidence before main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Resolve candidate
+        id: candidate
+        run: |
+          set -euo pipefail
+          candidate="${{ github.event_name == 'workflow_dispatch' && inputs.candidate_sha || github.event.pull_request.head.sha }}"
+          echo "sha=${candidate}" >> "$GITHUB_OUTPUT"
+          echo "Candidate SHA: ${candidate}"
+
+      - name: Verify candidate is contained in dev and test
+        run: |
+          set -euo pipefail
+          candidate="${{ steps.candidate.outputs.sha }}"
+          git fetch origin dev test main --prune
+          for branch in dev test; do
+            if ! git merge-base --is-ancestor "$candidate" "origin/${branch}"; then
+              echo "::error::Candidate ${candidate} is not contained in origin/${branch}. Main promotion requires dev first, then test." >&2
+              exit 1
+            fi
+          done
+          if git merge-base --is-ancestor "$candidate" origin/main; then
+            echo "Candidate is already contained in origin/main."
+          fi
+
+      - name: Verify successful persistent test-stack deploy for candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          candidate="${{ steps.candidate.outputs.sha }}"
+          runs_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/test-stack-deploy.yml/runs?branch=test&head_sha=${candidate}&status=success&per_page=10")"
+          count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("workflow_runs", [])))' <<<"$runs_json")"
+          if [[ "$count" == "0" ]]; then
+            echo "::error::No successful Test Stack Deploy workflow run found for ${candidate} on branch test." >&2
+            echo "Push/merge the candidate to test and wait for the persistent LAN stack deployment to pass before opening/promoting to main." >&2
+            exit 1
+          fi
+          run_url="$(python3 -c 'import json,sys; runs=json.load(sys.stdin).get("workflow_runs", []); print(runs[0].get("html_url", ""))' <<<"$runs_json")"
+          echo "Successful test-stack evidence: ${run_url}"
+
+      - name: Verify root contract authority checks still pass
+        run: ./gradlew --no-daemon --max-workers=1 contractAuthorityArchitectureCheck --console=plain

--- a/.github/workflows/test-stack-deploy.yml
+++ b/.github/workflows/test-stack-deploy.yml
@@ -1,0 +1,242 @@
+name: Test Stack Deploy
+
+on:
+  push:
+    branches:
+      - test
+  workflow_dispatch:
+    inputs:
+      reset_stack:
+        description: "Destroy and recreate local test-stack data before deploy"
+        required: false
+        default: false
+        type: boolean
+      run_flutter_integration:
+        description: "Run Flutter live integration tests after stack readiness"
+        required: false
+        default: false
+        type: boolean
+      weave_backend_image:
+        description: "Backend image; ghcr.io/* is pulled, other refs are built locally from the checked-out commit"
+        required: false
+        default: "weave-backend:test-stack"
+      weave_mcp_server_image:
+        description: "MCP server image; ghcr.io/* is pulled, other refs are built locally from the checked-out commit"
+        required: false
+        default: "weave-mcp-server:test-stack"
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: weave-test-stack-lan
+  cancel-in-progress: false
+
+jobs:
+  deploy-test-stack:
+    name: Deploy Persistent LAN Test Stack
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+    timeout-minutes: 90
+    env:
+      EXPECTED_RUNNER_NAME: weave-live-mac-mini
+      WEAVE_BACKEND_IMAGE: ${{ inputs.weave_backend_image || 'weave-backend:test-stack' }}
+      WEAVE_MCP_SERVER_IMAGE: ${{ inputs.weave_mcp_server_image || 'weave-mcp-server:test-stack' }}
+      WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
+      TF_VAR_test_user_password: ${{ secrets.WEAVE_TEST_PASSWORD }}
+      TF_VAR_db_admin_password: ci-db-admin-password
+      TF_VAR_keycloak_admin_password: ci-keycloak-admin-password
+      TF_VAR_keycloak_db_password: ci-keycloak-db-password
+      TF_VAR_mas_db_password: ci-mas-db-password
+      TF_VAR_synapse_db_password: ci-synapse-db-password
+      TF_VAR_nextcloud_db_password: ci-nextcloud-db-password
+      TF_VAR_nextcloud_admin_password: ci-nextcloud-admin-password
+      TF_VAR_matrix_mas_client_secret: ci-matrix-mas-client-secret
+      TF_VAR_mas_encryption_secret: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+      TF_VAR_mas_matrix_secret: ci-mas-matrix-secret
+      TF_VAR_synapse_registration_shared_secret: ci-synapse-registration-shared-secret
+      TF_VAR_synapse_macaroon_secret_key: ci-synapse-macaroon-secret-key
+      TF_VAR_synapse_form_secret: ci-synapse-form-secret
+      TF_VAR_create_test_user: 'true'
+      TF_VAR_boards_runtime_enabled: 'true'
+      TF_VAR_boards_provider: local-workspace
+      TF_VAR_tenant_domain: weave.test
+      TF_VAR_proxy_http_host_port: '44080'
+      TF_VAR_proxy_host_port: '44443'
+      TF_VAR_keycloak_host_port: '48080'
+      TF_VAR_mas_host_port: '48082'
+      TF_VAR_synapse_host_port: '48008'
+      TF_VAR_nextcloud_host_port: '48083'
+      TF_VAR_backend_host_port: '48084'
+      WEAVE_RUNNER_HYGIENE: 'false'
+      WEAVE_REMOVE_VOLUMES: 'false'
+      WEAVE_CONFIRM_DESTRUCTIVE_RESET: weave
+      WEAVE_INTEGRATION_TEST_DEVICE: macos
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Verify dedicated local runner
+        run: |
+          set -euo pipefail
+          echo "runner=${RUNNER_NAME:-unknown}"
+          if [[ "${RUNNER_NAME:-}" != "${EXPECTED_RUNNER_NAME}" ]]; then
+            echo "::error::Persistent LAN test stack must deploy only on ${EXPECTED_RUNNER_NAME}; got ${RUNNER_NAME:-unknown}." >&2
+            exit 1
+          fi
+
+      - name: Check out weave
+        uses: actions/checkout@v5
+
+      - name: Prepare test-stack evidence directory
+        run: |
+          set -euo pipefail
+          evidence_dir="$RUNNER_TEMP/weave-test-stack-evidence"
+          mkdir -p "$evidence_dir"
+          echo "WEAVE_TEST_STACK_EVIDENCE_DIR=$evidence_dir" >> "$GITHUB_ENV"
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.10.6
+          tofu_wrapper: false
+
+      - name: Ensure local Weave hostnames resolve on the runner
+        run: |
+          set -euo pipefail
+          hosts=(weave.test api.weave.test auth.weave.test files.weave.test matrix.weave.test admin.weave.test)
+          missing=()
+          for host in "${hosts[@]}"; do
+            if ! dscacheutil -q host -a name "$host" | grep -q 'ip_address:'; then
+              missing+=("$host")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            line="127.0.0.1 ${missing[*]}"
+            if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+              printf '%s\n' "$line" | sudo tee -a /etc/hosts >/dev/null
+              sudo dscacheutil -flushcache || true
+            else
+              echo "::error::Runner cannot resolve required Weave hostnames and passwordless sudo is unavailable. Configure weave.test DNS or add: $line" >&2
+              exit 1
+            fi
+          fi
+
+      - name: Build Java runtime artifacts
+        run: ./gradlew --no-daemon --max-workers=1 :server:bootJar :weave-mcp-server:bootJar
+
+      - name: Prepare backend image
+        run: |
+          set -euo pipefail
+          if [[ "${WEAVE_BACKEND_IMAGE}" == ghcr.io/* ]]; then
+            docker pull "${WEAVE_BACKEND_IMAGE}"
+          else
+            docker buildx build --load -t "${WEAVE_BACKEND_IMAGE}" -f server/Dockerfile .
+          fi
+
+      - name: Prepare MCP server image
+        run: |
+          set -euo pipefail
+          if [[ "${WEAVE_MCP_SERVER_IMAGE}" == ghcr.io/* ]]; then
+            docker pull "${WEAVE_MCP_SERVER_IMAGE}"
+          else
+            docker buildx build --load -t "${WEAVE_MCP_SERVER_IMAGE}" -f weave-mcp-server/Dockerfile .
+          fi
+
+      - name: Optional explicit test-stack reset
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.reset_stack }}
+        working-directory: infra/weave-workspace
+        env:
+          WEAVE_RUNNER_HYGIENE: 'true'
+          WEAVE_REMOVE_VOLUMES: 'true'
+          WEAVE_CONFIRM_DESTRUCTIVE_RESET: weave
+        run: bash ./teardown.sh
+
+      - name: Deploy or update persistent LAN test stack
+        working-directory: infra/weave-workspace
+        env:
+          TF_VAR_weave_backend_image: ${{ env.WEAVE_BACKEND_IMAGE }}
+          TF_VAR_weave_mcp_server_image: ${{ env.WEAVE_MCP_SERVER_IMAGE }}
+        run: ./install.sh
+
+      - name: Verify persistent stack readiness
+        working-directory: infra/weave-workspace
+        run: |
+          set -euo pipefail
+          bash ./smoke-test.sh
+          bash ./operator-check.sh
+
+      - name: Trust local Weave CA for optional runner-side app tests
+        run: |
+          set -euo pipefail
+          CA_FILE="$GITHUB_WORKSPACE/infra/weave-workspace/01-infrastructure/.generated/caddy/certs/weave-local-ca.pem"
+          if [[ ! -s "$CA_FILE" ]]; then
+            echo "::error::Weave local CA certificate not found at $CA_FILE" >&2
+            exit 1
+          fi
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo -n security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$CA_FILE" || \
+              echo "::warning::Could not add Weave local CA to the system keychain; optional app tests may fail TLS validation."
+          fi
+
+      - name: Optional Flutter live integration tests
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_flutter_integration }}
+        working-directory: client
+        env:
+          WEAVE_BOOTSTRAP_ENV: ${{ github.workspace }}/infra/weave-workspace/.generated/bootstrap.env
+        run: |
+          set -euo pipefail
+          flutter pub get
+          flutter gen-l10n
+          dart run build_runner build --delete-conflicting-outputs
+          make integration-test
+
+      - name: Write persistent test-stack manifest
+        if: always()
+        run: |
+          set -euo pipefail
+          manifest="$WEAVE_TEST_STACK_EVIDENCE_DIR/test-stack-manifest.json"
+          cat > "$manifest" <<EOF
+          {
+            "schemaVersion": 1,
+            "lane": "persistent-lan-test-stack",
+            "branch": "${GITHUB_REF_NAME}",
+            "commit": "${GITHUB_SHA}",
+            "runId": "${GITHUB_RUN_ID}",
+            "runAttempt": "${GITHUB_RUN_ATTEMPT}",
+            "runUrl": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
+            "runner": "${RUNNER_NAME:-unknown}",
+            "productUrl": "https://weave.test:44443/",
+            "platformConfigUrl": "https://api.weave.test:44443/api/platform/config",
+            "caBootstrapUrl": "http://weave.test:44080/weave-local-ca.pem",
+            "resetRequested": "${{ github.event_name == 'workflow_dispatch' && inputs.reset_stack || false }}"
+          }
+          EOF
+          cat "$manifest" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload persistent test-stack evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weave-test-stack-evidence
+          path: ${{ env.WEAVE_TEST_STACK_EVIDENCE_DIR }}
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/dev-test-main-promotion-flow.md
+++ b/docs/dev-test-main-promotion-flow.md
@@ -1,0 +1,98 @@
+# Dev → Test → Main promotion flow
+
+Status: active delivery policy.
+
+Weave uses three promotion lanes:
+
+- `dev`: normal integration branch. Feature PRs land here after ordinary CI, issue acceptance, and review/evidence gates.
+- `test`: persistent LAN dogfood branch. Advancing this branch deploys or updates the local test stack on the dedicated Mac runner.
+- `main`: stable/release-facing branch. A commit may reach `main` only after it has been integrated through `dev` and successfully deployed through `test`.
+
+## Why this exists
+
+`dev` proves that the repository builds and the offline/product-contract gates pass. It does not prove that Massimo can open Weave on a real device against a live local stack.
+
+`test` is the always-testable LAN stack. It is intended for human dogfood, physical iPhone checks, and integration evidence against the same deployed stack instead of one-off local shells.
+
+`main` must not receive commits that have bypassed either `dev` integration or `test` dogfood deployment.
+
+## Persistent LAN test stack
+
+The test stack is deployed by the `Test Stack Deploy` GitHub Actions workflow:
+
+- workflow file: `.github/workflows/test-stack-deploy.yml`
+- trigger: push to `test` or manual `workflow_dispatch`
+- runner: dedicated self-hosted macOS ARM64 runner `weave-live-mac-mini`
+- public local entrypoint: `https://weave.test:44443/`
+- platform config: `https://api.weave.test:44443/api/platform/config`
+- local CA bootstrap: `http://weave.test:44080/weave-local-ca.pem`
+
+The workflow uses the repo infrastructure scripts as implementation detail:
+
+- `infra/weave-workspace/install.sh`
+- `infra/weave-workspace/smoke-test.sh`
+- `infra/weave-workspace/operator-check.sh`
+
+Humans should not need to run those directly for normal test-stack use. The visible entrypoint is the `test` branch deployment result and the iPhone app pointed at the dogfood stack.
+
+## Update vs reset
+
+The persistent test stack defaults to update mode:
+
+- rebuild or pull the backend/MCP runtime images;
+- run `install.sh` idempotently;
+- keep stack data unless a reset is explicitly requested;
+- run smoke/operator checks;
+- upload a support-safe `weave-test-stack-evidence` artifact.
+
+Destructive reset is manual only through the workflow input `reset_stack=true`. It removes local test-stack data and must not be used as the normal promotion path.
+
+## Main promotion gate
+
+The `Main Promotion Gate` workflow enforces the branch order:
+
+1. the candidate commit is contained in `origin/dev`;
+2. the same candidate commit is contained in `origin/test`;
+3. a successful `Test Stack Deploy` workflow run exists for that commit on branch `test`;
+4. the root contract-authority architecture check still passes.
+
+If any of these checks fail, the candidate is not eligible for `main`.
+
+Bootstrap note: GitHub only treats new workflow files as branch-protection candidates after they exist on the protected/default branch. The first rollout of this policy therefore requires one explicitly reviewed bootstrap promotion that installs the workflows on `main`; after that, normal `main` PRs are expected to be guarded by this workflow and repository branch protection.
+
+## Provider model
+
+The persistent `test` stack is a disposable Weave-owned dogfood environment. It should not attach to Massimo's `~/server` services by default.
+
+Default local providers:
+
+- Identity/Auth: Keycloak
+- Chat: Matrix/Synapse + MAS
+- Files/Calendar: Nextcloud
+- Reverse proxy/TLS/CA: Caddy
+- Database: Postgres
+- Weave backend and Weave MCP runtime
+- Boards: `local-workspace` by default, with OpenProject gated separately
+
+Attaching to existing home services such as Authentik, Nextcloud, or Forgejo under `~/server` is a later `attach-existing-home` profile. It must start read-only/preflight, must not copy secrets into the repo, and must not mutate household services without explicit approval.
+
+## iPhone dogfood expectation
+
+The desired tester experience is:
+
+1. install/trust the Weave Local Development CA once on the iPhone;
+2. install or open the dogfood app build configured for `https://api.weave.test:44443/api/platform/config`;
+3. sign in once;
+4. later open Weave and return to the same test-stack organization without re-running setup scripts.
+
+Invite/QR handoff remains useful for first enrollment and reset cases, but should not be required every time the app opens.
+
+## Release discipline
+
+A change that affects sign-in, backend facade contracts, OpenAPI consumers, MCP/tool exposure, provider boundaries, local stack topology, or onboarding must normally prove:
+
+- ordinary PR CI on `dev`;
+- generated OpenAPI/admin/client freshness where relevant;
+- MCP/root architecture gates where relevant;
+- persistent `test` stack deployment;
+- targeted human or automated dogfood evidence before promotion to `main`.

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -57,11 +57,18 @@ It writes `build/evidence/ci-summary.json` even when the Gradle build fails, so 
 
 These checks are intentionally cheap enough for normal pull requests and do not require live credentials.
 
-## Live-stack evidence
+## Live-stack and persistent test-stack evidence
 
 The live-stack path is expensive and runs on a dedicated self-hosted macOS ARM64 runner. Use it when a change affects sign-in, backend facade contracts, Matrix/files/calendar live behavior, acceptance scenarios, or integration boundaries.
 
-The workflow prepares an acceptance evidence directory, runs the app-level live-stack E2E, and uploads support-safe acceptance evidence from the run. The artifact set includes `release-evidence-manifest.json`, which names the source lane, commit, workflow run metadata, artifact list, and RC promotion rule. On failure, the same uploaded artifact may include `failure-diagnostics/` with `failure-summary.md`, `failure-summary.json`, `container-status.tsv`, `failed-markers.json`, redacted readiness output, and a redacted support-bundle reference. It must not include blindly dumped raw container logs. Do not cite a single workflow run ID as a permanent product claim; link to the workflow, the relevant docs, the manifest, and the PR evidence instead.
+There are two live lanes:
+
+- `Live Stack E2E` (`.github/workflows/live-stack-e2e.yml`) is disposable release-candidate evidence. It bootstraps a stack, runs app-level live-stack E2E, uploads support-safe acceptance evidence, then tears the stack down.
+- `Test Stack Deploy` (`.github/workflows/test-stack-deploy.yml`) is the persistent LAN dogfood stack for the `test` branch. It updates the local `weave.test` stack idempotently and leaves it running for human testing.
+
+The persistent test stack is the required bridge between `dev` and `main`: a commit may be promoted to `main` only after it is contained in `dev`, contained in `test`, and has a successful `Test Stack Deploy` run on `test`. See [Dev/Test/Main promotion flow](dev-test-main-promotion-flow.md).
+
+The disposable live-stack workflow prepares an acceptance evidence directory, runs the app-level live-stack E2E, and uploads support-safe acceptance evidence from the run. The artifact set includes `release-evidence-manifest.json`, which names the source lane, commit, workflow run metadata, artifact list, and RC promotion rule. On failure, the same uploaded artifact may include `failure-diagnostics/` with `failure-summary.md`, `failure-summary.json`, `container-status.tsv`, `failed-markers.json`, redacted readiness output, and a redacted support-bundle reference. It must not include blindly dumped raw container logs. Do not cite a single workflow run ID as a permanent product claim; link to the workflow, the relevant docs, the manifest, and the PR evidence instead.
 
 ## Interpreting pass/fail states
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Lane-based PR and release workflow: gitflow-pr-workflow.md
       - DevOps branching model: devops/branching-model.md
       - DevOps release flow: devops/release-flow.md
+      - Dev/Test/Main promotion flow: dev-test-main-promotion-flow.md
       - DevOps release notes policy: devops/release-notes.md
       - DevOps spec governance: devops/spec-governance.md
       - Architecture: architecture.md


### PR DESCRIPTION
## Summary
- add persistent LAN dogfood deployment workflow for the `test` branch
- add main promotion gate requiring candidate commits to pass through `dev` and `test` with successful test-stack evidence
- keep the test stack update-mode by default, with destructive reset only via explicit workflow input
- document the dev/test/main branch responsibilities, iPhone dogfood entrypoint, provider model, and bootstrap caveat
- update Live Stack E2E runner targeting to match the currently registered dedicated runner name instead of the missing `weave-live` label

Closes #876.

## Verification
- YAML parse for changed workflows
- `./gradlew --no-daemon --max-workers=1 docsCheck contractAuthorityArchitectureCheck --console=plain`

## Notes
This PR installs the policy and workflow. After it lands, create/advance the `test` branch from `dev` to trigger the persistent stack deployment. The first rollout to `main` needs explicit bootstrap handling because GitHub branch protection can only require workflows after they exist on `main`.
