### PR TITLE
ci: use dogfood branch for persistent test stack promotion

### DIFF
--- a/.github/workflows/main-promotion-gate.yml
+++ b/.github/workflows/main-promotion-gate.yml
@@ -21,8 +21,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  verify-dev-test-promotion:
-    name: Verify dev → test evidence before main
+  verify-dev-dogfood-promotion:
+    name: Verify dev → dogfood evidence before main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -37,14 +37,14 @@ jobs:
           echo "sha=${candidate}" >> "$GITHUB_OUTPUT"
           echo "Candidate SHA: ${candidate}"
 
-      - name: Verify candidate is contained in dev and test
+      - name: Verify candidate is contained in dev and dogfood
         run: |
           set -euo pipefail
           candidate="${{ steps.candidate.outputs.sha }}"
-          git fetch origin dev test main --prune
-          for branch in dev test; do
+          git fetch origin dev dogfood main --prune
+          for branch in dev dogfood; do
             if ! git merge-base --is-ancestor "$candidate" "origin/${branch}"; then
-              echo "::error::Candidate ${candidate} is not contained in origin/${branch}. Main promotion requires dev first, then test." >&2
+              echo "::error::Candidate ${candidate} is not contained in origin/${branch}. Main promotion requires dev first, then dogfood." >&2
               exit 1
             fi
           done
@@ -58,11 +58,11 @@ jobs:
         run: |
           set -euo pipefail
           candidate="${{ steps.candidate.outputs.sha }}"
-          runs_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/test-stack-deploy.yml/runs?branch=test&head_sha=${candidate}&status=success&per_page=10")"
+          runs_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/test-stack-deploy.yml/runs?branch=dogfood&head_sha=${candidate}&status=success&per_page=10")"
           count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("workflow_runs", [])))' <<<"$runs_json")"
           if [[ "$count" == "0" ]]; then
-            echo "::error::No successful Test Stack Deploy workflow run found for ${candidate} on branch test." >&2
-            echo "Push/merge the candidate to test and wait for the persistent LAN stack deployment to pass before opening/promoting to main." >&2
+            echo "::error::No successful Test Stack Deploy workflow run found for ${candidate} on branch dogfood." >&2
+            echo "Push/merge the candidate to dogfood and wait for the persistent LAN stack deployment to pass before opening/promoting to main." >&2
             exit 1
           fi
           run_url="$(python3 -c 'import json,sys; runs=json.load(sys.stdin).get("workflow_runs", []); print(runs[0].get("html_url", ""))' <<<"$runs_json")"

--- a/.github/workflows/test-stack-deploy.yml
+++ b/.github/workflows/test-stack-deploy.yml
@@ -3,7 +3,7 @@ name: Test Stack Deploy
 on:
   push:
     branches:
-      - test
+      - dogfood
   workflow_dispatch:
     inputs:
       reset_stack:

--- a/docs/dev-test-main-promotion-flow.md
+++ b/docs/dev-test-main-promotion-flow.md
@@ -1,27 +1,27 @@
-# Dev → Test → Main promotion flow
+# Dev → Dogfood → Main promotion flow
 
 Status: active delivery policy.
 
 Weave uses three promotion lanes:
 
 - `dev`: normal integration branch. Feature PRs land here after ordinary CI, issue acceptance, and review/evidence gates.
-- `test`: persistent LAN dogfood branch. Advancing this branch deploys or updates the local test stack on the dedicated Mac runner.
-- `main`: stable/release-facing branch. A commit may reach `main` only after it has been integrated through `dev` and successfully deployed through `test`.
+- `dogfood`: persistent LAN dogfood branch. Advancing this branch deploys or updates the local test stack on the dedicated Mac runner. This branch is named `dogfood` because legacy `test/...` branches already occupy Git's `refs/heads/test/` namespace.
+- `main`: stable/release-facing branch. A commit may reach `main` only after it has been integrated through `dev` and successfully deployed through `dogfood`.
 
 ## Why this exists
 
 `dev` proves that the repository builds and the offline/product-contract gates pass. It does not prove that Massimo can open Weave on a real device against a live local stack.
 
-`test` is the always-testable LAN stack. It is intended for human dogfood, physical iPhone checks, and integration evidence against the same deployed stack instead of one-off local shells.
+`dogfood` is the always-testable LAN stack. It is intended for human dogfood, physical iPhone checks, and integration evidence against the same deployed stack instead of one-off local shells.
 
-`main` must not receive commits that have bypassed either `dev` integration or `test` dogfood deployment.
+`main` must not receive commits that have bypassed either `dev` integration or `dogfood` deployment.
 
 ## Persistent LAN test stack
 
 The test stack is deployed by the `Test Stack Deploy` GitHub Actions workflow:
 
 - workflow file: `.github/workflows/test-stack-deploy.yml`
-- trigger: push to `test` or manual `workflow_dispatch`
+- trigger: push to `dogfood` or manual `workflow_dispatch`
 - runner: dedicated self-hosted macOS ARM64 runner `weave-live-mac-mini`
 - public local entrypoint: `https://weave.test:44443/`
 - platform config: `https://api.weave.test:44443/api/platform/config`
@@ -33,7 +33,7 @@ The workflow uses the repo infrastructure scripts as implementation detail:
 - `infra/weave-workspace/smoke-test.sh`
 - `infra/weave-workspace/operator-check.sh`
 
-Humans should not need to run those directly for normal test-stack use. The visible entrypoint is the `test` branch deployment result and the iPhone app pointed at the dogfood stack.
+Humans should not need to run those directly for normal test-stack use. The visible entrypoint is the `dogfood` branch deployment result and the iPhone app pointed at the dogfood stack.
 
 ## Update vs reset
 
@@ -52,8 +52,8 @@ Destructive reset is manual only through the workflow input `reset_stack=true`. 
 The `Main Promotion Gate` workflow enforces the branch order:
 
 1. the candidate commit is contained in `origin/dev`;
-2. the same candidate commit is contained in `origin/test`;
-3. a successful `Test Stack Deploy` workflow run exists for that commit on branch `test`;
+2. the same candidate commit is contained in `origin/dogfood`;
+3. a successful `Test Stack Deploy` workflow run exists for that commit on branch `dogfood`;
 4. the root contract-authority architecture check still passes.
 
 If any of these checks fail, the candidate is not eligible for `main`.
@@ -62,7 +62,7 @@ Bootstrap note: GitHub only treats new workflow files as branch-protection candi
 
 ## Provider model
 
-The persistent `test` stack is a disposable Weave-owned dogfood environment. It should not attach to Massimo's `~/server` services by default.
+The persistent `dogfood` stack is a disposable Weave-owned dogfood environment. It should not attach to Massimo's `~/server` services by default.
 
 Default local providers:
 
@@ -94,5 +94,5 @@ A change that affects sign-in, backend facade contracts, OpenAPI consumers, MCP/
 - ordinary PR CI on `dev`;
 - generated OpenAPI/admin/client freshness where relevant;
 - MCP/root architecture gates where relevant;
-- persistent `test` stack deployment;
+- persistent `dogfood` stack deployment;
 - targeted human or automated dogfood evidence before promotion to `main`.

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -64,9 +64,9 @@ The live-stack path is expensive and runs on a dedicated self-hosted macOS ARM64
 There are two live lanes:
 
 - `Live Stack E2E` (`.github/workflows/live-stack-e2e.yml`) is disposable release-candidate evidence. It bootstraps a stack, runs app-level live-stack E2E, uploads support-safe acceptance evidence, then tears the stack down.
-- `Test Stack Deploy` (`.github/workflows/test-stack-deploy.yml`) is the persistent LAN dogfood stack for the `test` branch. It updates the local `weave.test` stack idempotently and leaves it running for human testing.
+- `Test Stack Deploy` (`.github/workflows/test-stack-deploy.yml`) is the persistent LAN dogfood stack for the `dogfood` branch. It updates the local `weave.test` stack idempotently and leaves it running for human testing.
 
-The persistent test stack is the required bridge between `dev` and `main`: a commit may be promoted to `main` only after it is contained in `dev`, contained in `test`, and has a successful `Test Stack Deploy` run on `test`. See [Dev/Test/Main promotion flow](dev-test-main-promotion-flow.md).
+The persistent test stack is the required bridge between `dev` and `main`: a commit may be promoted to `main` only after it is contained in `dev`, contained in `dogfood`, and has a successful `Test Stack Deploy` run on `dogfood`. See [Dev/Dogfood/Main promotion flow](dev-test-main-promotion-flow.md).
 
 The disposable live-stack workflow prepares an acceptance evidence directory, runs the app-level live-stack E2E, and uploads support-safe acceptance evidence from the run. The artifact set includes `release-evidence-manifest.json`, which names the source lane, commit, workflow run metadata, artifact list, and RC promotion rule. On failure, the same uploaded artifact may include `failure-diagnostics/` with `failure-summary.md`, `failure-summary.json`, `container-status.tsv`, `failed-markers.json`, redacted readiness output, and a redacted support-bundle reference. It must not include blindly dumped raw container logs. Do not cite a single workflow run ID as a permanent product claim; link to the workflow, the relevant docs, the manifest, and the PR evidence instead.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ nav:
       - Lane-based PR and release workflow: gitflow-pr-workflow.md
       - DevOps branching model: devops/branching-model.md
       - DevOps release flow: devops/release-flow.md
-      - Dev/Test/Main promotion flow: dev-test-main-promotion-flow.md
+      - Dev/Dogfood/Main promotion flow: dev-test-main-promotion-flow.md
       - DevOps release notes policy: devops/release-notes.md
       - DevOps spec governance: devops/spec-governance.md
       - Architecture: architecture.md


### PR DESCRIPTION
## Summary
- rename the persistent promotion branch from `test` to `dogfood`
- explain why: legacy `test/...` branches already occupy Git's refs/heads/test namespace, so a top-level `test` branch cannot be created
- update the main promotion gate, Test Stack Deploy trigger, nav, and evidence docs accordingly

## Verification
- YAML parse for changed workflows
- `git diff --check`
- `./gradlew --no-daemon --max-workers=1 docsCheck contractAuthorityArchitectureCheck --console=plain`

## Notes
Follow-up to #877 / #876. This keeps the policy semantics intact: dev integration, then persistent dogfood stack deployment, then main eligibility.
