### PR TITLE
fix: expose public Nextcloud fallback in platform config

### DIFF
--- a/server/docs/release-operations.md
+++ b/server/docs/release-operations.md
@@ -19,7 +19,8 @@ Optional:
 - `WEAVE_MATRIX_HOMESERVER_URL`: public Matrix homeserver URL, defaults to `https://matrix.weave.test`
 - `WEAVE_FILES_PRODUCT_URL`: public files product surface, defaults to `https://weave.test/files`
 - `WEAVE_CALENDAR_PRODUCT_URL`: public calendar product surface, defaults to `https://weave.test/calendar`
-- `WEAVE_NEXTCLOUD_BASE_URL`: canonical Nextcloud URL, defaults to `https://files.weave.test`
+- `WEAVE_NEXTCLOUD_PUBLIC_BASE_URL`: support-safe public Nextcloud technical/admin/protocol fallback exposed in platform config, defaults to `WEAVE_NEXTCLOUD_BASE_URL` or `https://files.weave.test`
+- `WEAVE_NEXTCLOUD_BASE_URL`: backend-internal Nextcloud adapter origin for WebDAV/CalDAV calls, defaults to `https://files.weave.test` outside container stacks
 - `WEAVE_ONBOARDING_MATRIX_PROVISIONING_STATE`: optional first-run Matrix provisioning override (`not_configured`, `pending`, `ready`, `degraded`, `failed`); blank derives status from the chat capability
 - `WEAVE_ONBOARDING_NEXTCLOUD_PROVISIONING_STATE`: optional first-run Nextcloud provisioning override (`not_configured`, `pending`, `ready`, `degraded`, `failed`); blank derives status from files/calendar capability and Nextcloud route configuration
 - `WEAVE_PROFILE_STORAGE_PATH`: durable JSON file path for mutable profile overrides accepted by `PATCH /api/profile`, defaults to `./data/profile-overrides.json`

--- a/server/docs/runtime-configuration.md
+++ b/server/docs/runtime-configuration.md
@@ -17,7 +17,8 @@ This document is the backend runtime reference for operators and local integrati
 - `WEAVE_MATRIX_HOMESERVER_URL`: public Matrix homeserver URL, defaults to `https://matrix.weave.test`.
 - `WEAVE_FILES_PRODUCT_URL`: public files product surface, defaults to `https://weave.test/files`.
 - `WEAVE_CALENDAR_PRODUCT_URL`: public calendar product surface, defaults to `https://weave.test/calendar`.
-- `WEAVE_NEXTCLOUD_BASE_URL`: canonical raw Nextcloud technical/admin/protocol URL, defaults to `https://files.weave.test`.
+- `WEAVE_NEXTCLOUD_PUBLIC_BASE_URL`: support-safe public Nextcloud technical/admin/protocol fallback exposed in platform config, defaults to `WEAVE_NEXTCLOUD_BASE_URL` or `https://files.weave.test`.
+- `WEAVE_NEXTCLOUD_BASE_URL`: backend-internal Nextcloud adapter origin for WebDAV/CalDAV calls, defaults to `https://files.weave.test` outside container stacks.
 - `WEAVE_TARGET_MOBILE`: advertise mobile as a supported client target, defaults to `true`.
 - `WEAVE_TARGET_DESKTOP`: advertise desktop as a supported client target, defaults to `true`.
 - `WEAVE_TARGET_WEB`: advertise web as a supported client target, defaults to `false`.

--- a/server/src/main/java/com/massimotter/weave/backend/service/PlatformContractService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/PlatformContractService.java
@@ -267,14 +267,14 @@ public class PlatformContractService {
             return new PlatformStatusResponse.DiagnosticStatus(
                     "up",
                     "ready",
-                    "The canonical Nextcloud technical route is configured for backend files/calendar diagnostics.",
+                    "The support-safe public Nextcloud fallback route is configured for files/calendar diagnostics.",
                     null);
         }
         return new PlatformStatusResponse.DiagnosticStatus(
                 "degraded",
                 "degraded",
-                "The canonical Nextcloud technical route is not configured.",
-                "Set WEAVE_NEXTCLOUD_BASE_URL to the raw Nextcloud/admin/protocol origin, for example https://files.weave.test.");
+                "The support-safe public Nextcloud fallback route is not configured.",
+                "Set WEAVE_NEXTCLOUD_PUBLIC_BASE_URL to the public Nextcloud/admin/protocol origin, for example https://files.weave.test.");
     }
 
     private PlatformStatusResponse.DiagnosticCheck check(

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -34,7 +34,7 @@ weave:
     matrix-homeserver-url: ${WEAVE_MATRIX_HOMESERVER_URL:https://matrix.weave.test}
     files-product-url: ${WEAVE_FILES_PRODUCT_URL:https://weave.test/files}
     calendar-product-url: ${WEAVE_CALENDAR_PRODUCT_URL:https://weave.test/calendar}
-    nextcloud-base-url: ${WEAVE_NEXTCLOUD_BASE_URL:https://files.weave.test}
+    nextcloud-base-url: ${WEAVE_NEXTCLOUD_PUBLIC_BASE_URL:${WEAVE_NEXTCLOUD_BASE_URL:https://files.weave.test}}
     targets:
       mobile: ${WEAVE_TARGET_MOBILE:true}
       desktop: ${WEAVE_TARGET_DESKTOP:true}

--- a/server/src/test/java/com/massimotter/weave/backend/service/PlatformContractServiceTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/service/PlatformContractServiceTest.java
@@ -71,7 +71,7 @@ class PlatformContractServiceTest {
     }
 
     @Test
-    void keepsPublicFilesProductUrlSeparateFromTechnicalNextcloudDiagnosticsRoute() {
+    void keepsPublicFilesProductUrlSeparateFromSupportSafeNextcloudFallbackRoute() {
         PlatformContractService service = service(
                 new MatrixChatProperties(false, null, null),
                 true,
@@ -82,16 +82,16 @@ class PlatformContractServiceTest {
                         "https://matrix.weave.test",
                         "https://weave.test/files",
                         "https://weave.test/calendar",
-                        "https://nextcloud.internal",
+                        "https://files.weave.test",
                         null));
 
         var config = service.config();
         var status = service.status("nextcloud-route-test");
 
         assertThat(config.filesProductUrl()).isEqualTo("https://weave.test/files");
-        assertThat(config.nextcloudBaseUrl()).isEqualTo("https://nextcloud.internal");
+        assertThat(config.nextcloudBaseUrl()).isEqualTo("https://files.weave.test");
         assertThat(status.nextcloud().readiness()).isEqualTo("ready");
-        assertThat(status.nextcloud().message()).contains("technical route");
+        assertThat(status.nextcloud().message()).contains("Nextcloud");
     }
 
     private PlatformContractService service(MatrixChatProperties matrixProperties, boolean chatEnabled) {


### PR DESCRIPTION
## Summary
- expose `WEAVE_NEXTCLOUD_PUBLIC_BASE_URL` through `/api/platform/config`
- keep `WEAVE_NEXTCLOUD_BASE_URL` as the backend-internal WebDAV/CalDAV adapter origin
- update diagnostics/tests/docs to describe the public fallback vs internal adapter split

## Why
The first real `dogfood` Test Stack Deploy reached deployment but failed readiness because `/api/platform/config` returned the internal container URL `http://weave-nextcloud` as `nextcloudBaseUrl`. That is not support-safe or usable from LAN/mobile clients.

## Verification
- `git diff --check`
- `./gradlew --no-daemon --max-workers=1 :server:test --tests com.massimotter.weave.backend.controller.PlatformControllerTest --tests com.massimotter.weave.backend.service.PlatformContractServiceTest docsCheck contractAuthorityArchitectureCheck --console=plain`

## Evidence
- Failed dogfood run: https://github.com/masssi164/weave/actions/runs/27947716684
