### PR TITLE
fix: tolerate partial Keycloak state during imports

### DIFF
--- a/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/outputs.tf
+++ b/infra/weave-workspace/02-keycloak-setup/modules/tenant-identity/outputs.tf
@@ -10,52 +10,52 @@ output "keycloak_issuer_url" {
 
 output "weave_app_client_id" {
   description = "Client ID configured for the Weave mobile app."
-  value       = keycloak_openid_client.client["weave_app"].client_id
+  value       = try(keycloak_openid_client.client["weave_app"].client_id, null)
 }
 
 output "weave_app_post_logout_redirect_uris" {
   description = "Allowed post-logout redirect URIs for the Weave mobile app."
-  value       = keycloak_openid_client.client["weave_app"].valid_post_logout_redirect_uris
+  value       = try(keycloak_openid_client.client["weave_app"].valid_post_logout_redirect_uris, [])
 }
 
 output "weave_app_redirect_uris" {
   description = "Allowed sign-in redirect URIs for the Weave mobile app."
-  value       = keycloak_openid_client.client["weave_app"].valid_redirect_uris
+  value       = try(keycloak_openid_client.client["weave_app"].valid_redirect_uris, [])
 }
 
 output "weave_app_optional_scopes" {
   description = "Optional scopes assigned to the Weave mobile app."
-  value       = keycloak_openid_client_optional_scopes.weave_app.optional_scopes
+  value       = try(keycloak_openid_client_optional_scopes.weave_app.optional_scopes, [])
 }
 
 output "weave_app_default_scopes" {
   description = "Default scopes assigned to the Weave mobile app."
-  value       = keycloak_openid_client_default_scopes.weave_app.default_scopes
+  value       = try(keycloak_openid_client_default_scopes.weave_app.default_scopes, [])
 }
 
 output "weave_backend_client_id" {
   description = "Client ID configured for the Weave backend."
-  value       = keycloak_openid_client.client["weave_backend"].client_id
+  value       = try(keycloak_openid_client.client["weave_backend"].client_id, null)
 }
 
 output "weave_backend_audience" {
   description = "Audience value emitted for access tokens that the Weave backend accepts."
-  value       = keycloak_openid_client.client["weave_app"].client_id
+  value       = try(keycloak_openid_client.client["weave_app"].client_id, null)
 }
 
 output "weave_workspace_scope_name" {
   description = "Client scope that adds the Weave backend-required audience."
-  value       = keycloak_openid_client_scope.weave_workspace.name
+  value       = try(keycloak_openid_client_scope.weave_workspace.name, null)
 }
 
 output "nextcloud_client_id" {
   description = "Client ID configured for Nextcloud."
-  value       = keycloak_openid_client.client["nextcloud"].client_id
+  value       = try(keycloak_openid_client.client["nextcloud"].client_id, null)
 }
 
 output "nextcloud_client_secret" {
   description = "Client secret configured for Nextcloud."
-  value       = keycloak_openid_client.client["nextcloud"].client_secret
+  value       = try(keycloak_openid_client.client["nextcloud"].client_secret, null)
   sensitive   = true
 }
 
@@ -82,10 +82,10 @@ output "weave_product_role_groups" {
 
 output "weave_admin_console_client_id" {
   description = "Client ID configured for the separate Organization/Admin Console."
-  value       = keycloak_openid_client.client["weave_admin_console"].client_id
+  value       = try(keycloak_openid_client.client["weave_admin_console"].client_id, null)
 }
 
 output "weave_admin_console_redirect_uris" {
   description = "Allowed sign-in redirect URIs for the Organization/Admin Console."
-  value       = keycloak_openid_client.client["weave_admin_console"].valid_redirect_uris
+  value       = try(keycloak_openid_client.client["weave_admin_console"].valid_redirect_uris, [])
 }


### PR DESCRIPTION
## Summary
- make tenant identity outputs tolerate partial Keycloak state during incremental imports
- keep final output values unchanged once apply has reconciled all clients/scopes

## Why
The dogfood deploy now imports existing Keycloak resources, but `tofu import` refreshes/evaluates outputs after each resource. After importing the first OIDC client, outputs that hard-indexed not-yet-imported clients failed with `Invalid index` before the remaining clients could be adopted.

## Verification
- `tofu -chdir=infra/weave-workspace/02-keycloak-setup fmt -check -recursive`
- `tofu -chdir=infra/weave-workspace/02-keycloak-setup init -backend=false -input=false`
- `tofu -chdir=infra/weave-workspace/02-keycloak-setup validate`
- `git diff --check`
- `./gradlew --no-daemon --max-workers=1 docsCheck contractAuthorityArchitectureCheck --console=plain`

## Evidence
- Failed dogfood run: https://github.com/masssi164/weave/actions/runs/27950494012
