### PR TITLE
fix: default dogfood test password when secret is absent

### DIFF
--- a/.github/workflows/test-stack-deploy.yml
+++ b/.github/workflows/test-stack-deploy.yml
@@ -45,8 +45,8 @@ jobs:
       EXPECTED_RUNNER_NAME: weave-live-mac-mini
       WEAVE_BACKEND_IMAGE: ${{ inputs.weave_backend_image || 'weave-backend:test-stack' }}
       WEAVE_MCP_SERVER_IMAGE: ${{ inputs.weave_mcp_server_image || 'weave-mcp-server:test-stack' }}
-      WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD }}
-      TF_VAR_test_user_password: ${{ secrets.WEAVE_TEST_PASSWORD }}
+      WEAVE_TEST_PASSWORD: ${{ secrets.WEAVE_TEST_PASSWORD || 'ci-dogfood-test-password' }}
+      TF_VAR_test_user_password: ${{ secrets.WEAVE_TEST_PASSWORD || 'ci-dogfood-test-password' }}
       TF_VAR_db_admin_password: ci-db-admin-password
       TF_VAR_keycloak_admin_password: ci-keycloak-admin-password
       TF_VAR_keycloak_db_password: ci-keycloak-db-password


### PR DESCRIPTION
## Summary
- prevent the dogfood workflow from overriding generated/test credentials with an empty missing secret
- use a stable local dogfood fallback password when `WEAVE_TEST_PASSWORD` is not configured as a GitHub secret

## Why
The latest persistent dogfood deploy completed the stack update but failed readiness at the Keycloak login check with HTTP 401 because both `WEAVE_TEST_PASSWORD` and `TF_VAR_test_user_password` were empty in the workflow environment.

## Verification
- YAML parse for `.github/workflows/test-stack-deploy.yml`
- `./gradlew --no-daemon --max-workers=1 docsCheck contractAuthorityArchitectureCheck --console=plain`

Follow-up for #883.
