### PR TITLE
fix(infra): reconcile dogfood Keycloak test credential

### DIFF
--- a/infra/weave-workspace/install.sh
+++ b/infra/weave-workspace/install.sh
@@ -452,6 +452,19 @@ keycloak_admin_get_query() {
     "http://${LOOPBACK_HOST}:${TF_VAR_keycloak_host_port}${path}"
 }
 
+keycloak_admin_put_json() {
+  local path="$1"
+  local body="$2"
+  local token=""
+
+  token="$(keycloak_admin_token)"
+  curl -fsS -X PUT \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Content-Type: application/json' \
+    --data "${body}" \
+    "http://${LOOPBACK_HOST}:${TF_VAR_keycloak_host_port}${path}" >/dev/null
+}
+
 keycloak_json_id_by_field() {
   local field="$1"
   local value="$2"
@@ -538,6 +551,23 @@ keycloak_lookup_client_mapper_id() {
 
   keycloak_admin_get "/admin/realms/${TF_VAR_tenant_slug}/clients/${client_uuid}/protocol-mappers/models" |
     keycloak_json_id_by_field name "${name}"
+}
+
+ensure_keycloak_test_user_password() {
+  local user_id=""
+  local body=""
+
+  if ! create_test_user_enabled; then
+    return
+  fi
+
+  [[ -n "${TF_VAR_test_user_password:-}" ]] || fail "Cannot repair Keycloak test-user credentials without TF_VAR_test_user_password."
+  user_id="$(keycloak_lookup_user_id test)"
+  [[ -n "${user_id}" ]] || fail "Cannot repair Keycloak test-user credentials because user test was not found."
+
+  body="$(jq -cn --arg password "${TF_VAR_test_user_password}" '{type:"password", temporary:false, value:$password}')"
+  keycloak_admin_put_json "/admin/realms/${TF_VAR_tenant_slug}/users/${user_id}/reset-password" "${body}"
+  log "Ensured Keycloak integration test-user credential matches the current test-stack SecretRef."
 }
 
 ensure_existing_keycloak_terraform_state() {
@@ -1695,6 +1725,7 @@ main() {
 
   log "Applying Keycloak configuration module..."
   terraform_apply "${KEYCLOAK_DIR}"
+  ensure_keycloak_test_user_password
 
   log "Waiting for Weave backend readiness..."
   wait_for_http_200 "Weave backend" "http://${LOOPBACK_HOST}:${TF_VAR_backend_host_port}/api/health/ready"


### PR DESCRIPTION
## Summary
- keep the persistent dogfood stack on the repo-owned Keycloak path, not Massimo's `~/server` services
- after the Keycloak OpenTofu apply, idempotently reset only the local integration test user's password to the current test-stack SecretRef value
- preserve the existing dev → dogfood → main promotion policy and human dogfood evidence boundary

## Evidence
- `bash -n infra/weave-workspace/install.sh infra/weave-workspace/smoke-test.sh infra/weave-workspace/operator-check.sh`
- `./gradlew --no-daemon infraStatic`

## Release notes
- release-notes-bugfix: Reconcile the dogfood Keycloak integration test-user credential during persistent test-stack updates.

## Human testing
- Environment: `dogfood` persistent LAN test stack only, after this PR lands on `dev` and is fast-forwarded/promoted to `dogfood`.
- Tester action: run or observe `Test Stack Deploy` for the candidate, then sign in with the repo-owned dogfood test identity or Massimo's dogfood member account against `https://api.weave.test:44443/api/platform/config`.
- Acceptable evidence: green `Test Stack Deploy` run with `Verify persistent stack readiness` passing and/or a sanitized note that the credential login succeeded on the dogfood stack. Do not mutate `~/server` services for this proof.
