### PR TITLE
docs: align dev test main promotion flow

### DIFF
--- a/docs/dev-test-main-promotion-flow.md
+++ b/docs/dev-test-main-promotion-flow.md
@@ -1,27 +1,27 @@
-# Dev → Dogfood → Main promotion flow
+# Dev → Test → Main promotion flow
 
 Status: active delivery policy.
 
 Weave uses three promotion lanes:
 
 - `dev`: normal integration branch. Feature PRs land here after ordinary CI, issue acceptance, and review/evidence gates.
-- `dogfood`: persistent LAN dogfood branch. Advancing this branch deploys or updates the local test stack on the dedicated Mac runner. This branch is named `dogfood` because legacy `test/...` branches already occupy Git's `refs/heads/test/` namespace.
-- `main`: stable/release-facing branch. A commit may reach `main` only after it has been integrated through `dev` and successfully deployed through `dogfood`.
+- `test`: persistent test-candidate branch. A `dev` -> `test` PR is the integration candidate for live E2E and human dogfood evidence on the dedicated Mac runner.
+- `main`: stable/release-facing branch. A commit may reach `main` only after it has been integrated through `dev`, validated through the `dev` -> `test` candidate, and backed by validated release evidence.
 
 ## Why this exists
 
 `dev` proves that the repository builds and the offline/product-contract gates pass. It does not prove that Massimo can open Weave on a real device against a live local stack.
 
-`dogfood` is the always-testable LAN stack. It is intended for human dogfood, physical iPhone checks, and integration evidence against the same deployed stack instead of one-off local shells.
+`test` is the always-testable LAN stack lane. It is intended for human dogfood, physical iPhone checks, and integration evidence against the same deployed stack instead of one-off local shells.
 
-`main` must not receive commits that have bypassed either `dev` integration or `dogfood` deployment.
+`main` must not receive commits that have bypassed either `dev` integration, the `dev` -> `test` E2E candidate, or validated release evidence.
 
 ## Persistent LAN test stack
 
-The test stack is deployed by the `Test Stack Deploy` GitHub Actions workflow:
+The test stack is deployed from the accepted `dev` -> `test` candidate by the `Test Stack Deploy` GitHub Actions workflow:
 
 - workflow file: `.github/workflows/test-stack-deploy.yml`
-- trigger: push to `dogfood` or manual `workflow_dispatch`
+- trigger: push to `test` or manual `workflow_dispatch`
 - runner: dedicated self-hosted macOS ARM64 runner `weave-live-mac-mini`
 - public local entrypoint: `https://weave.test:44443/`
 - platform config: `https://api.weave.test:44443/api/platform/config`
@@ -33,7 +33,7 @@ The workflow uses the repo infrastructure scripts as implementation detail:
 - `infra/weave-workspace/smoke-test.sh`
 - `infra/weave-workspace/operator-check.sh`
 
-Humans should not need to run those directly for normal test-stack use. The visible entrypoint is the `dogfood` branch deployment result and the iPhone app pointed at the dogfood stack.
+Humans should not need to run those directly for normal test-stack use. The visible entrypoint is the `test` branch deployment result and the iPhone app pointed at the test stack.
 
 ## Update vs reset
 
@@ -52,8 +52,8 @@ Destructive reset is manual only through the workflow input `reset_stack=true`. 
 The `Main Promotion Gate` workflow enforces the branch order:
 
 1. the candidate commit is contained in `origin/dev`;
-2. the same candidate commit is contained in `origin/dogfood`;
-3. a successful `Test Stack Deploy` workflow run exists for that commit on branch `dogfood`;
+2. the same candidate commit is contained in `origin/test` via a reviewed `dev` -> `test` candidate;
+3. a successful E2E / `Test Stack Deploy` workflow run exists for that commit on branch `test`;
 4. the root contract-authority architecture check still passes.
 
 If any of these checks fail, the candidate is not eligible for `main`.
@@ -62,7 +62,7 @@ Bootstrap note: GitHub only treats new workflow files as branch-protection candi
 
 ## Provider model
 
-The persistent `dogfood` stack is a disposable Weave-owned dogfood environment. It should not attach to Massimo's `~/server` services by default.
+The persistent `test` stack is a disposable Weave-owned dogfood environment. It should not attach to Massimo's `~/server` services by default.
 
 Default local providers:
 
@@ -81,7 +81,7 @@ Attaching to existing home services such as Authentik, Nextcloud, or Forgejo und
 The desired tester experience is:
 
 1. install/trust the Weave Local Development CA once on the iPhone;
-2. install or open the dogfood app build configured for `https://api.weave.test:44443/api/platform/config`;
+2. install or open the test-candidate app build configured for `https://api.weave.test:44443/api/platform/config`;
 3. sign in once;
 4. later open Weave and return to the same test-stack organization without re-running setup scripts.
 
@@ -94,5 +94,5 @@ A change that affects sign-in, backend facade contracts, OpenAPI consumers, MCP/
 - ordinary PR CI on `dev`;
 - generated OpenAPI/admin/client freshness where relevant;
 - MCP/root architecture gates where relevant;
-- persistent `dogfood` stack deployment;
-- targeted human or automated dogfood evidence before promotion to `main`.
+- persistent `test` stack deployment from the `dev` -> `test` candidate;
+- targeted human or automated E2E/dogfood evidence returned to the linked feature PR / owning agent before promotion to `main`.

--- a/docs/quality-and-evidence.md
+++ b/docs/quality-and-evidence.md
@@ -64,9 +64,9 @@ The live-stack path is expensive and runs on a dedicated self-hosted macOS ARM64
 There are two live lanes:
 
 - `Live Stack E2E` (`.github/workflows/live-stack-e2e.yml`) is disposable release-candidate evidence. It bootstraps a stack, runs app-level live-stack E2E, uploads support-safe acceptance evidence, then tears the stack down.
-- `Test Stack Deploy` (`.github/workflows/test-stack-deploy.yml`) is the persistent LAN dogfood stack for the `dogfood` branch. It updates the local `weave.test` stack idempotently and leaves it running for human testing.
+- `Test Stack Deploy` (`.github/workflows/test-stack-deploy.yml`) is the persistent LAN test-candidate stack for the `test` branch. It updates the local `weave.test` stack idempotently and leaves it running for human testing.
 
-The persistent test stack is the required bridge between `dev` and `main`: a commit may be promoted to `main` only after it is contained in `dev`, contained in `dogfood`, and has a successful `Test Stack Deploy` run on `dogfood`. See [Dev/Dogfood/Main promotion flow](dev-test-main-promotion-flow.md).
+The persistent test stack is the required bridge between `dev` and `main`: a commit may be promoted to `main` only after it is contained in `dev`, promoted through the reviewed `dev` -> `test` candidate, and has successful E2E / `Test Stack Deploy` evidence on `test`. The E2E result plus linked feature PR context returns to OpenClaw / the relevant owning agent before any `test` -> `main` release promotion. See [Dev/Test/Main promotion flow](dev-test-main-promotion-flow.md).
 
 The disposable live-stack workflow prepares an acceptance evidence directory, runs the app-level live-stack E2E, and uploads support-safe acceptance evidence from the run. The artifact set includes `release-evidence-manifest.json`, which names the source lane, commit, workflow run metadata, artifact list, and RC promotion rule. On failure, the same uploaded artifact may include `failure-diagnostics/` with `failure-summary.md`, `failure-summary.json`, `container-status.tsv`, `failed-markers.json`, redacted readiness output, and a redacted support-bundle reference. It must not include blindly dumped raw container logs. Do not cite a single workflow run ID as a permanent product claim; link to the workflow, the relevant docs, the manifest, and the PR evidence instead.
 


### PR DESCRIPTION
## Summary

Align the documented Weave promotion strategy around the approved Dev -> Test -> Main flow:

- feature work lands through PRs targeting `dev`;
- reviewed `dev` candidates promote to the persistent `test` branch/stack for evidence;
- `test` promotes to `main` only with validated release evidence.

## Target lane

`dev`

## Linked issue / intent

No dedicated product issue; this is a docs/process correction for the approved branch-promotion strategy.

## Release notes

`release-notes-feature` — developer/operator delivery process documentation changed.

## Spec impact

No fachliche product-spec change. This updates implementation-facing delivery/process documentation only.

## User/admin/operator impact

Developer/operator impact: clarifies how branch promotion, dogfood/human evidence, and release evidence flow across `dev`, `test`, and `main`.

## Evidence

- `/Users/flotterotter/.openclaw/workspace/tmp/weave-agent-contracts/dev-test-main-promotion-strategy-evidence-20260622-r2/evidence_package.json` — PASS
- `/Users/flotterotter/.openclaw/workspace/tmp/weave-agent-contracts/docs-review-verdict-dev-test-main-strategy-r2-20260622.json` — APPROVE
- `/Users/flotterotter/.openclaw/workspace/tmp/weave-agent-contracts/review_verdict_quality_dev_test_main_strategy_r2_20260622.json` — APPROVE
- `/Users/flotterotter/.openclaw/workspace/tmp/weave-agent-contracts/aggregate-verdict-dev-test-main-strategy-r2-20260622.json` — APPROVE

## Checks run

- `git -C /private/tmp/weave-dev-test-main-promotion-strategy diff --check`
- `python3 /Users/flotterotter/.openclaw/workspace/scripts/weave_agent_contract.py validate review_verdict /Users/flotterotter/.openclaw/workspace/tmp/weave-agent-contracts/aggregate-verdict-dev-test-main-strategy-r2-20260622.json`

## Risks

None known. Scope is limited to `docs/dev-test-main-promotion-flow.md` and `docs/quality-and-evidence.md`.
