### PR TITLE
promote dev to dogfood: spec SSOT consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Weave is one monorepo. `client/`, `server/`, `infra/`, `e2e/`, `docs/`, and `rel
 
 Old `weave-backend` and `weave-infra` checkouts are stale. Ignore them.
 
-Truth split: the canonical fachliche specification truth is the pinned Weave Specification Corpus in `specs/weave-specs.lock.json` (local default `../weave-specs`). This repo is implementation/evidence truth: code, tests, CI, release evidence, GitHub issues/PRs/milestones, and generated or transitional spec projections. If corpus and repo reality disagree, create an explicit spec-change or conformance-fix task; never let implementation state silently redefine product/domain meaning.
+Truth split: the canonical fachliche specification truth is the pinned Weave Specification Corpus in `specs/weave-specs.lock.json` (local default `../weave-specs`). This repo is implementation/evidence truth: code, tests, CI, release evidence, GitHub issues/PRs/milestones, and generated or transitional spec projections. Use `docs/specification-source-of-truth.md` and `specs/spec-inventory.yaml` before citing, editing, deleting, or migrating repo-local specs. If corpus and repo reality disagree, create an explicit spec-change or conformance-fix task; never let implementation state silently redefine product/domain meaning.
 
 Language policy: every `AGENTS.md`, agent prompt, checked-in project instruction, PR body, issue body, code comment, and documentation change must be written in English unless a user-facing localization file explicitly requires another language.
 
@@ -19,7 +19,7 @@ Before coding, opening PRs, merging, or declaring work complete, read and follow
 - `docs/developer-handbook.md` for coding conventions, Gradle gates, generated code, accessibility/i18n, and evidence expectations.
 - `docs/gitflow-pr-workflow.md` for lane-based DevOps flow, protected `main`/`dev`, PR readiness, merge rules, and release-notes labels.
 - `docs/weave-operating-model.md` for delivery lifecycle and governance.
-- `specs/weave-specs.lock.json`, the pinned spec corpus files, `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and transitional repo-local `specs/` for conformance context.
+- `specs/weave-specs.lock.json`, the pinned spec corpus files, `specs/spec-inventory.yaml`, `.specify/memory/constitution.md`, `docs/spec-driven-development.md`, and transitional repo-local `specs/` for conformance context.
 - Domain docs near the changed area (`client/`, `server/`, `infra/`, `e2e/`, `docs/`).
 
 Default gates: `./gradlew specCorpusConformance`, `./gradlew acceptanceContract`, `./gradlew clientCi`, `./gradlew serverCi`, `./gradlew adminCi`, `./gradlew infraStatic`, `./gradlew docsCheck`, and `./gradlew releaseEvidenceCheck`; use the smallest meaningful subset and `./gradlew ci` for cross-stack changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,13 +56,14 @@ Start with:
 1. [Developer Handbook](developer-handbook.md) — local prerequisites, Java 21+ requirement, Gradle gates, client/server/admin/infra workflows, and evidence expectations.
 2. [Lane-based PR and release workflow](gitflow-pr-workflow.md) — branch, review, label, release-note, and merge rules.
 3. [Spec-driven development for Weave](spec-driven-development.md) — pinned spec corpus, conformance lifecycle, evidence gates, and agent orchestration.
-4. [AI-assisted delivery orchestration](agent-team-orchestration.md) — repo-safe roles, handoff briefs, runtime-boundary guardrails, and optimization loop.
-5. [Canonical domains](architecture/canonical-domains.md) — product-owned domain registry for identity, people, spaces, chat, files, documents, calendar, boards, calls, decisions, notifications, health, and Weaver.
-6. [Provider portability contract](architecture/provider-portability.md) — adapter manifests, mapping tables, reports, and no-unaccounted-data-loss rules.
-7. [Weaver OpenClaw-derived runtime profile](architecture/weaver-openclaw-profile.md) — future optional PA runtime foundation and blockers.
-8. [Canonical feature models](canonical-feature-models.md) — provider-neutral domain vocabulary.
-9. [Accessible workflow context contract](workflow-context-contract.md) — linear workflow primitives, context references, agent dry-run rules, and the MVP slice before a visual builder.
-10. [Architecture](architecture.md) and [Diagrams](diagrams/index.md) — facades, data flow, and domain diagrams.
+4. [Specification source of truth](specification-source-of-truth.md) — product corpus, repo-local spec inventory, implementation evidence, and Weaver/OpenClaw runtime boundary.
+5. [AI-assisted delivery orchestration](agent-team-orchestration.md) — repo-safe roles, handoff briefs, runtime-boundary guardrails, and optimization loop.
+6. [Canonical domains](architecture/canonical-domains.md) — product-owned domain registry for identity, people, spaces, chat, files, documents, calendar, boards, calls, decisions, notifications, health, and Weaver.
+7. [Provider portability contract](architecture/provider-portability.md) — adapter manifests, mapping tables, reports, and no-unaccounted-data-loss rules.
+8. [Weaver OpenClaw-derived runtime profile](architecture/weaver-openclaw-profile.md) — future optional PA runtime foundation and blockers.
+9. [Canonical feature models](canonical-feature-models.md) — provider-neutral domain vocabulary.
+10. [Accessible workflow context contract](workflow-context-contract.md) — linear workflow primitives, context references, agent dry-run rules, and the MVP slice before a visual builder.
+11. [Architecture](architecture.md) and [Diagrams](diagrams/index.md) — facades, data flow, and domain diagrams.
 
 ### Security / compliance reviewer
 
@@ -82,6 +83,7 @@ Implementation conformance docs and product-facing projections:
 - [v0.1 Golden Path readiness](v0.1-golden-path.md)
 - [Weave product line and Weaver integration plan](product-line-and-weaver-plan.md)
 - [Spec-driven development for Weave](spec-driven-development.md)
+- [Specification source of truth](specification-source-of-truth.md)
 - [AI-assisted delivery orchestration](agent-team-orchestration.md)
 - [Canonical domains](architecture/canonical-domains.md)
 - [Provider portability contract](architecture/provider-portability.md)

--- a/docs/spec-driven-development.md
+++ b/docs/spec-driven-development.md
@@ -44,15 +44,23 @@ This repo owns:
 - GitHub issue/PR/milestone state;
 - generated projections or historical transitional specs that prove conformance.
 
+## Repo-local spec inventory
+
+Repo-local spec-like artifacts are classified in `specs/spec-inventory.yaml`. Treat that file as the implementation repository inventory for transitional packets, conformance fixtures, and repo-owned evidence. It does not replace the pinned corpus; it explains how this repo still depends on local packets while migration/conformance work continues.
+
+Runtime evidence from the separate Weaver/OpenClaw repository may be required when Weave work depends on runtime behavior, but that runtime repository does not redefine Weave product/domain meaning.
+
 ## Required first step for agents
 
 Before coding, opening PRs, merging, or declaring work complete:
 
 1. Read `specs/weave-specs.lock.json`.
 2. Read the relevant files in the pinned spec corpus.
-3. Identify the bounded context, provider boundary, examples, contracts, and Veto dimensions.
-4. Only then inspect implementation repo files and GitHub state.
-5. Run `./gradlew specCorpusConformance` for spec-driven work.
+3. Read `specs/spec-inventory.yaml` for any repo-local transitional packet, fixture, or evidence artifact in scope.
+4. Identify the bounded context, provider boundary, examples, contracts, and Veto dimensions.
+5. Only then inspect implementation repo files and GitHub state.
+6. If the work depends on Weaver/OpenClaw runtime behavior, inspect that separate runtime repository as dependency evidence.
+7. Run `./gradlew specCorpusConformance` for spec-driven work.
 
 ## Product-core safety rule
 

--- a/docs/specification-source-of-truth.md
+++ b/docs/specification-source-of-truth.md
@@ -1,0 +1,45 @@
+# Specification source of truth
+
+Status: active repo policy.
+
+Weave uses a split source-of-truth model so product meaning, implementation proof, and runtime dependency evidence do not drift into competing specifications.
+
+## Authoritative layers
+
+1. **Product/domain truth** lives in the pinned Weave Specification Corpus referenced by `specs/weave-specs.lock.json`.
+2. **Implementation/evidence truth** lives in this repository: code, tests, CI, generated contracts, support-safe evidence, release notes, GitHub issues/PRs/checks, and milestones.
+3. **Runtime dependency truth** for Weaver/OpenClaw behavior lives in the Weaver/OpenClaw runtime repository and its own specs, docs, source, tests, and CI. Those artifacts can prove runtime capability, but they do not override the Weave product corpus.
+
+## Local repo specs
+
+The `specs/` directory in this repository is not a second product corpus. It contains transitional Spec Kit packets, conformance projections, fixtures, and implementation evidence that must conform to the pinned corpus.
+
+The machine-readable classification is `specs/spec-inventory.yaml`.
+
+Use it before editing or deleting repo-local spec-like artifacts:
+
+- `transitional-conformance`: product/domain meaning should move to the pinned corpus; keep the repo copy only while tasks, traceability, or gates still need it.
+- `conformance-fixture`: keep fixtures/projections that tests or gates consume, but do not use them to redefine product meaning.
+- `implementation-evidence`: repo-owned evidence, topology, CI, or release proof; keep it in this repo unless promoted into corpus release gates.
+
+## Required workflow
+
+Before product/domain, architecture, provider, auth/policy, acceptance, release-claim, or Weaver-related implementation work:
+
+1. Read `specs/weave-specs.lock.json`.
+2. Read the governing files in the pinned Weave Specification Corpus.
+3. Check `specs/spec-inventory.yaml` for any repo-local transitional packet or fixture in scope.
+4. If the change depends on Weaver/OpenClaw runtime behavior, inspect the separate runtime repository's relevant specs/docs/source/tests as dependency evidence.
+5. If corpus and repo reality disagree, open an explicit spec-corpus change or implementation conformance fix. Do not silently let code, repo-local specs, issues, or chat redefine product/domain truth.
+6. Run `./gradlew specCorpusConformance` and the smallest relevant implementation/evidence gate.
+
+## Cleanup policy
+
+Do not mass-delete repo-local specs just because the corpus is canonical. Cleanup must preserve evidence and gates:
+
+1. Migrate remaining product/domain meaning into the pinned corpus.
+2. Move required fixtures/projections into clear test/evidence locations or keep them documented in `specs/spec-inventory.yaml`.
+3. Update tests/gates to consume the canonical corpus or generated projections.
+4. Remove duplicate transitional packets in focused PRs with local gate evidence.
+
+This policy also applies to AI-assisted work: agents must cite file paths, spec IDs, issues/PRs, and gate results instead of copying product truth into prompts or inventing acceptance from memory.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
       - Overview: developer-handbook.md
       - Weave operating model: weave-operating-model.md
       - Spec-driven development: spec-driven-development.md
+      - Specification source of truth: specification-source-of-truth.md
       - AI-assisted delivery orchestration: agent-team-orchestration.md
       - Lane-based PR and release workflow: gitflow-pr-workflow.md
       - DevOps branching model: devops/branching-model.md

--- a/specs/README.md
+++ b/specs/README.md
@@ -14,7 +14,16 @@ This implementation repository is the **conformance and evidence truth**. It con
 - Specification truth: the corpus at the lockfile `specCorpus.localPath` (default `../weave-specs`), pinned by `specs/weave-specs.lock.json`.
 - Implementation/evidence truth: this repo, GitHub issues/PRs/checks, CI artifacts, and checked-in release evidence.
 - Generated docs/indexes/projections are not canonical.
-- Legacy `specs/0000-*` through `specs/0007-*` remain transitional implementation-conformance artifacts until migrated into the spec corpus. They must not override the corpus.
+- Repo-local spec packets are classified in `specs/spec-inventory.yaml`. Transitional packets and fixtures must not override the corpus, including newer packets such as local dogfood topology, domain-first MCP, full-product target, and governed Weaver PA target.
+
+
+## Inventory
+
+The classification for every repo-local spec-like artifact is maintained in:
+
+- `specs/spec-inventory.yaml`
+
+Use that inventory before editing, deleting, or citing repo-local packets. It records which artifacts are transitional conformance packets, conformance fixtures, or implementation evidence, and points to likely corpus owners for migration.
 
 ## Required workflow
 

--- a/specs/spec-inventory.yaml
+++ b/specs/spec-inventory.yaml
@@ -1,0 +1,115 @@
+schemaVersion: 1
+purpose: >-
+  Classify specification-like artifacts in this implementation repository so
+  contributors and AI-assisted agents do not treat transitional packets as
+  canonical product/domain truth.
+canonicalProductDomainTruth:
+  lockfile: specs/weave-specs.lock.json
+  owner: pinned Weave Specification Corpus
+  localDefaultPath: ../weave-specs
+implementationEvidenceTruth:
+  owner: this repository
+  includes:
+    - code
+    - tests
+    - CI and Gradle gates
+    - generated projections
+    - support-safe release evidence
+    - GitHub issues, PRs, checks, and milestones
+policies:
+  - Repo-local specs may prove implementation conformance but must not redefine product/domain meaning.
+  - If repo reality conflicts with the pinned corpus, open either a spec-corpus change or an implementation conformance fix.
+  - Deletion or migration of transitional packets must preserve any fixture/evidence value that gates still consume.
+  - Weaver/OpenClaw runtime specifications live in their own repository and are dependency/runtime evidence only for Weave product work.
+artifacts:
+  - path: specs/0000-weave-spec-framework
+    status: transitional-conformance
+    action: keep-until-migrated-or-replaced-by-corpus-manifest
+    notes: Historical framework packet; corpus steering files own canonical method.
+  - path: specs/0001-organization-embedding-product-core
+    status: transitional-conformance
+    action: migrate-product-meaning-to-corpus-then-prune-repo-copy
+    corpusCandidates:
+      - steering/product-constitution.md
+      - steering/domain-context-map.md
+      - domains/identity-idm/spec.md
+      - domains/admin-health-ops/spec.md
+  - path: specs/0002-context-driven-workflows
+    status: transitional-conformance
+    action: migrate-product-meaning-to-corpus-then-prune-repo-copy
+    corpusCandidates:
+      - domains/spaces/spec.md
+      - steering/ubiquitous-language.md
+  - path: specs/0003-contextual-meetings
+    status: transitional-conformance
+    action: migrate-product-meaning-to-corpus-then-prune-repo-copy
+    corpusCandidates:
+      - domains/meetings-calls/spec.md
+      - domains/calendar/spec.md
+      - domains/chat/spec.md
+  - path: specs/0004-domain-registry
+    status: conformance-fixture
+    action: keep-while-generated-domain-registry-and-contract-gates-consume-it
+    corpusCandidates:
+      - steering/domain-context-map.md
+      - generated/manifest.json
+    notes: Contains canonical-domain-registry-v1.json used as repo-side projection/evidence.
+  - path: specs/0005-spaces-anchor
+    status: conformance-fixture
+    action: keep-while-tests-or-evidence-consume-fixtures
+    corpusCandidates:
+      - domains/spaces/spec.md
+  - path: specs/0006-portability-contract
+    status: conformance-fixture
+    action: keep-fixtures-and-migrate-product-policy-to-corpus
+    corpusCandidates:
+      - steering/provider-portability-principles.md
+      - domains/files/spec.md
+      - domains/calendar/spec.md
+      - domains/chat/spec.md
+      - domains/boards-tasks/spec.md
+      - contracts/jsonschema/portability-report.schema.json
+    notes: JSON dry-run and negative fixtures are implementation evidence unless promoted to corpus contracts.
+  - path: specs/0007-governed-weaver-runtime
+    status: transitional-conformance
+    action: split-weave-product-policy-from-weaver-runtime-dependency-evidence
+    corpusCandidates:
+      - domains/weaver-governed-pa/spec.md
+      - steering/openclaw-orchestrator-pattern.md
+    notes: Weaver/OpenClaw runtime implementation proof belongs to the Weaver/OpenClaw runtime repository.
+  - path: specs/0008-local-dogfood-topology-weave-test
+    status: implementation-evidence
+    action: keep-as-repo-owned-dogfood-evidence-unless-replaced-by-release-gate
+    corpusCandidates:
+      - releases/rc-gates/release-candidate-gate.md
+      - steering/devops-conformance.md
+  - path: specs/0009-domain-first-mcp-tools
+    status: transitional-conformance
+    action: keep-until-domain-mcp-contract-is-owned-by-corpus-or-runtime-repo
+    corpusCandidates:
+      - steering/openclaw-orchestrator-pattern.md
+      - domains/weaver-governed-pa/spec.md
+    notes: Domain naming is product truth; MCP runtime mechanics are Weaver/OpenClaw runtime truth.
+  - path: specs/0010-full-product-target
+    status: transitional-conformance
+    action: migrate-product-scope-to-corpus-then-prune-repo-copy
+    corpusCandidates:
+      - steering/product-constitution.md
+      - domains/*/spec.md
+  - path: specs/0011-weaver-governed-pa-target
+    status: transitional-conformance
+    action: split-product-policy-into-corpus-and-runtime-proof-into-weaver-repo
+    corpusCandidates:
+      - domains/weaver-governed-pa/spec.md
+      - steering/openclaw-orchestrator-pattern.md
+  - path: specs/admin-ci-cd-orchestration-contract.md
+    status: implementation-evidence
+    action: keep-as-repo-owned-devops-conformance-unless-migrated-to-corpus-release-gate
+    corpusCandidates:
+      - steering/devops-conformance.md
+      - releases/rc-gates/release-candidate-gate.md
+cleanupSequence:
+  - Add or update corpus files for any remaining product/domain meaning.
+  - Update repo tests/gates to consume corpus contracts or generated projections.
+  - Preserve fixtures that gates still need under evidence or test fixture paths.
+  - Remove migrated repo-local duplicate specs in focused PRs with gate evidence.


### PR DESCRIPTION
## Summary

Promote the current `dev` head to the persistent dogfood/test lane.

Included change since `dogfood`:

- `b2b3d8a270` — docs: consolidate specification source of truth

## Verification before promotion

- PR #887 to `dev` merged after green Gradle CI and Release Notes Label Check
- local `./gradlew specCorpusConformance`
- local `./gradlew docsCheck`

## Dogfood expectation

This PR should trigger the normal dogfood/test-stack validation path after merge to `dogfood`. It is documentation/spec-governance only and does not intentionally change runtime behavior.
