### PR TITLE
docs: anchor dev dogfood main promotion flow

### DIFF
--- a/.github/workflows/live-stack-e2e.yml
+++ b/.github/workflows/live-stack-e2e.yml
@@ -1,6 +1,14 @@
 name: Live Stack E2E
 
 on:
+  pull_request:
+    branches:
+      - dogfood
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   workflow_dispatch:
     inputs:
       weave_backend_image:
@@ -11,9 +19,6 @@ on:
         description: "MCP server image built from CI-built weave-mcp-server JAR artifacts; ghcr.io/* is pulled"
         required: false
         default: "weave-mcp-server:live-stack-ci"
-  schedule:
-    # Nightly release-evidence run on the dedicated self-hosted live runner.
-    - cron: "17 2 * * *"
   workflow_call:
     inputs:
       weave_backend_image:
@@ -280,7 +285,7 @@ jobs:
             --test-log "$WEAVE_ACCEPTANCE_TEST_LOG" \
             --append-summary "$GITHUB_STEP_SUMMARY" \
             --source live-stack-e2e \
-            --lane release-candidate-live-evidence \
+            --lane dogfood-candidate-live-evidence \
             --commit "$GITHUB_SHA" \
             --run-id "$GITHUB_RUN_ID" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" \

--- a/.github/workflows/main-promotion-gate.yml
+++ b/.github/workflows/main-promotion-gate.yml
@@ -52,20 +52,36 @@ jobs:
             echo "Candidate is already contained in origin/main."
           fi
 
+      - name: Verify successful dogfood candidate Live Stack E2E for candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          candidate="${{ steps.candidate.outputs.sha }}"
+          runs_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/live-stack-e2e.yml/runs?head_sha=${candidate}&status=completed&per_page=20")"
+          count="$(python3 -c 'import json,sys; print(sum(1 for run in json.load(sys.stdin).get("workflow_runs", []) if run.get("conclusion") == "success"))' <<<"$runs_json")"
+          if [[ "$count" == "0" ]]; then
+            echo "::error::No successful Live Stack E2E workflow run found for ${candidate}." >&2
+            echo "Open or update the dev -> dogfood promotion PR and wait for dogfood candidate Live Stack E2E evidence before promoting to main." >&2
+            exit 1
+          fi
+          run_url="$(python3 -c 'import json,sys; runs=[run for run in json.load(sys.stdin).get("workflow_runs", []) if run.get("conclusion") == "success"]; print(runs[0].get("html_url", "") if runs else "")' <<<"$runs_json")"
+          echo "Successful dogfood candidate Live Stack E2E evidence: ${run_url}"
+
       - name: Verify successful persistent test-stack deploy for candidate
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           candidate="${{ steps.candidate.outputs.sha }}"
-          runs_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/test-stack-deploy.yml/runs?branch=dogfood&head_sha=${candidate}&status=success&per_page=10")"
-          count="$(python3 -c 'import json,sys; print(len(json.load(sys.stdin).get("workflow_runs", [])))' <<<"$runs_json")"
+          runs_json="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/test-stack-deploy.yml/runs?branch=dogfood&head_sha=${candidate}&status=completed&per_page=10")"
+          count="$(python3 -c 'import json,sys; print(sum(1 for run in json.load(sys.stdin).get("workflow_runs", []) if run.get("conclusion") == "success"))' <<<"$runs_json")"
           if [[ "$count" == "0" ]]; then
             echo "::error::No successful Test Stack Deploy workflow run found for ${candidate} on branch dogfood." >&2
             echo "Push/merge the candidate to dogfood and wait for the persistent LAN stack deployment to pass before opening/promoting to main." >&2
             exit 1
           fi
-          run_url="$(python3 -c 'import json,sys; runs=json.load(sys.stdin).get("workflow_runs", []); print(runs[0].get("html_url", ""))' <<<"$runs_json")"
+          run_url="$(python3 -c 'import json,sys; runs=[run for run in json.load(sys.stdin).get("workflow_runs", []) if run.get("conclusion") == "success"]; print(runs[0].get("html_url", "") if runs else "")' <<<"$runs_json")"
           echo "Successful test-stack evidence: ${run_url}"
 
       - name: Verify root contract authority checks still pass

--- a/docs/dev-test-main-promotion-flow.md
+++ b/docs/dev-test-main-promotion-flow.md
@@ -4,15 +4,15 @@ Status: active delivery policy.
 
 Weave uses three promotion lanes:
 
-- `dev`: normal integration branch. Feature PRs land here after ordinary CI, issue acceptance, and review/evidence gates.
-- `dogfood`: persistent LAN dogfood branch. Advancing this branch deploys or updates the local test stack on the dedicated Mac runner. This branch is named `dogfood` because legacy `test/...` branches already occupy Git's `refs/heads/test/` namespace.
-- `main`: stable/release-facing branch. A commit may reach `main` only after it has been integrated through `dev` and successfully deployed through `dogfood`.
+- `dev`: normal integration branch and the base for feature branches. Feature PRs are cut from `dev` and return to `dev` after the review/refactor loop, feature-specific tests, acceptance/Gherkin/Cucumber mappings, docs/evidence, and PR-safe CI/contracts/unit/acceptance/docs gates.
+- `dogfood`: persistent LAN dogfood branch and candidate/test-stack promotion lane. Promotion PRs from `dev` to `dogfood` run the feature-relevant E2E/live/dogfood validation for that candidate; missing feature-relevant Gherkin/Cucumber scenarios or deterministic mappings must be added by this stage at the latest. Advancing this branch deploys or updates the local test stack on the dedicated Mac runner. This branch is named `dogfood` because legacy `test/...` branches already occupy Git's `refs/heads/test/` namespace.
+- `main`: stable/release-capable branch after dogfood validation. A commit may reach `main` only after it has been integrated through `dev`, validated through `dogfood`, and has green dogfood E2E/live evidence plus human-test signoff where the change requires it.
 
 ## Why this exists
 
-`dev` proves that the repository builds and the offline/product-contract gates pass. It does not prove that Massimo can open Weave on a real device against a live local stack.
+`dev` proves that the repository builds and the offline/product-contract gates pass. Feature work belongs here first: branch from `dev`, PR back to `dev`, and add the feature-specific tests, acceptance scenarios, documentation, and evidence while the review/refactor loop is still cheap.
 
-`dogfood` is the always-testable LAN stack. It is intended for human dogfood, physical iPhone checks, and integration evidence against the same deployed stack instead of one-off local shells.
+`dogfood` is the always-testable LAN stack and candidate validation truth. It is intended for human dogfood, physical iPhone checks, and integration evidence against the same deployed stack instead of one-off local shells. It is not a disposable release-only stack.
 
 `main` must not receive commits that have bypassed either `dev` integration or `dogfood` deployment.
 
@@ -22,6 +22,7 @@ The test stack is deployed by the `Test Stack Deploy` GitHub Actions workflow:
 
 - workflow file: `.github/workflows/test-stack-deploy.yml`
 - trigger: push to `dogfood` or manual `workflow_dispatch`
+- candidate E2E workflow: `.github/workflows/live-stack-e2e.yml` on promotion PRs targeting `dogfood` and manual dispatch
 - runner: dedicated self-hosted macOS ARM64 runner `weave-live-mac-mini`
 - public local entrypoint: `https://weave.test:44443/`
 - platform config: `https://api.weave.test:44443/api/platform/config`
@@ -47,14 +48,21 @@ The persistent test stack defaults to update mode:
 
 Destructive reset is manual only through the workflow input `reset_stack=true`. It removes local test-stack data and must not be used as the normal promotion path.
 
+## Dogfood candidate validation
+
+A promotion PR from `dev` to `dogfood` is the normal place for full or feature-relevant live validation. The `Live Stack E2E` workflow must run against the promotion candidate, generate acceptance-contract evidence from `e2e/features/` and `e2e/scenario_mappings.json`, and upload support-safe artifacts. It may destructively reset its temporary validation stack, but the persistent dogfood stack is updated separately by `Test Stack Deploy` after the candidate lands on `dogfood`.
+
+The old pattern of a scheduled destructive full-E2E run from `main` is not the target model. `main` may keep lightweight smoke, release, or tag checks, but it must not be the primary noisy/destructive full-stack reset lane.
+
 ## Main promotion gate
 
 The `Main Promotion Gate` workflow enforces the branch order:
 
 1. the candidate commit is contained in `origin/dev`;
 2. the same candidate commit is contained in `origin/dogfood`;
-3. a successful `Test Stack Deploy` workflow run exists for that commit on branch `dogfood`;
-4. the root contract-authority architecture check still passes.
+3. successful dogfood candidate E2E/live evidence exists for that commit;
+4. a successful `Test Stack Deploy` workflow run exists for that commit on branch `dogfood`;
+5. the root contract-authority architecture check still passes.
 
 If any of these checks fail, the candidate is not eligible for `main`.
 
@@ -85,7 +93,7 @@ The desired tester experience is:
 3. sign in once;
 4. later open Weave and return to the same test-stack organization without re-running setup scripts.
 
-Invite/QR handoff remains useful for first enrollment and reset cases, but should not be required every time the app opens.
+Invite/QR handoff remains useful for first enrollment and reset cases, but should not be required every time the app opens. Wording must be precise: the current join/handoff link is a non-secret enrollment handoff, not bearer access. Actual access control is the provisioned account, organization/workspace membership, and identity-provider session.
 
 ## Release discipline
 
@@ -94,5 +102,6 @@ A change that affects sign-in, backend facade contracts, OpenAPI consumers, MCP/
 - ordinary PR CI on `dev`;
 - generated OpenAPI/admin/client freshness where relevant;
 - MCP/root architecture gates where relevant;
+- promotion PR evidence from `dev` to `dogfood`, including feature-relevant Gherkin/Cucumber scenarios or deterministic mappings;
 - persistent `dogfood` stack deployment;
 - targeted human or automated dogfood evidence before promotion to `main`.

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -103,7 +103,7 @@ make offline-contract-test
 
 ## Lane-based PR and release workflow
 
-Use the lane-based DevOps flow: protected `main` for stable release truth, protected `dev` for integration, `future/*` for larger not-yet-release-ready lines, `rc/*` for release candidates and Live Stack E2E evidence, and `hotfix/*` for emergency stable-line fixes. See [Weave DevOps branching model](devops/branching-model.md), [release flow](devops/release-flow.md), [release notes policy](devops/release-notes.md), and [spec governance](devops/spec-governance.md). Every PR must deliberately choose exactly one release-notes label before review/merge:
+Use the lane-based DevOps flow: protected `dev` for integration and normal feature PRs, protected `dogfood` for persistent LAN candidate/human validation, protected `main` for stable release-capable truth, `future/*` for larger not-yet-release-ready lines, optional `rc/*` for later release hardening, and `hotfix/*` for emergency stable-line fixes. See [Weave DevOps branching model](devops/branching-model.md), [release flow](devops/release-flow.md), [release notes policy](devops/release-notes.md), and [spec governance](devops/spec-governance.md). Every PR must deliberately choose exactly one release-notes label before review/merge:
 
 - `release-notes-feature`
 - `release-notes-bugfix`

--- a/docs/devops/branching-model.md
+++ b/docs/devops/branching-model.md
@@ -4,24 +4,27 @@ Weave uses a lane-based flow. The goal is a stable basis where the pinned specif
 
 ## Lanes
 
-- `main` is protected stable and release truth.
-  - It must contain release-ready code and release evidence only.
+- `main` is protected stable and release-capable truth.
+  - It must contain dogfood-validated code and release evidence only.
   - Normal product work does not target `main` directly.
-  - PRs to `main` are limited to promoted `rc/*` branches or documented emergency `hotfix/*` exceptions.
+  - PRs to `main` normally promote `dogfood` after green dogfood E2E/live evidence and required human signoff; documented emergency `hotfix/*` exceptions are allowed.
   - Release tags are generated from `main`.
 - `dev` is the protected integration lane.
-  - Issue branches, bugfix branches, documentation branches, and spec-integration branches normally target `dev`.
+  - Issue branches, bugfix branches, documentation branches, and spec-integration branches are cut from current `dev` and normally target `dev`.
+  - Review/refactor loops, feature-specific tests, acceptance/Gherkin/Cucumber scenarios, docs/evidence, and PR-safe CI/contracts/unit/acceptance/docs gates happen here when possible.
   - `dev` is allowed to be ahead of the current release, but it must stay buildable and evidence-backed.
-  - CI/spec gates run here before release-candidate cutting.
 - `future/*` lanes hold larger product lines that are not release-ready yet.
   - They must keep spec reconciliation explicit.
   - They periodically PR back into `dev` in reviewable slices.
   - They are not a shortcut around release notes, linked issues, or acceptance evidence.
-- `rc/<version>` lanes are release-candidate and E2E lanes.
-  - Cut them from `dev` when the candidate scope is ready.
-  - Only stabilization fixes, release evidence, and release-note corrections belong here.
-  - Full Live Stack E2E and release-evidence gates run here before promotion.
-  - A green and reviewed `rc/*` branch promotes to `main` by PR.
+- `dogfood` is the persistent LAN test-stack and human dogfood lane.
+  - Promote `dev` to `dogfood` by PR when a candidate is ready for live validation.
+  - Full or feature-relevant Live Stack E2E, dogfood evidence, and missing scenario/mapping updates belong on this promotion by the latest.
+  - Merging to `dogfood` deploys or updates the persistent LAN stack for human/iPhone/accessibility validation.
+  - A green and signed-off `dogfood` candidate promotes to `main` by PR.
+- `rc/<version>` lanes are optional later release-hardening lanes.
+  - Cut them from `main` or `dogfood` only when a named release needs extra stabilization, release notes, packaging, or publication evidence beyond ordinary dogfood validation.
+  - `rc/*` is not the normal human dogfood path and must not bypass `dev` -> `dogfood` -> `main`.
 - `hotfix/*` lanes are emergency exceptions.
   - Cut them from `main` for urgent release-truth fixes.
   - PR them to `main`, then backport or merge the fix into `dev` so the lanes do not diverge silently.
@@ -50,7 +53,7 @@ Every PR declares:
 
 Branch protection should make the lane names meaningful:
 
-- protect `main`, `dev`, and active `rc/*` branches;
+- protect `main`, `dev`, `dogfood`, and active `rc/*` branches;
 - require reviews and green required checks before merge;
 - require linear or squash history according to the repository merge policy;
 - prevent direct pushes except for documented administrator recovery;

--- a/docs/devops/release-flow.md
+++ b/docs/devops/release-flow.md
@@ -1,14 +1,14 @@
 # Weave release flow
 
-This release flow keeps `main` stable while still giving Weave a practical integration lane for issues, specification work, and release-candidate evidence.
+This release flow keeps `main` stable while giving Weave a practical integration lane for issues, a persistent dogfood lane for candidate validation, and optional later release-hardening lanes.
 
 ## Normal issue flow
 
 - Recover truth from the pinned spec corpus in `specs/weave-specs.lock.json` and the linked issue.
 - Create a short-lived issue branch from current `dev`.
 - Implement the smallest reviewable slice.
-- Update acceptance evidence, docs, and release-note text in the same PR when behavior or operations change.
-- Open the PR to `dev` with the PR template filled.
+- Update feature-specific tests, acceptance/Gherkin/Cucumber scenarios or deterministic mappings, docs, evidence, and release-note text in the same PR when behavior or operations change.
+- Open the PR back to `dev` with the PR template filled.
 - Run the smallest meaningful local gate and let CI validate the lane.
 
 ## Spec integration flow
@@ -20,13 +20,19 @@ This release flow keeps `main` stable while still giving Weave a practical integ
   - open or link a conformance-fix task in this repo.
 - Do not let implementation state silently redefine product or domain meaning.
 
-## Release-candidate flow
+## Dogfood promotion flow
 
-- Cut `rc/<version>` from `dev` only after the candidate scope is coherent.
-- Freeze scope on `rc/<version>` to stabilization, evidence, release-note fixes, and release blockers.
-- Run release evidence gates, including Live Stack E2E when relevant for the release.
-- Record candidate evidence in the release evidence docs or artifacts.
-- Promote `rc/<version>` to `main` by PR only when gates and reviews are green or an accepted release-gate exception is documented.
+- Promote `dev` to `dogfood` by PR when the integrated candidate is ready for live validation.
+- Run full or feature-relevant E2E/live/dogfood checks on that promotion candidate, including acceptance-contract evidence mapped from `e2e/features/` and `e2e/scenario_mappings.json`.
+- Add or update missing feature-relevant Gherkin/Cucumber scenarios or deterministic mappings by this stage at the latest.
+- Merge to `dogfood` only when the candidate evidence is green or an accepted test-gate exception is documented.
+- The merge to `dogfood` deploys or updates the persistent LAN dogfood stack for human, iPhone, and accessibility validation.
+- Promote `dogfood` to `main` by PR only after green dogfood E2E/live evidence and required human-test signoff.
+
+## Optional release-candidate hardening flow
+
+- Use `rc/<version>` only when a named release needs extra hardening, packaging, release-note, or publication evidence beyond ordinary dogfood validation.
+- `rc/*` is optional/later release hardening, not the ordinary human dogfood path. It must not bypass `dev` -> `dogfood` -> `main`.
 - Tag releases from `main` after promotion.
 
 ## Hotfix flow
@@ -38,4 +44,4 @@ This release flow keeps `main` stable while still giving Weave a practical integ
 
 ## No release-ready claim by default
 
-A green PR or local gate is not a release-ready claim. Release readiness requires the relevant `rc/*` evidence, release notes, protected checks, and closure of named release blockers.
+A green PR or local gate is not a release-ready claim. Release readiness requires dogfood validation evidence, release notes, protected checks, and closure of named release blockers; optional `rc/*` evidence is added only when a named release hardening lane is used.

--- a/docs/gitflow-pr-workflow.md
+++ b/docs/gitflow-pr-workflow.md
@@ -1,10 +1,10 @@
 # Lane-based PR and release workflow
 
-Weave uses clear DevOps lanes instead of heavy classic GitFlow: `main` for stable release truth, `dev` for integration, `future/*` for larger not-yet-release-ready lines, `rc/*` for release candidates and Live Stack E2E evidence, and `hotfix/*` for urgent stable-line fixes. Keep changes spec-driven: intent -> issue/spec note -> acceptance/evidence -> implementation -> review. For the full delivery contract, see [Weave operating model](weave-operating-model.md) and the DevOps docs under `docs/devops/`.
+Weave uses clear DevOps lanes instead of heavy classic GitFlow: `dev` for integration, feature branches cut from and returned to `dev`, `dogfood` for persistent LAN candidate/human validation, `main` for stable release-capable truth, `future/*` for larger not-yet-release-ready lines, optional `rc/*` for later release hardening, and `hotfix/*` for urgent stable-line fixes. Keep changes spec-driven: intent -> issue/spec note -> acceptance/evidence -> implementation -> review. For the full delivery contract, see [Weave operating model](weave-operating-model.md) and the DevOps docs under `docs/devops/`.
 
 ## Branch and PR rules
 
-1. Start from the correct current lane: normally `origin/dev`, `future/*` for large future lines, `rc/*` for candidate stabilization, or `origin/main` only for emergency hotfixes.
+1. Start from the correct current lane: normally `origin/dev` for feature/bugfix/docs/spec work, `origin/dev` -> `dogfood` for candidate promotion, `origin/dogfood` -> `main` for stable promotion, `future/*` for large future lines, optional `rc/*` for named release hardening, or `origin/main` only for emergency hotfixes.
 2. Create a focused branch named for the scope, for example `docs/mkdocs-handbook-foundation`, `feat/admin-policy-profiles`, or `fix/chat-empty-state`.
 3. Keep unrelated local files and assistant workspace files out of commits.
 4. Open a PR early enough for CI and review, but mark it draft if it is not review-ready.
@@ -18,8 +18,9 @@ Weave uses clear DevOps lanes instead of heavy classic GitFlow: `main` for stabl
 
 - `dev` is a branch lane for integration; it is not a deployed environment.
 - Local development and temporary previews still use developer machines or disposable worktrees.
-- Testing/staging is represented by GitHub Environments or workflow targets, especially for release-candidate and Live Stack E2E evidence.
-- Release candidates use `rc/<version>` branches cut from `dev`; release tags are generated from `main` after promotion.
+- `dogfood` is the persistent LAN test/human-validation stack. Promotion PRs from `dev` to `dogfood` run full or feature-relevant E2E/live validation; merges to `dogfood` deploy or update the persistent stack.
+- `main` promotion follows dogfood validation and required human signoff.
+- `rc/<version>` branches are optional later release-hardening lanes, not the ordinary human dogfood path; release tags are generated from `main` after promotion.
 - Production releases use final SemVer tags such as `vX.Y.Z` plus explicit production approval.
 - A merge to `main` makes Weave release-capable; it is not an automatic production deploy.
 

--- a/docs/sprint-31-iphone-lan-dogfood-runbook.md
+++ b/docs/sprint-31-iphone-lan-dogfood-runbook.md
@@ -17,7 +17,7 @@ WEAVE_LAN_HOST=<Mac LAN IP> tools/weavectl profile apply \
 
 For dry validation before the stack is listening, use `--preflight-mode validate-only`. The command writes one run id under `build/evidence/local-lan-dogfood/<run-id>/` with `readiness.json`, `handoff.json`, and `evidence.json`.
 
-The command rejects `localhost`, `127.0.0.1`, `0.0.0.0`, container-only names, and Mac-only `.local` assumptions before handoff output. Handoff evidence stores refs and endpoint classes, not raw secrets or provider diagnostics. The handoff includes one canonical product join URL (`/join`) plus a `weave:/join?...` local-dev fallback. Both point at the public `/api/platform/config` app-start discovery contract; the member client must not derive provider topology from a guessed base URL.
+The command rejects `localhost`, `127.0.0.1`, `0.0.0.0`, container-only names, and Mac-only `.local` assumptions before handoff output. Handoff evidence stores refs and endpoint classes, not raw secrets or provider diagnostics. The handoff includes one canonical product join URL (`/join`) plus a `weave:/join?...` local-dev fallback. These are non-secret enrollment handoff links, not bearer access. Real access control is the provisioned account, organization/workspace membership, and identity-provider session. Both handoff links point at the public `/api/platform/config` app-start discovery contract; the member client must not derive provider topology from a guessed base URL.
 
 ## What Massimo should see
 
@@ -33,15 +33,15 @@ It includes the local CA downloads, iPhone trust steps, DNS-first service links,
 infra/weave-workspace/local-invite-link.sh --json
 ```
 
-Default invite link to give Massimo:
+Default non-secret enrollment handoff link to give Massimo:
 
 ```text
 https://weave.test:44443/join?handoff_ref=handoff-s32-massimo-dogfood-home&org=massimo-dogfood&workspace=home&profile=local-lan-dogfood&run_id=s32-massimo-dogfood
 ```
 
-Give Massimo the QR/link from `handoff.json` or the deterministic local invite above and say:
+Give Massimo the QR/link from `handoff.json` or the deterministic local handoff above and say:
 
-> Open this Weave invite on the iPhone while it is on the same LAN as the Mac. It starts sign-in and then opens the Weave workspace home.
+> Open this Weave enrollment handoff on the iPhone while it is on the same LAN as the Mac. It is not a secret access token; your account and membership control access. It starts sign-in and then opens the Weave workspace home.
 
 Expected tester path:
 

--- a/docs/sprint-32-local-dns-server-and-invite-onboarding-plan.md
+++ b/docs/sprint-32-local-dns-server-and-invite-onboarding-plan.md
@@ -4,14 +4,14 @@ Status: implemented locally for Sprint 32 dogfood verification. This is an imple
 
 ## Sprint goal
 
-Make the local dogfood stack DNS-first for `*.weave.test`, keep any LAN host/IP input non-canonical, bootstrap the local CA from `weave.test`, and prove that a member can join Weave by invitation link, QR code, or normal credential login without seeing raw provider configuration.
+Make the local dogfood stack DNS-first for `*.weave.test`, keep any LAN host/IP input non-canonical, bootstrap the local CA from `weave.test`, and prove that a member can join Weave by non-secret enrollment handoff link, QR code, or normal credential login without seeing raw provider configuration. Account provisioning, organization/workspace membership, and the identity-provider session remain the real access-control boundary.
 
 ## Governing context
 
 - Current branch: `feat/enterprise-app-start-ux`.
 - Current dogfood contract: DNS-first `weave.test` / `*.weave.test`; LAN IPs are not canonical app, issuer, service, or CA URLs.
 - New operator fact: Massimo added LAN DNS for `*.weave.test`.
-- Product direction: Weave remains provider-neutral and organization-first. Normal members consume invite/auth URL plus `/api/platform/config`; they must not configure Matrix, Nextcloud, raw provider URLs, secrets, diagnostics, or admin setup details.
+- Product direction: Weave remains provider-neutral and organization-first. Normal members consume non-secret enrollment handoff/auth URL plus `/api/platform/config`; they must not configure Matrix, Nextcloud, raw provider URLs, secrets, diagnostics, or admin setup details.
 - Sprint 31 baseline: physical iPhone LAN dogfood used a single LAN host/IP path-routed fallback because local DNS could not be assumed.
 - Sprint 32 correction: local DNS can now be assumed for Massimo's LAN dogfood profile, so DNS names become canonical. The LAN host/IP may remain an operator input for SAN/debug compatibility, but it is not an advertised app/service/CA URL truth.
 
@@ -82,7 +82,7 @@ DNS-first path:
   - Auth/IAM: `https://auth.weave.test:44443/realms/weave` or canonical-port equivalent.
   - Matrix: `https://matrix.weave.test:44443` or canonical-port equivalent.
   - Files technical fallback: `https://files.weave.test:44443` or canonical-port equivalent.
-- Native app startup uses `/join` and `/api/platform/config`; the app does not derive provider topology from a guessed base URL.
+- Native app startup uses `/join` and `/api/platform/config`; `/join` is an enrollment handoff, not bearer access, and the app does not derive provider topology from a guessed base URL.
 - Services that call back into local HTTPS trust the same central local CA instead of disabling verification.
 
 IP fallback and CA bootstrap path:
@@ -230,38 +230,38 @@ Evidence:
 - Relevant client analysis gate if surrounding code changes require it.
 ```
 
-### 5. Invitation link, QR, and IAM URL onboarding flow
+### 5. Enrollment handoff link, QR, and IAM URL onboarding flow
 
 Acceptance criteria:
 
-- Admin/operator can produce a support-safe invitation handoff containing only refs, organization/workspace context, and discovery URL; no secrets or provider diagnostics appear in the link or QR payload.
-- The same payload can be rendered as a URL, QR code source, and app/deep link fallback.
+- Admin/operator can produce a support-safe enrollment handoff containing only refs, organization/workspace context, and discovery URL; no secrets or provider diagnostics appear in the link or QR payload.
+- The same non-secret payload can be rendered as a URL, QR code source, and app/deep link fallback.
 - Member can alternatively enter the organization IAM/auth URL, such as `https://auth.weave.test[:port]/realms/weave`, and the app can discover or derive the platform config through an explicit supported contract rather than guessing provider topology.
-- Invitation flow is inspired by organizations: invite link/QR for most members; IAM URL plus credentials/SSO for credential-based entry; both land in the same authenticated workspace/home path.
-- Expiry, revocation, tenant/workspace binding, and audit are specified or explicitly deferred with follow-up issues before production/customer claims.
+- Enrollment flow is organization-shaped: handoff link/QR for most members; IAM URL plus credentials/SSO for credential-based entry; both land in the same authenticated workspace/home path.
+- The handoff is not bearer access. Real access control is the provisioned account, organization/workspace membership, and identity-provider session; expiry/revocation for handoff usability is specified or explicitly deferred before production/customer claims.
 - Accessibility: QR has adjacent copyable link text and screen-reader label; manual IAM URL entry has validation errors that do not rely on color alone.
-- Acceptance is mapped to e2e/product scenarios for member join through invite, organization URL, or deep link.
+- Acceptance is mapped to e2e/product scenarios for member join through handoff, organization URL, or deep link.
 
 Recommended issue draft:
 
 ```markdown
-Title: onboarding: prepare invite link, QR, and IAM URL member join flow
+Title: onboarding: prepare enrollment handoff link, QR, and IAM URL member join flow
 
 Body:
-Implement the first test invitation flow for Weave local dogfood. Members should join through an invitation link or QR code, or manually enter the IAM/auth URL and authenticate with credentials/SSO. The app must still consume `/api/platform/config` and must not expose raw provider setup to normal members.
+Implement the first test enrollment handoff flow for Weave local dogfood. Members should join through a non-secret handoff link or QR code, or manually enter the IAM/auth URL and authenticate with credentials/SSO. The app must still consume `/api/platform/config` and must not expose raw provider setup to normal members. The handoff is not bearer access; account provisioning and organization/workspace membership remain the access-control boundary.
 
 Acceptance:
-- Operator/admin flow emits a support-safe invite URL and QR payload with no secrets, raw provider diagnostics, Matrix URL, Nextcloud URL, or credential URL.
-- Native app consumes the invite/deep link, fetches `/api/platform/config`, starts SSO, and lands in workspace/home.
+- Operator/admin flow emits a support-safe enrollment handoff URL and QR payload with no secrets, raw provider diagnostics, Matrix URL, Nextcloud URL, or credential URL.
+- Native app consumes the handoff/deep link, fetches `/api/platform/config`, starts SSO, and lands in workspace/home.
 - Manual IAM URL entry is supported through a documented discovery path and does not ask for provider internals.
-- Invite link/QR and IAM URL paths share the same authenticated organization manifest/capability state after login.
-- Tests or e2e mapping cover link, QR payload, IAM URL entry, invalid/expired invite, and no-secret redaction.
+- Handoff link/QR and IAM URL paths share the same authenticated organization manifest/capability state after login.
+- Tests or e2e mapping cover link, QR payload, IAM URL entry, invalid/expired handoff, no-secret redaction, and account/membership-based denial.
 - QR/manual entry UI is accessible and localizable.
 
 Evidence:
 - onboarding unit/widget tests
 - acceptance/e2e scenario mapping update
-- local dogfood smoke command with emitted invite/QR payload
+- local dogfood smoke command with emitted handoff/QR payload
 ```
 
 ## Implemented in the first DNS-first slice
@@ -271,14 +271,14 @@ Evidence:
 - Certificate SAN generation includes `weave.test`, `*.weave.test`, and concrete service hostnames.
 - Caddy advertises CA bootstrap on `http://weave.test:44080/weave-local-ca.pem`.
 - App handoff validation permits the intentional `weave.test` / `*.weave.test` LAN DNS domain and rejects LAN-IP app-start links, loopback, container-only names, and unrelated `.local` names.
-- Client tests cover invite link onboarding, deterministic QR payload/decode, DNS-first app-start config consumption, and existing credential-login integration coverage.
+- Client tests cover non-secret enrollment handoff onboarding, deterministic QR payload/decode, DNS-first app-start config consumption, and existing credential-login integration coverage.
 - `client/ios/Podfile.lock` remains pre-existing/unassessed working-tree state.
 
 ## Suggested follow-up issue DAG
 
 - First: review and land the local DNS-first infra/client slice.
 - Second: run the same evidence on the physical iPhone after installing/trusting `Weave Local Development CA`.
-- Third: improve visible invite/QR/IAM URL onboarding UX beyond the deterministic parser/discovery contracts.
+- Third: improve visible enrollment handoff/QR/IAM URL onboarding UX beyond the deterministic parser/discovery contracts.
 - Final: sprint closure report with Massimo's physical-device result.
 
 ## Risks and open decisions

--- a/docs/user-handbook.md
+++ b/docs/user-handbook.md
@@ -4,8 +4,8 @@ This handbook is for people using a Weave organization after an owner/admin has 
 
 ## Onboarding and login
 
-1. Open the organization invite, deep link, or organization auth URL from your admin.
-2. Complete SSO in the configured identity provider.
+1. Open the organization enrollment handoff link, deep link, or organization auth URL from your admin. The link helps the app find the organization; it is not bearer access.
+2. Complete SSO in the configured identity provider. Your provisioned account and organization/workspace membership decide whether you can enter.
 3. Weave fetches the authenticated organization manifest and shows only the work surfaces and capability states available to you.
 
 If your organization is not usable yet, Weave should explain the impact in plain language from the provider-neutral manifest vocabulary: `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, or `coming_later`. Provider setup details stay with admins/operators.

--- a/docs/weave-control-bootstrap-to-client-contract.md
+++ b/docs/weave-control-bootstrap-to-client-contract.md
@@ -8,7 +8,7 @@ The Bootstrap foundation defines the enterprise component split: Control Plane =
 
 The Admin Console is the organization management surface that sits on top of the same Weave Server contract after or during bootstrap. It owns organization/provider category management, IDM/RBAC sync, users/groups/roles, capability/RBAC profiles, policy preview, whitelists, audit views, readiness/diagnostics, and future governed Weaver category controls. It may show support-safe pipeline/evidence refs produced by Weave Control, but it must not become a raw CI log viewer or secret console.
 
-Weave App is the member product surface. A normal member enters through an organization auth URL, invite link, or deep link, completes SSO, and sees Weave product capabilities. Members never configure CI/CD targets, Forgejo/GitHub/GitLab/Azure repositories, OIDC clients, provider URLs, service endpoints, SecretRefs, Matrix/Nextcloud/OpenProject/LiveKit internals, Weaver runtime internals, or bootstrap diagnostics.
+Weave App is the member product surface. A normal member enters through an organization auth URL, non-secret enrollment handoff link, or deep link, completes SSO, and sees Weave product capabilities. The handoff link is not bearer access; account provisioning, organization/workspace membership, and the identity-provider session are the access control boundary. Members never configure CI/CD targets, Forgejo/GitHub/GitLab/Azure repositories, OIDC clients, provider URLs, service endpoints, SecretRefs, Matrix/Nextcloud/OpenProject/LiveKit internals, Weaver runtime internals, or bootstrap diagnostics.
 
 | Surface | Primary responsibility | Must not own |
 | --- | --- | --- |
@@ -45,15 +45,15 @@ flowchart TD
   I --> J{Deployment handoff booleans true?}
   J -->|no| Z[Keep deployment handoff blocked]
   J -->|yes| K[Emit pipeline_terminal_success, server_infra_readiness_passed, weave_control_ready, client_bootstrap_handoff_ready]
-  K --> L[Produce organization URL, invite link, or deep-link handoff target]
+  K --> L[Produce organization URL, enrollment handoff link, or deep-link target]
   L --> M[Claim deployment handoff only; wait for separate app/client E2E lane]
 ```
 
-The separate app/client E2E lane consumes the handoff target. For screen readers: a client test receives the organization URL, invite link, or deep link, opens Weave App, completes SSO as a normal member, loads the provider-neutral organization manifest and product surfaces, checks that provider setup details are absent, and only then emits member/client evidence signals. This lane is intentionally client-owned; the Forgejo deployment runner stays client-free and never emits member join or app E2E booleans.
+The separate app/client E2E lane consumes the handoff target. For screen readers: a client test receives the organization URL, enrollment handoff link, or deep link, opens Weave App, completes SSO as a normal member, loads the provider-neutral organization manifest and product surfaces, checks that provider setup details are absent, and only then emits member/client evidence signals. This lane is intentionally client-owned; the Forgejo deployment runner stays client-free and never emits member join or app E2E booleans.
 
 ```mermaid
 flowchart TD
-  A[Receive deployment handoff target from Weave Control] --> B[Open Weave App through organization URL, invite link, or deep link]
+  A[Receive deployment handoff target from Weave Control] --> B[Open Weave App through organization URL, enrollment handoff link, or deep link]
   B --> C[Complete SSO as normal member]
   C --> D[Fetch provider-neutral organization manifest]
   D --> E[Render product surfaces and capability states]
@@ -87,7 +87,7 @@ Required plan fields:
 - member capability preview using provider-neutral states;
 - evidence refs to be emitted: plan, pipeline, readiness, E2E, audit, support bundle, and claim gate.
 
-Required terminal booleans for the local Forgejo deployment handoff are `pipeline_terminal_success`, `server_infra_readiness_passed`, `weave_control_ready`, and `client_bootstrap_handoff_ready`. They remain false/unknown until an approved local run deploys the selected Weave Control, server, and infra target and emits support-safe handoff evidence. Flutter/App E2E is a separate client lane: the Forgejo deployment runner must not install Flutter, Linux desktop dependencies, Xvfb/GTK, or app/client E2E harnesses, and must not emit `member_provider_neutral_join_passed` or `weave_client_e2e_passed` as deployment-lane results. A dispatched workflow, generated plan, or preflight-only proof is `dispatch_preflight_only` until all deployment handoff booleans are true for the selected target. The member handoff may claim `member_provider_neutral_join_passed` only when a normal member has joined through an organization URL, invite link, or deep link and seen product surfaces without provider setup leakage; `weave_client_e2e_passed` may be true only when the separate app/client E2E lane has passed against that target.
+Required terminal booleans for the local Forgejo deployment handoff are `pipeline_terminal_success`, `server_infra_readiness_passed`, `weave_control_ready`, and `client_bootstrap_handoff_ready`. They remain false/unknown until an approved local run deploys the selected Weave Control, server, and infra target and emits support-safe handoff evidence. Flutter/App E2E is a separate client lane: the Forgejo deployment runner must not install Flutter, Linux desktop dependencies, Xvfb/GTK, or app/client E2E harnesses, and must not emit `member_provider_neutral_join_passed` or `weave_client_e2e_passed` as deployment-lane results. A dispatched workflow, generated plan, or preflight-only proof is `dispatch_preflight_only` until all deployment handoff booleans are true for the selected target. The member handoff may claim `member_provider_neutral_join_passed` only when a normal member has joined through an organization URL, non-secret enrollment handoff link, or deep link and seen product surfaces without provider setup leakage; `weave_client_e2e_passed` may be true only when the separate app/client E2E lane has passed against that target.
 
 Error responses must use stable codes such as `unsupported_hybrid_combination`, `missing_secretref`, `preflight_failed`, `approval_required`, `pipeline_not_terminal`, `readiness_degraded`, `e2e_not_proven`, `manual_at_missing`, or `claim_blocked`. Support-safe evidence may include opaque refs and reason codes only. The repo-local CLI guard exercises this surface through `tools/weavectl bootstrap plan` plus dry-run `tools/weavectl bootstrap apply` and rejects client-deployment or readiness overclaims.
 
@@ -95,7 +95,7 @@ Error responses must use stable codes such as `unsupported_hybrid_combination`, 
 
 The member path may contain:
 
-- organization/invite/deep-link entry;
+- organization/non-secret enrollment handoff/deep-link entry;
 - Weave SSO sign-in;
 - member states `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, or `coming_later`;
 - short impact/fallback copy such as “Calendar is unavailable; ask an admin.”

--- a/docs/weave-operating-model.md
+++ b/docs/weave-operating-model.md
@@ -13,10 +13,11 @@ This page is the compact working contract for Weave delivery. It keeps sprint, r
 
 ## Branch and release model
 
-- `main` is protected stable and release truth; only promoted `rc/*` branches or documented emergency `hotfix/*` exceptions target it.
-- `dev` is the protected integration lane for normal issue, bugfix, documentation, and spec-integration PRs.
+- `dev` is the protected integration lane. Normal feature, bugfix, documentation, and spec-integration branches are cut from `dev` and PR back to `dev` with review/refactor loops, feature tests, acceptance/Gherkin/Cucumber mappings, docs/evidence, and PR-safe gates.
+- `dogfood` is the persistent LAN candidate and human-validation lane. Promotion PRs from `dev` to `dogfood` run full or feature-relevant E2E/live validation; missing feature-relevant scenarios or deterministic mappings must be added by this stage at the latest. Merges deploy/update the persistent dogfood stack.
+- `main` is protected stable and release-capable truth after green dogfood E2E/live evidence and required human-test signoff; documented emergency `hotfix/*` exceptions are allowed.
 - `future/*` lanes hold larger not-yet-release-ready product lines and periodically reconcile back to `dev`.
-- `rc/<version>` lanes are cut from `dev` for release-candidate stabilization, full Live Stack E2E, and release evidence before promotion to `main`.
+- `rc/<version>` lanes are optional later release hardening for named releases; they are not the ordinary human dogfood path and must not bypass `dev` -> `dogfood` -> `main`.
 - `hotfix/*` lanes are cut from `main` for urgent stable-line fixes and must be backported or merged into `dev`.
 - Every PR declares its target lane, linked issue, release-note text or explicit none reason, spec impact, gates run, and exactly one release-notes label:
   - `release-notes-feature`
@@ -29,7 +30,8 @@ This page is the compact working contract for Weave delivery. It keeps sprint, r
 ## Environments
 
 - Local developer machines and disposable worktrees remain temporary environments. The durable `dev` branch is an integration lane, not a deployed environment.
-- `testing`/`staging` is a GitHub Environment or workflow target for release-candidate verification and Live Stack E2E evidence.
+- `dogfood` is the persistent LAN test/human-validation stack. Its enrollment handoff links are non-secret handoff links; real access control is account and membership provisioning plus the identity-provider session.
+- `testing`/`staging` is a GitHub Environment or workflow target for dogfood candidate validation, optional release-candidate verification, and Live Stack E2E evidence.
 - `production` is a GitHub Environment guarded by manual approval and release evidence.
 - Live Stack E2E is release evidence, not a replacement for local or PR-safe gates.
 


### PR DESCRIPTION
## Summary
- anchor the target `dev -> feature -> dev -> dogfood -> main` delivery flow as repository truth
- move destructive/full Live Stack E2E away from scheduled `main` and onto dogfood promotion candidates/manual calls
- clarify dogfood access wording: the join link is a non-secret enrollment handoff; actual access control is account, org/workspace membership, and IdP session

## Target lane
`dev`

## Spec impact
No product-domain spec change. This is repository process/workflow truth for delivery, promotion gates, and dogfood access wording.

## User/admin/operator impact
- Operators get a clearer branch/promotion model.
- Dogfood testers get clearer onboarding wording.
- `main` is no longer the primary scheduled destructive full-E2E lane.

## Release note
Changed: Documented and enforced the dev/dogfood/main promotion flow and clarified dogfood enrollment access semantics.

## Checks run
- `ruby -e 'require "yaml"; %w[.github/workflows/live-stack-e2e.yml .github/workflows/main-promotion-gate.yml .github/workflows/test-stack-deploy.yml].each { |f| YAML.load_file(f); puts "yaml ok #{f}" }'`
- `git diff --check`
- `./gradlew --no-daemon --max-workers=1 docsCheck --console=plain`

## Notes
`docs/requirements.txt` was installed into the worktree-local `build/docs-venv` to satisfy the repo's docs task convention.
