### PR TITLE
fix(client): fence Matrix security diagnostics from member settings

### DIFF
--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -14,7 +14,6 @@ import 'package:weave/core/widgets/error_state.dart';
 import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/core/widgets/weave_logo.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
-import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
 import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
@@ -1250,7 +1249,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
     final workspace = ref.watch(workspaceConnectionStateProvider);
     final capabilities = ref.watch(workspaceCapabilitySnapshotProvider);
     final backendState = ref.watch(weaveBackendConnectionStateProvider);
-    final matrixDiagnostic = ref.watch(weaveApiMatrixE2eeDiagnosticProvider);
     final canViewWorkspaceHealth = ref
         .watch(userProfileProvider)
         .maybeWhen(
@@ -1302,7 +1300,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                       ref.invalidate(
                         weaveApiWorkspaceCapabilitySnapshotProvider,
                       );
-                      ref.invalidate(weaveApiMatrixE2eeDiagnosticProvider);
                       ref.invalidate(weaveApiProviderStackSnapshotProvider);
                       ref.invalidate(
                         weaveApiOfficeCapabilitiesSnapshotProvider,
@@ -1333,7 +1330,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                   label: l10n.settingsWorkspaceChatLabel,
                   capability: capabilitySnapshot.chat,
                   connection: workspaceState.matrix,
-                  matrixDiagnostic: matrixDiagnostic.asData?.value,
                 ),
                 const Divider(height: 32),
                 _WorkspaceReadinessRow(
@@ -1360,7 +1356,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
               ref.invalidate(matrixIntegrationConnectionProvider);
               ref.invalidate(nextcloudIntegrationConnectionProvider);
               ref.invalidate(weaveApiWorkspaceCapabilitySnapshotProvider);
-              ref.invalidate(weaveApiMatrixE2eeDiagnosticProvider);
               ref.invalidate(weaveApiProviderStackSnapshotProvider);
               ref.invalidate(weaveApiOfficeCapabilitiesSnapshotProvider);
             },
@@ -2017,13 +2012,11 @@ class _WorkspaceReadinessRow extends StatelessWidget {
     required this.label,
     required this.capability,
     required this.connection,
-    this.matrixDiagnostic,
   });
 
   final String label;
   final WorkspaceCapabilityState capability;
   final IntegrationConnectionState connection;
-  final MatrixE2eeDiagnostic? matrixDiagnostic;
 
   @override
   Widget build(BuildContext context) {
@@ -2065,26 +2058,6 @@ class _WorkspaceReadinessRow extends StatelessWidget {
                     connection.lastInvalidation!.reason,
                   ),
                 ),
-              if (matrixDiagnostic case final diagnostic?) ...[
-                _StatusPill(
-                  label: l10n.settingsWorkspaceMatrixE2eeGateLabel,
-                  value: diagnostic.isValidated
-                      ? l10n.settingsWorkspaceMatrixE2eeValidated
-                      : l10n.settingsWorkspaceMatrixE2eeNotValidated,
-                ),
-                _StatusPill(
-                  label: l10n.settingsWorkspaceMatrixServerBodiesLabel,
-                  value: diagnostic.keepsMessageBodiesOpaque
-                      ? l10n.settingsWorkspaceMatrixServerBodiesOpaque
-                      : l10n.settingsWorkspaceMatrixServerBodiesReadable,
-                ),
-                _StatusPill(
-                  label: l10n.settingsWorkspaceMatrixAgentWritesLabel,
-                  value: diagnostic.keepsAgentsAndConnectorsFailClosed
-                      ? l10n.settingsWorkspaceMatrixAgentWritesBlocked
-                      : l10n.settingsWorkspaceMatrixAgentWritesReview,
-                ),
-              ],
             ],
           ),
         ],
@@ -2152,7 +2125,7 @@ class _WorkspaceReadinessRow extends StatelessWidget {
       IntegrationInvalidationReason.authConfigurationChanged =>
         l10n.settingsWorkspaceInvalidationAuthConfigurationChanged,
       IntegrationInvalidationReason.matrixHomeserverChanged =>
-        l10n.settingsWorkspaceInvalidationMatrixHomeserverChanged,
+        l10n.settingsWorkspaceInvalidationChatConfigurationChanged,
       IntegrationInvalidationReason.nextcloudBaseUrlChanged =>
         l10n.settingsWorkspaceInvalidationNextcloudBaseUrlChanged,
       IntegrationInvalidationReason.backendApiBaseUrlChanged =>

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -23,7 +23,6 @@ import 'package:weave/features/agents/presentation/providers/agent_capability_po
 import 'package:weave/features/agents/presentation/widgets/agent_capability_policy_card.dart';
 import 'package:weave/features/app/presentation/providers/workspace_connection_provider.dart';
 import 'package:weave/features/auth/presentation/providers/auth_flow_controller.dart';
-import 'package:weave/features/chat/presentation/widgets/chat_security_settings_section.dart';
 import 'package:weave/features/connectors/presentation/providers/connector_preview_provider.dart';
 import 'package:weave/features/connectors/presentation/widgets/connector_settings_preview_card.dart';
 import 'package:weave/features/guests/presentation/providers/guest_preview_provider.dart';
@@ -87,8 +86,6 @@ class SettingsScreen extends ConsumerWidget {
                   ],
                   const SizedBox(height: 32),
                   _AdminSetupSection(configuration: configuration),
-                  const SizedBox(height: 32),
-                  const ChatSecuritySettingsSection(),
                   const SizedBox(height: 32),
                   Text(
                     l10n.settingsSignOutTitle,

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -413,6 +413,7 @@
   "settingsWorkspaceCapabilityLabel": "Bereitschaft",
   "settingsWorkspaceConnectionLabel": "Verbindung",
   "settingsWorkspaceLastChangeLabel": "Letzte Änderung",
+  "settingsWorkspaceInvalidationChatConfigurationChanged": "Chat-Konfiguration geändert",
   "settingsWorkspaceMatrixE2eeGateLabel": "E2EE-Gate",
   "settingsWorkspaceMatrixE2eeValidated": "Validiert",
   "settingsWorkspaceMatrixE2eeNotValidated": "Nicht validiert",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -2067,6 +2067,10 @@
   "@settingsWorkspaceInvalidationMatrixHomeserverChanged": {
     "description": "Invalidation label for Matrix homeserver changes"
   },
+  "settingsWorkspaceInvalidationChatConfigurationChanged": "Chat configuration changed",
+  "@settingsWorkspaceInvalidationChatConfigurationChanged": {
+    "description": "Provider-neutral invalidation label for chat configuration changes"
+  },
   "settingsWorkspaceInvalidationNextcloudBaseUrlChanged": "Nextcloud base URL changed",
   "@settingsWorkspaceInvalidationNextcloudBaseUrlChanged": {
     "description": "Invalidation label for Nextcloud base URL changes"

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -3083,6 +3083,12 @@ abstract class AppLocalizations {
   /// **'Matrix homeserver changed'**
   String get settingsWorkspaceInvalidationMatrixHomeserverChanged;
 
+  /// Provider-neutral invalidation label for chat configuration changes
+  ///
+  /// In en, this message translates to:
+  /// **'Chat configuration changed'**
+  String get settingsWorkspaceInvalidationChatConfigurationChanged;
+
   /// Invalidation label for Nextcloud base URL changes
   ///
   /// In en, this message translates to:

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -1858,6 +1858,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Matrix-Homeserver geändert';
 
   @override
+  String get settingsWorkspaceInvalidationChatConfigurationChanged =>
+      'Chat-Konfiguration geändert';
+
+  @override
   String get settingsWorkspaceInvalidationNextcloudBaseUrlChanged =>
       'Nextcloud-Basis-URL geändert';
 

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -1834,6 +1834,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Matrix homeserver changed';
 
   @override
+  String get settingsWorkspaceInvalidationChatConfigurationChanged =>
+      'Chat configuration changed';
+
+  @override
   String get settingsWorkspaceInvalidationNextcloudBaseUrlChanged =>
       'Nextcloud base URL changed';
 

--- a/client/test/architecture/backend_facade_contract_test.dart
+++ b/client/test/architecture/backend_facade_contract_test.dart
@@ -160,6 +160,17 @@ void main() {
           source,
           isNot(contains('chat_security_repository_provider.dart')),
         );
+        expect(source, isNot(contains('weaveApiMatrixE2eeDiagnosticProvider')));
+        expect(source, isNot(contains('MatrixE2eeDiagnostic')));
+        expect(source, isNot(contains('settingsWorkspaceMatrixE2eeGateLabel')));
+        expect(
+          source,
+          isNot(contains('settingsWorkspaceMatrixServerBodiesLabel')),
+        );
+        expect(
+          source,
+          isNot(contains('settingsWorkspaceMatrixAgentWritesLabel')),
+        );
       }
     },
   );

--- a/client/test/architecture/backend_facade_contract_test.dart
+++ b/client/test/architecture/backend_facade_contract_test.dart
@@ -139,6 +139,31 @@ void main() {
     expect(securityProvider, contains('until #895'));
   });
 
+  test(
+    'normal member surfaces do not mount Matrix security diagnostics',
+    () async {
+      final chatScreen = await File(
+        'lib/features/chat/presentation/chat_screen.dart',
+      ).readAsString();
+      final settingsScreen = await File(
+        'lib/features/settings/presentation/settings_screen.dart',
+      ).readAsString();
+
+      for (final source in <String>[chatScreen, settingsScreen]) {
+        expect(source, isNot(contains('chatSecurityProvider')));
+        expect(source, isNot(contains('ChatSecurityBanner')));
+        expect(source, isNot(contains('ChatSecuritySettingsSection')));
+        expect(source, isNot(contains('chat_security_provider.dart')));
+        expect(source, isNot(contains('chat_security_banner.dart')));
+        expect(source, isNot(contains('chat_security_settings_section.dart')));
+        expect(
+          source,
+          isNot(contains('chat_security_repository_provider.dart')),
+        );
+      }
+    },
+  );
+
   test('member Chat screen stays on Weave-domain readiness language', () async {
     final screen = await File(
       'lib/features/chat/presentation/chat_screen.dart',

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -297,20 +297,23 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.text('Last change: Matrix homeserver changed', findRichText: true),
+        find.text(
+          'Last change: Chat configuration changed',
+          findRichText: true,
+        ),
         findsOneWidget,
       );
       expect(
         find.text('E2EE gate: Not validated', findRichText: true),
-        findsOneWidget,
+        findsNothing,
       );
       expect(
         find.text('Server-readable bodies: No', findRichText: true),
-        findsOneWidget,
+        findsNothing,
       );
       expect(
         find.text('Agent writes: Blocked/fail-closed', findRichText: true),
-        findsOneWidget,
+        findsNothing,
       );
       await tester.scrollUntilVisible(
         find.text('AI agent capability governance'),


### PR DESCRIPTION
## Summary
- remove the Matrix E2EE/security diagnostic settings section from normal member Settings
- add architecture coverage proving Chat and Settings do not mount direct Matrix security diagnostics
- keep the Matrix security repository seam diagnostic-only for follow-up #895

## Evidence
- `./gradlew clientCi`
- `./gradlew acceptanceContract checkClientOpenApiModelsFresh`
- independent follow-up review: PASS for commit `9607a42a97`

## Release notes
- Internal hardening: normal member surfaces no longer mount direct Matrix security diagnostics.