### PR TITLE
feat(client): ground feature adapters in OpenAPI DTOs

### DIFF
--- a/admin-console/src/generated/openapi.ts
+++ b/admin-console/src/generated/openapi.ts
@@ -128,10 +128,10 @@ export type GeneratedChatReadiness = {
 };
 
 export type GeneratedChatReadinessResponse = {
-  "diagnosticsRedacted"?: boolean;
-  "grantedCapabilities"?: string[];
-  "impactState"?: "degraded" | "disabled" | "policy-blocked" | "usable";
-  "memberImpact"?: string;
+  "diagnosticsRedacted": boolean;
+  "grantedCapabilities": string[];
+  "impactState": "degraded" | "disabled" | "policy-blocked" | "usable";
+  "memberImpact": string;
 };
 
 export type GeneratedConsequencePreview = {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ registerRootCommandTask('generateAdminOpenApiTypes', ['python3', 'tools/generate
 registerRootCommandTask('checkAdminOpenApiTypesFresh', ['bash', '-lc', 'tmp=$(mktemp); cp admin-console/src/generated/openapi.ts "$tmp"; python3 tools/generate_admin_openapi_types.py; cmp -s "$tmp" admin-console/src/generated/openapi.ts || { echo "Admin OpenAPI generated types are stale. Run ./gradlew generateAdminOpenApiTypes and commit the result." >&2; git --no-pager diff -- admin-console/src/generated/openapi.ts >&2 || true; rm -f "$tmp"; exit 1; }; rm -f "$tmp"'], 'Fail when Admin Console generated OpenAPI types are stale.')
 registerRootCommandTask('generateClientOpenApiModels', ['bash', '-lc', 'python3 tools/generate_client_openapi_models.py && dart format client/lib/generated/openapi_models.dart'], 'Generate Flutter/Dart JSON models from the server-owned OpenAPI artifact.')
 registerRootCommandTask('checkClientOpenApiModelsFresh', ['bash', '-lc', 'tmp=$(mktemp); cp client/lib/generated/openapi_models.dart "$tmp"; python3 tools/generate_client_openapi_models.py; dart format client/lib/generated/openapi_models.dart >/dev/null; cmp -s "$tmp" client/lib/generated/openapi_models.dart || { echo "Flutter OpenAPI generated models are stale. Run ./gradlew generateClientOpenApiModels and commit the result." >&2; git --no-pager diff -- client/lib/generated/openapi_models.dart >&2 || true; rm -f "$tmp"; exit 1; }; rm -f "$tmp"'], 'Fail when Flutter/Dart generated OpenAPI models are stale.')
+tasks.named('clientCi') {
+    dependsOn 'checkClientOpenApiModelsFresh'
+}
 registerRootCommandTask('pythonMcpCi', ['bash', 'infra/weave-workspace/tests/weave-mcp-server-test.sh'], 'Run the transitional Python Weave MCP gateway unit smoke tests from the root build.')
 tasks.register('javaMcpServerCi') {
     group = 'verification'

--- a/client/lib/features/chat/data/dtos/chat_openapi_mappers.dart
+++ b/client/lib/features/chat/data/dtos/chat_openapi_mappers.dart
@@ -1,0 +1,145 @@
+import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
+import 'package:weave/features/chat/domain/entities/chat_failure.dart';
+import 'package:weave/features/chat/domain/entities/chat_message.dart';
+import 'package:weave/features/chat/domain/entities/chat_room_timeline.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
+import 'package:weave/integrations/weave_api/domain/entities/openapi_feature_adapter.dart';
+
+const _chatFeatureKey = 'chat';
+
+extension ChatReadinessOpenApiMapper on openapi.ChatReadiness {
+  OpenApiFeatureReadiness toFeatureReadiness() {
+    return OpenApiFeatureReadiness(
+      featureKey: _chatFeatureKey,
+      state: OpenApiFeatureCapabilityState.fromApi(memberState),
+      memberImpact: _fallbackText(
+        memberImpact,
+        'Weave Chat readiness unknown.',
+      ),
+      supportSafe: supportSafe ?? true,
+      diagnosticsRedacted: downstreamDiagnosticsExposedToMember != true,
+    );
+  }
+}
+
+extension ChatReadinessResponseOpenApiMapper on openapi.ChatReadinessResponse {
+  OpenApiFeatureReadiness toFeatureReadiness() {
+    return OpenApiFeatureReadiness(
+      featureKey: _chatFeatureKey,
+      state: OpenApiFeatureCapabilityState.fromApi(impactState),
+      memberImpact: _fallbackText(
+        memberImpact,
+        'Weave Chat readiness unknown.',
+      ),
+      capabilities: (grantedCapabilities ?? const <String>[])
+          .map(
+            (capability) => OpenApiFeatureCapability(
+              key: capability,
+              state: OpenApiFeatureCapabilityState.available,
+            ),
+          )
+          .toList(growable: false),
+      diagnosticsRedacted: diagnosticsRedacted ?? true,
+    );
+  }
+}
+
+extension ChatConversationsOpenApiMapper on openapi.ChatConversationsResponse {
+  OpenApiResourcePage<ChatConversation> toConversationPage() {
+    final conversationDtos = conversations;
+    if (conversationDtos == null) {
+      throw const ChatFailure.configuration(
+        'The Weave Chat facade returned an invalid conversation list.',
+      );
+    }
+    return OpenApiResourcePage<ChatConversation>(
+      featureKey: _chatFeatureKey,
+      readiness:
+          readiness?.toFeatureReadiness() ??
+          OpenApiFeatureReadiness.unknown(_chatFeatureKey),
+      resources: conversationDtos
+          .map((conversation) => conversation.toDomainConversation())
+          .toList(growable: false),
+    );
+  }
+}
+
+extension ChatMessagesOpenApiMapper on openapi.ChatMessagesResponse {
+  ChatRoomTimeline toRoomTimeline(String fallbackConversationId) {
+    final messageDtos = messages;
+    if (messageDtos == null) {
+      throw const ChatFailure.configuration(
+        'The Weave Chat facade returned an invalid timeline.',
+      );
+    }
+    final roomId = _fallbackText(conversationId, fallbackConversationId);
+    return ChatRoomTimeline(
+      roomId: roomId,
+      roomTitle: roomId,
+      isInvite: false,
+      canSendMessages: true,
+      messages: messageDtos
+          .map((message) => message.toDomainMessage(roomId))
+          .toList(growable: false),
+    );
+  }
+}
+
+extension ChatConversationResponseOpenApiMapper
+    on openapi.ChatConversationResponse {
+  ChatConversation toDomainConversation() {
+    final conversationKind = _fallbackText(kind, 'channel');
+    return ChatConversation(
+      id: _requiredText(id, 'id'),
+      title: _requiredText(title, 'title'),
+      previewType: ChatConversationPreviewType.text,
+      previewText: 'Weave Chat conversation',
+      lastActivityAt: _readDateTime(lastMessageAt),
+      unreadCount: 0,
+      isInvite: false,
+      isDirectMessage: conversationKind == 'direct',
+      isAiChat: conversationKind == 'ai',
+    );
+  }
+}
+
+extension ChatMessageResponseOpenApiMapper on openapi.ChatMessageResponse {
+  ChatMessage toDomainMessage(String fallbackConversationId) {
+    final redacted = encryptedProviderContentRedacted == true;
+    final sender = _requiredText(senderRef, 'senderRef');
+    return ChatMessage(
+      id: _requiredText(id, 'id'),
+      senderId: sender,
+      senderDisplayName: sender,
+      sentAt: _readDateTime(sentAt) ?? DateTime.fromMillisecondsSinceEpoch(0),
+      isMine: isMine == true,
+      deliveryState: ChatMessageDeliveryState.sent,
+      contentType: redacted
+          ? ChatMessageContentType.encrypted
+          : ChatMessageContentType.text,
+      text: text,
+    );
+  }
+}
+
+String _requiredText(String? value, String key) {
+  final trimmed = value?.trim();
+  if (trimmed != null && trimmed.isNotEmpty) {
+    return trimmed;
+  }
+  throw ChatFailure.configuration(
+    'The Weave Chat facade returned an invalid "$key" value.',
+  );
+}
+
+String _fallbackText(String? value, String fallback) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? fallback : trimmed;
+}
+
+DateTime? _readDateTime(String? value) {
+  if (value == null || value.trim().isEmpty) {
+    return null;
+  }
+  return DateTime.tryParse(value)?.toLocal();
+}

--- a/client/lib/features/chat/data/dtos/chat_openapi_mappers.dart
+++ b/client/lib/features/chat/data/dtos/chat_openapi_mappers.dart
@@ -31,7 +31,7 @@ extension ChatReadinessResponseOpenApiMapper on openapi.ChatReadinessResponse {
         memberImpact,
         'Weave Chat readiness unknown.',
       ),
-      capabilities: (grantedCapabilities ?? const <String>[])
+      capabilities: grantedCapabilities
           .map(
             (capability) => OpenApiFeatureCapability(
               key: capability,
@@ -39,25 +39,17 @@ extension ChatReadinessResponseOpenApiMapper on openapi.ChatReadinessResponse {
             ),
           )
           .toList(growable: false),
-      diagnosticsRedacted: diagnosticsRedacted ?? true,
+      diagnosticsRedacted: diagnosticsRedacted,
     );
   }
 }
 
 extension ChatConversationsOpenApiMapper on openapi.ChatConversationsResponse {
   OpenApiResourcePage<ChatConversation> toConversationPage() {
-    final conversationDtos = conversations;
-    if (conversationDtos == null) {
-      throw const ChatFailure.configuration(
-        'The Weave Chat facade returned an invalid conversation list.',
-      );
-    }
     return OpenApiResourcePage<ChatConversation>(
       featureKey: _chatFeatureKey,
-      readiness:
-          readiness?.toFeatureReadiness() ??
-          OpenApiFeatureReadiness.unknown(_chatFeatureKey),
-      resources: conversationDtos
+      readiness: readiness.toFeatureReadiness(),
+      resources: conversations
           .map((conversation) => conversation.toDomainConversation())
           .toList(growable: false),
     );
@@ -66,19 +58,13 @@ extension ChatConversationsOpenApiMapper on openapi.ChatConversationsResponse {
 
 extension ChatMessagesOpenApiMapper on openapi.ChatMessagesResponse {
   ChatRoomTimeline toRoomTimeline(String fallbackConversationId) {
-    final messageDtos = messages;
-    if (messageDtos == null) {
-      throw const ChatFailure.configuration(
-        'The Weave Chat facade returned an invalid timeline.',
-      );
-    }
     final roomId = _fallbackText(conversationId, fallbackConversationId);
     return ChatRoomTimeline(
       roomId: roomId,
       roomTitle: roomId,
       isInvite: false,
       canSendMessages: true,
-      messages: messageDtos
+      messages: messages
           .map((message) => message.toDomainMessage(roomId))
           .toList(growable: false),
     );
@@ -111,7 +97,7 @@ extension ChatMessageResponseOpenApiMapper on openapi.ChatMessageResponse {
       id: _requiredText(id, 'id'),
       senderId: sender,
       senderDisplayName: sender,
-      sentAt: _readDateTime(sentAt) ?? DateTime.fromMillisecondsSinceEpoch(0),
+      sentAt: _requiredDateTime(sentAt, 'sentAt'),
       isMine: isMine == true,
       deliveryState: ChatMessageDeliveryState.sent,
       contentType: redacted
@@ -142,4 +128,14 @@ DateTime? _readDateTime(String? value) {
     return null;
   }
   return DateTime.tryParse(value)?.toLocal();
+}
+
+DateTime _requiredDateTime(String value, String key) {
+  final parsed = DateTime.tryParse(value);
+  if (parsed == null) {
+    throw ChatFailure.configuration(
+      'The Weave Chat facade returned an invalid "$key" value.',
+    );
+  }
+  return parsed.toLocal();
 }

--- a/client/lib/features/chat/data/repositories/backend_chat_repository.dart
+++ b/client/lib/features/chat/data/repositories/backend_chat_repository.dart
@@ -3,13 +3,14 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
 import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/chat/data/dtos/chat_openapi_mappers.dart';
 import 'package:weave/features/chat/domain/entities/chat_conversation.dart';
 import 'package:weave/features/chat/domain/entities/chat_failure.dart';
-import 'package:weave/features/chat/domain/entities/chat_message.dart';
 import 'package:weave/features/chat/domain/entities/chat_room_timeline.dart';
 import 'package:weave/features/chat/domain/repositories/chat_repository.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
 
 class BackendChatRepository implements ChatRepository {
   const BackendChatRepository({
@@ -27,16 +28,10 @@ class BackendChatRepository implements ChatRepository {
   @override
   Future<List<ChatConversation>> loadConversations() async {
     final payload = await _getJson('/api/chat/conversations');
-    final conversations = payload['conversations'];
-    if (conversations is! List<dynamic>) {
-      throw const ChatFailure.configuration(
-        'The Weave Chat facade returned an invalid conversation list.',
-      );
-    }
-    final values = conversations
-        .whereType<Map<String, dynamic>>()
-        .map(_conversationFromJson)
-        .toList(growable: false);
+    final page = openapi.ChatConversationsResponse.fromJson(
+      payload,
+    ).toConversationPage();
+    final values = [...page.resources];
     values.sort((a, b) {
       final activityComparison =
           (b.lastActivityAt ?? DateTime.fromMillisecondsSinceEpoch(0))
@@ -54,23 +49,9 @@ class BackendChatRepository implements ChatRepository {
   @override
   Future<ChatRoomTimeline> loadRoomTimeline(String roomId) async {
     final payload = await _getJson('/api/chat/conversations/$roomId/messages');
-    final messages = payload['messages'];
-    if (messages is! List<dynamic>) {
-      throw const ChatFailure.configuration(
-        'The Weave Chat facade returned an invalid timeline.',
-      );
-    }
-    final parsedMessages = messages
-        .whereType<Map<String, dynamic>>()
-        .map(_messageFromJson)
-        .toList(growable: false);
-    return ChatRoomTimeline(
-      roomId: roomId,
-      roomTitle: roomId,
-      isInvite: false,
-      canSendMessages: true,
-      messages: parsedMessages,
-    );
+    return openapi.ChatMessagesResponse.fromJson(
+      payload,
+    ).toRoomTimeline(roomId);
   }
 
   @override
@@ -78,10 +59,14 @@ class BackendChatRepository implements ChatRepository {
     required String roomId,
     required String message,
   }) async {
+    final request = openapi.ChatSendMessageRequest(
+      text: message,
+      attachmentRefs: const <String>[],
+    );
     await _requestJson(
       'POST',
       '/api/chat/conversations/$roomId/messages',
-      body: <String, Object?>{'text': message, 'attachmentRefs': <String>[]},
+      body: request.toJson(),
     );
   }
 
@@ -94,13 +79,11 @@ class BackendChatRepository implements ChatRepository {
   @override
   Future<void> connect() async {
     final readiness = await _getJson('/api/chat/readiness');
-    final state = readiness['impactState'] ?? readiness['memberState'];
-    if (state != 'usable' && state != 'ready') {
-      throw ChatFailure.configuration(
-        readiness['memberImpact'] is String
-            ? readiness['memberImpact'] as String
-            : 'Weave Chat is not ready in this workspace.',
-      );
+    final featureReadiness = openapi.ChatReadiness.fromJson(
+      readiness,
+    ).toFeatureReadiness();
+    if (!featureReadiness.isUsable) {
+      throw ChatFailure.configuration(featureReadiness.memberImpact);
     }
   }
 
@@ -112,41 +95,6 @@ class BackendChatRepository implements ChatRepository {
 
   @override
   Future<void> clearSession() => _authSessionRepository.clearLocalSession();
-
-  ChatConversation _conversationFromJson(Map<String, dynamic> json) {
-    final id = _readString(json, 'id');
-    final title = _readString(json, 'title');
-    final kind = json['kind'] is String ? json['kind'] as String : 'channel';
-    return ChatConversation(
-      id: id,
-      title: title,
-      previewType: ChatConversationPreviewType.text,
-      previewText: 'Weave Chat conversation',
-      lastActivityAt: _readDateTime(json['lastMessageAt']),
-      unreadCount: 0,
-      isInvite: false,
-      isDirectMessage: kind == 'direct',
-      isAiChat: kind == 'ai',
-    );
-  }
-
-  ChatMessage _messageFromJson(Map<String, dynamic> json) {
-    final redacted = json['encryptedProviderContentRedacted'] == true;
-    return ChatMessage(
-      id: _readString(json, 'id'),
-      senderId: _readString(json, 'senderRef'),
-      senderDisplayName: _readString(json, 'senderRef'),
-      sentAt:
-          _readDateTime(json['sentAt']) ??
-          DateTime.fromMillisecondsSinceEpoch(0),
-      isMine: json['isMine'] == true,
-      deliveryState: ChatMessageDeliveryState.sent,
-      contentType: redacted
-          ? ChatMessageContentType.encrypted
-          : ChatMessageContentType.text,
-      text: json['text'] is String ? json['text'] as String : null,
-    );
-  }
 
   Future<Map<String, dynamic>> _getJson(String path) {
     return _requestJson('GET', path);
@@ -207,22 +155,5 @@ class BackendChatRepository implements ChatRepository {
       issuer: configuration.oidcIssuerUrl,
       clientId: configuration.oidcClientRegistration.clientId.trim(),
     );
-  }
-
-  String _readString(Map<String, dynamic> json, String key) {
-    final value = json[key];
-    if (value is String && value.trim().isNotEmpty) {
-      return value.trim();
-    }
-    throw ChatFailure.configuration(
-      'The Weave Chat facade returned an invalid "$key" value.',
-    );
-  }
-
-  DateTime? _readDateTime(Object? value) {
-    if (value is! String || value.trim().isEmpty) {
-      return null;
-    }
-    return DateTime.tryParse(value)?.toLocal();
   }
 }

--- a/client/lib/features/chat/data/repositories/backend_chat_repository.dart
+++ b/client/lib/features/chat/data/repositories/backend_chat_repository.dart
@@ -11,6 +11,7 @@ import 'package:weave/features/chat/domain/repositories/chat_repository.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
 import 'package:weave/generated/openapi_models.dart' as openapi;
+import 'package:weave/integrations/weave_api/domain/entities/openapi_feature_adapter.dart';
 
 class BackendChatRepository implements ChatRepository {
   const BackendChatRepository({
@@ -28,9 +29,7 @@ class BackendChatRepository implements ChatRepository {
   @override
   Future<List<ChatConversation>> loadConversations() async {
     final payload = await _getJson('/api/chat/conversations');
-    final page = openapi.ChatConversationsResponse.fromJson(
-      payload,
-    ).toConversationPage();
+    final page = _decodeConversations(payload);
     final values = [...page.resources];
     values.sort((a, b) {
       final activityComparison =
@@ -49,9 +48,7 @@ class BackendChatRepository implements ChatRepository {
   @override
   Future<ChatRoomTimeline> loadRoomTimeline(String roomId) async {
     final payload = await _getJson('/api/chat/conversations/$roomId/messages');
-    return openapi.ChatMessagesResponse.fromJson(
-      payload,
-    ).toRoomTimeline(roomId);
+    return _decodeMessages(payload, roomId);
   }
 
   @override
@@ -137,6 +134,39 @@ class BackendChatRepository implements ChatRepository {
     throw const ChatFailure.configuration(
       'The Weave Chat facade returned an invalid response.',
     );
+  }
+
+  OpenApiResourcePage<ChatConversation> _decodeConversations(
+    Map<String, dynamic> payload,
+  ) {
+    try {
+      return openapi.ChatConversationsResponse.fromJson(
+        payload,
+      ).toConversationPage();
+    } on ChatFailure {
+      rethrow;
+    } catch (_) {
+      throw const ChatFailure.configuration(
+        'The Weave Chat facade returned an invalid conversation list.',
+      );
+    }
+  }
+
+  ChatRoomTimeline _decodeMessages(
+    Map<String, dynamic> payload,
+    String fallbackRoomId,
+  ) {
+    try {
+      return openapi.ChatMessagesResponse.fromJson(
+        payload,
+      ).toRoomTimeline(fallbackRoomId);
+    } on ChatFailure {
+      rethrow;
+    } catch (_) {
+      throw const ChatFailure.configuration(
+        'The Weave Chat facade returned an invalid timeline.',
+      );
+    }
   }
 
   Future<ServerConfiguration> _loadConfiguration() async {

--- a/client/lib/features/files/data/dtos/files_openapi_mappers.dart
+++ b/client/lib/features/files/data/dtos/files_openapi_mappers.dart
@@ -8,6 +8,12 @@ const _filesFeatureKey = 'files';
 
 extension FileListResponseOpenApiMapper on openapi.FileListResponse {
   OpenApiResourcePage<FileEntry> toFileEntryPage() {
+    final itemDtos = items;
+    if (itemDtos == null) {
+      throw const FilesFailure.protocol(
+        'The Weave backend returned a files listing without items.',
+      );
+    }
     return OpenApiResourcePage<FileEntry>(
       featureKey: _filesFeatureKey,
       readiness: const OpenApiFeatureReadiness(
@@ -15,7 +21,7 @@ extension FileListResponseOpenApiMapper on openapi.FileListResponse {
         state: OpenApiFeatureCapabilityState.available,
         memberImpact: 'Weave Files are available.',
       ),
-      resources: (items ?? const <openapi.FileItemResponse>[])
+      resources: itemDtos
           .map((item) => item.toDomainEntry())
           .toList(growable: false),
     );

--- a/client/lib/features/files/data/dtos/files_openapi_mappers.dart
+++ b/client/lib/features/files/data/dtos/files_openapi_mappers.dart
@@ -1,0 +1,66 @@
+import 'package:weave/features/files/domain/entities/directory_listing.dart';
+import 'package:weave/features/files/domain/entities/file_entry.dart';
+import 'package:weave/features/files/domain/entities/files_failure.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
+import 'package:weave/integrations/weave_api/domain/entities/openapi_feature_adapter.dart';
+
+const _filesFeatureKey = 'files';
+
+extension FileListResponseOpenApiMapper on openapi.FileListResponse {
+  OpenApiResourcePage<FileEntry> toFileEntryPage() {
+    return OpenApiResourcePage<FileEntry>(
+      featureKey: _filesFeatureKey,
+      readiness: const OpenApiFeatureReadiness(
+        featureKey: _filesFeatureKey,
+        state: OpenApiFeatureCapabilityState.available,
+        memberImpact: 'Weave Files are available.',
+      ),
+      resources: (items ?? const <openapi.FileItemResponse>[])
+          .map((item) => item.toDomainEntry())
+          .toList(growable: false),
+    );
+  }
+
+  DirectoryListing toDomainListing() {
+    return DirectoryListing(
+      path: _fallbackText(path, '/'),
+      entries: toFileEntryPage().resources,
+    );
+  }
+}
+
+extension FileItemResponseOpenApiMapper on openapi.FileItemResponse {
+  FileEntry toDomainEntry() {
+    final entryType = _requiredText(type, 'type');
+    return FileEntry(
+      id: _requiredText(id, 'id'),
+      name: _requiredText(name, 'name'),
+      path: _requiredText(path, 'path'),
+      isDirectory: entryType == 'folder' || entryType == 'directory',
+      modifiedAt: _readDateTime(modifiedAt),
+      sizeInBytes: size,
+    );
+  }
+}
+
+String _requiredText(String? value, String key) {
+  final trimmed = value?.trim();
+  if (trimmed != null && trimmed.isNotEmpty) {
+    return trimmed;
+  }
+  throw FilesFailure.protocol(
+    'The Weave backend returned a file item without $key.',
+  );
+}
+
+String _fallbackText(String? value, String fallback) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? fallback : trimmed;
+}
+
+DateTime? _readDateTime(String? value) {
+  if (value == null || value.isEmpty) {
+    return null;
+  }
+  return DateTime.tryParse(value);
+}

--- a/client/lib/features/files/data/dtos/files_openapi_mappers.dart
+++ b/client/lib/features/files/data/dtos/files_openapi_mappers.dart
@@ -8,12 +8,6 @@ const _filesFeatureKey = 'files';
 
 extension FileListResponseOpenApiMapper on openapi.FileListResponse {
   OpenApiResourcePage<FileEntry> toFileEntryPage() {
-    final itemDtos = items;
-    if (itemDtos == null) {
-      throw const FilesFailure.protocol(
-        'The Weave backend returned a files listing without items.',
-      );
-    }
     return OpenApiResourcePage<FileEntry>(
       featureKey: _filesFeatureKey,
       readiness: const OpenApiFeatureReadiness(
@@ -21,7 +15,7 @@ extension FileListResponseOpenApiMapper on openapi.FileListResponse {
         state: OpenApiFeatureCapabilityState.available,
         memberImpact: 'Weave Files are available.',
       ),
-      resources: itemDtos
+      resources: items
           .map((item) => item.toDomainEntry())
           .toList(growable: false),
     );

--- a/client/lib/features/files/data/repositories/backend_files_repository.dart
+++ b/client/lib/features/files/data/repositories/backend_files_repository.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
 import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/files/data/dtos/files_openapi_mappers.dart';
 import 'package:weave/features/files/domain/entities/directory_listing.dart';
 import 'package:weave/features/files/domain/entities/file_download.dart';
 import 'package:weave/features/files/domain/entities/file_entry.dart';
@@ -14,6 +15,7 @@ import 'package:weave/features/files/domain/entities/files_failure.dart';
 import 'package:weave/features/files/domain/repositories/files_repository.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
 
 /// Files repository backed by the Weave backend product facade.
 ///
@@ -148,12 +150,16 @@ class BackendFilesRepository
     required String name,
   }) async {
     final context = await _requireContext();
+    final request = openapi.CreateFolderRequest(
+      parentPath: parentPath,
+      name: name,
+    );
     final response = await _sendAuthenticated(
       context,
       (accessToken) => _httpClient.post(
         _apiUri(context.baseUrl, const ['api', 'files', 'folders']),
         headers: _jsonHeaders(accessToken),
-        body: jsonEncode({'parentPath': parentPath, 'name': name}),
+        body: jsonEncode(request.toJson()),
       ),
       fallbackMessage: 'Unable to create the folder through the Weave backend.',
     );
@@ -388,32 +394,21 @@ class BackendFilesRepository
   }
 
   DirectoryListing _decodeListing(String body) {
-    final json = _decodeObject(body);
-    final rawItems = json['items'];
-    if (rawItems is! List) {
+    try {
+      return openapi.FileListResponse.fromJson(
+        _decodeObject(body),
+      ).toDomainListing();
+    } on FilesFailure {
+      rethrow;
+    } catch (error) {
       throw const FilesFailure.protocol(
         'The Weave backend returned an invalid files listing.',
       );
     }
-    return DirectoryListing(
-      path: _readString(json, 'path', fallback: '/'),
-      entries: rawItems
-          .whereType<Map<String, dynamic>>()
-          .map(_decodeEntry)
-          .toList(growable: false),
-    );
   }
 
   FileEntry _decodeEntry(Map<String, dynamic> json) {
-    final type = _readString(json, 'type');
-    return FileEntry(
-      id: _readString(json, 'id'),
-      name: _readString(json, 'name'),
-      path: _readString(json, 'path'),
-      isDirectory: type == 'folder' || type == 'directory',
-      modifiedAt: _readDateTime(json['modifiedAt']),
-      sizeInBytes: _readInt(json['size']),
-    );
+    return openapi.FileItemResponse.fromJson(json).toDomainEntry();
   }
 
   Map<String, dynamic> _decodeObject(String body) {
@@ -443,40 +438,6 @@ class BackendFilesRepository
       return null;
     }
     return null;
-  }
-
-  String _readString(
-    Map<String, dynamic> json,
-    String key, {
-    String? fallback,
-  }) {
-    final value = json[key];
-    if (value is String && value.trim().isNotEmpty) {
-      return value;
-    }
-    if (fallback != null) {
-      return fallback;
-    }
-    throw FilesFailure.protocol(
-      'The Weave backend returned a file item without $key.',
-    );
-  }
-
-  int? _readInt(Object? value) {
-    if (value is int) {
-      return value;
-    }
-    if (value is num) {
-      return value.toInt();
-    }
-    return null;
-  }
-
-  DateTime? _readDateTime(Object? value) {
-    if (value is! String || value.isEmpty) {
-      return null;
-    }
-    return DateTime.tryParse(value);
   }
 
   Map<String, String> _jsonHeaders(String accessToken) {

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -23,7 +23,6 @@ import 'package:weave/features/agents/presentation/providers/agent_capability_po
 import 'package:weave/features/agents/presentation/widgets/agent_capability_policy_card.dart';
 import 'package:weave/features/app/presentation/providers/workspace_connection_provider.dart';
 import 'package:weave/features/auth/presentation/providers/auth_flow_controller.dart';
-import 'package:weave/features/chat/presentation/widgets/chat_security_settings_section.dart';
 import 'package:weave/features/connectors/presentation/providers/connector_preview_provider.dart';
 import 'package:weave/features/connectors/presentation/widgets/connector_settings_preview_card.dart';
 import 'package:weave/features/guests/presentation/providers/guest_preview_provider.dart';
@@ -87,8 +86,6 @@ class SettingsScreen extends ConsumerWidget {
                   ],
                   const SizedBox(height: 32),
                   _AdminSetupSection(configuration: configuration),
-                  const SizedBox(height: 32),
-                  const ChatSecuritySettingsSection(),
                   const SizedBox(height: 32),
                   Text(
                     l10n.settingsSignOutTitle,

--- a/client/lib/generated/openapi_models.dart
+++ b/client/lib/generated/openapi_models.dart
@@ -577,11 +577,11 @@ class BoardProviderCapabilities {
 class BoardsCreateTaskRequest {
   const BoardsCreateTaskRequest({
     this.assigneeRefs,
-    this.columnId,
+    required this.columnId,
     this.description,
     this.dueAt,
     this.labelRefs,
-    this.title,
+    required this.title,
   });
 
   factory BoardsCreateTaskRequest.fromJson(Map<String, dynamic> json) =>
@@ -589,21 +589,21 @@ class BoardsCreateTaskRequest {
         assigneeRefs: (json["assigneeRefs"] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList(),
-        columnId: json["columnId"] as String?,
+        columnId: json["columnId"] as String,
         description: json["description"] as String?,
         dueAt: json["dueAt"] as String?,
         labelRefs: (json["labelRefs"] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList(),
-        title: json["title"] as String?,
+        title: json["title"] as String,
       );
 
   final List<String>? assigneeRefs;
-  final String? columnId;
+  final String columnId;
   final String? description;
   final String? dueAt;
   final List<String>? labelRefs;
-  final String? title;
+  final String title;
 
   Map<String, dynamic> toJson() => {
     "assigneeRefs": _openApiJsonValue(assigneeRefs),
@@ -616,12 +616,12 @@ class BoardsCreateTaskRequest {
 }
 
 class BoardsLinkDecisionRequest {
-  const BoardsLinkDecisionRequest({this.decisionRef});
+  const BoardsLinkDecisionRequest({required this.decisionRef});
 
   factory BoardsLinkDecisionRequest.fromJson(Map<String, dynamic> json) =>
-      BoardsLinkDecisionRequest(decisionRef: json["decisionRef"] as String?);
+      BoardsLinkDecisionRequest(decisionRef: json["decisionRef"] as String);
 
-  final String? decisionRef;
+  final String decisionRef;
 
   Map<String, dynamic> toJson() => {
     "decisionRef": _openApiJsonValue(decisionRef),
@@ -629,15 +629,18 @@ class BoardsLinkDecisionRequest {
 }
 
 class BoardsMoveTaskRequest {
-  const BoardsMoveTaskRequest({this.targetColumnId, this.targetPosition});
+  const BoardsMoveTaskRequest({
+    required this.targetColumnId,
+    this.targetPosition,
+  });
 
   factory BoardsMoveTaskRequest.fromJson(Map<String, dynamic> json) =>
       BoardsMoveTaskRequest(
-        targetColumnId: json["targetColumnId"] as String?,
+        targetColumnId: json["targetColumnId"] as String,
         targetPosition: (json["targetPosition"] as num?)?.toInt(),
       );
 
-  final String? targetColumnId;
+  final String targetColumnId;
   final int? targetPosition;
 
   Map<String, dynamic> toJson() => {
@@ -1685,7 +1688,7 @@ class CapabilityWhitelistResponse {
 class CapabilityWhitelistUpdateRequest {
   const CapabilityWhitelistUpdateRequest({
     this.capabilityKeys,
-    this.profileKey,
+    required this.profileKey,
     this.reason,
   });
 
@@ -1695,12 +1698,12 @@ class CapabilityWhitelistUpdateRequest {
     capabilityKeys: (json["capabilityKeys"] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
-    profileKey: json["profileKey"] as String?,
+    profileKey: json["profileKey"] as String,
     reason: json["reason"] as String?,
   );
 
   final List<String>? capabilityKeys;
-  final String? profileKey;
+  final String profileKey;
   final String? reason;
 
   Map<String, dynamic> toJson() => {
@@ -1756,22 +1759,22 @@ class ChangeRecord {
 
 class ChatAttachmentPolicyResponse {
   const ChatAttachmentPolicyResponse({
-    this.attachmentRefsSupported,
-    this.maxAttachmentRefs,
-    this.rawProviderMediaUrlsExposed,
+    required this.attachmentRefsSupported,
+    required this.maxAttachmentRefs,
+    required this.rawProviderMediaUrlsExposed,
   });
 
   factory ChatAttachmentPolicyResponse.fromJson(Map<String, dynamic> json) =>
       ChatAttachmentPolicyResponse(
-        attachmentRefsSupported: json["attachmentRefsSupported"] as bool?,
-        maxAttachmentRefs: (json["maxAttachmentRefs"] as num?)?.toInt(),
+        attachmentRefsSupported: json["attachmentRefsSupported"] as bool,
+        maxAttachmentRefs: (json["maxAttachmentRefs"] as num).toInt(),
         rawProviderMediaUrlsExposed:
-            json["rawProviderMediaUrlsExposed"] as bool?,
+            json["rawProviderMediaUrlsExposed"] as bool,
       );
 
-  final bool? attachmentRefsSupported;
-  final int? maxAttachmentRefs;
-  final bool? rawProviderMediaUrlsExposed;
+  final bool attachmentRefsSupported;
+  final int maxAttachmentRefs;
+  final bool rawProviderMediaUrlsExposed;
 
   Map<String, dynamic> toJson() => {
     "attachmentRefsSupported": _openApiJsonValue(attachmentRefsSupported),
@@ -1784,53 +1787,47 @@ class ChatAttachmentPolicyResponse {
 
 class ChatConversationResponse {
   const ChatConversationResponse({
-    this.attachmentPolicy,
-    this.availableActions,
-    this.contextId,
-    this.historyPolicy,
-    this.id,
-    this.kind,
+    required this.attachmentPolicy,
+    required this.availableActions,
+    required this.contextId,
+    required this.historyPolicy,
+    required this.id,
+    required this.kind,
     this.lastMessageAt,
-    this.membership,
-    this.title,
+    required this.membership,
+    required this.title,
   });
 
   factory ChatConversationResponse.fromJson(Map<String, dynamic> json) =>
       ChatConversationResponse(
-        attachmentPolicy: json["attachmentPolicy"] == null
-            ? null
-            : ChatAttachmentPolicyResponse.fromJson(
-                json["attachmentPolicy"] as Map<String, dynamic>,
-              ),
-        availableActions: (json["availableActions"] as List<dynamic>?)
-            ?.map((e) => e as String)
+        attachmentPolicy: ChatAttachmentPolicyResponse.fromJson(
+          json["attachmentPolicy"] as Map<String, dynamic>,
+        ),
+        availableActions: (json["availableActions"] as List<dynamic>)
+            .map((e) => e as String)
             .toList(),
-        contextId: json["contextId"] as String?,
-        historyPolicy: json["historyPolicy"] == null
-            ? null
-            : ChatHistoryPolicyResponse.fromJson(
-                json["historyPolicy"] as Map<String, dynamic>,
-              ),
-        id: json["id"] as String?,
-        kind: json["kind"] as String?,
+        contextId: json["contextId"] as String,
+        historyPolicy: ChatHistoryPolicyResponse.fromJson(
+          json["historyPolicy"] as Map<String, dynamic>,
+        ),
+        id: json["id"] as String,
+        kind: json["kind"] as String,
         lastMessageAt: json["lastMessageAt"] as String?,
-        membership: json["membership"] == null
-            ? null
-            : ChatMembershipResponse.fromJson(
-                json["membership"] as Map<String, dynamic>,
-              ),
-        title: json["title"] as String?,
+        membership: ChatMembershipResponse.fromJson(
+          json["membership"] as Map<String, dynamic>,
+        ),
+        title: json["title"] as String,
       );
 
-  final ChatAttachmentPolicyResponse? attachmentPolicy;
-  final List<String>? availableActions;
-  final String? contextId;
-  final ChatHistoryPolicyResponse? historyPolicy;
-  final String? id;
-  final String? kind;
+  final ChatAttachmentPolicyResponse attachmentPolicy;
+  final List<String> availableActions;
+  final String contextId;
+  final ChatHistoryPolicyResponse historyPolicy;
+  final String id;
+  final String kind;
   final String? lastMessageAt;
-  final ChatMembershipResponse? membership;
-  final String? title;
+  final ChatMembershipResponse membership;
+  final String title;
 
   Map<String, dynamic> toJson() => {
     "attachmentPolicy": _openApiJsonValue(attachmentPolicy),
@@ -1847,36 +1844,34 @@ class ChatConversationResponse {
 
 class ChatConversationsResponse {
   const ChatConversationsResponse({
-    this.conversations,
-    this.domain,
-    this.readiness,
-    this.releaseStatus,
-    this.source,
+    required this.conversations,
+    required this.domain,
+    required this.readiness,
+    required this.releaseStatus,
+    required this.source,
   });
 
   factory ChatConversationsResponse.fromJson(Map<String, dynamic> json) =>
       ChatConversationsResponse(
-        conversations: (json["conversations"] as List<dynamic>?)
-            ?.map(
+        conversations: (json["conversations"] as List<dynamic>)
+            .map(
               (e) =>
                   ChatConversationResponse.fromJson(e as Map<String, dynamic>),
             )
             .toList(),
-        domain: json["domain"] as String?,
-        readiness: json["readiness"] == null
-            ? null
-            : ChatReadinessResponse.fromJson(
-                json["readiness"] as Map<String, dynamic>,
-              ),
-        releaseStatus: json["releaseStatus"] as String?,
-        source: json["source"] as String?,
+        domain: json["domain"] as String,
+        readiness: ChatReadinessResponse.fromJson(
+          json["readiness"] as Map<String, dynamic>,
+        ),
+        releaseStatus: json["releaseStatus"] as String,
+        source: json["source"] as String,
       );
 
-  final List<ChatConversationResponse>? conversations;
-  final String? domain;
-  final ChatReadinessResponse? readiness;
-  final String? releaseStatus;
-  final String? source;
+  final List<ChatConversationResponse> conversations;
+  final String domain;
+  final ChatReadinessResponse readiness;
+  final String releaseStatus;
+  final String source;
 
   Map<String, dynamic> toJson() => {
     "conversations": _openApiJsonValue(conversations),
@@ -1924,25 +1919,25 @@ class ChatHistoryPolicy {
 
 class ChatHistoryPolicyResponse {
   const ChatHistoryPolicyResponse({
-    this.backendReadable,
-    this.encryptedProviderContentRedacted,
-    this.policyKey,
-    this.visibility,
+    required this.backendReadable,
+    required this.encryptedProviderContentRedacted,
+    required this.policyKey,
+    required this.visibility,
   });
 
   factory ChatHistoryPolicyResponse.fromJson(Map<String, dynamic> json) =>
       ChatHistoryPolicyResponse(
-        backendReadable: json["backendReadable"] as bool?,
+        backendReadable: json["backendReadable"] as bool,
         encryptedProviderContentRedacted:
-            json["encryptedProviderContentRedacted"] as bool?,
-        policyKey: json["policyKey"] as String?,
-        visibility: json["visibility"] as String?,
+            json["encryptedProviderContentRedacted"] as bool,
+        policyKey: json["policyKey"] as String,
+        visibility: json["visibility"] as String,
       );
 
-  final bool? backendReadable;
-  final bool? encryptedProviderContentRedacted;
-  final String? policyKey;
-  final String? visibility;
+  final bool backendReadable;
+  final bool encryptedProviderContentRedacted;
+  final String policyKey;
+  final String visibility;
 
   Map<String, dynamic> toJson() => {
     "backendReadable": _openApiJsonValue(backendReadable),
@@ -1955,18 +1950,22 @@ class ChatHistoryPolicyResponse {
 }
 
 class ChatMembershipResponse {
-  const ChatMembershipResponse({this.principalRef, this.role, this.state});
+  const ChatMembershipResponse({
+    required this.principalRef,
+    required this.role,
+    required this.state,
+  });
 
   factory ChatMembershipResponse.fromJson(Map<String, dynamic> json) =>
       ChatMembershipResponse(
-        principalRef: json["principalRef"] as String?,
-        role: json["role"] as String?,
-        state: json["state"] as String?,
+        principalRef: json["principalRef"] as String,
+        role: json["role"] as String,
+        state: json["state"] as String,
       );
 
-  final String? principalRef;
-  final String? role;
-  final String? state;
+  final String principalRef;
+  final String role;
+  final String state;
 
   Map<String, dynamic> toJson() => {
     "principalRef": _openApiJsonValue(principalRef),
@@ -1977,42 +1976,42 @@ class ChatMembershipResponse {
 
 class ChatMessageResponse {
   const ChatMessageResponse({
-    this.attachmentRefs,
-    this.conversationId,
-    this.deliveryEvidence,
-    this.encryptedProviderContentRedacted,
-    this.id,
-    this.isMine,
-    this.senderRef,
-    this.sentAt,
+    required this.attachmentRefs,
+    required this.conversationId,
+    required this.deliveryEvidence,
+    required this.encryptedProviderContentRedacted,
+    required this.id,
+    required this.isMine,
+    required this.senderRef,
+    required this.sentAt,
     this.text,
   });
 
   factory ChatMessageResponse.fromJson(Map<String, dynamic> json) =>
       ChatMessageResponse(
-        attachmentRefs: (json["attachmentRefs"] as List<dynamic>?)
-            ?.map((e) => e as String)
+        attachmentRefs: (json["attachmentRefs"] as List<dynamic>)
+            .map((e) => e as String)
             .toList(),
-        conversationId: json["conversationId"] as String?,
-        deliveryEvidence: (json["deliveryEvidence"] as Map<String, dynamic>?)
-            ?.cast<String, Object?>(),
+        conversationId: json["conversationId"] as String,
+        deliveryEvidence: (json["deliveryEvidence"] as Map<String, dynamic>)
+            .cast<String, Object?>(),
         encryptedProviderContentRedacted:
-            json["encryptedProviderContentRedacted"] as bool?,
-        id: json["id"] as String?,
-        isMine: json["isMine"] as bool?,
-        senderRef: json["senderRef"] as String?,
-        sentAt: json["sentAt"] as String?,
+            json["encryptedProviderContentRedacted"] as bool,
+        id: json["id"] as String,
+        isMine: json["isMine"] as bool,
+        senderRef: json["senderRef"] as String,
+        sentAt: json["sentAt"] as String,
         text: json["text"] as String?,
       );
 
-  final List<String>? attachmentRefs;
-  final String? conversationId;
-  final Map<String, Object?>? deliveryEvidence;
-  final bool? encryptedProviderContentRedacted;
-  final String? id;
-  final bool? isMine;
-  final String? senderRef;
-  final String? sentAt;
+  final List<String> attachmentRefs;
+  final String conversationId;
+  final Map<String, Object?> deliveryEvidence;
+  final bool encryptedProviderContentRedacted;
+  final String id;
+  final bool isMine;
+  final String senderRef;
+  final String sentAt;
   final String? text;
 
   Map<String, dynamic> toJson() => {
@@ -2032,29 +2031,25 @@ class ChatMessageResponse {
 
 class ChatMessagesResponse {
   const ChatMessagesResponse({
-    this.conversationId,
-    this.messages,
-    this.readiness,
+    required this.conversationId,
+    required this.messages,
+    required this.readiness,
   });
 
   factory ChatMessagesResponse.fromJson(Map<String, dynamic> json) =>
       ChatMessagesResponse(
-        conversationId: json["conversationId"] as String?,
-        messages: (json["messages"] as List<dynamic>?)
-            ?.map(
-              (e) => ChatMessageResponse.fromJson(e as Map<String, dynamic>),
-            )
+        conversationId: json["conversationId"] as String,
+        messages: (json["messages"] as List<dynamic>)
+            .map((e) => ChatMessageResponse.fromJson(e as Map<String, dynamic>))
             .toList(),
-        readiness: json["readiness"] == null
-            ? null
-            : ChatReadinessResponse.fromJson(
-                json["readiness"] as Map<String, dynamic>,
-              ),
+        readiness: ChatReadinessResponse.fromJson(
+          json["readiness"] as Map<String, dynamic>,
+        ),
       );
 
-  final String? conversationId;
-  final List<ChatMessageResponse>? messages;
-  final ChatReadinessResponse? readiness;
+  final String conversationId;
+  final List<ChatMessageResponse> messages;
+  final ChatReadinessResponse readiness;
 
   Map<String, dynamic> toJson() => {
     "conversationId": _openApiJsonValue(conversationId),
@@ -2181,8 +2176,8 @@ class ChatProviderReplacementDryRunRequest {
     this.encryptedRoomCount,
     this.identityConflictCount,
     this.messageCount,
-    this.sourceAdapter,
-    this.targetAdapter,
+    required this.sourceAdapter,
+    required this.targetAdapter,
   });
 
   factory ChatProviderReplacementDryRunRequest.fromJson(
@@ -2193,8 +2188,8 @@ class ChatProviderReplacementDryRunRequest {
     encryptedRoomCount: (json["encryptedRoomCount"] as num?)?.toInt(),
     identityConflictCount: (json["identityConflictCount"] as num?)?.toInt(),
     messageCount: (json["messageCount"] as num?)?.toInt(),
-    sourceAdapter: json["sourceAdapter"] as String?,
-    targetAdapter: json["targetAdapter"] as String?,
+    sourceAdapter: json["sourceAdapter"] as String,
+    targetAdapter: json["targetAdapter"] as String,
   );
 
   final int? attachmentCount;
@@ -2202,8 +2197,8 @@ class ChatProviderReplacementDryRunRequest {
   final int? encryptedRoomCount;
   final int? identityConflictCount;
   final int? messageCount;
-  final String? sourceAdapter;
-  final String? targetAdapter;
+  final String sourceAdapter;
+  final String targetAdapter;
 
   Map<String, dynamic> toJson() => {
     "attachmentCount": _openApiJsonValue(attachmentCount),
@@ -2371,26 +2366,26 @@ class ChatReadiness {
 
 class ChatReadinessResponse {
   const ChatReadinessResponse({
-    this.diagnosticsRedacted,
-    this.grantedCapabilities,
-    this.impactState,
-    this.memberImpact,
+    required this.diagnosticsRedacted,
+    required this.grantedCapabilities,
+    required this.impactState,
+    required this.memberImpact,
   });
 
   factory ChatReadinessResponse.fromJson(Map<String, dynamic> json) =>
       ChatReadinessResponse(
-        diagnosticsRedacted: json["diagnosticsRedacted"] as bool?,
-        grantedCapabilities: (json["grantedCapabilities"] as List<dynamic>?)
-            ?.map((e) => e as String)
+        diagnosticsRedacted: json["diagnosticsRedacted"] as bool,
+        grantedCapabilities: (json["grantedCapabilities"] as List<dynamic>)
+            .map((e) => e as String)
             .toList(),
-        impactState: json["impactState"] as String?,
-        memberImpact: json["memberImpact"] as String?,
+        impactState: json["impactState"] as String,
+        memberImpact: json["memberImpact"] as String,
       );
 
-  final bool? diagnosticsRedacted;
-  final List<String>? grantedCapabilities;
-  final String? impactState;
-  final String? memberImpact;
+  final bool diagnosticsRedacted;
+  final List<String> grantedCapabilities;
+  final String impactState;
+  final String memberImpact;
 
   Map<String, dynamic> toJson() => {
     "diagnosticsRedacted": _openApiJsonValue(diagnosticsRedacted),
@@ -2401,18 +2396,18 @@ class ChatReadinessResponse {
 }
 
 class ChatSendMessageRequest {
-  const ChatSendMessageRequest({this.attachmentRefs, this.text});
+  const ChatSendMessageRequest({this.attachmentRefs, required this.text});
 
   factory ChatSendMessageRequest.fromJson(Map<String, dynamic> json) =>
       ChatSendMessageRequest(
         attachmentRefs: (json["attachmentRefs"] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList(),
-        text: json["text"] as String?,
+        text: json["text"] as String,
       );
 
   final List<String>? attachmentRefs;
-  final String? text;
+  final String text;
 
   Map<String, dynamic> toJson() => {
     "attachmentRefs": _openApiJsonValue(attachmentRefs),
@@ -2487,8 +2482,8 @@ class ConnectorManifestValidationRequest {
     this.capabilities,
     this.commands,
     this.cursorRefs,
-    this.id,
-    this.provider,
+    required this.id,
+    required this.provider,
     this.providerWritesEnabled,
     this.redactionPolicy,
     this.releaseStatus,
@@ -2507,8 +2502,8 @@ class ConnectorManifestValidationRequest {
         .toList(),
     cursorRefs: (json["cursorRefs"] as Map<String, dynamic>?)
         ?.cast<String, Object?>(),
-    id: json["id"] as String?,
-    provider: json["provider"] as String?,
+    id: json["id"] as String,
+    provider: json["provider"] as String,
     providerWritesEnabled: json["providerWritesEnabled"] as bool?,
     redactionPolicy: json["redactionPolicy"] as String?,
     releaseStatus: json["releaseStatus"] as String?,
@@ -2521,8 +2516,8 @@ class ConnectorManifestValidationRequest {
   final List<String>? capabilities;
   final List<String>? commands;
   final Map<String, Object?>? cursorRefs;
-  final String? id;
-  final String? provider;
+  final String id;
+  final String provider;
   final bool? providerWritesEnabled;
   final String? redactionPolicy;
   final String? releaseStatus;
@@ -2730,41 +2725,41 @@ class CreateCalendarEventRequest {
   const CreateCalendarEventRequest({
     this.allDay,
     this.description,
-    this.endsAt,
+    required this.endsAt,
     this.location,
     this.scope,
-    this.startsAt,
+    required this.startsAt,
     this.timeRangeValid,
-    this.timezone,
-    this.title,
+    required this.timezone,
+    required this.title,
   });
 
   factory CreateCalendarEventRequest.fromJson(Map<String, dynamic> json) =>
       CreateCalendarEventRequest(
         allDay: json["allDay"] as bool?,
         description: json["description"] as String?,
-        endsAt: json["endsAt"] as String?,
+        endsAt: json["endsAt"] as String,
         location: json["location"] as String?,
         scope: json["scope"] == null
             ? null
             : CalendarScopeResponse.fromJson(
                 json["scope"] as Map<String, dynamic>,
               ),
-        startsAt: json["startsAt"] as String?,
+        startsAt: json["startsAt"] as String,
         timeRangeValid: json["timeRangeValid"] as bool?,
-        timezone: json["timezone"] as String?,
-        title: json["title"] as String?,
+        timezone: json["timezone"] as String,
+        title: json["title"] as String,
       );
 
   final bool? allDay;
   final String? description;
-  final String? endsAt;
+  final String endsAt;
   final String? location;
   final CalendarScopeResponse? scope;
-  final String? startsAt;
+  final String startsAt;
   final bool? timeRangeValid;
-  final String? timezone;
-  final String? title;
+  final String timezone;
+  final String title;
 
   Map<String, dynamic> toJson() => {
     "allDay": _openApiJsonValue(allDay),
@@ -2780,16 +2775,16 @@ class CreateCalendarEventRequest {
 }
 
 class CreateFolderRequest {
-  const CreateFolderRequest({this.name, this.parentPath});
+  const CreateFolderRequest({required this.name, required this.parentPath});
 
   factory CreateFolderRequest.fromJson(Map<String, dynamic> json) =>
       CreateFolderRequest(
-        name: json["name"] as String?,
-        parentPath: json["parentPath"] as String?,
+        name: json["name"] as String,
+        parentPath: json["parentPath"] as String,
       );
 
-  final String? name;
-  final String? parentPath;
+  final String name;
+  final String parentPath;
 
   Map<String, dynamic> toJson() => {
     "name": _openApiJsonValue(name),
@@ -2845,7 +2840,7 @@ class DecisionLedgerCreateRequest {
     this.references,
     this.risks,
     this.status,
-    this.title,
+    required this.title,
   });
 
   factory DecisionLedgerCreateRequest.fromJson(Map<String, dynamic> json) =>
@@ -2867,7 +2862,7 @@ class DecisionLedgerCreateRequest {
             ?.map((e) => e as String)
             .toList(),
         status: json["status"] as String?,
-        title: json["title"] as String?,
+        title: json["title"] as String,
       );
 
   final List<String>? followUpRefs;
@@ -2875,7 +2870,7 @@ class DecisionLedgerCreateRequest {
   final List<DecisionLedgerReferenceRequest>? references;
   final List<String>? risks;
   final String? status;
-  final String? title;
+  final String title;
 
   Map<String, dynamic> toJson() => {
     "followUpRefs": _openApiJsonValue(followUpRefs),
@@ -3039,23 +3034,23 @@ class DecisionLedgerRecordsResponse {
 class DecisionLedgerReferenceRequest {
   const DecisionLedgerReferenceRequest({
     this.excerpt,
-    this.label,
-    this.ref,
-    this.type,
+    required this.label,
+    required this.ref,
+    required this.type,
   });
 
   factory DecisionLedgerReferenceRequest.fromJson(Map<String, dynamic> json) =>
       DecisionLedgerReferenceRequest(
         excerpt: json["excerpt"] as String?,
-        label: json["label"] as String?,
-        ref: json["ref"] as String?,
-        type: json["type"] as String?,
+        label: json["label"] as String,
+        ref: json["ref"] as String,
+        type: json["type"] as String,
       );
 
   final String? excerpt;
-  final String? label;
-  final String? ref;
-  final String? type;
+  final String label;
+  final String ref;
+  final String type;
 
   Map<String, dynamic> toJson() => {
     "excerpt": _openApiJsonValue(excerpt),
@@ -3742,21 +3737,21 @@ class E2eeStatus {
 
 class EffectivePolicyDenyResponse {
   const EffectivePolicyDenyResponse({
-    this.capability,
-    this.reason,
-    this.source,
+    required this.capability,
+    required this.reason,
+    required this.source,
   });
 
   factory EffectivePolicyDenyResponse.fromJson(Map<String, dynamic> json) =>
       EffectivePolicyDenyResponse(
-        capability: json["capability"] as String?,
-        reason: json["reason"] as String?,
-        source: json["source"] as String?,
+        capability: json["capability"] as String,
+        reason: json["reason"] as String,
+        source: json["source"] as String,
       );
 
-  final String? capability;
-  final String? reason;
-  final String? source;
+  final String capability;
+  final String reason;
+  final String source;
 
   Map<String, dynamic> toJson() => {
     "capability": _openApiJsonValue(capability),
@@ -3767,82 +3762,80 @@ class EffectivePolicyDenyResponse {
 
 class EffectivePolicyResponse {
   const EffectivePolicyResponse({
-    this.auditRefs,
-    this.capabilityGrants,
-    this.context,
-    this.contextRoles,
-    this.denies,
-    this.denyByDefault,
-    this.emailPrimaryKey,
-    this.groups,
-    this.identitySources,
-    this.orgRoles,
-    this.organization,
-    this.primaryIdentityKey,
-    this.providerRoleMappings,
-    this.readinessImpact,
-    this.subject,
-    this.supportSafe,
+    required this.auditRefs,
+    required this.capabilityGrants,
+    required this.context,
+    required this.contextRoles,
+    required this.denies,
+    required this.denyByDefault,
+    required this.emailPrimaryKey,
+    required this.groups,
+    required this.identitySources,
+    required this.orgRoles,
+    required this.organization,
+    required this.primaryIdentityKey,
+    required this.providerRoleMappings,
+    required this.readinessImpact,
+    required this.subject,
+    required this.supportSafe,
   });
 
-  factory EffectivePolicyResponse.fromJson(Map<String, dynamic> json) =>
-      EffectivePolicyResponse(
-        auditRefs: (json["auditRefs"] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-        capabilityGrants: (json["capabilityGrants"] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-        context: json["context"] as String?,
-        contextRoles: (json["contextRoles"] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-        denies: (json["denies"] as List<dynamic>?)
-            ?.map(
-              (e) => EffectivePolicyDenyResponse.fromJson(
-                e as Map<String, dynamic>,
-              ),
-            )
-            .toList(),
-        denyByDefault: json["denyByDefault"] as bool?,
-        emailPrimaryKey: json["emailPrimaryKey"] as bool?,
-        groups: (json["groups"] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-        identitySources: (json["identitySources"] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-        orgRoles: (json["orgRoles"] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-        organization: json["organization"] as String?,
-        primaryIdentityKey: json["primaryIdentityKey"] as String?,
-        providerRoleMappings: (json["providerRoleMappings"] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-        readinessImpact: (json["readinessImpact"] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList(),
-        subject: json["subject"] as String?,
-        supportSafe: json["supportSafe"] as bool?,
-      );
+  factory EffectivePolicyResponse.fromJson(
+    Map<String, dynamic> json,
+  ) => EffectivePolicyResponse(
+    auditRefs: (json["auditRefs"] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    capabilityGrants: (json["capabilityGrants"] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    context: json["context"] as String,
+    contextRoles: (json["contextRoles"] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    denies: (json["denies"] as List<dynamic>)
+        .map(
+          (e) =>
+              EffectivePolicyDenyResponse.fromJson(e as Map<String, dynamic>),
+        )
+        .toList(),
+    denyByDefault: json["denyByDefault"] as bool,
+    emailPrimaryKey: json["emailPrimaryKey"] as bool,
+    groups: (json["groups"] as List<dynamic>).map((e) => e as String).toList(),
+    identitySources: (json["identitySources"] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    orgRoles: (json["orgRoles"] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    organization: json["organization"] as String,
+    primaryIdentityKey: json["primaryIdentityKey"] as String,
+    providerRoleMappings: (json["providerRoleMappings"] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    readinessImpact: (json["readinessImpact"] as List<dynamic>)
+        .map((e) => e as String)
+        .toList(),
+    subject: json["subject"] as String,
+    supportSafe: json["supportSafe"] as bool,
+  );
 
-  final List<String>? auditRefs;
-  final List<String>? capabilityGrants;
-  final String? context;
-  final List<String>? contextRoles;
-  final List<EffectivePolicyDenyResponse>? denies;
-  final bool? denyByDefault;
-  final bool? emailPrimaryKey;
-  final List<String>? groups;
-  final List<String>? identitySources;
-  final List<String>? orgRoles;
-  final String? organization;
-  final String? primaryIdentityKey;
-  final List<String>? providerRoleMappings;
-  final List<String>? readinessImpact;
-  final String? subject;
-  final bool? supportSafe;
+  final List<String> auditRefs;
+  final List<String> capabilityGrants;
+  final String context;
+  final List<String> contextRoles;
+  final List<EffectivePolicyDenyResponse> denies;
+  final bool denyByDefault;
+  final bool emailPrimaryKey;
+  final List<String> groups;
+  final List<String> identitySources;
+  final List<String> orgRoles;
+  final String organization;
+  final String primaryIdentityKey;
+  final List<String> providerRoleMappings;
+  final List<String> readinessImpact;
+  final String subject;
+  final bool supportSafe;
 
   Map<String, dynamic> toJson() => {
     "auditRefs": _openApiJsonValue(auditRefs),
@@ -4054,36 +4047,36 @@ class Features {
 
 class FileItemResponse {
   const FileItemResponse({
-    this.downloadable,
-    this.id,
+    required this.downloadable,
+    required this.id,
     this.mimeType,
     this.modifiedAt,
-    this.name,
-    this.path,
+    required this.name,
+    required this.path,
     this.size,
-    this.type,
+    required this.type,
   });
 
   factory FileItemResponse.fromJson(Map<String, dynamic> json) =>
       FileItemResponse(
-        downloadable: json["downloadable"] as bool?,
-        id: json["id"] as String?,
+        downloadable: json["downloadable"] as bool,
+        id: json["id"] as String,
         mimeType: json["mimeType"] as String?,
         modifiedAt: json["modifiedAt"] as String?,
-        name: json["name"] as String?,
-        path: json["path"] as String?,
+        name: json["name"] as String,
+        path: json["path"] as String,
         size: (json["size"] as num?)?.toInt(),
-        type: json["type"] as String?,
+        type: json["type"] as String,
       );
 
-  final bool? downloadable;
-  final String? id;
+  final bool downloadable;
+  final String id;
   final String? mimeType;
   final String? modifiedAt;
-  final String? name;
-  final String? path;
+  final String name;
+  final String path;
   final int? size;
-  final String? type;
+  final String type;
 
   Map<String, dynamic> toJson() => {
     "downloadable": _openApiJsonValue(downloadable),
@@ -4098,21 +4091,21 @@ class FileItemResponse {
 }
 
 class FileListResponse {
-  const FileListResponse({this.items, this.path, this.quota});
+  const FileListResponse({required this.items, required this.path, this.quota});
 
   factory FileListResponse.fromJson(Map<String, dynamic> json) =>
       FileListResponse(
-        items: (json["items"] as List<dynamic>?)
-            ?.map((e) => FileItemResponse.fromJson(e as Map<String, dynamic>))
+        items: (json["items"] as List<dynamic>)
+            .map((e) => FileItemResponse.fromJson(e as Map<String, dynamic>))
             .toList(),
-        path: json["path"] as String?,
+        path: json["path"] as String,
         quota: json["quota"] == null
             ? null
             : FileQuotaResponse.fromJson(json["quota"] as Map<String, dynamic>),
       );
 
-  final List<FileItemResponse>? items;
-  final String? path;
+  final List<FileItemResponse> items;
+  final String path;
   final FileQuotaResponse? quota;
 
   Map<String, dynamic> toJson() => {
@@ -4141,16 +4134,14 @@ class FileQuotaResponse {
 }
 
 class FileUploadResponse {
-  const FileUploadResponse({this.item});
+  const FileUploadResponse({required this.item});
 
   factory FileUploadResponse.fromJson(Map<String, dynamic> json) =>
       FileUploadResponse(
-        item: json["item"] == null
-            ? null
-            : FileItemResponse.fromJson(json["item"] as Map<String, dynamic>),
+        item: FileItemResponse.fromJson(json["item"] as Map<String, dynamic>),
       );
 
-  final FileItemResponse? item;
+  final FileItemResponse item;
 
   Map<String, dynamic> toJson() => {"item": _openApiJsonValue(item)};
 }
@@ -4285,7 +4276,7 @@ class GuestInvitationRequest {
   const GuestInvitationRequest({
     this.capabilities,
     this.displayName,
-    this.email,
+    required this.email,
   });
 
   factory GuestInvitationRequest.fromJson(Map<String, dynamic> json) =>
@@ -4294,12 +4285,12 @@ class GuestInvitationRequest {
             ?.map((e) => e as String)
             .toList(),
         displayName: json["displayName"] as String?,
-        email: json["email"] as String?,
+        email: json["email"] as String,
       );
 
   final List<String>? capabilities;
   final String? displayName;
-  final String? email;
+  final String email;
 
   Map<String, dynamic> toJson() => {
     "capabilities": _openApiJsonValue(capabilities),
@@ -5278,7 +5269,7 @@ class MeetingCapsuleCreateRequest {
   const MeetingCapsuleCreateRequest({
     this.agendaItems,
     this.followUpRefs,
-    this.title,
+    required this.title,
   });
 
   factory MeetingCapsuleCreateRequest.fromJson(Map<String, dynamic> json) =>
@@ -5289,12 +5280,12 @@ class MeetingCapsuleCreateRequest {
         followUpRefs: (json["followUpRefs"] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList(),
-        title: json["title"] as String?,
+        title: json["title"] as String,
       );
 
   final List<String>? agendaItems;
   final List<String>? followUpRefs;
-  final String? title;
+  final String title;
 
   Map<String, dynamic> toJson() => {
     "agendaItems": _openApiJsonValue(agendaItems),
@@ -5432,20 +5423,20 @@ class MigrationApplyGateRequest {
     this.auditSinkAvailable,
     this.conflictReportRef,
     this.contentHashes,
-    this.domainKey,
+    required this.domainKey,
     this.dryRunReportRef,
     this.exportSnapshotRef,
     this.identityMappingComplete,
     this.importPlanRef,
     this.lossyMappingReportRef,
     this.memberImpactPreviewRef,
-    this.objectCounts,
+    required this.objectCounts,
     this.postApplyVerificationRef,
     this.providerDiagnostics,
     this.providerMappingRef,
-    this.requestedLifecycle,
+    required this.requestedLifecycle,
     this.rollbackArchiveRef,
-    this.runId,
+    required this.runId,
   });
 
   factory MigrationApplyGateRequest.fromJson(Map<String, dynamic> json) =>
@@ -5460,23 +5451,23 @@ class MigrationApplyGateRequest {
         contentHashes: (json["contentHashes"] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList(),
-        domainKey: json["domainKey"] as String?,
+        domainKey: json["domainKey"] as String,
         dryRunReportRef: json["dryRunReportRef"] as String?,
         exportSnapshotRef: json["exportSnapshotRef"] as String?,
         identityMappingComplete: json["identityMappingComplete"] as bool?,
         importPlanRef: json["importPlanRef"] as String?,
         lossyMappingReportRef: json["lossyMappingReportRef"] as String?,
         memberImpactPreviewRef: json["memberImpactPreviewRef"] as String?,
-        objectCounts: (json["objectCounts"] as Map<String, dynamic>?)
-            ?.cast<String, Object?>(),
+        objectCounts: (json["objectCounts"] as Map<String, dynamic>)
+            .cast<String, Object?>(),
         postApplyVerificationRef: json["postApplyVerificationRef"] as String?,
         providerDiagnostics: (json["providerDiagnostics"] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList(),
         providerMappingRef: json["providerMappingRef"] as String?,
-        requestedLifecycle: json["requestedLifecycle"] as String?,
+        requestedLifecycle: json["requestedLifecycle"] as String,
         rollbackArchiveRef: json["rollbackArchiveRef"] as String?,
-        runId: json["runId"] as String?,
+        runId: json["runId"] as String,
       );
 
   final String? adminApprovalRef;
@@ -5485,20 +5476,20 @@ class MigrationApplyGateRequest {
   final bool? auditSinkAvailable;
   final String? conflictReportRef;
   final List<String>? contentHashes;
-  final String? domainKey;
+  final String domainKey;
   final String? dryRunReportRef;
   final String? exportSnapshotRef;
   final bool? identityMappingComplete;
   final String? importPlanRef;
   final String? lossyMappingReportRef;
   final String? memberImpactPreviewRef;
-  final Map<String, Object?>? objectCounts;
+  final Map<String, Object?> objectCounts;
   final String? postApplyVerificationRef;
   final List<String>? providerDiagnostics;
   final String? providerMappingRef;
-  final String? requestedLifecycle;
+  final String requestedLifecycle;
   final String? rollbackArchiveRef;
-  final String? runId;
+  final String runId;
 
   Map<String, dynamic> toJson() => {
     "adminApprovalRef": _openApiJsonValue(adminApprovalRef),
@@ -5597,20 +5588,21 @@ class MigrationApplyGateResponse {
 }
 
 class MigrationDryRunRequest {
-  const MigrationDryRunRequest({this.inventory, this.sourceProvider});
+  const MigrationDryRunRequest({
+    required this.inventory,
+    required this.sourceProvider,
+  });
 
   factory MigrationDryRunRequest.fromJson(Map<String, dynamic> json) =>
       MigrationDryRunRequest(
-        inventory: json["inventory"] == null
-            ? null
-            : SourceInventory.fromJson(
-                json["inventory"] as Map<String, dynamic>,
-              ),
-        sourceProvider: json["sourceProvider"] as String?,
+        inventory: SourceInventory.fromJson(
+          json["inventory"] as Map<String, dynamic>,
+        ),
+        sourceProvider: json["sourceProvider"] as String,
       );
 
-  final SourceInventory? inventory;
-  final String? sourceProvider;
+  final SourceInventory inventory;
+  final String sourceProvider;
 
   Map<String, dynamic> toJson() => {
     "inventory": _openApiJsonValue(inventory),
@@ -5977,16 +5969,19 @@ class OfficeCapabilityFlagsResponse {
 }
 
 class OfficeLaunchRequest {
-  const OfficeLaunchRequest({this.fileId, this.requestedMode});
+  const OfficeLaunchRequest({
+    required this.fileId,
+    required this.requestedMode,
+  });
 
   factory OfficeLaunchRequest.fromJson(Map<String, dynamic> json) =>
       OfficeLaunchRequest(
-        fileId: json["fileId"] as String?,
-        requestedMode: json["requestedMode"] as String?,
+        fileId: json["fileId"] as String,
+        requestedMode: json["requestedMode"] as String,
       );
 
-  final String? fileId;
-  final String? requestedMode;
+  final String fileId;
+  final String requestedMode;
 
   Map<String, dynamic> toJson() => {
     "fileId": _openApiJsonValue(fileId),
@@ -6198,7 +6193,7 @@ class OrganizationBootstrapRequest {
   const OrganizationBootstrapRequest({
     this.adminPrimaryIdentityKeys,
     this.bootstrapMode,
-    this.organizationId,
+    required this.organizationId,
     this.reason,
   });
 
@@ -6209,13 +6204,13 @@ class OrganizationBootstrapRequest {
                 ?.map((e) => e as String)
                 .toList(),
         bootstrapMode: json["bootstrapMode"] as String?,
-        organizationId: json["organizationId"] as String?,
+        organizationId: json["organizationId"] as String,
         reason: json["reason"] as String?,
       );
 
   final List<String>? adminPrimaryIdentityKeys;
   final String? bootstrapMode;
-  final String? organizationId;
+  final String organizationId;
   final String? reason;
 
   Map<String, dynamic> toJson() => {
@@ -6228,41 +6223,41 @@ class OrganizationBootstrapRequest {
 
 class OrganizationBootstrapResponse {
   const OrganizationBootstrapResponse({
-    this.actorPrimaryIdentityKey,
-    this.auditRefs,
-    this.bootstrapMode,
-    this.bootstrappedAt,
-    this.lastAdminGuardPassed,
-    this.organizationId,
-    this.retainedAdminPrimaryIdentityKeys,
-    this.supportSafe,
+    required this.actorPrimaryIdentityKey,
+    required this.auditRefs,
+    required this.bootstrapMode,
+    required this.bootstrappedAt,
+    required this.lastAdminGuardPassed,
+    required this.organizationId,
+    required this.retainedAdminPrimaryIdentityKeys,
+    required this.supportSafe,
   });
 
   factory OrganizationBootstrapResponse.fromJson(Map<String, dynamic> json) =>
       OrganizationBootstrapResponse(
-        actorPrimaryIdentityKey: json["actorPrimaryIdentityKey"] as String?,
-        auditRefs: (json["auditRefs"] as List<dynamic>?)
-            ?.map((e) => e as String)
+        actorPrimaryIdentityKey: json["actorPrimaryIdentityKey"] as String,
+        auditRefs: (json["auditRefs"] as List<dynamic>)
+            .map((e) => e as String)
             .toList(),
-        bootstrapMode: json["bootstrapMode"] as String?,
-        bootstrappedAt: json["bootstrappedAt"] as String?,
-        lastAdminGuardPassed: json["lastAdminGuardPassed"] as bool?,
-        organizationId: json["organizationId"] as String?,
+        bootstrapMode: json["bootstrapMode"] as String,
+        bootstrappedAt: json["bootstrappedAt"] as String,
+        lastAdminGuardPassed: json["lastAdminGuardPassed"] as bool,
+        organizationId: json["organizationId"] as String,
         retainedAdminPrimaryIdentityKeys:
-            (json["retainedAdminPrimaryIdentityKeys"] as List<dynamic>?)
-                ?.map((e) => e as String)
+            (json["retainedAdminPrimaryIdentityKeys"] as List<dynamic>)
+                .map((e) => e as String)
                 .toList(),
-        supportSafe: json["supportSafe"] as bool?,
+        supportSafe: json["supportSafe"] as bool,
       );
 
-  final String? actorPrimaryIdentityKey;
-  final List<String>? auditRefs;
-  final String? bootstrapMode;
-  final String? bootstrappedAt;
-  final bool? lastAdminGuardPassed;
-  final String? organizationId;
-  final List<String>? retainedAdminPrimaryIdentityKeys;
-  final bool? supportSafe;
+  final String actorPrimaryIdentityKey;
+  final List<String> auditRefs;
+  final String bootstrapMode;
+  final String bootstrappedAt;
+  final bool lastAdminGuardPassed;
+  final String organizationId;
+  final List<String> retainedAdminPrimaryIdentityKeys;
+  final bool supportSafe;
 
   Map<String, dynamic> toJson() => {
     "actorPrimaryIdentityKey": _openApiJsonValue(actorPrimaryIdentityKey),
@@ -6936,19 +6931,19 @@ class ProviderChoiceModelResponse {
 
 class ProviderReadinessTestRequest {
   const ProviderReadinessTestRequest({
-    this.providerKey,
+    required this.providerKey,
     this.secretRef,
     this.testKind,
   });
 
   factory ProviderReadinessTestRequest.fromJson(Map<String, dynamic> json) =>
       ProviderReadinessTestRequest(
-        providerKey: json["providerKey"] as String?,
+        providerKey: json["providerKey"] as String,
         secretRef: json["secretRef"] as String?,
         testKind: json["testKind"] as String?,
       );
 
-  final String? providerKey;
+  final String providerKey;
   final String? secretRef;
   final String? testKind;
 
@@ -7133,24 +7128,24 @@ class ProviderRegistryResponse {
 
 class ProviderReplacementDryRunRequest {
   const ProviderReplacementDryRunRequest({
-    this.category,
+    required this.category,
     this.choiceModel,
-    this.currentAdapter,
+    required this.currentAdapter,
     this.lossyMappingNotes,
     this.portableExportImportRequired,
     this.reason,
     this.requestedSwitchPlan,
-    this.secretRef,
-    this.sourceOfTruth,
-    this.targetAdapter,
+    required this.secretRef,
+    required this.sourceOfTruth,
+    required this.targetAdapter,
   });
 
   factory ProviderReplacementDryRunRequest.fromJson(
     Map<String, dynamic> json,
   ) => ProviderReplacementDryRunRequest(
-    category: json["category"] as String?,
+    category: json["category"] as String,
     choiceModel: json["choiceModel"] as String?,
-    currentAdapter: json["currentAdapter"] as String?,
+    currentAdapter: json["currentAdapter"] as String,
     lossyMappingNotes: (json["lossyMappingNotes"] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
@@ -7158,21 +7153,21 @@ class ProviderReplacementDryRunRequest {
     reason: json["reason"] as String?,
     requestedSwitchPlan: (json["requestedSwitchPlan"] as Map<String, dynamic>?)
         ?.cast<String, Object?>(),
-    secretRef: json["secretRef"] as String?,
-    sourceOfTruth: json["sourceOfTruth"] as String?,
-    targetAdapter: json["targetAdapter"] as String?,
+    secretRef: json["secretRef"] as String,
+    sourceOfTruth: json["sourceOfTruth"] as String,
+    targetAdapter: json["targetAdapter"] as String,
   );
 
-  final String? category;
+  final String category;
   final String? choiceModel;
-  final String? currentAdapter;
+  final String currentAdapter;
   final List<String>? lossyMappingNotes;
   final bool? portableExportImportRequired;
   final String? reason;
   final Map<String, Object?>? requestedSwitchPlan;
-  final String? secretRef;
-  final String? sourceOfTruth;
-  final String? targetAdapter;
+  final String secretRef;
+  final String sourceOfTruth;
+  final String targetAdapter;
 
   Map<String, dynamic> toJson() => {
     "category": _openApiJsonValue(category),
@@ -7397,33 +7392,33 @@ class ProviderSelection {
 
 class ProviderSelectionRequest {
   const ProviderSelectionRequest({
-    this.category,
+    required this.category,
     this.choiceModel,
     this.dryRun,
     this.lossyMappingNotes,
-    this.providerKey,
+    required this.providerKey,
     this.reason,
     this.secretRef,
   });
 
   factory ProviderSelectionRequest.fromJson(Map<String, dynamic> json) =>
       ProviderSelectionRequest(
-        category: json["category"] as String?,
+        category: json["category"] as String,
         choiceModel: json["choiceModel"] as String?,
         dryRun: json["dryRun"] as bool?,
         lossyMappingNotes: (json["lossyMappingNotes"] as List<dynamic>?)
             ?.map((e) => e as String)
             .toList(),
-        providerKey: json["providerKey"] as String?,
+        providerKey: json["providerKey"] as String,
         reason: json["reason"] as String?,
         secretRef: json["secretRef"] as String?,
       );
 
-  final String? category;
+  final String category;
   final String? choiceModel;
   final bool? dryRun;
   final List<String>? lossyMappingNotes;
-  final String? providerKey;
+  final String providerKey;
   final String? reason;
   final String? secretRef;
 
@@ -7984,17 +7979,21 @@ class SlackOAuthCallbackRequest {
 }
 
 class SlackOutboundMessageRequest {
-  const SlackOutboundMessageRequest({this.eventId, this.text, this.threadTs});
+  const SlackOutboundMessageRequest({
+    required this.eventId,
+    required this.text,
+    this.threadTs,
+  });
 
   factory SlackOutboundMessageRequest.fromJson(Map<String, dynamic> json) =>
       SlackOutboundMessageRequest(
-        eventId: json["eventId"] as String?,
-        text: json["text"] as String?,
+        eventId: json["eventId"] as String,
+        text: json["text"] as String,
         threadTs: json["threadTs"] as String?,
       );
 
-  final String? eventId;
-  final String? text;
+  final String eventId;
+  final String text;
   final String? threadTs;
 
   Map<String, dynamic> toJson() => {
@@ -9006,139 +9005,139 @@ class WeaverRuntimeProfileChangeResponse {
 
 class WeaverRuntimeProfileResponse {
   const WeaverRuntimeProfileResponse({
-    this.allowedCapabilities,
-    this.approvalPolicy,
-    this.auditPolicy,
-    this.auditRequired,
-    this.baselineProfile,
-    this.channelProjection,
-    this.containerImage,
-    this.credentialBrokerContract,
-    this.dockerNetworkMode,
-    this.elevatedEnabled,
-    this.enabled,
-    this.execEnabled,
-    this.expiresAt,
-    this.forkRequired,
-    this.generatedFrom,
-    this.isolatedAgentDirectory,
-    this.isolationBoundary,
-    this.mcpProjection,
-    this.memberImpact,
-    this.modelProvider,
-    this.pluginAllowlist,
-    this.posture,
-    this.previousProfileHash,
-    this.profileVersion,
-    this.revocationGeneration,
-    this.revocationStatus,
-    this.revoked,
-    this.rollbackProfileHash,
-    this.runtimeKind,
-    this.runtimeProfileHash,
-    this.runtimeProvider,
-    this.secretPosture,
-    this.signature,
-    this.supportSafeProfileReceipt,
-    this.toolAllowlist,
-    this.toolProvider,
-    this.userRef,
-    this.workspacePath,
+    required this.allowedCapabilities,
+    required this.approvalPolicy,
+    required this.auditPolicy,
+    required this.auditRequired,
+    required this.baselineProfile,
+    required this.channelProjection,
+    required this.containerImage,
+    required this.credentialBrokerContract,
+    required this.dockerNetworkMode,
+    required this.elevatedEnabled,
+    required this.enabled,
+    required this.execEnabled,
+    required this.expiresAt,
+    required this.forkRequired,
+    required this.generatedFrom,
+    required this.isolatedAgentDirectory,
+    required this.isolationBoundary,
+    required this.mcpProjection,
+    required this.memberImpact,
+    required this.modelProvider,
+    required this.pluginAllowlist,
+    required this.posture,
+    required this.previousProfileHash,
+    required this.profileVersion,
+    required this.revocationGeneration,
+    required this.revocationStatus,
+    required this.revoked,
+    required this.rollbackProfileHash,
+    required this.runtimeKind,
+    required this.runtimeProfileHash,
+    required this.runtimeProvider,
+    required this.secretPosture,
+    required this.signature,
+    required this.supportSafeProfileReceipt,
+    required this.toolAllowlist,
+    required this.toolProvider,
+    required this.userRef,
+    required this.workspacePath,
   });
 
   factory WeaverRuntimeProfileResponse.fromJson(Map<String, dynamic> json) =>
       WeaverRuntimeProfileResponse(
-        allowedCapabilities: (json["allowedCapabilities"] as List<dynamic>?)
-            ?.map((e) => e as String)
+        allowedCapabilities: (json["allowedCapabilities"] as List<dynamic>)
+            .map((e) => e as String)
             .toList(),
-        approvalPolicy: json["approvalPolicy"] as String?,
-        auditPolicy: (json["auditPolicy"] as Map<String, dynamic>?)
-            ?.cast<String, Object?>(),
-        auditRequired: json["auditRequired"] as bool?,
-        baselineProfile: json["baselineProfile"] as String?,
-        channelProjection: (json["channelProjection"] as Map<String, dynamic>?)
-            ?.cast<String, Object?>(),
-        containerImage: json["containerImage"] as String?,
+        approvalPolicy: json["approvalPolicy"] as String,
+        auditPolicy: (json["auditPolicy"] as Map<String, dynamic>)
+            .cast<String, Object?>(),
+        auditRequired: json["auditRequired"] as bool,
+        baselineProfile: json["baselineProfile"] as String,
+        channelProjection: (json["channelProjection"] as Map<String, dynamic>)
+            .cast<String, Object?>(),
+        containerImage: json["containerImage"] as String,
         credentialBrokerContract:
-            (json["credentialBrokerContract"] as Map<String, dynamic>?)
-                ?.cast<String, Object?>(),
-        dockerNetworkMode: json["dockerNetworkMode"] as String?,
-        elevatedEnabled: json["elevatedEnabled"] as bool?,
-        enabled: json["enabled"] as bool?,
-        execEnabled: json["execEnabled"] as bool?,
-        expiresAt: json["expiresAt"] as String?,
-        forkRequired: json["forkRequired"] as bool?,
-        generatedFrom: json["generatedFrom"] as String?,
-        isolatedAgentDirectory: json["isolatedAgentDirectory"] as String?,
-        isolationBoundary: json["isolationBoundary"] as String?,
-        mcpProjection: (json["mcpProjection"] as Map<String, dynamic>?)
-            ?.cast<String, Object?>(),
-        memberImpact: json["memberImpact"] as String?,
-        modelProvider: json["modelProvider"] as String?,
-        pluginAllowlist: (json["pluginAllowlist"] as List<dynamic>?)
-            ?.map((e) => e as String)
+            (json["credentialBrokerContract"] as Map<String, dynamic>)
+                .cast<String, Object?>(),
+        dockerNetworkMode: json["dockerNetworkMode"] as String,
+        elevatedEnabled: json["elevatedEnabled"] as bool,
+        enabled: json["enabled"] as bool,
+        execEnabled: json["execEnabled"] as bool,
+        expiresAt: json["expiresAt"] as String,
+        forkRequired: json["forkRequired"] as bool,
+        generatedFrom: json["generatedFrom"] as String,
+        isolatedAgentDirectory: json["isolatedAgentDirectory"] as String,
+        isolationBoundary: json["isolationBoundary"] as String,
+        mcpProjection: (json["mcpProjection"] as Map<String, dynamic>)
+            .cast<String, Object?>(),
+        memberImpact: json["memberImpact"] as String,
+        modelProvider: json["modelProvider"] as String,
+        pluginAllowlist: (json["pluginAllowlist"] as List<dynamic>)
+            .map((e) => e as String)
             .toList(),
-        posture: json["posture"] as String?,
-        previousProfileHash: json["previousProfileHash"] as String?,
-        profileVersion: json["profileVersion"] as String?,
-        revocationGeneration: (json["revocationGeneration"] as num?)?.toInt(),
-        revocationStatus: json["revocationStatus"] as String?,
-        revoked: json["revoked"] as bool?,
-        rollbackProfileHash: json["rollbackProfileHash"] as String?,
-        runtimeKind: json["runtimeKind"] as String?,
-        runtimeProfileHash: json["runtimeProfileHash"] as String?,
-        runtimeProvider: json["runtimeProvider"] as String?,
-        secretPosture: json["secretPosture"] as String?,
-        signature: json["signature"] as String?,
+        posture: json["posture"] as String,
+        previousProfileHash: json["previousProfileHash"] as String,
+        profileVersion: json["profileVersion"] as String,
+        revocationGeneration: (json["revocationGeneration"] as num).toInt(),
+        revocationStatus: json["revocationStatus"] as String,
+        revoked: json["revoked"] as bool,
+        rollbackProfileHash: json["rollbackProfileHash"] as String,
+        runtimeKind: json["runtimeKind"] as String,
+        runtimeProfileHash: json["runtimeProfileHash"] as String,
+        runtimeProvider: json["runtimeProvider"] as String,
+        secretPosture: json["secretPosture"] as String,
+        signature: json["signature"] as String,
         supportSafeProfileReceipt:
-            (json["supportSafeProfileReceipt"] as Map<String, dynamic>?)
-                ?.cast<String, Object?>(),
-        toolAllowlist: (json["toolAllowlist"] as List<dynamic>?)
-            ?.map((e) => e as String)
+            (json["supportSafeProfileReceipt"] as Map<String, dynamic>)
+                .cast<String, Object?>(),
+        toolAllowlist: (json["toolAllowlist"] as List<dynamic>)
+            .map((e) => e as String)
             .toList(),
-        toolProvider: json["toolProvider"] as String?,
-        userRef: json["userRef"] as String?,
-        workspacePath: json["workspacePath"] as String?,
+        toolProvider: json["toolProvider"] as String,
+        userRef: json["userRef"] as String,
+        workspacePath: json["workspacePath"] as String,
       );
 
-  final List<String>? allowedCapabilities;
-  final String? approvalPolicy;
-  final Map<String, Object?>? auditPolicy;
-  final bool? auditRequired;
-  final String? baselineProfile;
-  final Map<String, Object?>? channelProjection;
-  final String? containerImage;
-  final Map<String, Object?>? credentialBrokerContract;
-  final String? dockerNetworkMode;
-  final bool? elevatedEnabled;
-  final bool? enabled;
-  final bool? execEnabled;
-  final String? expiresAt;
-  final bool? forkRequired;
-  final String? generatedFrom;
-  final String? isolatedAgentDirectory;
-  final String? isolationBoundary;
-  final Map<String, Object?>? mcpProjection;
-  final String? memberImpact;
-  final String? modelProvider;
-  final List<String>? pluginAllowlist;
-  final String? posture;
-  final String? previousProfileHash;
-  final String? profileVersion;
-  final int? revocationGeneration;
-  final String? revocationStatus;
-  final bool? revoked;
-  final String? rollbackProfileHash;
-  final String? runtimeKind;
-  final String? runtimeProfileHash;
-  final String? runtimeProvider;
-  final String? secretPosture;
-  final String? signature;
-  final Map<String, Object?>? supportSafeProfileReceipt;
-  final List<String>? toolAllowlist;
-  final String? toolProvider;
-  final String? userRef;
-  final String? workspacePath;
+  final List<String> allowedCapabilities;
+  final String approvalPolicy;
+  final Map<String, Object?> auditPolicy;
+  final bool auditRequired;
+  final String baselineProfile;
+  final Map<String, Object?> channelProjection;
+  final String containerImage;
+  final Map<String, Object?> credentialBrokerContract;
+  final String dockerNetworkMode;
+  final bool elevatedEnabled;
+  final bool enabled;
+  final bool execEnabled;
+  final String expiresAt;
+  final bool forkRequired;
+  final String generatedFrom;
+  final String isolatedAgentDirectory;
+  final String isolationBoundary;
+  final Map<String, Object?> mcpProjection;
+  final String memberImpact;
+  final String modelProvider;
+  final List<String> pluginAllowlist;
+  final String posture;
+  final String previousProfileHash;
+  final String profileVersion;
+  final int revocationGeneration;
+  final String revocationStatus;
+  final bool revoked;
+  final String rollbackProfileHash;
+  final String runtimeKind;
+  final String runtimeProfileHash;
+  final String runtimeProvider;
+  final String secretPosture;
+  final String signature;
+  final Map<String, Object?> supportSafeProfileReceipt;
+  final List<String> toolAllowlist;
+  final String toolProvider;
+  final String userRef;
+  final String workspacePath;
 
   Map<String, dynamic> toJson() => {
     "allowedCapabilities": _openApiJsonValue(allowedCapabilities),
@@ -9346,15 +9345,18 @@ class WeaverScoutSourceResponse {
 }
 
 class WeaverScoutSummaryRequest {
-  const WeaverScoutSummaryRequest({this.question, this.requestedAction});
+  const WeaverScoutSummaryRequest({
+    required this.question,
+    this.requestedAction,
+  });
 
   factory WeaverScoutSummaryRequest.fromJson(Map<String, dynamic> json) =>
       WeaverScoutSummaryRequest(
-        question: json["question"] as String?,
+        question: json["question"] as String,
         requestedAction: json["requestedAction"] as String?,
       );
 
-  final String? question;
+  final String question;
   final String? requestedAction;
 
   Map<String, dynamic> toJson() => {
@@ -9430,96 +9432,72 @@ class WeaverScoutSummaryResponse {
 
 class WorkspaceCapabilitiesResponse {
   const WorkspaceCapabilitiesResponse({
-    this.adminControlPlane,
-    this.boards,
-    this.calendar,
-    this.chat,
-    this.decisionsEvidence,
-    this.documentsCollaboration,
-    this.files,
-    this.manualsHelp,
-    this.meetingsCalls,
-    this.releaseEvidence,
-    this.shellAccess,
-    this.weaver,
+    required this.adminControlPlane,
+    required this.boards,
+    required this.calendar,
+    required this.chat,
+    required this.decisionsEvidence,
+    required this.documentsCollaboration,
+    required this.files,
+    required this.manualsHelp,
+    required this.meetingsCalls,
+    required this.releaseEvidence,
+    required this.shellAccess,
+    required this.weaver,
   });
 
   factory WorkspaceCapabilitiesResponse.fromJson(Map<String, dynamic> json) =>
       WorkspaceCapabilitiesResponse(
-        adminControlPlane: json["adminControlPlane"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["adminControlPlane"] as Map<String, dynamic>,
-              ),
-        boards: json["boards"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["boards"] as Map<String, dynamic>,
-              ),
-        calendar: json["calendar"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["calendar"] as Map<String, dynamic>,
-              ),
-        chat: json["chat"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["chat"] as Map<String, dynamic>,
-              ),
-        decisionsEvidence: json["decisionsEvidence"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["decisionsEvidence"] as Map<String, dynamic>,
-              ),
-        documentsCollaboration: json["documentsCollaboration"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["documentsCollaboration"] as Map<String, dynamic>,
-              ),
-        files: json["files"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["files"] as Map<String, dynamic>,
-              ),
-        manualsHelp: json["manualsHelp"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["manualsHelp"] as Map<String, dynamic>,
-              ),
-        meetingsCalls: json["meetingsCalls"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["meetingsCalls"] as Map<String, dynamic>,
-              ),
-        releaseEvidence: json["releaseEvidence"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["releaseEvidence"] as Map<String, dynamic>,
-              ),
-        shellAccess: json["shellAccess"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["shellAccess"] as Map<String, dynamic>,
-              ),
-        weaver: json["weaver"] == null
-            ? null
-            : WorkspaceCapabilityStatusResponse.fromJson(
-                json["weaver"] as Map<String, dynamic>,
-              ),
+        adminControlPlane: WorkspaceCapabilityStatusResponse.fromJson(
+          json["adminControlPlane"] as Map<String, dynamic>,
+        ),
+        boards: WorkspaceCapabilityStatusResponse.fromJson(
+          json["boards"] as Map<String, dynamic>,
+        ),
+        calendar: WorkspaceCapabilityStatusResponse.fromJson(
+          json["calendar"] as Map<String, dynamic>,
+        ),
+        chat: WorkspaceCapabilityStatusResponse.fromJson(
+          json["chat"] as Map<String, dynamic>,
+        ),
+        decisionsEvidence: WorkspaceCapabilityStatusResponse.fromJson(
+          json["decisionsEvidence"] as Map<String, dynamic>,
+        ),
+        documentsCollaboration: WorkspaceCapabilityStatusResponse.fromJson(
+          json["documentsCollaboration"] as Map<String, dynamic>,
+        ),
+        files: WorkspaceCapabilityStatusResponse.fromJson(
+          json["files"] as Map<String, dynamic>,
+        ),
+        manualsHelp: WorkspaceCapabilityStatusResponse.fromJson(
+          json["manualsHelp"] as Map<String, dynamic>,
+        ),
+        meetingsCalls: WorkspaceCapabilityStatusResponse.fromJson(
+          json["meetingsCalls"] as Map<String, dynamic>,
+        ),
+        releaseEvidence: WorkspaceCapabilityStatusResponse.fromJson(
+          json["releaseEvidence"] as Map<String, dynamic>,
+        ),
+        shellAccess: WorkspaceCapabilityStatusResponse.fromJson(
+          json["shellAccess"] as Map<String, dynamic>,
+        ),
+        weaver: WorkspaceCapabilityStatusResponse.fromJson(
+          json["weaver"] as Map<String, dynamic>,
+        ),
       );
 
-  final WorkspaceCapabilityStatusResponse? adminControlPlane;
-  final WorkspaceCapabilityStatusResponse? boards;
-  final WorkspaceCapabilityStatusResponse? calendar;
-  final WorkspaceCapabilityStatusResponse? chat;
-  final WorkspaceCapabilityStatusResponse? decisionsEvidence;
-  final WorkspaceCapabilityStatusResponse? documentsCollaboration;
-  final WorkspaceCapabilityStatusResponse? files;
-  final WorkspaceCapabilityStatusResponse? manualsHelp;
-  final WorkspaceCapabilityStatusResponse? meetingsCalls;
-  final WorkspaceCapabilityStatusResponse? releaseEvidence;
-  final WorkspaceCapabilityStatusResponse? shellAccess;
-  final WorkspaceCapabilityStatusResponse? weaver;
+  final WorkspaceCapabilityStatusResponse adminControlPlane;
+  final WorkspaceCapabilityStatusResponse boards;
+  final WorkspaceCapabilityStatusResponse calendar;
+  final WorkspaceCapabilityStatusResponse chat;
+  final WorkspaceCapabilityStatusResponse decisionsEvidence;
+  final WorkspaceCapabilityStatusResponse documentsCollaboration;
+  final WorkspaceCapabilityStatusResponse files;
+  final WorkspaceCapabilityStatusResponse manualsHelp;
+  final WorkspaceCapabilityStatusResponse meetingsCalls;
+  final WorkspaceCapabilityStatusResponse releaseEvidence;
+  final WorkspaceCapabilityStatusResponse shellAccess;
+  final WorkspaceCapabilityStatusResponse weaver;
 
   Map<String, dynamic> toJson() => {
     "adminControlPlane": _openApiJsonValue(adminControlPlane),
@@ -9539,52 +9517,50 @@ class WorkspaceCapabilitiesResponse {
 
 class WorkspaceCapabilityPolicyResponse {
   const WorkspaceCapabilityPolicyResponse({
-    this.adapterContract,
-    this.defaultIdmProvider,
-    this.denyByDefault,
-    this.grantedCapabilities,
-    this.groups,
-    this.idmProviderCategory,
-    this.principalSource,
-    this.profileKeys,
-    this.roles,
-    this.supportSafe,
-    this.weaverRuntimePosture,
+    required this.adapterContract,
+    required this.defaultIdmProvider,
+    required this.denyByDefault,
+    required this.grantedCapabilities,
+    required this.groups,
+    required this.idmProviderCategory,
+    required this.principalSource,
+    required this.profileKeys,
+    required this.roles,
+    required this.supportSafe,
+    required this.weaverRuntimePosture,
   });
 
   factory WorkspaceCapabilityPolicyResponse.fromJson(
     Map<String, dynamic> json,
   ) => WorkspaceCapabilityPolicyResponse(
-    adapterContract: json["adapterContract"] as String?,
-    defaultIdmProvider: json["defaultIdmProvider"] as String?,
-    denyByDefault: json["denyByDefault"] as bool?,
-    grantedCapabilities: (json["grantedCapabilities"] as List<dynamic>?)
-        ?.map((e) => e as String)
+    adapterContract: json["adapterContract"] as String,
+    defaultIdmProvider: json["defaultIdmProvider"] as String,
+    denyByDefault: json["denyByDefault"] as bool,
+    grantedCapabilities: (json["grantedCapabilities"] as List<dynamic>)
+        .map((e) => e as String)
         .toList(),
-    groups: (json["groups"] as List<dynamic>?)
-        ?.map((e) => e as String)
+    groups: (json["groups"] as List<dynamic>).map((e) => e as String).toList(),
+    idmProviderCategory: json["idmProviderCategory"] as String,
+    principalSource: json["principalSource"] as String,
+    profileKeys: (json["profileKeys"] as List<dynamic>)
+        .map((e) => e as String)
         .toList(),
-    idmProviderCategory: json["idmProviderCategory"] as String?,
-    principalSource: json["principalSource"] as String?,
-    profileKeys: (json["profileKeys"] as List<dynamic>?)
-        ?.map((e) => e as String)
-        .toList(),
-    roles: (json["roles"] as List<dynamic>?)?.map((e) => e as String).toList(),
-    supportSafe: json["supportSafe"] as bool?,
-    weaverRuntimePosture: json["weaverRuntimePosture"] as String?,
+    roles: (json["roles"] as List<dynamic>).map((e) => e as String).toList(),
+    supportSafe: json["supportSafe"] as bool,
+    weaverRuntimePosture: json["weaverRuntimePosture"] as String,
   );
 
-  final String? adapterContract;
-  final String? defaultIdmProvider;
-  final bool? denyByDefault;
-  final List<String>? grantedCapabilities;
-  final List<String>? groups;
-  final String? idmProviderCategory;
-  final String? principalSource;
-  final List<String>? profileKeys;
-  final List<String>? roles;
-  final bool? supportSafe;
-  final String? weaverRuntimePosture;
+  final String adapterContract;
+  final String defaultIdmProvider;
+  final bool denyByDefault;
+  final List<String> grantedCapabilities;
+  final List<String> groups;
+  final String idmProviderCategory;
+  final String principalSource;
+  final List<String> profileKeys;
+  final List<String> roles;
+  final bool supportSafe;
+  final String weaverRuntimePosture;
 
   Map<String, dynamic> toJson() => {
     "adapterContract": _openApiJsonValue(adapterContract),

--- a/client/lib/integrations/weave_api/domain/entities/openapi_feature_adapter.dart
+++ b/client/lib/integrations/weave_api/domain/entities/openapi_feature_adapter.dart
@@ -1,5 +1,6 @@
 enum OpenApiFeatureCapabilityState {
   available,
+  disabled,
   disabledByPolicy,
   notConfigured,
   degraded,
@@ -14,10 +15,14 @@ enum OpenApiFeatureCapabilityState {
       case 'usable':
       case 'ready':
         return OpenApiFeatureCapabilityState.available;
+      case 'disabled':
+        return OpenApiFeatureCapabilityState.disabled;
       case 'disabled_by_policy':
       case 'policy_blocked':
+      case 'policy-blocked':
         return OpenApiFeatureCapabilityState.disabledByPolicy;
       case 'not_configured':
+      case 'misconfigured':
         return OpenApiFeatureCapabilityState.notConfigured;
       case 'degraded':
         return OpenApiFeatureCapabilityState.degraded;

--- a/client/lib/integrations/weave_api/domain/entities/openapi_feature_adapter.dart
+++ b/client/lib/integrations/weave_api/domain/entities/openapi_feature_adapter.dart
@@ -1,0 +1,81 @@
+enum OpenApiFeatureCapabilityState {
+  available,
+  disabledByPolicy,
+  notConfigured,
+  degraded,
+  unavailable,
+  comingLater,
+  unsupported,
+  unknown;
+
+  static OpenApiFeatureCapabilityState fromApi(String? value) {
+    switch (value) {
+      case 'available':
+      case 'usable':
+      case 'ready':
+        return OpenApiFeatureCapabilityState.available;
+      case 'disabled_by_policy':
+      case 'policy_blocked':
+        return OpenApiFeatureCapabilityState.disabledByPolicy;
+      case 'not_configured':
+        return OpenApiFeatureCapabilityState.notConfigured;
+      case 'degraded':
+        return OpenApiFeatureCapabilityState.degraded;
+      case 'unavailable':
+        return OpenApiFeatureCapabilityState.unavailable;
+      case 'coming_later':
+        return OpenApiFeatureCapabilityState.comingLater;
+      case 'unsupported':
+        return OpenApiFeatureCapabilityState.unsupported;
+      default:
+        return OpenApiFeatureCapabilityState.unknown;
+    }
+  }
+}
+
+class OpenApiFeatureCapability {
+  const OpenApiFeatureCapability({required this.key, required this.state});
+
+  final String key;
+  final OpenApiFeatureCapabilityState state;
+}
+
+class OpenApiFeatureReadiness {
+  const OpenApiFeatureReadiness({
+    required this.featureKey,
+    required this.state,
+    required this.memberImpact,
+    this.capabilities = const <OpenApiFeatureCapability>[],
+    this.diagnosticsRedacted = true,
+    this.supportSafe = true,
+  });
+
+  factory OpenApiFeatureReadiness.unknown(String featureKey) {
+    return OpenApiFeatureReadiness(
+      featureKey: featureKey,
+      state: OpenApiFeatureCapabilityState.unknown,
+      memberImpact: '$featureKey readiness is not present in the response.',
+    );
+  }
+
+  final String featureKey;
+  final OpenApiFeatureCapabilityState state;
+  final String memberImpact;
+  final List<OpenApiFeatureCapability> capabilities;
+  final bool diagnosticsRedacted;
+  final bool supportSafe;
+
+  bool get isUsable => state == OpenApiFeatureCapabilityState.available;
+}
+
+class OpenApiResourcePage<TResource> {
+  const OpenApiResourcePage({
+    required this.featureKey,
+    required this.resources,
+    required this.readiness,
+  });
+
+  final String featureKey;
+  final List<TResource> resources;
+  final OpenApiFeatureReadiness readiness;
+}

--- a/client/test/architecture/backend_facade_contract_test.dart
+++ b/client/test/architecture/backend_facade_contract_test.dart
@@ -59,6 +59,53 @@ void main() {
     expect(client, isNot(contains('UserProfileDto.fromJson')));
   });
 
+  test(
+    'Chat and Files facades map generated OpenAPI DTOs in data only',
+    () async {
+      final chatRepository = await File(
+        'lib/features/chat/data/repositories/backend_chat_repository.dart',
+      ).readAsString();
+      final chatMapper = await File(
+        'lib/features/chat/data/dtos/chat_openapi_mappers.dart',
+      ).readAsString();
+      final filesRepository = await File(
+        'lib/features/files/data/repositories/backend_files_repository.dart',
+      ).readAsString();
+      final filesMapper = await File(
+        'lib/features/files/data/dtos/files_openapi_mappers.dart',
+      ).readAsString();
+
+      expect(chatRepository, contains('openapi.ChatConversationsResponse'));
+      expect(chatRepository, contains('openapi.ChatMessagesResponse'));
+      expect(chatRepository, contains('openapi.ChatSendMessageRequest'));
+      expect(chatMapper, contains('openapi.ChatConversationResponse'));
+      expect(chatMapper, contains('OpenApiResourcePage<ChatConversation>'));
+      expect(chatMapper, isNot(contains('Matrix')));
+
+      expect(filesRepository, contains('openapi.FileListResponse'));
+      expect(filesRepository, contains('openapi.FileItemResponse'));
+      expect(filesRepository, contains('openapi.CreateFolderRequest'));
+      expect(filesMapper, contains('openapi.FileListResponse'));
+      expect(filesMapper, contains('OpenApiResourcePage<FileEntry>'));
+      expect(filesMapper, isNot(contains('Nextcloud')));
+
+      for (final file in <String>[
+        'lib/features/chat/domain/repositories/chat_repository.dart',
+        'lib/features/chat/presentation/providers/chat_provider.dart',
+        'lib/features/files/domain/repositories/files_repository.dart',
+        'lib/features/files/presentation/providers/files_provider.dart',
+      ]) {
+        final source = await File(file).readAsString();
+        expect(
+          source,
+          isNot(contains('generated/openapi_models.dart')),
+          reason:
+              '$file must consume feature domain models, not raw OpenAPI DTOs.',
+        );
+      }
+    },
+  );
+
   test('workspace API DTOs use generated OpenAPI response models', () async {
     final client = await File(
       'lib/integrations/weave_api/data/services/weave_api_client.dart',

--- a/client/test/architecture/backend_facade_contract_test.dart
+++ b/client/test/architecture/backend_facade_contract_test.dart
@@ -89,12 +89,14 @@ void main() {
       expect(filesMapper, contains('OpenApiResourcePage<FileEntry>'));
       expect(filesMapper, isNot(contains('Nextcloud')));
 
-      for (final file in <String>[
-        'lib/features/chat/domain/repositories/chat_repository.dart',
-        'lib/features/chat/presentation/providers/chat_provider.dart',
-        'lib/features/files/domain/repositories/files_repository.dart',
-        'lib/features/files/presentation/providers/files_provider.dart',
-      ]) {
+      final featureBoundaryFiles = <String>[
+        'lib/features/chat/domain',
+        'lib/features/chat/presentation',
+        'lib/features/files/domain',
+        'lib/features/files/presentation',
+      ].expand(_dartFilesUnder);
+
+      for (final file in featureBoundaryFiles) {
         final source = await File(file).readAsString();
         expect(
           source,
@@ -235,4 +237,12 @@ void main() {
       expect(memberChatCopy, isNot(contains(forbidden)), reason: forbidden);
     }
   });
+}
+
+Iterable<String> _dartFilesUnder(String directoryPath) {
+  return Directory(directoryPath)
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((file) => file.path.endsWith('.dart'))
+      .map((file) => file.path.replaceAll(r'\', '/'));
 }

--- a/client/test/architecture/member_client_provider_boundary_contract_test.dart
+++ b/client/test/architecture/member_client_provider_boundary_contract_test.dart
@@ -133,4 +133,16 @@ void main() {
       }
     },
   );
+
+  test('normal member settings cannot reach Matrix security diagnostics', () {
+    final settings = File(
+      'lib/features/settings/presentation/settings_screen.dart',
+    ).readAsStringSync();
+
+    expect(settings, isNot(contains('ChatSecuritySettingsSection')));
+    expect(settings, isNot(contains('chat_security_settings_section.dart')));
+    expect(settings, isNot(contains('chatSecurityProvider')));
+    expect(settings, isNot(contains('chatSecurityRepositoryProvider')));
+    expect(settings, isNot(contains('MatrixChatSecurityRepository')));
+  });
 }

--- a/client/test/architecture/member_client_provider_boundary_contract_test.dart
+++ b/client/test/architecture/member_client_provider_boundary_contract_test.dart
@@ -73,4 +73,64 @@ void main() {
       }
     },
   );
+
+  test(
+    'member feature providers do not import provider SDKs outside approved seams',
+    () {
+      final allowedMatrixImportFiles = <String>{
+        'lib/features/chat/data/services/matrix_client_factory.dart',
+        'lib/features/chat/data/services/matrix_client_factory_io.dart',
+        'lib/features/chat/data/services/matrix_client_factory_web.dart',
+        'lib/features/chat/data/services/matrix_conversation_service.dart',
+        'lib/features/chat/data/services/matrix_error_mapper.dart',
+        'lib/features/chat/data/services/matrix_room_service.dart',
+        'lib/features/chat/data/services/matrix_security_service.dart',
+        'lib/features/chat/data/services/matrix_session_service.dart',
+        'lib/features/chat/data/services/matrix_verification_service.dart',
+      };
+      final libFiles = Directory('lib')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.dart'));
+
+      for (final file in libFiles) {
+        final source = file.readAsStringSync();
+        final normalizedPath = file.path.replaceAll(r'\', '/');
+        if (source.contains("package:matrix/")) {
+          expect(
+            allowedMatrixImportFiles,
+            contains(normalizedPath),
+            reason:
+                '$normalizedPath must not import Matrix SDK outside the approved diagnostic/service seam.',
+          );
+        }
+      }
+
+      final filesFeatureSources = Directory('lib/features/files')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((file) => file.path.endsWith('.dart'));
+      final forbiddenFilesFragments = <String>[
+        'integrations/nextcloud',
+        'nextcloudDavClientProvider',
+        'NextcloudDavClient',
+        'WebDAV',
+        'webdav',
+      ];
+      for (final file in filesFeatureSources) {
+        final imports = file
+            .readAsLinesSync()
+            .where((line) => line.trimLeft().startsWith('import '))
+            .join('\n');
+        for (final fragment in forbiddenFilesFragments) {
+          expect(
+            imports,
+            isNot(contains(fragment)),
+            reason:
+                '${file.path} must use the backend Files facade instead of direct provider seams.',
+          );
+        }
+      }
+    },
+  );
 }

--- a/client/test/features/chat/data/repositories/backend_chat_repository_test.dart
+++ b/client/test/features/chat/data/repositories/backend_chat_repository_test.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
+import 'package:weave/features/auth/domain/entities/auth_state.dart';
+import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/chat/data/repositories/backend_chat_repository.dart';
+import 'package:weave/features/chat/domain/entities/chat_failure.dart';
+import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
+import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+
+import '../../../../helpers/auth_test_data.dart';
+import '../../../../helpers/server_config_test_data.dart';
+
+class _FakeServerConfigurationRepository
+    implements ServerConfigurationRepository {
+  _FakeServerConfigurationRepository(this.configuration);
+
+  ServerConfiguration? configuration;
+
+  @override
+  Future<void> clearConfiguration() async {}
+
+  @override
+  Future<ServerConfiguration?> loadConfiguration() async => configuration;
+
+  @override
+  Future<void> saveConfiguration(ServerConfiguration configuration) async {
+    this.configuration = configuration;
+  }
+}
+
+class _FakeAuthSessionRepository implements AuthSessionRepository {
+  _FakeAuthSessionRepository(this.state);
+
+  AuthState state;
+
+  @override
+  Future<void> clearLocalSession() async {}
+
+  @override
+  Future<AuthState> refreshSession(AuthConfiguration configuration) async =>
+      state;
+
+  @override
+  Future<AuthState> restoreSession(AuthConfiguration configuration) async =>
+      state;
+
+  @override
+  Future<AuthState> signIn(AuthConfiguration configuration) async => state;
+
+  @override
+  Future<void> signOut(AuthConfiguration configuration) async {}
+}
+
+void main() {
+  late _FakeServerConfigurationRepository configurationRepository;
+  late _FakeAuthSessionRepository authSessionRepository;
+
+  BackendChatRepository repository(http.Client client) {
+    return BackendChatRepository(
+      serverConfigurationRepository: configurationRepository,
+      authSessionRepository: authSessionRepository,
+      httpClient: client,
+    );
+  }
+
+  setUp(() {
+    configurationRepository = _FakeServerConfigurationRepository(
+      buildTestConfiguration(backendApiBaseUrl: 'https://api.weave.test/api'),
+    );
+    authSessionRepository = _FakeAuthSessionRepository(
+      AuthState.authenticated(buildTestAuthSession(accessToken: 'chat-token')),
+    );
+  });
+
+  test('lists conversations through generated OpenAPI DTO mapping', () async {
+    late http.Request capturedRequest;
+    final client = MockClient((request) async {
+      capturedRequest = request;
+      return http.Response(
+        jsonEncode({
+          'domain': 'chat',
+          'source': 'weave-backend',
+          'conversations': [
+            {
+              'id': 'chat:quiet',
+              'title': 'Quiet',
+              'kind': 'channel',
+              'lastMessageAt': '2026-05-01T09:00:00Z',
+            },
+            {
+              'id': 'chat:recent',
+              'title': 'Recent',
+              'kind': 'direct',
+              'lastMessageAt': '2026-05-01T10:00:00Z',
+            },
+          ],
+          'readiness': {
+            'impactState': 'available',
+            'memberImpact': 'Weave Chat is available.',
+            'diagnosticsRedacted': true,
+            'grantedCapabilities': ['chat.message.read'],
+          },
+        }),
+        200,
+      );
+    });
+
+    final conversations = await repository(client).loadConversations();
+
+    expect(
+      capturedRequest.url.toString(),
+      'https://api.weave.test/api/chat/conversations',
+    );
+    expect(capturedRequest.headers['authorization'], 'Bearer chat-token');
+    expect(conversations.map((conversation) => conversation.id), [
+      'chat:recent',
+      'chat:quiet',
+    ]);
+    expect(conversations.first.isDirectMessage, isTrue);
+  });
+
+  test(
+    'loads timeline and sends message through OpenAPI DTO mapping',
+    () async {
+      final requests = <http.Request>[];
+      final client = MockClient((request) async {
+        requests.add(request);
+        if (request.method == 'POST') {
+          expect(jsonDecode(request.body), {
+            'attachmentRefs': <Object>[],
+            'text': 'Hello Weave',
+          });
+          return http.Response(
+            jsonEncode({
+              'id': 'message:2',
+              'conversationId': 'chat:recent',
+              'senderRef': 'user:me',
+              'sentAt': '2026-05-01T10:01:00Z',
+              'isMine': true,
+              'text': 'Hello Weave',
+            }),
+            200,
+          );
+        }
+        return http.Response(
+          jsonEncode({
+            'conversationId': 'chat:recent',
+            'messages': [
+              {
+                'id': 'message:1',
+                'conversationId': 'chat:recent',
+                'senderRef': 'user:alex',
+                'sentAt': '2026-05-01T10:00:00Z',
+                'isMine': false,
+                'text': 'Ready',
+              },
+            ],
+          }),
+          200,
+        );
+      });
+      final backend = repository(client);
+
+      final timeline = await backend.loadRoomTimeline('chat:recent');
+      await backend.sendMessage(roomId: 'chat:recent', message: 'Hello Weave');
+
+      expect(timeline.roomId, 'chat:recent');
+      expect(timeline.messages.single.senderId, 'user:alex');
+      expect(requests.map((request) => request.method), ['GET', 'POST']);
+    },
+  );
+
+  test('fails closed when Chat readiness is not available', () async {
+    final client = MockClient(
+      (_) async => http.Response(
+        jsonEncode({
+          'domain': 'chat',
+          'memberState': 'not_configured',
+          'memberImpact': 'Ask an admin to finish Chat setup.',
+          'supportSafe': true,
+          'downstreamDiagnosticsExposedToMember': false,
+        }),
+        200,
+      ),
+    );
+
+    await expectLater(
+      repository(client).connect(),
+      throwsA(
+        isA<ChatFailure>().having(
+          (failure) => failure.message,
+          'message',
+          'Ask an admin to finish Chat setup.',
+        ),
+      ),
+    );
+  });
+}

--- a/client/test/features/chat/data/repositories/backend_chat_repository_test.dart
+++ b/client/test/features/chat/data/repositories/backend_chat_repository_test.dart
@@ -6,10 +6,13 @@ import 'package:http/testing.dart';
 import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
 import 'package:weave/features/auth/domain/entities/auth_state.dart';
 import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/chat/data/dtos/chat_openapi_mappers.dart';
 import 'package:weave/features/chat/data/repositories/backend_chat_repository.dart';
 import 'package:weave/features/chat/domain/entities/chat_failure.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
+import 'package:weave/integrations/weave_api/domain/entities/openapi_feature_adapter.dart';
 
 import '../../../../helpers/auth_test_data.dart';
 import '../../../../helpers/server_config_test_data.dart';
@@ -99,7 +102,7 @@ void main() {
             },
           ],
           'readiness': {
-            'impactState': 'available',
+            'impactState': 'usable',
             'memberImpact': 'Weave Chat is available.',
             'diagnosticsRedacted': true,
             'grantedCapabilities': ['chat.message.read'],
@@ -179,7 +182,7 @@ void main() {
       (_) async => http.Response(
         jsonEncode({
           'domain': 'chat',
-          'memberState': 'not_configured',
+          'memberState': 'misconfigured',
           'memberImpact': 'Ask an admin to finish Chat setup.',
           'supportSafe': true,
           'downstreamDiagnosticsExposedToMember': false,
@@ -197,6 +200,37 @@ void main() {
           'Ask an admin to finish Chat setup.',
         ),
       ),
+    );
+  });
+
+  test('maps server Chat readiness states into adapter states', () {
+    expect(
+      const openapi.ChatReadiness(
+        memberState: 'ready',
+        memberImpact: 'Ready.',
+      ).toFeatureReadiness().state,
+      OpenApiFeatureCapabilityState.available,
+    );
+    expect(
+      const openapi.ChatReadiness(
+        memberState: 'misconfigured',
+        memberImpact: 'Ask an admin to finish Chat setup.',
+      ).toFeatureReadiness().state,
+      OpenApiFeatureCapabilityState.notConfigured,
+    );
+    expect(
+      const openapi.ChatReadiness(
+        memberState: 'disabled',
+        memberImpact: 'Chat is disabled.',
+      ).toFeatureReadiness().state,
+      OpenApiFeatureCapabilityState.disabled,
+    );
+    expect(
+      const openapi.ChatReadinessResponse(
+        impactState: 'policy-blocked',
+        memberImpact: 'Chat is blocked by policy.',
+      ).toFeatureReadiness().state,
+      OpenApiFeatureCapabilityState.disabledByPolicy,
     );
   });
 }

--- a/client/test/features/chat/data/repositories/backend_chat_repository_test.dart
+++ b/client/test/features/chat/data/repositories/backend_chat_repository_test.dart
@@ -87,18 +87,55 @@ void main() {
         jsonEncode({
           'domain': 'chat',
           'source': 'weave-backend',
+          'releaseStatus': 'canonical-domain-facade',
           'conversations': [
             {
               'id': 'chat:quiet',
+              'contextId': 'workspace-default',
               'title': 'Quiet',
               'kind': 'channel',
               'lastMessageAt': '2026-05-01T09:00:00Z',
+              'membership': {
+                'principalRef': 'user:me',
+                'state': 'joined',
+                'role': 'member',
+              },
+              'historyPolicy': {
+                'policyKey': 'workspace-default-history',
+                'visibility': 'joined-members',
+                'backendReadable': true,
+                'encryptedProviderContentRedacted': true,
+              },
+              'attachmentPolicy': {
+                'attachmentRefsSupported': true,
+                'maxAttachmentRefs': 8,
+                'rawProviderMediaUrlsExposed': false,
+              },
+              'availableActions': ['send-message'],
             },
             {
               'id': 'chat:recent',
+              'contextId': 'workspace-default',
               'title': 'Recent',
               'kind': 'direct',
               'lastMessageAt': '2026-05-01T10:00:00Z',
+              'membership': {
+                'principalRef': 'user:me',
+                'state': 'joined',
+                'role': 'member',
+              },
+              'historyPolicy': {
+                'policyKey': 'workspace-default-history',
+                'visibility': 'joined-members',
+                'backendReadable': true,
+                'encryptedProviderContentRedacted': true,
+              },
+              'attachmentPolicy': {
+                'attachmentRefsSupported': true,
+                'maxAttachmentRefs': 8,
+                'rawProviderMediaUrlsExposed': false,
+              },
+              'availableActions': ['send-message'],
             },
           ],
           'readiness': {
@@ -145,6 +182,9 @@ void main() {
               'sentAt': '2026-05-01T10:01:00Z',
               'isMine': true,
               'text': 'Hello Weave',
+              'attachmentRefs': <Object>[],
+              'encryptedProviderContentRedacted': false,
+              'deliveryEvidence': <String, Object>{},
             }),
             200,
           );
@@ -152,6 +192,12 @@ void main() {
         return http.Response(
           jsonEncode({
             'conversationId': 'chat:recent',
+            'readiness': {
+              'impactState': 'usable',
+              'memberImpact': 'Weave Chat is available.',
+              'diagnosticsRedacted': true,
+              'grantedCapabilities': ['chat.message.read'],
+            },
             'messages': [
               {
                 'id': 'message:1',
@@ -160,6 +206,9 @@ void main() {
                 'sentAt': '2026-05-01T10:00:00Z',
                 'isMine': false,
                 'text': 'Ready',
+                'attachmentRefs': <Object>[],
+                'encryptedProviderContentRedacted': false,
+                'deliveryEvidence': <String, Object>{},
               },
             ],
           }),
@@ -229,8 +278,40 @@ void main() {
       const openapi.ChatReadinessResponse(
         impactState: 'policy-blocked',
         memberImpact: 'Chat is blocked by policy.',
+        grantedCapabilities: <String>[],
+        diagnosticsRedacted: true,
       ).toFeatureReadiness().state,
       OpenApiFeatureCapabilityState.disabledByPolicy,
+    );
+  });
+
+  test('fails closed when generated Chat payload misses required fields', () {
+    final client = MockClient(
+      (_) async => http.Response(
+        jsonEncode({
+          'domain': 'chat',
+          'releaseStatus': 'canonical-domain-facade',
+          'source': 'weave-backend',
+          'readiness': {
+            'impactState': 'usable',
+            'memberImpact': 'Weave Chat is available.',
+            'diagnosticsRedacted': true,
+            'grantedCapabilities': ['chat.message.read'],
+          },
+        }),
+        200,
+      ),
+    );
+
+    expect(
+      repository(client).loadConversations(),
+      throwsA(
+        isA<ChatFailure>().having(
+          (failure) => failure.message,
+          'message',
+          'The Weave Chat facade returned an invalid conversation list.',
+        ),
+      ),
     );
   });
 }

--- a/client/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
+++ b/client/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
@@ -211,7 +211,7 @@ void main() {
                 .having(
                   (failure) => failure.message,
                   'message',
-                  contains('without id'),
+                  contains('invalid files listing'),
                 ),
           ),
         );
@@ -235,7 +235,7 @@ void main() {
               .having(
                 (failure) => failure.message,
                 'message',
-                contains('without items'),
+                contains('invalid files listing'),
               ),
         ),
       );

--- a/client/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
+++ b/client/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
@@ -181,6 +181,44 @@ void main() {
     );
 
     test(
+      'fails closed when OpenAPI files response misses item identity',
+      () async {
+        final client = MockClient(
+          (_) async => http.Response(
+            jsonEncode({
+              'path': '/Team',
+              'items': [
+                {
+                  'name': 'readme.md',
+                  'path': '/Team/readme.md',
+                  'type': 'file',
+                },
+              ],
+            }),
+            200,
+          ),
+        );
+
+        await expectLater(
+          repository(client).listDirectory('/Team'),
+          throwsA(
+            isA<FilesFailure>()
+                .having(
+                  (failure) => failure.type,
+                  'type',
+                  FilesFailureType.protocol,
+                )
+                .having(
+                  (failure) => failure.message,
+                  'message',
+                  contains('without id'),
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
       'creates folders, prepares downloads, and deletes via backend endpoints',
       () async {
         final requests = <http.Request>[];

--- a/client/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
+++ b/client/test/features/files/presentation/providers/files_backend_facade_provider_test.dart
@@ -218,6 +218,29 @@ void main() {
       },
     );
 
+    test('fails closed when OpenAPI files response misses items', () async {
+      final client = MockClient(
+        (_) async => http.Response(jsonEncode({'path': '/Team'}), 200),
+      );
+
+      await expectLater(
+        repository(client).listDirectory('/Team'),
+        throwsA(
+          isA<FilesFailure>()
+              .having(
+                (failure) => failure.type,
+                'type',
+                FilesFailureType.protocol,
+              )
+              .having(
+                (failure) => failure.message,
+                'message',
+                contains('without items'),
+              ),
+        ),
+      );
+    });
+
     test(
       'creates folders, prepares downloads, and deletes via backend endpoints',
       () async {

--- a/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -31,6 +31,56 @@ http.StreamedResponse _jsonResponse(
   );
 }
 
+Map<String, Object?> _capability({
+  required bool enabled,
+  required String readiness,
+  String policyState = 'allowed',
+  List<String> grantedCapabilities = const <String>[],
+}) {
+  return {
+    'enabled': enabled,
+    'readiness': readiness,
+    'policyState': policyState,
+    'grantedCapabilities': grantedCapabilities,
+  };
+}
+
+Map<String, Object?> _workspaceCapabilitiesJson({
+  Map<String, Object?> overrides = const <String, Object?>{},
+}) {
+  return {
+    'shellAccess': _capability(enabled: true, readiness: 'ready'),
+    'chat': _capability(
+      enabled: true,
+      readiness: 'ready',
+      grantedCapabilities: const ['chat.read', 'chat.send'],
+    ),
+    'files': _capability(enabled: true, readiness: 'ready'),
+    'calendar': _capability(enabled: true, readiness: 'ready'),
+    'boards': _capability(enabled: true, readiness: 'ready'),
+    'meetingsCalls': _capability(
+      enabled: false,
+      readiness: 'unavailable',
+      policyState: 'disabled',
+    ),
+    'documentsCollaboration': _capability(
+      enabled: false,
+      readiness: 'unavailable',
+      policyState: 'disabled',
+    ),
+    'decisionsEvidence': _capability(enabled: true, readiness: 'ready'),
+    'manualsHelp': _capability(enabled: true, readiness: 'ready'),
+    'releaseEvidence': _capability(enabled: true, readiness: 'ready'),
+    'adminControlPlane': _capability(enabled: true, readiness: 'ready'),
+    'weaver': _capability(
+      enabled: false,
+      readiness: 'unavailable',
+      policyState: 'disabled',
+    ),
+    ...overrides,
+  };
+}
+
 Map<String, Object?> _organizationManifestJson({
   String organizationAuthUrl = 'https://auth.weave.test/realms/weave',
   bool supportSafe = true,
@@ -70,39 +120,16 @@ Map<String, Object?> _organizationManifestJson({
       'meetings': 'not_configured',
       'forms-contacts': 'coming_later',
     },
-    'capabilities': {
-      'shellAccess': {
-        'enabled': true,
-        'readiness': 'ready',
-        'policyState': 'allowed',
+    'capabilities': _workspaceCapabilitiesJson(
+      overrides: {
+        'calendar': _capability(enabled: true, readiness: 'degraded'),
+        'boards': _capability(
+          enabled: true,
+          readiness: 'blocked',
+          policyState: 'policy_blocked',
+        ),
       },
-      'chat': {
-        'enabled': true,
-        'readiness': 'ready',
-        'policyState': 'allowed',
-        'grantedCapabilities': ['chat.read', 'chat.send'],
-      },
-      'files': {
-        'enabled': true,
-        'readiness': 'ready',
-        'policyState': 'allowed',
-      },
-      'calendar': {
-        'enabled': true,
-        'readiness': 'degraded',
-        'policyState': 'allowed',
-      },
-      'boards': {
-        'enabled': true,
-        'readiness': 'blocked',
-        'policyState': 'policy_blocked',
-      },
-      'weaver': {
-        'enabled': false,
-        'readiness': 'unavailable',
-        'policyState': 'disabled',
-      },
-    },
+    ),
   };
 }
 
@@ -113,13 +140,23 @@ void main() {
       final client = HttpWeaveApiClient(
         httpClient: _RecordingHttpClient((request) async {
           capturedRequest = request;
-          return _jsonResponse({
-            'shellAccess': {'enabled': true, 'readiness': 'ready'},
-            'chat': {'enabled': true, 'readiness': 'degraded'},
-            'files': {'enabled': true, 'readiness': 'ready'},
-            'calendar': {'enabled': false, 'readiness': 'unavailable'},
-            'boards': {'enabled': false, 'readiness': 'unavailable'},
-          });
+          return _jsonResponse(
+            _workspaceCapabilitiesJson(
+              overrides: {
+                'chat': _capability(enabled: true, readiness: 'degraded'),
+                'calendar': _capability(
+                  enabled: false,
+                  readiness: 'unavailable',
+                  policyState: 'disabled',
+                ),
+                'boards': _capability(
+                  enabled: false,
+                  readiness: 'unavailable',
+                  policyState: 'disabled',
+                ),
+              },
+            ),
+          );
         }),
       );
 
@@ -373,13 +410,7 @@ void main() {
         final client = HttpWeaveApiClient(
           httpClient: _RecordingHttpClient((request) async {
             capturedRequest = request;
-            return _jsonResponse({
-              'shellAccess': {'enabled': true, 'readiness': 'ready'},
-              'chat': {'enabled': true, 'readiness': 'ready'},
-              'files': {'enabled': true, 'readiness': 'ready'},
-              'calendar': {'enabled': true, 'readiness': 'ready'},
-              'boards': {'enabled': true, 'readiness': 'ready'},
-            });
+            return _jsonResponse(_workspaceCapabilitiesJson());
           }),
         );
 
@@ -402,13 +433,7 @@ void main() {
         final client = HttpWeaveApiClient(
           httpClient: _RecordingHttpClient((request) async {
             capturedRequest = request;
-            return _jsonResponse({
-              'shellAccess': {'enabled': true, 'readiness': 'ready'},
-              'chat': {'enabled': true, 'readiness': 'ready'},
-              'files': {'enabled': true, 'readiness': 'ready'},
-              'calendar': {'enabled': true, 'readiness': 'ready'},
-              'boards': {'enabled': true, 'readiness': 'ready'},
-            });
+            return _jsonResponse(_workspaceCapabilitiesJson());
           }),
         );
 

--- a/contracts/openapi/weave-openapi.json
+++ b/contracts/openapi/weave-openapi.json
@@ -1434,6 +1434,11 @@
             "type": "boolean"
           }
         },
+        "required": [
+          "attachmentRefsSupported",
+          "maxAttachmentRefs",
+          "rawProviderMediaUrlsExposed"
+        ],
         "type": "object"
       },
       "ChatConversationResponse": {
@@ -1482,6 +1487,16 @@
             "type": "string"
           }
         },
+        "required": [
+          "attachmentPolicy",
+          "availableActions",
+          "contextId",
+          "historyPolicy",
+          "id",
+          "kind",
+          "membership",
+          "title"
+        ],
         "type": "object"
       },
       "ChatConversationsResponse": {
@@ -1512,6 +1527,13 @@
             "type": "string"
           }
         },
+        "required": [
+          "conversations",
+          "domain",
+          "readiness",
+          "releaseStatus",
+          "source"
+        ],
         "type": "object"
       },
       "ChatHistoryPolicy": {
@@ -1561,6 +1583,12 @@
             "type": "string"
           }
         },
+        "required": [
+          "backendReadable",
+          "encryptedProviderContentRedacted",
+          "policyKey",
+          "visibility"
+        ],
         "type": "object"
       },
       "ChatMembershipResponse": {
@@ -1582,6 +1610,11 @@
             "type": "string"
           }
         },
+        "required": [
+          "principalRef",
+          "role",
+          "state"
+        ],
         "type": "object"
       },
       "ChatMessageResponse": {
@@ -1637,6 +1670,16 @@
             "type": "string"
           }
         },
+        "required": [
+          "attachmentRefs",
+          "conversationId",
+          "deliveryEvidence",
+          "encryptedProviderContentRedacted",
+          "id",
+          "isMine",
+          "senderRef",
+          "sentAt"
+        ],
         "type": "object"
       },
       "ChatMessagesResponse": {
@@ -1657,6 +1700,11 @@
             "$ref": "#/components/schemas/ChatReadinessResponse"
           }
         },
+        "required": [
+          "conversationId",
+          "messages",
+          "readiness"
+        ],
         "type": "object"
       },
       "ChatMigrationPreflightRequest": {
@@ -1965,6 +2013,12 @@
             "type": "string"
           }
         },
+        "required": [
+          "diagnosticsRedacted",
+          "grantedCapabilities",
+          "impactState",
+          "memberImpact"
+        ],
         "type": "object"
       },
       "ChatSendMessageRequest": {
@@ -3377,6 +3431,13 @@
             "type": "string"
           }
         },
+        "required": [
+          "downloadable",
+          "id",
+          "name",
+          "path",
+          "type"
+        ],
         "type": "object"
       },
       "FileListResponse": {
@@ -3398,6 +3459,10 @@
             "$ref": "#/components/schemas/FileQuotaResponse"
           }
         },
+        "required": [
+          "items",
+          "path"
+        ],
         "type": "object"
       },
       "FileQuotaResponse": {
@@ -3425,6 +3490,9 @@
             "$ref": "#/components/schemas/FileItemResponse"
           }
         },
+        "required": [
+          "item"
+        ],
         "type": "object"
       },
       "GoLiveReadinessResponse": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,12 +152,12 @@ Each feature follows the same three layers:
 
 Shared integrations follow the same layering under `lib/integrations/<integration>/` when multiple features need the same protocol/platform boundary.
 
-Current repository-first stub boundaries:
+Current feature repository boundaries:
 
 - `auth` -> `AuthSessionRepository` + `OidcClient`
-- `chat` -> `ChatRepository` + `MatrixClient`
-- `integrations/nextcloud` -> `NextcloudConnectionService` + `NextcloudAuthClient` + `NextcloudSessionRepository` + shared providers
-- `files` -> `FilesRepository` + `NextcloudDavClient`
+- `chat` -> `ChatRepository` + backend Chat facade OpenAPI DTO mapping in `data/`; Matrix SDK access is fenced to legacy/diagnostic chat-owned services until #895 removes or replaces that seam
+- `files` -> `FilesRepository` + backend Files facade OpenAPI DTO mapping in `data/`; direct Nextcloud/WebDAV transport stays outside normal member UI paths
+- `integrations/nextcloud` -> transitional Nextcloud auth/session helpers only for fenced legacy or provider-owned integration work; normal member Files presentation must use the backend Files facade
 - `calendar` -> `CalendarRepository` + backend `CalendarFacadeClient` (no direct Flutter-to-CalDAV product path)
 - `deck` / future `tasks_boards` -> exploratory board repository/client boundaries; future work should use a provider-neutral Weave model with adapters
 
@@ -172,11 +172,11 @@ Boundary rule:
 - features may depend on integrations, but integrations must not depend on feature presentation state or feature-owned transport mappings they are meant to support
 
 ## Session separation
-App auth, Matrix auth, and shared Nextcloud session handling are intentionally separate concerns:
+App auth, legacy Matrix diagnostic auth, and transitional Nextcloud integration state are intentionally separate concerns:
 
 - `auth/` owns the app-level OIDC session that decides whether the shell is reachable
-- `chat/` owns Matrix protocol discovery, Matrix Native OAuth 2.0 login, refresh, logout, and SDK persistence
-- `integrations/nextcloud/` consumes app-auth state when available, but owns Nextcloud bearer/app-password selection, secure Nextcloud session persistence, reconnect rules, and app-password revocation
+- `chat/data/repositories/BackendChatRepository` consumes the Weave app session and calls the canonical backend Chat facade; remaining Matrix protocol discovery, Matrix Native OAuth 2.0 login, refresh, logout, and SDK persistence are fenced legacy/diagnostic seams pending #895
+- `files/data/repositories/BackendFilesRepository` consumes the Weave app session and calls the canonical backend Files facade; `integrations/nextcloud/` remains transitional provider-integration code rather than the normal member Files path
 - the app does not assume an app-level OIDC access token is also a Matrix access token
 - the app does not assume an app-level OIDC token can be persisted as a raw Nextcloud bearer session; persisted Nextcloud bearer sessions are stored as tokenless markers and rehydrated from app auth state
 - changing the Matrix homeserver invalidates the Matrix session without redesigning bootstrap

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,6 +166,8 @@ Presentation depends on repository contracts and Riverpod providers only. It doe
 Boundary rule:
 
 - feature-specific mapping stays in the feature
+- generated OpenAPI DTOs are transport contracts for feature `data/` mappers, not presentation or domain models
+- shared OpenAPI adapter primitives may represent reusable resource pages, readiness/capability states, support-safe errors, and future watch-stream envelopes, while Chat, Files, and other features keep feature-specific repository methods where their semantics differ
 - reusable external-service auth/session/orchestration belongs in an integration layer
 - features may depend on integrations, but integrations must not depend on feature presentation state or feature-owned transport mappings they are meant to support
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,7 +84,7 @@ Shell destinations:
 - **Channels** contain team/topic rooms and remain the main collaboration spine for future channel workspaces.
 - **AI chats** provide a distinct home for specialized assistant and agent chats instead of mixing them into ordinary DMs.
 
-The first implementation slice keeps Matrix as the conversation source, classifies direct messages versus channels from existing room metadata, and renders honest empty states for favorites and AI chats until backend/product metadata is ready. Channel detail treats a channel as a workspace container, but normal member copy may only show available product surfaces or impact-level unavailable states. Files, board/task, calendar, and meeting setup details stay behind admin/operator Workspace Health until the corresponding backend capability is enabled; channel UX must not expose provider setup diagnostics or preview claims.
+The current member Chat path uses the backend Chat facade as the conversation source. Flutter maps `/api/chat/*` OpenAPI DTOs inside `features/chat/data/` and presents Weave-domain conversations, messages, and readiness through `ChatRepository`. Channel detail treats a channel as a workspace container, but normal member copy may only show available product surfaces or impact-level unavailable states. Files, board/task, calendar, and meeting setup details stay behind admin/operator Workspace Health until the corresponding backend capability is enabled; channel UX must not expose provider setup diagnostics or preview claims.
 
 The server now owns a Chat domain facade seam. Member routes under `/api/chat/*` return Weave-domain readiness/conversation/message contracts and fail closed for missing, unsupported, degraded, blocked, or unconfigured Chat mappings. Admin/operator routes under `/api/admin/chat/*` may show support-safe selected mapping, redacted readiness diagnostics, and migration dry-run/preflight reports; destructive migration apply is intentionally out of scope.
 
@@ -192,7 +192,7 @@ Matrix E2EE state also stays inside `features/chat/`:
 - verification state must stay chat-owned as well; SDK states such as `askSSSS` are surfaced as recovery/unlock prompts rather than exposed directly in widgets
 - current verification support is limited to SAS emoji/numbers plus SSSS unlock; QR verification remains out of scope until the client explicitly supports QR methods end-to-end
 
-The current Matrix integration uses:
+The remaining Matrix integration is a fenced legacy/diagnostic seam pending #895. It uses:
 
 - the configured Matrix homeserver URL from `ServerConfiguration`
 - `Client.checkHomeserver(..., fetchAuthMetadata: true)` for capability discovery
@@ -201,12 +201,12 @@ The current Matrix integration uses:
 - Matrix SDK crypto setup helpers for first-device bootstrap, recovery reconnect, and self-verification continuation
 
 ## Nextcloud integration split
-Nextcloud is now split into:
+Normal member Files uses the backend Files facade through `BackendFilesRepository`; Flutter maps `/api/files/*` OpenAPI DTOs inside `features/files/data/` and presents Weave-domain `DirectoryListing` and `FileEntry` objects. The transitional Nextcloud integration is now split into fenced provider-owned helpers:
 
-- `integrations/nextcloud/` for shared auth, session, account validation, login-flow handling, revoke policy, provider wiring, and connection lifecycle orchestration
-- `features/files/` for DAV directory browsing, file-entry mapping, and file-facing presentation/state
+- `integrations/nextcloud/` for legacy/shared auth, session, account validation, login-flow handling, revoke policy, provider wiring, and connection lifecycle orchestration where a fenced provider adapter still needs it
+- `features/files/` for backend Files facade calls, OpenAPI DTO-to-domain mapping, and file-facing presentation/state
 
-This keeps the current Files UX intact while making the same Nextcloud platform layer reusable for future Calendar or provider-adapter board work without importing `features/files/`.
+This keeps the current Files UX intact while moving provider transport behind backend domain services. Future Calendar or provider-adapter board work must not import `features/files/` or add direct member UI provider setup paths.
 
 ## Calendar backend facade scope
 

--- a/docs/architecture/adr-004-server-openapi-contract-authority.md
+++ b/docs/architecture/adr-004-server-openapi-contract-authority.md
@@ -41,6 +41,9 @@ MCP tool annotations are UX/risk hints only. They are not enforcement. Approval,
 ## Consequences
 
 - New client/admin/MCP work must not add parallel hand-written DTO truth when the server OpenAPI can describe the surface.
+- Flutter remains feature-centered under `client/lib/features/<feature>/`. Generated OpenAPI DTOs belong in feature `data/` mappers or shared integration data, then map into feature-owned domain models and repository contracts before presentation/application code consumes them.
+- Reusable client feature-adapter primitives may cover OpenAPI-backed resource pages, capability/readiness state, errors, and future realtime watch streams. They must stay small and must not erase feature-specific repository methods such as Chat message sending or Files folder mutation.
+- Normal member Flutter surfaces consume canonical server feature APIs such as `/api/chat/*` and `/api/files/*`; provider SDKs and provider-native IDs remain behind server services or deliberately fenced diagnostic seams.
 - OpenAPI quality becomes a build gate: stable `operationId`, stable schema names, validation constraints, support-safe errors, and no provider secret/raw payload leakage.
 - The root build orchestrates all consumer checks from the repository root; it does not replace Flutter, npm, or Python tooling.
 - Existing `weave-contract` usages remain compatibility debt until migrated. Follow-up PRs must move authority back into server/OpenAPI before deleting the module.

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatAttachmentPolicyResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatAttachmentPolicyResponse.java
@@ -4,10 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Support-safe attachment policy metadata for Weave Chat.")
 public record ChatAttachmentPolicyResponse(
-        @Schema(description = "Whether message attachment references are supported by this facade.", example = "true")
+        @Schema(description = "Whether message attachment references are supported by this facade.", example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean attachmentRefsSupported,
-        @Schema(description = "Maximum attachment references accepted on one message.", example = "8")
+        @Schema(description = "Maximum attachment references accepted on one message.", example = "8",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         int maxAttachmentRefs,
-        @Schema(description = "Whether raw provider media URLs are exposed to clients. Always false for release behavior.", example = "false")
+        @Schema(description = "Whether raw provider media URLs are exposed to clients. Always false for release behavior.", example = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean rawProviderMediaUrlsExposed) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatConversationResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatConversationResponse.java
@@ -1,23 +1,41 @@
 package com.massimotter.weave.backend.model.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 
 @Schema(description = "Canonical Weave Chat conversation. Provider-specific room/channel ids are deliberately omitted.")
 public record ChatConversationResponse(
-        @Schema(description = "Stable Weave conversation id.", example = "channel-general")
+        @Schema(description = "Stable Weave conversation id.", example = "channel-general",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String id,
-        @Schema(description = "Weave Context/Space id that owns the conversation.", example = "workspace-default")
+        @Schema(description = "Weave Context/Space id that owns the conversation.", example = "workspace-default",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String contextId,
-        @Schema(description = "Conversation kind in Weave vocabulary.", example = "channel")
+        @Schema(description = "Conversation kind in Weave vocabulary.", example = "channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String kind,
-        @Schema(description = "Member-facing conversation title.", example = "General workspace channel")
+        @Schema(description = "Member-facing conversation title.", example = "General workspace channel",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String title,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         ChatMembershipResponse membership,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         ChatHistoryPolicyResponse historyPolicy,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         ChatAttachmentPolicyResponse attachmentPolicy,
-        @Schema(description = "Member-visible product actions available in this conversation.")
+        @Schema(description = "Member-visible product actions available in this conversation.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         List<String> availableActions,
         @Schema(description = "Last canonical message timestamp, if any.")
         Instant lastMessageAt) {

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatConversationsResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatConversationsResponse.java
@@ -1,16 +1,28 @@
 package com.massimotter.weave.backend.model.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @Schema(description = "Canonical Weave Chat conversation snapshot.")
 public record ChatConversationsResponse(
-        @Schema(description = "Product domain.", example = "chat")
+        @Schema(description = "Product domain.", example = "chat",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String domain,
-        @Schema(description = "Release posture for this facade.", example = "canonical-domain-facade")
+        @Schema(description = "Release posture for this facade.", example = "canonical-domain-facade",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String releaseStatus,
-        @Schema(description = "Support-safe source label; not a raw provider name, URL, room id, or channel id.", example = "weave-chat-domain-facade")
+        @Schema(description = "Support-safe source label; not a raw provider name, URL, room id, or channel id.", example = "weave-chat-domain-facade",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String source,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         ChatReadinessResponse readiness,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         List<ChatConversationResponse> conversations) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatHistoryPolicyResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatHistoryPolicyResponse.java
@@ -1,15 +1,22 @@
 package com.massimotter.weave.backend.model.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "Support-safe chat history policy metadata for a canonical Weave conversation.")
 public record ChatHistoryPolicyResponse(
-        @Schema(description = "Stable policy key, not a raw provider room or channel identifier.", example = "workspace-default-history")
+        @Schema(description = "Stable policy key, not a raw provider room or channel identifier.", example = "workspace-default-history",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String policyKey,
-        @Schema(description = "Member-visible history visibility.", example = "joined-members")
+        @Schema(description = "Member-visible history visibility.", example = "joined-members",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String visibility,
-        @Schema(description = "Whether backend-held chat history is readable through this facade.", example = "true")
+        @Schema(description = "Whether backend-held chat history is readable through this facade.", example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean backendReadable,
-        @Schema(description = "Whether encrypted-provider content is intentionally hidden from the backend facade.", example = "true")
+        @Schema(description = "Whether encrypted-provider content is intentionally hidden from the backend facade.", example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean encryptedProviderContentRedacted) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatMembershipResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatMembershipResponse.java
@@ -1,13 +1,20 @@
 package com.massimotter.weave.backend.model.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "Canonical Weave Chat membership summary for the authenticated principal.")
 public record ChatMembershipResponse(
-        @Schema(description = "Weave principal reference, not a raw provider user id.", example = "user:alice")
+        @Schema(description = "Weave principal reference, not a raw provider user id.", example = "user:alice",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String principalRef,
-        @Schema(description = "Conversation membership state.", example = "joined")
+        @Schema(description = "Conversation membership state.", example = "joined",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String state,
-        @Schema(description = "Conversation role in Weave vocabulary.", example = "member")
+        @Schema(description = "Conversation role in Weave vocabulary.", example = "member",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String role) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatMessageResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatMessageResponse.java
@@ -1,27 +1,43 @@
 package com.massimotter.weave.backend.model.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
 @Schema(description = "Canonical Weave Chat message. Provider event ids, room ids, and raw media URLs are deliberately omitted.")
 public record ChatMessageResponse(
-        @Schema(description = "Stable Weave message id.", example = "msg-001")
+        @Schema(description = "Stable Weave message id.", example = "msg-001",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String id,
-        @Schema(description = "Stable Weave conversation id.", example = "channel-general")
+        @Schema(description = "Stable Weave conversation id.", example = "channel-general",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String conversationId,
-        @Schema(description = "Weave principal reference, not a raw provider user id.", example = "user:alice")
+        @Schema(description = "Weave principal reference, not a raw provider user id.", example = "user:alice",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String senderRef,
         @Schema(description = "Message text when readable through the Weave facade.")
         String text,
-        @Schema(description = "Attachment references mediated by Weave product/file facades, never raw provider URLs.")
+        @Schema(description = "Attachment references mediated by Weave product/file facades, never raw provider URLs.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         List<String> attachmentRefs,
-        @Schema(description = "Whether this message belongs to the authenticated member, computed server-side from the Weave principal.", example = "true")
+        @Schema(description = "Whether this message belongs to the authenticated member, computed server-side from the Weave principal.", example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean isMine,
-        @Schema(description = "Whether encrypted-provider content was redacted from this facade response.", example = "false")
+        @Schema(description = "Whether encrypted-provider content was redacted from this facade response.", example = "false",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean encryptedProviderContentRedacted,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         Instant sentAt,
-        @Schema(description = "Support-safe delivery/runtime evidence. Raw provider ids, URLs, tokens, and diagnostics are deliberately omitted.")
+        @Schema(description = "Support-safe delivery/runtime evidence. Raw provider ids, URLs, tokens, and diagnostics are deliberately omitted.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         Map<String, Object> deliveryEvidence) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatMessagesResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatMessagesResponse.java
@@ -1,12 +1,20 @@
 package com.massimotter.weave.backend.model.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @Schema(description = "Canonical Weave Chat messages for one conversation.")
 public record ChatMessagesResponse(
-        @Schema(description = "Stable Weave conversation id.", example = "channel-general")
+        @Schema(description = "Stable Weave conversation id.", example = "channel-general",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String conversationId,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         ChatReadinessResponse readiness,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         List<ChatMessageResponse> messages) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatReadinessResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatReadinessResponse.java
@@ -1,16 +1,25 @@
 package com.massimotter.weave.backend.model.chat;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @Schema(description = "Member-safe Weave Chat readiness and policy state.")
 public record ChatReadinessResponse(
-        @Schema(description = "Stable member impact state.", allowableValues = {"usable", "disabled", "degraded", "policy-blocked"}, example = "usable")
+        @Schema(description = "Stable member impact state.", allowableValues = {"usable", "disabled", "degraded", "policy-blocked"}, example = "usable",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String impactState,
-        @Schema(description = "Support-safe member impact explanation.")
+        @Schema(description = "Support-safe member impact explanation.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String memberImpact,
-        @Schema(description = "Capabilities granted to the current principal for this domain.")
+        @Schema(description = "Capabilities granted to the current principal for this domain.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         List<String> grantedCapabilities,
-        @Schema(description = "Whether provider diagnostics have been intentionally redacted from this member response.", example = "true")
+        @Schema(description = "Whether provider diagnostics have been intentionally redacted from this member response.", example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean diagnosticsRedacted) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/files/FileItemResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/files/FileItemResponse.java
@@ -1,17 +1,26 @@
 package com.massimotter.weave.backend.model.files;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import java.time.OffsetDateTime;
 
 @Schema(description = "Product file or folder metadata returned by the Weave files facade.")
 public record FileItemResponse(
-        @Schema(description = "Stable backend facade identifier for this item.", example = "files:/Team/readme.md")
+        @Schema(description = "Stable backend facade identifier for this item.", example = "files:/Team/readme.md",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String id,
-        @Schema(description = "Display name of the file or folder.", example = "readme.md")
+        @Schema(description = "Display name of the file or folder.", example = "readme.md",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String name,
-        @Schema(description = "Product-relative path of the item.", example = "/Team/readme.md")
+        @Schema(description = "Product-relative path of the item.", example = "/Team/readme.md",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String path,
-        @Schema(description = "Item type.", example = "file", allowableValues = {"file", "folder"})
+        @Schema(description = "Item type.", example = "file", allowableValues = {"file", "folder"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String type,
         @Schema(description = "MIME type for files when known.", example = "text/markdown")
         String mimeType,
@@ -19,6 +28,7 @@ public record FileItemResponse(
         Long size,
         @Schema(description = "Last modified timestamp when provided by the backing store.")
         OffsetDateTime modifiedAt,
-        @Schema(description = "Whether the item can be downloaded through the product facade.")
+        @Schema(description = "Whether the item can be downloaded through the product facade.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
         boolean downloadable) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/files/FileListResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/files/FileListResponse.java
@@ -1,13 +1,19 @@
 package com.massimotter.weave.backend.model.files;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @Schema(description = "Files facade folder listing response.")
 public record FileListResponse(
-        @Schema(description = "Listed product-relative folder path.", example = "/")
+        @Schema(description = "Listed product-relative folder path.", example = "/",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String path,
-        @Schema(description = "Files and folders directly under the listed path.")
+        @Schema(description = "Files and folders directly under the listed path.",
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         List<FileItemResponse> items,
         @Schema(description = "Quota snapshot when the backing store exposes one.")
         FileQuotaResponse quota) {

--- a/server/src/main/java/com/massimotter/weave/backend/model/files/FileUploadResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/files/FileUploadResponse.java
@@ -1,7 +1,11 @@
 package com.massimotter.weave.backend.model.files;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "Uploaded file metadata returned after a successful files facade upload.")
-public record FileUploadResponse(FileItemResponse item) {
+public record FileUploadResponse(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        FileItemResponse item) {
 }

--- a/tools/generate_client_openapi_models.py
+++ b/tools/generate_client_openapi_models.py
@@ -47,13 +47,14 @@ def refs_in(value: Any) -> set[str]:
     return found
 
 
-def type_for(schema: dict[str, Any] | None) -> str:
+def type_for(schema: dict[str, Any] | None, *, required: bool = False) -> str:
     if not schema:
         return "Object?"
     if "$ref" in schema:
-        return f"{pascal(schema['$ref'].split('/')[-1])}?"
+        base = pascal(schema["$ref"].split("/")[-1])
+        return base if required else f"{base}?"
     if "allOf" in schema and schema["allOf"]:
-        return type_for(schema["allOf"][0])
+        return type_for(schema["allOf"][0], required=required)
     if "oneOf" in schema or "anyOf" in schema:
         return "Object?"
     schema_type = schema.get("type")
@@ -77,25 +78,37 @@ def type_for(schema: dict[str, Any] | None) -> str:
         base = "String"
     else:
         base = "Object?"
-    return base if nullable or base.endswith("?") else f"{base}?"
+    if nullable or base.endswith("?"):
+        return base
+    return base if required else f"{base}?"
 
 
 def read_expr(field_type: str, key: str) -> str:
     value = f"json[{json.dumps(key)}]"
+    if field_type == "String": return f"{value} as String"
     if field_type == "String?": return f"{value} as String?"
+    if field_type == "bool": return f"{value} as bool"
     if field_type == "bool?": return f"{value} as bool?"
+    if field_type == "int": return f"({value} as num).toInt()"
     if field_type == "int?": return f"({value} as num?)?.toInt()"
+    if field_type == "num": return f"{value} as num"
     if field_type == "num?": return f"{value} as num?"
     if field_type.startswith("List<"):
-        inner = field_type[len("List<"):-2]
+        nullable = field_type.endswith("?")
+        inner = field_type[len("List<"):-2 if nullable else -1]
         if inner in {"String", "bool", "int", "num", "Object"}:
             conv = "e"
             if inner == "int": conv = "(e as num).toInt()"
             elif inner != "Object": conv = f"e as {inner}"
-            return f"({value} as List<dynamic>?)?.map((e) => {conv}).toList()"
-        return f"({value} as List<dynamic>?)?.map((e) => {inner}.fromJson(e as Map<String, dynamic>)).toList()"
+            cast = f"{value} as List<dynamic>{'?' if nullable else ''}"
+            return f"({cast}){'?' if nullable else ''}.map((e) => {conv}).toList()"
+        cast = f"{value} as List<dynamic>{'?' if nullable else ''}"
+        return f"({cast}){'?' if nullable else ''}.map((e) => {inner}.fromJson(e as Map<String, dynamic>)).toList()"
     if field_type.startswith("Map<"):
-        return f"({value} as Map<String, dynamic>?)?.cast<String, Object?>()"
+        nullable = field_type.endswith("?")
+        return f"({value} as Map<String, dynamic>{'?' if nullable else ''}){'?' if nullable else ''}.cast<String, Object?>()"
+    if not field_type.endswith("?") and field_type not in {"Object"}:
+        return f"{field_type}.fromJson({value} as Map<String, dynamic>)"
     if field_type.endswith("?") and field_type[:-1] not in {"Object"}:
         cls = field_type[:-1]
         return f"{value} == null ? null : {cls}.fromJson({value} as Map<String, dynamic>)"
@@ -105,17 +118,21 @@ def read_expr(field_type: str, key: str) -> str:
 def emit_class(name: str, schema: dict[str, Any]) -> list[str]:
     cls = pascal(name)
     props = schema.get("properties") if isinstance(schema.get("properties"), dict) else {}
+    required_props = set(schema.get("required", [])) if isinstance(schema.get("required"), list) else set()
     lines = [f"class {cls} {{"]
-    params = [f"this.{camel(k)}" for k in sorted(props)]
+    params = [
+        f"{'required ' if k in required_props else ''}this.{camel(k)}"
+        for k in sorted(props)
+    ]
     lines.append(f"  const {cls}({{{', '.join(params)}}});" if params else f"  const {cls}();")
     lines.append("")
     lines.append(f"  factory {cls}.fromJson(Map<String, dynamic> json) => {cls}(")
     for k, v in sorted(props.items()):
-        lines.append(f"    {camel(k)}: {read_expr(type_for(v), k)},")
+        lines.append(f"    {camel(k)}: {read_expr(type_for(v, required=k in required_props), k)},")
     lines.append("  );")
     lines.append("")
     for k, v in sorted(props.items()):
-        lines.append(f"  final {type_for(v)} {camel(k)};")
+        lines.append(f"  final {type_for(v, required=k in required_props)} {camel(k)};")
     if props: lines.append("")
     lines.append("  Map<String, dynamic> toJson() => {")
     for k in sorted(props):


### PR DESCRIPTION
## Summary

- add shared client OpenAPI feature-adapter primitives for resource pages and member-safe capability/readiness state
- move Chat and Files backend facade response/request mapping to generated OpenAPI DTOs inside feature data mappers
- add architecture guards for generated DTO boundaries and provider SDK import allowlists, and wire `checkClientOpenApiModelsFresh` into `clientCi`
- document the feature-centered OpenAPI adapter architecture and follow-up migration path

## Scope and user impact

This is an internal architecture foundation slice. Normal member UI behavior should stay unchanged: Chat and Files still expose feature repositories/domain models to presentation, while provider SDKs and provider details stay out of normal member surfaces.

## Spec / acceptance link

- Issue: #864, #899, #900
- Repo spec / Spec Kit package: pinned spec corpus `specs/weave-specs.lock.json` (`WEAVE-DOMAIN-CHAT`, `WEAVE-DOMAIN-FILES`, provider portability, domain context map)
- Plan/tasks/traceability: ADR-004 and `docs/architecture.md` now state the client feature-adapter migration rules
- Mapped Gherkin feature/scenario when product behavior changed: no new product behavior; existing acceptance contract unchanged
- Evidence mode / reality level: `offline-spec` / `contract_only`
- Product-core questions intentionally left unresolved: none for this slice; Files readiness/events are tracked in #899/#900

Quality Reset rule: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance before merge. `offline-spec` / `contract_only` fixture evidence must not be described as `live-runtime`, isolated E2E, `release_ready`, or customer-ready evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [x] implements locked spec
- [x] changes evidence only

## Release note

- Release note: Developer architecture: Chat and Files client facades now map generated server OpenAPI DTOs through feature data layers, with provider-boundary guards.

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- Docs updated: `docs/architecture.md`, `docs/architecture/adr-004-server-openapi-contract-authority.md`
- No UI screenshots changed.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: provider SDK import allowlists tightened; generated DTOs remain out of feature domain/presentation layers.
- Accessibility/localization impact: no UI copy or widget changes.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: client consumption rule documented in ADR-004 and architecture docs; no server API schema changed
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: architecture/client/provider-boundary review
- If Copilot is unavailable/insufficient, matching reviewer used: fallback scoped agent reviews: architecture/client, backend/OpenAPI, quality/security

## Checks run

- [x] `git diff --check`
- [x] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [x] `flutter pub get`
- [x] `flutter gen-l10n`
- [x] `dart run build_runner build --delete-conflicting-outputs`
- [x] `dart format --output=none --set-exit-if-changed .`
- [x] `flutter analyze --fatal-infos`
- [x] `flutter test`
- [x] `make offline-contract-test`
- [x] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant; no live-stack behavior changed

Additional gates:
- [x] `./gradlew checkClientOpenApiModelsFresh --console=plain --no-daemon --max-workers=1`
- [x] `flutter test test/architecture/backend_facade_contract_test.dart test/architecture/member_client_provider_boundary_contract_test.dart test/features/files/presentation/providers/files_backend_facade_provider_test.dart test/features/chat/data/repositories/backend_chat_repository_test.dart`
- [x] `./gradlew contractAuthorityArchitectureCheck --console=plain --no-daemon --max-workers=1`

## Notes for reviewers

Review for the intended boundary: generated OpenAPI DTOs are allowed in feature `data/` mapping, but feature domain/presentation must continue to consume domain entities and repositories. Events/watch streams and a dedicated Files readiness contract are intentionally left to #899/#900 because no canonical server event/readiness contract exists yet.
