### PR TITLE
feat(client): migrate Calendar and Boards OpenAPI mappers

### DIFF
--- a/client/lib/features/boards/data/dtos/boards_openapi_mappers.dart
+++ b/client/lib/features/boards/data/dtos/boards_openapi_mappers.dart
@@ -1,0 +1,143 @@
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/boards/domain/entities/board_workspace.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
+
+extension BoardsWorkspaceOpenApiMapper on openapi.BoardsWorkspaceResponse {
+  BoardWorkspace toDomain() {
+    final release = _requiredString(releaseStatus, 'Boards release status');
+    final facadeSource = _requiredString(source, 'Boards workspace source');
+    if (workspace != true ||
+        release != 'active-dogfood-production' ||
+        !_isKnownWorkspaceFacadeSource(facadeSource)) {
+      throw const AppFailure.unknown(
+        'The Weave backend returned a Boards workspace outside the active dogfood-production facade.',
+      );
+    }
+
+    final board = _firstBoard(boards);
+    final boardColumns = board.columns ?? const [];
+    final taskItems = tasks ?? const [];
+    return BoardWorkspace(
+      id: _optionalString(board.id) ?? 'backend-board',
+      name: _optionalString(board.name) ?? 'Boards workspace',
+      description: _optionalString(board.description) ?? '',
+      source: BoardWorkspaceSource.backendFacade,
+      releaseStatus: release,
+      capabilities:
+          capabilities?.toDomain() ??
+          const BoardProviderWorkspaceCapabilities.blocked(),
+      columns: [
+        for (final column in boardColumns)
+          column.toDomain(
+            tasks: taskItems
+                .where((task) => task.columnId == column.id)
+                .toList(growable: false),
+          ),
+      ],
+    );
+  }
+}
+
+extension BoardColumnOpenApiMapper on openapi.BoardColumn {
+  BoardColumnWorkspace toDomain({required List<openapi.TaskItem> tasks}) {
+    final status = _columnStatus(semanticStatus);
+    return BoardColumnWorkspace(
+      id: _optionalString(id) ?? 'backend-column',
+      name: _optionalString(name) ?? 'Column',
+      semanticStatus: status,
+      wipLimit: wipLimit,
+      tasks: [for (final task in tasks) task.toDomain(columnFallback: status)],
+    );
+  }
+}
+
+extension TaskItemOpenApiMapper on openapi.TaskItem {
+  BoardTaskWorkspace toDomain({required BoardTaskStatus columnFallback}) {
+    return BoardTaskWorkspace(
+      id: _optionalString(id) ?? 'backend-task',
+      title: _optionalString(title) ?? 'Untitled task',
+      description: _optionalString(description) ?? '',
+      status: _taskStatus(status, columnFallback),
+      assigneeLabel: _labelList(assigneeRefs, fallback: 'Unassigned'),
+      dueLabel: _optionalString(dueAt) ?? 'No due date',
+      labels: _stringList(labelRefs),
+      priorityLabel: _optionalString(priority) ?? 'normal',
+    );
+  }
+}
+
+extension BoardProviderCapabilitiesOpenApiMapper
+    on openapi.BoardProviderCapabilities {
+  BoardProviderWorkspaceCapabilities toDomain() {
+    return BoardProviderWorkspaceCapabilities(
+      provider: _optionalString(provider) ?? 'unknown',
+      enabled: enabled == true,
+      supported: _stringList(supported),
+      unsupported: _stringList(unsupported),
+      supportSafeSummary:
+          _optionalString(supportSafeSummary) ??
+          'Backend Boards workspace capabilities were not described.',
+    );
+  }
+}
+
+openapi.Board _firstBoard(List<openapi.Board>? boards) {
+  final first = boards == null || boards.isEmpty ? null : boards.first;
+  if (first == null) {
+    throw const AppFailure.unknown(
+      'The Weave backend returned no Boards workspace board.',
+    );
+  }
+  return first;
+}
+
+bool _isKnownWorkspaceFacadeSource(String source) {
+  return const {
+    'local-workspace-backend-facade',
+    'openproject-workspace-sync-backend-facade',
+  }.contains(source);
+}
+
+String _requiredString(String? value, String label) {
+  final trimmed = _optionalString(value);
+  if (trimmed != null) {
+    return trimmed;
+  }
+  throw AppFailure.unknown('The Weave backend returned $label as empty.');
+}
+
+String? _optionalString(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
+List<String> _stringList(List<String>? value) {
+  return value
+          ?.map((item) => item.trim())
+          .where((item) => item.isNotEmpty)
+          .toList(growable: false) ??
+      const [];
+}
+
+String _labelList(List<String>? value, {required String fallback}) {
+  final values = _stringList(value);
+  return values.isEmpty ? fallback : values.join(', ');
+}
+
+BoardTaskStatus _columnStatus(String? value) {
+  return switch (value) {
+    'in_progress' => BoardTaskStatus.inProgress,
+    'blocked' => BoardTaskStatus.blocked,
+    'done' || 'completed' => BoardTaskStatus.done,
+    _ => BoardTaskStatus.notStarted,
+  };
+}
+
+BoardTaskStatus _taskStatus(String? value, BoardTaskStatus columnFallback) {
+  return switch (value) {
+    'blocked' => BoardTaskStatus.blocked,
+    'completed' || 'done' => BoardTaskStatus.done,
+    'open' => columnFallback,
+    _ => columnFallback,
+  };
+}

--- a/client/lib/features/boards/data/repositories/backend_boards_workspace_repository.dart
+++ b/client/lib/features/boards/data/repositories/backend_boards_workspace_repository.dart
@@ -3,8 +3,10 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/boards/data/dtos/boards_openapi_mappers.dart';
 import 'package:weave/features/boards/domain/entities/board_workspace.dart';
 import 'package:weave/features/boards/domain/repositories/boards_workspace_repository.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
 import 'package:weave/integrations/weave_api/data/services/weave_api_uri_builder.dart';
 
 class BackendBoardsWorkspaceRepository implements BoardsWorkspaceRepository {
@@ -51,13 +53,13 @@ class BackendBoardsWorkspaceRepository implements BoardsWorkspaceRepository {
     }
 
     try {
-      final payload = jsonDecode(response.body);
-      if (payload is! Map<String, dynamic>) {
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, dynamic>) {
         throw const AppFailure.unknown(
           'The Weave backend returned an invalid Boards workspace payload.',
         );
       }
-      return _parseWorkspace(payload);
+      return openapi.BoardsWorkspaceResponse.fromJson(decoded).toDomain();
     } on AppFailure {
       rethrow;
     } catch (error) {
@@ -66,70 +68,6 @@ class BackendBoardsWorkspaceRepository implements BoardsWorkspaceRepository {
         cause: error,
       );
     }
-  }
-
-  BoardWorkspace _parseWorkspace(Map<String, dynamic> payload) {
-    final workspace = payload['workspace'];
-    final releaseStatus = _string(payload['releaseStatus']);
-    final source = _string(payload['source']);
-    if (workspace != true ||
-        releaseStatus != 'active-dogfood-production' ||
-        !_isKnownWorkspaceFacadeSource(source)) {
-      throw const AppFailure.unknown(
-        'The Weave backend returned a Boards workspace outside the active dogfood-production facade.',
-      );
-    }
-
-    final boards = _listOfMaps(payload['boards']);
-    final tasks = _listOfMaps(payload['tasks']);
-    if (boards.isEmpty) {
-      throw const AppFailure.unknown(
-        'The Weave backend returned no Boards workspace board.',
-      );
-    }
-
-    final board = boards.first;
-    final columns = _listOfMaps(board['columns']);
-    return BoardWorkspace(
-      id: _string(board['id'], fallback: 'backend-board'),
-      name: _string(board['name'], fallback: 'Boards workspace'),
-      description: _string(board['description']),
-      source: BoardWorkspaceSource.backendFacade,
-      releaseStatus: releaseStatus,
-      capabilities: _capabilities(payload['capabilities']),
-      columns: [
-        for (final column in columns)
-          BoardColumnWorkspace(
-            id: _string(column['id'], fallback: 'backend-column'),
-            name: _string(column['name'], fallback: 'Column'),
-            semanticStatus: _columnStatus(_string(column['semanticStatus'])),
-            wipLimit: column['wipLimit'] is int
-                ? column['wipLimit'] as int
-                : null,
-            tasks: [
-              for (final task in tasks.where(
-                (task) => task['columnId'] == column['id'],
-              ))
-                BoardTaskWorkspace(
-                  id: _string(task['id'], fallback: 'backend-task'),
-                  title: _string(task['title'], fallback: 'Untitled task'),
-                  description: _string(task['description']),
-                  status: _taskStatus(
-                    _string(task['status']),
-                    _columnStatus(_string(column['semanticStatus'])),
-                  ),
-                  assigneeLabel: _labelList(
-                    task['assigneeRefs'],
-                    fallback: 'Unassigned',
-                  ),
-                  dueLabel: _string(task['dueAt'], fallback: 'No due date'),
-                  labels: _stringList(task['labelRefs']),
-                  priorityLabel: _string(task['priority'], fallback: 'normal'),
-                ),
-            ],
-          ),
-      ],
-    );
   }
 
   Future<void> moveTask({
@@ -225,9 +163,9 @@ class BackendBoardsWorkspaceRepository implements BoardsWorkspaceRepository {
 
   String? _errorCode(String body) {
     try {
-      final payload = jsonDecode(body);
-      return payload is Map<String, dynamic>
-          ? payload['code'] as String?
+      final decoded = jsonDecode(body);
+      return decoded is Map<String, dynamic>
+          ? decoded['code'] as String?
           : null;
     } catch (_) {
       return null;
@@ -251,79 +189,4 @@ class BackendBoardsWorkspaceRepository implements BoardsWorkspaceRepository {
 
   Uri _apiUri(List<String> tailSegments) =>
       weaveApiUri(_apiBaseUrl, ['api', ...tailSegments]);
-}
-
-bool _isKnownWorkspaceFacadeSource(String source) {
-  return const {
-    'local-workspace-backend-facade',
-    'openproject-workspace-sync-backend-facade',
-  }.contains(source);
-}
-
-BoardProviderWorkspaceCapabilities _capabilities(Object? value) {
-  if (value is! Map) {
-    return const BoardProviderWorkspaceCapabilities.blocked();
-  }
-  final json = value.cast<String, dynamic>();
-  return BoardProviderWorkspaceCapabilities(
-    provider: _string(json['provider'], fallback: 'unknown'),
-    enabled: json['enabled'] == true,
-    supported: _stringList(json['supported']),
-    unsupported: _stringList(json['unsupported']),
-    supportSafeSummary: _string(
-      json['supportSafeSummary'],
-      fallback: 'Backend Boards workspace capabilities were not described.',
-    ),
-  );
-}
-
-List<Map<String, dynamic>> _listOfMaps(Object? value) {
-  if (value is! List) {
-    return const [];
-  }
-  return value
-      .whereType<Map>()
-      .map((item) => item.cast<String, dynamic>())
-      .toList(growable: false);
-}
-
-String _string(Object? value, {String fallback = ''}) {
-  if (value is String && value.trim().isNotEmpty) {
-    return value.trim();
-  }
-  return fallback;
-}
-
-List<String> _stringList(Object? value) {
-  if (value is! List) {
-    return const [];
-  }
-  return value
-      .whereType<String>()
-      .map((item) => item.trim())
-      .where((item) => item.isNotEmpty)
-      .toList(growable: false);
-}
-
-String _labelList(Object? value, {required String fallback}) {
-  final values = _stringList(value);
-  return values.isEmpty ? fallback : values.join(', ');
-}
-
-BoardTaskStatus _columnStatus(String value) {
-  return switch (value) {
-    'in_progress' => BoardTaskStatus.inProgress,
-    'blocked' => BoardTaskStatus.blocked,
-    'done' || 'completed' => BoardTaskStatus.done,
-    _ => BoardTaskStatus.notStarted,
-  };
-}
-
-BoardTaskStatus _taskStatus(String value, BoardTaskStatus columnFallback) {
-  return switch (value) {
-    'blocked' => BoardTaskStatus.blocked,
-    'completed' || 'done' => BoardTaskStatus.done,
-    'open' => columnFallback,
-    _ => columnFallback,
-  };
 }

--- a/client/lib/features/calendar/data/dtos/calendar_openapi_mappers.dart
+++ b/client/lib/features/calendar/data/dtos/calendar_openapi_mappers.dart
@@ -1,0 +1,271 @@
+import 'package:weave/core/failures/app_failure.dart';
+import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
+
+extension CalendarScopesOpenApiMapper on openapi.CalendarScopesResponse {
+  CalendarScopeList toDomain() {
+    final mapped = scopes
+        ?.map((scope) => scope.toDomain())
+        .toList(growable: false);
+    return CalendarScopeList(
+      scopes: mapped == null || mapped.isEmpty
+          ? const [CalendarScope.workspace]
+          : mapped,
+    );
+  }
+}
+
+extension CalendarEventsOpenApiMapper on openapi.CalendarEventsResponse {
+  CalendarEventList toDomain() {
+    final responseScope = scope?.toDomain() ?? CalendarScope.workspace;
+    final mappedEvents = events
+        ?.map((event) => event.toDomain(defaultScope: responseScope))
+        .toList(growable: false);
+    return CalendarEventList(
+      scope: responseScope,
+      events: mappedEvents ?? const [],
+    );
+  }
+}
+
+extension CalendarClientSetupOpenApiMapper
+    on openapi.CalendarClientSetupResponse {
+  CalendarClientSetup toDomain() {
+    return CalendarClientSetup(
+      scope: scope?.toDomain() ?? CalendarScope.workspace,
+      username: _requiredString(username, 'calendar setup username'),
+      endpoints: endpoints?.toDomain() ?? _missingEndpoints(),
+      credentialPolicy: _requiredString(
+        credentialPolicy,
+        'calendar credential policy',
+      ),
+      accessModel:
+          accessModel?.toDomain() ??
+          CalendarAccessModel.workspaceBlockedPrivateCalendars,
+      credentialReadiness:
+          credentialReadiness?.toDomain() ??
+          CalendarCredentialReadiness.blockedUntilRevocableCredentials,
+      options:
+          options?.map((option) => option.toDomain()).toList(growable: false) ??
+          const [],
+    );
+  }
+}
+
+extension CalendarEventOpenApiMapper on openapi.CalendarEventResponse {
+  CalendarEvent toDomain({
+    CalendarScope defaultScope = CalendarScope.workspace,
+  }) {
+    final eventScope =
+        scope?.toDomain(defaultScope: defaultScope) ?? defaultScope;
+    return CalendarEvent(
+      id: _requiredString(id, 'calendar event id'),
+      title: _requiredString(title, 'calendar event title'),
+      description: _optionalString(description),
+      startTime: _requiredDateTime(startsAt, 'calendar event start'),
+      endTime: _requiredDateTime(endsAt, 'calendar event end'),
+      timezone: _optionalString(timezone),
+      location: _optionalString(location),
+      allDay: allDay == true,
+      etag: _optionalString(etag),
+      scope: eventScope,
+      threadRef:
+          threadRef?.toDomain(defaultScope: eventScope) ??
+          CalendarThreadRef.forScope(eventScope),
+      attendees:
+          attendees
+              ?.map((attendee) => attendee.toDomain())
+              .toList(growable: false) ??
+          const [],
+      providerRef: providerRef?.toDomain(),
+      updatedAt: _optionalDateTime(updatedAt),
+    );
+  }
+}
+
+extension CalendarScopeOpenApiMapper on openapi.CalendarScopeResponse {
+  CalendarScope toDomain({
+    CalendarScope defaultScope = CalendarScope.workspace,
+  }) {
+    final scopeType = _optionalString(type);
+    if (scopeType == null) {
+      return defaultScope;
+    }
+    final team = _optionalString(teamId);
+    final channel = _optionalString(channelId);
+    return CalendarScope(
+      id: _optionalString(id) ?? _fallbackScopeId(scopeType, team, channel),
+      type: scopeType,
+      label: _optionalString(label) ?? _fallbackScopeLabel(scopeType),
+      workspaceId: _optionalString(workspaceId) ?? defaultScope.workspaceId,
+      contextId:
+          _optionalString(contextId) ??
+          _fallbackContextId(scopeType, teamId: team, channelId: channel),
+      teamId: team,
+      channelId: channel,
+      accessModel: _optionalString(accessModel) ?? defaultScope.accessModel,
+      capabilities: capabilities ?? const [],
+    );
+  }
+}
+
+extension CalendarThreadRefOpenApiMapper on openapi.CalendarThreadRefResponse {
+  CalendarThreadRef toDomain({required CalendarScope defaultScope}) {
+    return CalendarThreadRef(
+      kind: _optionalString(kind) ?? 'context',
+      contextId: _optionalString(contextId) ?? defaultScope.contextId,
+      meetingThreadId: _optionalString(meetingThreadId),
+      channelId: _optionalString(channelId),
+      matrixRoomId: _optionalString(matrixRoomId),
+      matrixThreadId: _optionalString(matrixThreadId),
+      boardTaskIds: boardTaskIds ?? const [],
+    );
+  }
+}
+
+extension CalendarAttendeeOpenApiMapper on openapi.CalendarAttendeeResponse {
+  CalendarAttendee toDomain() {
+    return CalendarAttendee(
+      name: _optionalString(name),
+      email: _optionalString(email),
+      role: _optionalString(role),
+      responseStatus: _optionalString(responseStatus),
+    );
+  }
+}
+
+extension CalendarProviderRefOpenApiMapper
+    on openapi.CalendarProviderRefResponse {
+  CalendarProviderRef toDomain() {
+    return CalendarProviderRef(
+      provider: _requiredString(provider, 'calendar provider ref provider'),
+      objectKind: _requiredString(
+        objectKind,
+        'calendar provider ref object kind',
+      ),
+      opaqueId: _optionalString(opaqueId),
+      etag: _optionalString(etag),
+      lastSyncedAt: _optionalDateTime(lastSyncedAt),
+      rawProviderPathExposed: rawProviderPathExposed == true,
+    );
+  }
+}
+
+extension CalendarExternalEndpointsOpenApiMapper
+    on openapi.CalendarExternalEndpointsResponse {
+  CalendarExternalEndpoints toDomain() {
+    return CalendarExternalEndpoints(
+      serverUrl: _requiredString(serverUrl, 'calendar server URL'),
+      caldavDiscoveryUrl: _requiredString(
+        caldavDiscoveryUrl,
+        'calendar discovery URL',
+      ),
+      principalUrl: _requiredString(principalUrl, 'calendar principal URL'),
+    );
+  }
+}
+
+extension CalendarAccessModelOpenApiMapper
+    on openapi.CalendarAccessModelResponse {
+  CalendarAccessModel toDomain() {
+    return CalendarAccessModel(
+      type: _requiredString(type, 'calendar access model type'),
+      productScope: _requiredString(productScope, 'calendar product scope'),
+      privateUserCalendarsAvailable: privateUserCalendarsAvailable == true,
+      privateUserCalendarsReason: _requiredString(
+        privateUserCalendarsReason,
+        'calendar private calendar reason',
+      ),
+      externalClientCredentialModel: _requiredString(
+        externalClientCredentialModel,
+        'calendar credential model',
+      ),
+      notes: notes ?? const [],
+    );
+  }
+}
+
+extension CalendarCredentialReadinessOpenApiMapper
+    on openapi.CalendarCredentialReadinessResponse {
+  CalendarCredentialReadiness toDomain() {
+    return CalendarCredentialReadiness(
+      status: _requiredString(status, 'calendar credential readiness status'),
+      appleProfileSigned: appleProfileSigned == true,
+      appleProfilePasswordIncluded: appleProfilePasswordIncluded == true,
+      revocableCredentialsAvailable: revocableCredentialsAvailable == true,
+      readOnlySubscriptionTokensAvailable:
+          readOnlySubscriptionTokensAvailable == true,
+      backendActorCredentialsExposed: backendActorCredentialsExposed == true,
+      blockers: blockers ?? const [],
+    );
+  }
+}
+
+extension CalendarClientSetupOptionOpenApiMapper
+    on openapi.CalendarClientSetupOptionResponse {
+  CalendarClientSetupOption toDomain() {
+    return CalendarClientSetupOption(
+      platform: _requiredString(platform, 'calendar setup platform'),
+      method: _requiredString(method, 'calendar setup method'),
+      available: available == true,
+      actionUrl: _optionalString(actionUrl),
+      unavailableReason: _optionalString(unavailableReason),
+      guidance: notes ?? const [],
+    );
+  }
+}
+
+CalendarExternalEndpoints _missingEndpoints() {
+  throw const AppFailure.unknown(
+    'The Weave backend returned calendar setup data without endpoints.',
+  );
+}
+
+String _requiredString(String? value, String label) {
+  final trimmed = value?.trim();
+  if (trimmed != null && trimmed.isNotEmpty) {
+    return trimmed;
+  }
+  throw AppFailure.unknown('The Weave backend returned $label as empty.');
+}
+
+String? _optionalString(String? value) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}
+
+DateTime _requiredDateTime(String? value, String label) {
+  final parsed = _optionalDateTime(value);
+  if (parsed != null) {
+    return parsed;
+  }
+  throw AppFailure.unknown('The Weave backend returned invalid $label.');
+}
+
+DateTime? _optionalDateTime(String? value) {
+  final trimmed = _optionalString(value);
+  return trimmed == null ? null : DateTime.tryParse(trimmed);
+}
+
+String _fallbackScopeId(String type, String? teamId, String? channelId) {
+  return switch (type) {
+    'team' => teamId == null ? 'team' : 'team:$teamId',
+    'channel' => channelId == null ? 'channel' : 'channel:$channelId',
+    _ => CalendarScope.workspace.id,
+  };
+}
+
+String _fallbackScopeLabel(String type) {
+  return switch (type) {
+    'workspace' => CalendarScope.workspace.label,
+    _ => type,
+  };
+}
+
+String _fallbackContextId(String type, {String? teamId, String? channelId}) {
+  return switch (type) {
+    'team' => 'team-${teamId ?? 'engineering'}',
+    'channel' => 'channel-${channelId ?? 'engineering-general'}',
+    _ => 'workspace-default',
+  };
+}

--- a/client/lib/features/calendar/data/services/calendar_facade_client.dart
+++ b/client/lib/features/calendar/data/services/calendar_facade_client.dart
@@ -4,9 +4,11 @@ import 'package:http/http.dart' as http;
 import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/features/auth/domain/entities/auth_configuration.dart';
 import 'package:weave/features/auth/domain/repositories/auth_session_repository.dart';
+import 'package:weave/features/calendar/data/dtos/calendar_openapi_mappers.dart';
 import 'package:weave/features/calendar/domain/entities/calendar_event.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
+import 'package:weave/generated/openapi_models.dart' as openapi;
 
 /// HTTP client for the Weave backend calendar product facade.
 ///
@@ -36,20 +38,9 @@ class CalendarFacadeClient {
       fallbackMessage: 'Unable to load calendar scopes from the Weave backend.',
     );
     _ensureSuccess(response, successCodes: const {200});
-    final payload = _decodeObject(response.body);
-    final rawScopes = payload['scopes'];
-    if (rawScopes is! List) {
-      throw const AppFailure.unknown(
-        'The Weave backend returned an invalid calendar scopes payload.',
-      );
-    }
-    final scopes = rawScopes
-        .whereType<Map<String, dynamic>>()
-        .map(_decodeScope)
-        .toList(growable: false);
-    return CalendarScopeList(
-      scopes: scopes.isEmpty ? const [CalendarScope.workspace] : scopes,
-    );
+    return openapi.CalendarScopesResponse.fromJson(
+      _decodeObject(response.body),
+    ).toDomain();
   }
 
   Future<CalendarEventList> listEvents({
@@ -80,19 +71,9 @@ class CalendarFacadeClient {
       fallbackMessage: 'Unable to load calendar events from the Weave backend.',
     );
     _ensureSuccess(response, successCodes: const {200});
-    final payload = _decodeObject(response.body);
-    final rawEvents = payload['events'];
-    if (rawEvents is! List) {
-      throw const AppFailure.unknown(
-        'The Weave backend returned an invalid calendar payload.',
-      );
-    }
-    final responseScope = _decodeScope(payload['scope']);
-    final events = rawEvents
-        .whereType<Map<String, dynamic>>()
-        .map((event) => _decodeEvent(event, defaultScope: responseScope))
-        .toList(growable: false);
-    return CalendarEventList(scope: responseScope, events: events);
+    return openapi.CalendarEventsResponse.fromJson(
+      _decodeObject(response.body),
+    ).toDomain();
   }
 
   Future<CalendarClientSetup> clientSetup() async {
@@ -107,36 +88,9 @@ class CalendarFacadeClient {
           'Unable to load calendar setup metadata from the Weave backend.',
     );
     _ensureSuccess(response, successCodes: const {200});
-    final payload = _decodeObject(response.body);
-    final endpoints = _decodeObjectValue(
-      payload['endpoints'],
-      'calendar setup endpoints',
-    );
-    final rawOptions = payload['options'];
-    if (rawOptions is! List) {
-      throw const AppFailure.unknown(
-        'The Weave backend returned calendar setup data without options.',
-      );
-    }
-
-    return CalendarClientSetup(
-      scope: _decodeScope(payload['scope']),
-      username: _readString(payload, 'username'),
-      endpoints: CalendarExternalEndpoints(
-        serverUrl: _readString(endpoints, 'serverUrl'),
-        caldavDiscoveryUrl: _readString(endpoints, 'caldavDiscoveryUrl'),
-        principalUrl: _readString(endpoints, 'principalUrl'),
-      ),
-      credentialPolicy: _readString(payload, 'credentialPolicy'),
-      accessModel: _decodeAccessModel(payload['accessModel']),
-      credentialReadiness: _decodeCredentialReadiness(
-        payload['credentialReadiness'],
-      ),
-      options: rawOptions
-          .whereType<Map<String, dynamic>>()
-          .map(_decodeSetupOption)
-          .toList(growable: false),
-    );
+    return openapi.CalendarClientSetupResponse.fromJson(
+      _decodeObject(response.body),
+    ).toDomain();
   }
 
   Future<CalendarEvent> readEvent(String id) async {
@@ -150,7 +104,9 @@ class CalendarFacadeClient {
       fallbackMessage: 'Unable to read the calendar event.',
     );
     _ensureSuccess(response, successCodes: const {200});
-    return _decodeEvent(_decodeObject(response.body));
+    return openapi.CalendarEventResponse.fromJson(
+      _decodeObject(response.body),
+    ).toDomain();
   }
 
   Future<CalendarEvent> createEvent(CalendarEventDraft draft) async {
@@ -165,7 +121,9 @@ class CalendarFacadeClient {
       fallbackMessage: 'Unable to create the calendar event.',
     );
     _ensureSuccess(response, successCodes: const {200});
-    return _decodeEvent(_decodeObject(response.body));
+    return openapi.CalendarEventResponse.fromJson(
+      _decodeObject(response.body),
+    ).toDomain();
   }
 
   Future<CalendarEvent> updateEvent({
@@ -183,7 +141,9 @@ class CalendarFacadeClient {
       fallbackMessage: 'Unable to update the calendar event.',
     );
     _ensureSuccess(response, successCodes: const {200});
-    return _decodeEvent(_decodeObject(response.body));
+    return openapi.CalendarEventResponse.fromJson(
+      _decodeObject(response.body),
+    ).toDomain();
   }
 
   Future<void> deleteEvent(String id) async {
@@ -319,221 +279,6 @@ class CalendarFacadeClient {
     );
   }
 
-  CalendarEvent _decodeEvent(
-    Map<String, dynamic> json, {
-    CalendarScope defaultScope = CalendarScope.workspace,
-  }) {
-    final eventScope = _decodeScope(json['scope'], defaultScope: defaultScope);
-    return CalendarEvent(
-      id: _readString(json, 'id'),
-      title: _readString(json, 'title'),
-      description: _readNullableString(json, 'description'),
-      startTime: _readDateTime(json, 'startsAt'),
-      endTime: _readDateTime(json, 'endsAt'),
-      timezone: _readNullableString(json, 'timezone'),
-      location: _readNullableString(json, 'location'),
-      allDay: json['allDay'] == true,
-      etag: _readNullableString(json, 'etag'),
-      scope: eventScope,
-      threadRef: _decodeThreadRef(json['threadRef'], defaultScope: eventScope),
-      attendees: _decodeAttendees(json['attendees']),
-      providerRef: _decodeProviderRef(json['providerRef']),
-      updatedAt: _readNullableDateTime(json, 'updatedAt'),
-    );
-  }
-
-  CalendarScope _decodeScope(
-    Object? rawScope, {
-    CalendarScope defaultScope = CalendarScope.workspace,
-  }) {
-    if (rawScope is! Map<String, dynamic>) {
-      return defaultScope;
-    }
-
-    final rawType = rawScope['type'];
-    final type = rawType is String ? rawType.trim() : '';
-    if (type.isEmpty) {
-      return defaultScope;
-    }
-
-    final rawLabel = rawScope['label'];
-    final label = rawLabel is String && rawLabel.trim().isNotEmpty
-        ? rawLabel.trim()
-        : switch (type) {
-            'workspace' => CalendarScope.workspace.label,
-            _ => type,
-          };
-
-    final rawId = rawScope['id'];
-    final rawWorkspaceId = rawScope['workspaceId'];
-    final rawContextId = rawScope['contextId'];
-    final rawTeamId = rawScope['teamId'];
-    final rawChannelId = rawScope['channelId'];
-    final rawAccessModel = rawScope['accessModel'];
-
-    final teamId = rawTeamId is String && rawTeamId.trim().isNotEmpty
-        ? rawTeamId.trim()
-        : null;
-    final channelId = rawChannelId is String && rawChannelId.trim().isNotEmpty
-        ? rawChannelId.trim()
-        : null;
-    final fallbackId = switch (type) {
-      'team' => teamId == null ? 'team' : 'team:$teamId',
-      'channel' => channelId == null ? 'channel' : 'channel:$channelId',
-      _ => defaultScope.id,
-    };
-
-    return CalendarScope(
-      id: rawId is String && rawId.trim().isNotEmpty
-          ? rawId.trim()
-          : fallbackId,
-      type: type,
-      label: label,
-      workspaceId: rawWorkspaceId is String && rawWorkspaceId.trim().isNotEmpty
-          ? rawWorkspaceId.trim()
-          : defaultScope.workspaceId,
-      contextId: rawContextId is String && rawContextId.trim().isNotEmpty
-          ? rawContextId.trim()
-          : _defaultContextId(type, teamId: teamId, channelId: channelId),
-      teamId: teamId,
-      channelId: channelId,
-      accessModel: rawAccessModel is String && rawAccessModel.trim().isNotEmpty
-          ? rawAccessModel.trim()
-          : defaultScope.accessModel,
-      capabilities: _readStringList(rawScope['capabilities']),
-    );
-  }
-
-  CalendarThreadRef _decodeThreadRef(
-    Object? rawThreadRef, {
-    required CalendarScope defaultScope,
-  }) {
-    if (rawThreadRef is! Map<String, dynamic>) {
-      return CalendarThreadRef.forScope(defaultScope);
-    }
-
-    final rawContextId = rawThreadRef['contextId'];
-    final contextId = rawContextId is String && rawContextId.trim().isNotEmpty
-        ? rawContextId.trim()
-        : defaultScope.contextId;
-    final rawKind = rawThreadRef['kind'];
-
-    return CalendarThreadRef(
-      kind: rawKind is String && rawKind.trim().isNotEmpty
-          ? rawKind.trim()
-          : 'context',
-      contextId: contextId,
-      meetingThreadId: _readNullableString(rawThreadRef, 'meetingThreadId'),
-      channelId: _readNullableString(rawThreadRef, 'channelId'),
-      matrixRoomId: _readNullableString(rawThreadRef, 'matrixRoomId'),
-      matrixThreadId: _readNullableString(rawThreadRef, 'matrixThreadId'),
-      boardTaskIds: _readStringList(rawThreadRef['boardTaskIds']),
-    );
-  }
-
-  List<CalendarAttendee> _decodeAttendees(Object? rawAttendees) {
-    if (rawAttendees is! List) {
-      return const [];
-    }
-
-    return rawAttendees
-        .whereType<Map<String, dynamic>>()
-        .map((attendee) {
-          return CalendarAttendee(
-            name: _readNullableString(attendee, 'name'),
-            email: _readNullableString(attendee, 'email'),
-            role: _readNullableString(attendee, 'role'),
-            responseStatus: _readNullableString(attendee, 'responseStatus'),
-          );
-        })
-        .toList(growable: false);
-  }
-
-  CalendarProviderRef? _decodeProviderRef(Object? rawProviderRef) {
-    if (rawProviderRef is! Map<String, dynamic>) {
-      return null;
-    }
-
-    return CalendarProviderRef(
-      provider: _readString(rawProviderRef, 'provider'),
-      objectKind: _readString(rawProviderRef, 'objectKind'),
-      opaqueId: _readNullableString(rawProviderRef, 'opaqueId'),
-      etag: _readNullableString(rawProviderRef, 'etag'),
-      lastSyncedAt: _readNullableDateTime(rawProviderRef, 'lastSyncedAt'),
-      rawProviderPathExposed: rawProviderRef['rawProviderPathExposed'] == true,
-    );
-  }
-
-  String _defaultContextId(String type, {String? teamId, String? channelId}) {
-    return switch (type) {
-      'team' => 'team-${teamId ?? 'engineering'}',
-      'channel' => 'channel-${channelId ?? 'engineering-general'}',
-      _ => 'workspace-default',
-    };
-  }
-
-  CalendarAccessModel _decodeAccessModel(Object? rawAccessModel) {
-    if (rawAccessModel is! Map<String, dynamic>) {
-      return CalendarAccessModel.workspaceBlockedPrivateCalendars;
-    }
-
-    return CalendarAccessModel(
-      type: _readString(rawAccessModel, 'type'),
-      productScope: _readString(rawAccessModel, 'productScope'),
-      privateUserCalendarsAvailable:
-          rawAccessModel['privateUserCalendarsAvailable'] == true,
-      privateUserCalendarsReason: _readString(
-        rawAccessModel,
-        'privateUserCalendarsReason',
-      ),
-      externalClientCredentialModel: _readString(
-        rawAccessModel,
-        'externalClientCredentialModel',
-      ),
-      notes: _readStringList(rawAccessModel['notes']),
-    );
-  }
-
-  CalendarCredentialReadiness _decodeCredentialReadiness(
-    Object? rawCredentialReadiness,
-  ) {
-    if (rawCredentialReadiness is! Map<String, dynamic>) {
-      return CalendarCredentialReadiness.blockedUntilRevocableCredentials;
-    }
-
-    return CalendarCredentialReadiness(
-      status: _readString(rawCredentialReadiness, 'status'),
-      appleProfileSigned: rawCredentialReadiness['appleProfileSigned'] == true,
-      appleProfilePasswordIncluded:
-          rawCredentialReadiness['appleProfilePasswordIncluded'] == true,
-      revocableCredentialsAvailable:
-          rawCredentialReadiness['revocableCredentialsAvailable'] == true,
-      readOnlySubscriptionTokensAvailable:
-          rawCredentialReadiness['readOnlySubscriptionTokensAvailable'] == true,
-      backendActorCredentialsExposed:
-          rawCredentialReadiness['backendActorCredentialsExposed'] == true,
-      blockers: _readStringList(rawCredentialReadiness['blockers']),
-    );
-  }
-
-  CalendarClientSetupOption _decodeSetupOption(Map<String, dynamic> json) {
-    final rawGuidance = json['guidance'];
-    return CalendarClientSetupOption(
-      platform: _readString(json, 'platform'),
-      method: _readString(json, 'method'),
-      available: json['available'] == true,
-      actionUrl: _readNullableString(json, 'actionUrl'),
-      unavailableReason: _readNullableString(json, 'unavailableReason'),
-      guidance: _readStringList(rawGuidance),
-    );
-  }
-
-  List<String> _readStringList(Object? value) {
-    return value is List
-        ? value.whereType<String>().toList(growable: false)
-        : const [];
-  }
-
   Map<String, dynamic> _decodeObject(String body) {
     try {
       final payload = jsonDecode(body);
@@ -548,63 +293,17 @@ class CalendarFacadeClient {
     );
   }
 
-  Map<String, dynamic> _decodeObjectValue(Object? value, String label) {
-    if (value is Map<String, dynamic>) {
-      return value;
-    }
-    throw AppFailure.unknown('The Weave backend returned invalid $label.');
-  }
-
   String? _errorMessage(String body) {
     try {
-      final payload = jsonDecode(body);
-      if (payload is Map<String, dynamic>) {
-        final message = payload['message'];
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        final message = decoded['message'];
         if (message is String && message.trim().isNotEmpty) {
           return message;
         }
       }
     } catch (_) {
       return null;
-    }
-    return null;
-  }
-
-  String _readString(Map<String, dynamic> json, String key) {
-    final value = json[key];
-    if (value is String && value.trim().isNotEmpty) {
-      return value;
-    }
-    throw AppFailure.unknown(
-      'The Weave backend returned a calendar event without $key.',
-    );
-  }
-
-  String? _readNullableString(Map<String, dynamic> json, String key) {
-    final value = json[key];
-    if (value is String && value.trim().isNotEmpty) {
-      return value;
-    }
-    return null;
-  }
-
-  DateTime _readDateTime(Map<String, dynamic> json, String key) {
-    final value = json[key];
-    if (value is String) {
-      final parsed = DateTime.tryParse(value);
-      if (parsed != null) {
-        return parsed;
-      }
-    }
-    throw AppFailure.unknown(
-      'The Weave backend returned a calendar event without a valid $key.',
-    );
-  }
-
-  DateTime? _readNullableDateTime(Map<String, dynamic> json, String key) {
-    final value = json[key];
-    if (value is String && value.trim().isNotEmpty) {
-      return DateTime.tryParse(value);
     }
     return null;
   }

--- a/client/test/architecture/openapi_drift_prevention_contract_test.dart
+++ b/client/test/architecture/openapi_drift_prevention_contract_test.dart
@@ -176,21 +176,6 @@ const _legacyResponseDtoAllowlist = <LegacyFence>[
 
 const _rawJsonMemberFacadeAllowlist = <LegacyFence>[
   LegacyFence(
-    path: 'lib/features/calendar/data/services/calendar_facade_client.dart',
-    issue: '#903',
-    reason:
-        'Calendar still parses raw facade JSON until the Calendar OpenAPI adapter '
-        'slice replaces it with generated Calendar*Response models.',
-  ),
-  LegacyFence(
-    path:
-        'lib/features/boards/data/repositories/backend_boards_workspace_repository.dart',
-    issue: '#903',
-    reason:
-        'Boards still parses raw facade JSON until the Boards OpenAPI adapter '
-        'slice replaces it with generated Boards*Response models.',
-  ),
-  LegacyFence(
     path: 'lib/features/files/data/repositories/backend_files_repository.dart',
     issue: '#908',
     reason:


### PR DESCRIPTION
## Summary
- Closes #903 as part of #902.
- Routes Calendar facade responses through generated OpenAPI DTOs and feature mappers before domain entities.
- Routes Boards workspace responses through generated OpenAPI DTOs and feature mappers before domain entities.
- Removes the Calendar/Boards raw JSON drift allowlist so the architecture gate now enforces the generated DTO -> mapper -> domain pattern.

## Evidence
- PATH="/Users/flotterotter/flutter/bin/cache/dart-sdk/bin:/Users/flotterotter/flutter/bin:$PATH" ./gradlew checkClientOpenApiModelsFresh clientCi acceptanceContract --console=plain --no-daemon --max-workers=1
- git diff --check origin/dev...HEAD

## Review
- Copilot unavailable; using internal architecture/contract and client QA review gates before merge.