### PR TITLE
feat(server): harden member state and error contracts

### DIFF
--- a/admin-console/src/generated/openapi.ts
+++ b/admin-console/src/generated/openapi.ts
@@ -77,7 +77,7 @@ export type GeneratedChatProviderMappingRecord = {
   "downstreamErrorsReturned"?: boolean;
   "failClosed"?: boolean;
   "lossyMappingWarnings"?: string[];
-  "readinessState"?: "degraded" | "disabled" | "misconfigured" | "policy_blocked" | "ready" | "unavailable";
+  "readinessState"?: "available" | "coming_later" | "degraded" | "disabled_by_policy" | "not_configured" | "unavailable";
   "secretsReturned"?: boolean;
   "selectedByAdmin"?: boolean;
   "selectedProviderKey"?: string;
@@ -120,7 +120,7 @@ export type GeneratedChatReadiness = {
   "failClosed"?: boolean;
   "memberClientMayConfigureProvider"?: boolean;
   "memberImpact"?: string;
-  "memberState"?: "degraded" | "disabled" | "misconfigured" | "policy_blocked" | "ready" | "unavailable";
+  "memberState"?: "available" | "coming_later" | "degraded" | "disabled_by_policy" | "not_configured" | "unavailable";
   "migrationDryRunRequired"?: boolean;
   "providerMapping"?: GeneratedChatProviderMappingRecord;
   "supportSafe"?: boolean;
@@ -130,7 +130,7 @@ export type GeneratedChatReadiness = {
 export type GeneratedChatReadinessResponse = {
   "diagnosticsRedacted": boolean;
   "grantedCapabilities": string[];
-  "impactState": "degraded" | "disabled" | "policy-blocked" | "usable";
+  "impactState": "available" | "coming_later" | "degraded" | "disabled_by_policy" | "not_configured" | "unavailable";
   "memberImpact": string;
 };
 

--- a/client/lib/features/app/domain/entities/provider_stack_snapshot.dart
+++ b/client/lib/features/app/domain/entities/provider_stack_snapshot.dart
@@ -168,10 +168,12 @@ class ProviderCategoryContractSnapshot {
 
   bool get keepsMemberSemanticsStable =>
       !normalMembersConfigureProviders &&
-      stableMemberImpactStates.contains('usable') &&
-      stableMemberImpactStates.contains('disabled') &&
+      stableMemberImpactStates.contains('available') &&
+      stableMemberImpactStates.contains('disabled_by_policy') &&
+      stableMemberImpactStates.contains('not_configured') &&
       stableMemberImpactStates.contains('degraded') &&
-      stableMemberImpactStates.contains('policy-blocked');
+      stableMemberImpactStates.contains('unavailable') &&
+      stableMemberImpactStates.contains('coming_later');
 }
 
 class ProviderChoiceModelSnapshot {

--- a/client/lib/generated/openapi_models.dart
+++ b/client/lib/generated/openapi_models.dart
@@ -262,31 +262,39 @@ class AdminControlPlaneResponse {
 
 class ApiErrorResponse {
   const ApiErrorResponse({
-    this.code,
-    this.details,
-    this.message,
-    this.requestId,
+    required this.code,
+    required this.details,
+    this.memberImpact,
+    required this.message,
+    required this.requestId,
+    required this.supportRef,
   });
 
   factory ApiErrorResponse.fromJson(Map<String, dynamic> json) =>
       ApiErrorResponse(
-        code: json["code"] as String?,
-        details: (json["details"] as Map<String, dynamic>?)
-            ?.cast<String, Object?>(),
-        message: json["message"] as String?,
-        requestId: json["requestId"] as String?,
+        code: json["code"] as String,
+        details: (json["details"] as Map<String, dynamic>)
+            .cast<String, Object?>(),
+        memberImpact: json["memberImpact"] as String?,
+        message: json["message"] as String,
+        requestId: json["requestId"] as String,
+        supportRef: json["supportRef"] as String,
       );
 
-  final String? code;
-  final Map<String, Object?>? details;
-  final String? message;
-  final String? requestId;
+  final String code;
+  final Map<String, Object?> details;
+  final String? memberImpact;
+  final String message;
+  final String requestId;
+  final String supportRef;
 
   Map<String, dynamic> toJson() => {
     "code": _openApiJsonValue(code),
     "details": _openApiJsonValue(details),
+    "memberImpact": _openApiJsonValue(memberImpact),
     "message": _openApiJsonValue(message),
     "requestId": _openApiJsonValue(requestId),
+    "supportRef": _openApiJsonValue(supportRef),
   };
 }
 

--- a/client/lib/integrations/weave_api/data/dtos/provider_stack_openapi_mappers.dart
+++ b/client/lib/integrations/weave_api/data/dtos/provider_stack_openapi_mappers.dart
@@ -371,13 +371,39 @@ extension OfficeLaunchOpenApiMapper on openapi.OfficeLaunchResponse {
   );
 }
 
-OfficeLaunchSnapshot officeLaunchFailClosedSnapshot(Map<String, dynamic> json) {
-  final error = openapi.ApiErrorResponse.fromJson(json);
+OfficeLaunchSnapshot officeLaunchFailClosedSnapshot(
+  Map<String, dynamic> errorEnvelope,
+) {
+  final fallbackRequestId = _nullableString(errorEnvelope['requestId']) ?? '';
+  final error = openapi.ApiErrorResponse.fromJson({
+    'code': _string(
+      errorEnvelope['code'],
+      fallback: 'office-launch-fail-closed',
+    ),
+    'details': errorEnvelope['details'] is Map<String, dynamic>
+        ? errorEnvelope['details']
+        : <String, Object?>{},
+    'memberImpact': errorEnvelope['memberImpact'],
+    'message': _string(
+      errorEnvelope['message'],
+      fallback: 'office-launch-fail-closed',
+    ),
+    'requestId': fallbackRequestId,
+    'supportRef': _string(
+      errorEnvelope['supportRef'],
+      fallback: _supportRef(fallbackRequestId),
+    ),
+  });
   return OfficeLaunchSnapshot.failClosed(
     errorCode: _string(error.code, fallback: 'office-launch-fail-closed'),
     message: _safeText(error.message),
     requestId: _nullableString(error.requestId),
   );
+}
+
+String _supportRef(String requestId) {
+  final value = requestId.isEmpty ? 'office-launch-fail-closed' : requestId;
+  return ['support', value].join(':');
 }
 
 ProviderCategoryReadiness _providerCategoryReadiness(String value) {

--- a/client/lib/integrations/weave_api/domain/entities/openapi_feature_adapter.dart
+++ b/client/lib/integrations/weave_api/domain/entities/openapi_feature_adapter.dart
@@ -12,17 +12,10 @@ enum OpenApiFeatureCapabilityState {
   static OpenApiFeatureCapabilityState fromApi(String? value) {
     switch (value) {
       case 'available':
-      case 'usable':
-      case 'ready':
         return OpenApiFeatureCapabilityState.available;
-      case 'disabled':
-        return OpenApiFeatureCapabilityState.disabled;
       case 'disabled_by_policy':
-      case 'policy_blocked':
-      case 'policy-blocked':
         return OpenApiFeatureCapabilityState.disabledByPolicy;
       case 'not_configured':
-      case 'misconfigured':
         return OpenApiFeatureCapabilityState.notConfigured;
       case 'degraded':
         return OpenApiFeatureCapabilityState.degraded;
@@ -30,8 +23,6 @@ enum OpenApiFeatureCapabilityState {
         return OpenApiFeatureCapabilityState.unavailable;
       case 'coming_later':
         return OpenApiFeatureCapabilityState.comingLater;
-      case 'unsupported':
-        return OpenApiFeatureCapabilityState.unsupported;
       default:
         return OpenApiFeatureCapabilityState.unknown;
     }

--- a/client/test/features/chat/data/repositories/backend_chat_repository_test.dart
+++ b/client/test/features/chat/data/repositories/backend_chat_repository_test.dart
@@ -139,7 +139,7 @@ void main() {
             },
           ],
           'readiness': {
-            'impactState': 'usable',
+            'impactState': 'available',
             'memberImpact': 'Weave Chat is available.',
             'diagnosticsRedacted': true,
             'grantedCapabilities': ['chat.message.read'],
@@ -193,7 +193,7 @@ void main() {
           jsonEncode({
             'conversationId': 'chat:recent',
             'readiness': {
-              'impactState': 'usable',
+              'impactState': 'available',
               'memberImpact': 'Weave Chat is available.',
               'diagnosticsRedacted': true,
               'grantedCapabilities': ['chat.message.read'],
@@ -231,7 +231,7 @@ void main() {
       (_) async => http.Response(
         jsonEncode({
           'domain': 'chat',
-          'memberState': 'misconfigured',
+          'memberState': 'not_configured',
           'memberImpact': 'Ask an admin to finish Chat setup.',
           'supportSafe': true,
           'downstreamDiagnosticsExposedToMember': false,
@@ -255,34 +255,46 @@ void main() {
   test('maps server Chat readiness states into adapter states', () {
     expect(
       const openapi.ChatReadiness(
-        memberState: 'ready',
+        memberState: 'available',
         memberImpact: 'Ready.',
       ).toFeatureReadiness().state,
       OpenApiFeatureCapabilityState.available,
     );
     expect(
       const openapi.ChatReadiness(
-        memberState: 'misconfigured',
+        memberState: 'not_configured',
         memberImpact: 'Ask an admin to finish Chat setup.',
       ).toFeatureReadiness().state,
       OpenApiFeatureCapabilityState.notConfigured,
     );
     expect(
       const openapi.ChatReadiness(
-        memberState: 'disabled',
+        memberState: 'disabled_by_policy',
         memberImpact: 'Chat is disabled.',
       ).toFeatureReadiness().state,
-      OpenApiFeatureCapabilityState.disabled,
+      OpenApiFeatureCapabilityState.disabledByPolicy,
     );
     expect(
       const openapi.ChatReadinessResponse(
-        impactState: 'policy-blocked',
+        impactState: 'disabled_by_policy',
         memberImpact: 'Chat is blocked by policy.',
         grantedCapabilities: <String>[],
         diagnosticsRedacted: true,
       ).toFeatureReadiness().state,
       OpenApiFeatureCapabilityState.disabledByPolicy,
     );
+    for (final legacyAlias in <String>[
+      'ready',
+      'usable',
+      'policy_blocked',
+      'policy-blocked',
+      'misconfigured',
+    ]) {
+      expect(
+        OpenApiFeatureCapabilityState.fromApi(legacyAlias),
+        OpenApiFeatureCapabilityState.unknown,
+      );
+    }
   });
 
   test('fails closed when generated Chat payload misses required fields', () {
@@ -293,7 +305,7 @@ void main() {
           'releaseStatus': 'canonical-domain-facade',
           'source': 'weave-backend',
           'readiness': {
-            'impactState': 'usable',
+            'impactState': 'available',
             'memberImpact': 'Weave Chat is available.',
             'diagnosticsRedacted': true,
             'grantedCapabilities': ['chat.message.read'],

--- a/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
+++ b/client/test/integrations/weave_api/data/services/weave_api_client_test.dart
@@ -558,10 +558,12 @@ void main() {
                     ],
                     'adapterModules': ['identity-realm', 'matrix-auth'],
                     'stableMemberImpactStates': [
-                      'usable',
-                      'disabled',
+                      'available',
+                      'disabled_by_policy',
+                      'not_configured',
                       'degraded',
-                      'policy-blocked',
+                      'unavailable',
+                      'coming_later',
                     ],
                     'adminSelectable': true,
                     'normalMembersConfigureProviders': false,
@@ -625,10 +627,12 @@ void main() {
                     ],
                     'adapterModules': [],
                     'stableMemberImpactStates': [
-                      'usable',
-                      'disabled',
+                      'available',
+                      'disabled_by_policy',
+                      'not_configured',
                       'degraded',
-                      'policy-blocked',
+                      'unavailable',
+                      'coming_later',
                     ],
                     'adminSelectable': true,
                     'normalMembersConfigureProviders': false,
@@ -1002,7 +1006,9 @@ void main() {
             'code': 'office-provider-not-configured',
             'message':
                 'Office launch is fail-closed until the backend provider is configured.',
+            'details': <String, Object?>{},
             'requestId': 'request-123',
+            'supportRef': 'support:request-123',
           }, statusCode: 503);
         }),
       );

--- a/contracts/openapi/weave-openapi.json
+++ b/contracts/openapi/weave-openapi.json
@@ -198,8 +198,13 @@
             "description": "Non-secret diagnostic details for this failure.",
             "type": "object"
           },
+          "memberImpact": {
+            "description": "Optional member-facing impact state or recovery hint owned by the backend facade.",
+            "example": "unavailable",
+            "type": "string"
+          },
           "message": {
-            "description": "Operator-facing explanation of what failed.",
+            "description": "Support-safe explanation of what failed.",
             "example": "Bearer authentication is required to access this endpoint.",
             "type": "string"
           },
@@ -207,8 +212,20 @@
             "description": "Correlation identifier for support and log lookup.",
             "example": "8c2f4d7a-4d5f-4f88-92e8-4fcbb81dd527",
             "type": "string"
+          },
+          "supportRef": {
+            "description": "Stable reference members can share with support without provider payloads.",
+            "example": "support:8c2f4d7a-4d5f-4f88-92e8-4fcbb81dd527",
+            "type": "string"
           }
         },
+        "required": [
+          "code",
+          "details",
+          "message",
+          "requestId",
+          "supportRef"
+        ],
         "type": "object"
       },
       "ApprovalReceipt": {
@@ -1766,11 +1783,11 @@
           "readinessState": {
             "description": "Stable product-level Chat state returned to member clients.",
             "enum": [
+              "available",
+              "coming_later",
               "degraded",
-              "disabled",
-              "misconfigured",
-              "policy_blocked",
-              "ready",
+              "disabled_by_policy",
+              "not_configured",
               "unavailable"
             ],
             "type": "string"
@@ -1954,11 +1971,11 @@
           "memberState": {
             "description": "Stable product-level Chat state returned to member clients.",
             "enum": [
+              "available",
+              "coming_later",
               "degraded",
-              "disabled",
-              "misconfigured",
-              "policy_blocked",
-              "ready",
+              "disabled_by_policy",
+              "not_configured",
               "unavailable"
             ],
             "type": "string"
@@ -2000,12 +2017,14 @@
           "impactState": {
             "description": "Stable member impact state.",
             "enum": [
+              "available",
+              "coming_later",
               "degraded",
-              "disabled",
-              "policy-blocked",
-              "usable"
+              "disabled_by_policy",
+              "not_configured",
+              "unavailable"
             ],
-            "example": "usable",
+            "example": "available",
             "type": "string"
           },
           "memberImpact": {

--- a/server/src/main/java/com/massimotter/weave/backend/chat/ChatDomainFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/chat/ChatDomainFacadeService.java
@@ -215,7 +215,7 @@ public class ChatDomainFacadeService {
             return ChatMemberState.POLICY_BLOCKED;
         }
         if (policyState == WorkspaceCapabilityPolicyState.DISABLED || !capabilityEnabled) {
-            return ChatMemberState.DISABLED;
+            return ChatMemberState.POLICY_BLOCKED;
         }
         if (maybeSelection.isEmpty()) {
             return ChatMemberState.MISCONFIGURED;
@@ -225,7 +225,7 @@ public class ChatDomainFacadeService {
         }
         ProviderStatusResponse provider = maybeProvider.get();
         if (!provider.enabled() || provider.state() == ProviderState.DISABLED) {
-            return ChatMemberState.DISABLED;
+            return ChatMemberState.POLICY_BLOCKED;
         }
         if (!provider.configured() || provider.state() == ProviderState.NOT_CONFIGURED) {
             return ChatMemberState.MISCONFIGURED;
@@ -321,11 +321,11 @@ public class ChatDomainFacadeService {
     private String memberImpact(ChatMemberState state, String capabilityImpact) {
         return switch (state) {
             case READY -> "Chat is available through the Weave workspace.";
-            case DISABLED -> "Chat is disabled by workspace policy.";
             case DEGRADED -> "Chat is degraded. You can keep working where available; ask an admin to review Workspace Health.";
             case POLICY_BLOCKED -> "Chat is blocked by your role or group policy. Ask an admin if you need access.";
             case UNAVAILABLE -> "Chat is unavailable for this workspace right now.";
             case MISCONFIGURED -> "Chat is not ready for members in this workspace. Ask an admin to review Workspace Health.";
+            case COMING_LATER -> "Chat is not enabled for this workspace yet.";
         };
     }
 

--- a/server/src/main/java/com/massimotter/weave/backend/chat/domain/ChatMemberState.java
+++ b/server/src/main/java/com/massimotter/weave/backend/chat/domain/ChatMemberState.java
@@ -5,12 +5,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Stable product-level Chat state returned to member clients.")
 public enum ChatMemberState {
-    READY("ready"),
-    DISABLED("disabled"),
+    READY("available"),
     DEGRADED("degraded"),
-    POLICY_BLOCKED("policy_blocked"),
+    POLICY_BLOCKED("disabled_by_policy"),
     UNAVAILABLE("unavailable"),
-    MISCONFIGURED("misconfigured");
+    MISCONFIGURED("not_configured"),
+    COMING_LATER("coming_later");
 
     private final String value;
 

--- a/server/src/main/java/com/massimotter/weave/backend/config/ApiErrorResponseWriter.java
+++ b/server/src/main/java/com/massimotter/weave/backend/config/ApiErrorResponseWriter.java
@@ -46,15 +46,37 @@ public class ApiErrorResponseWriter {
         if (additionalDetails != null) {
             details.putAll(additionalDetails);
         }
+        String supportRef = supportSafeText(details.get("supportRef"), "support:" + requestId);
+        String memberImpact = supportSafeText(details.get("memberImpact"), null);
         objectMapper.writeValue(response.getWriter(), new ApiErrorResponse(
                 code,
                 message,
                 details,
-                requestId));
+                requestId,
+                supportRef,
+                memberImpact));
     }
 
     private String defaultCode(HttpStatus status) {
         return status.name().toLowerCase().replace('_', '-');
+    }
+
+    private String supportSafeText(Object value, String fallback) {
+        if (!(value instanceof String text) || text.isBlank()) {
+            return fallback;
+        }
+        String trimmed = text.trim();
+        String lower = trimmed.toLowerCase();
+        if (lower.contains("authorization:")
+                || lower.contains("bearer ")
+                || lower.contains("password")
+                || lower.contains("secret")
+                || lower.contains("token")
+                || lower.contains("http://")
+                || lower.contains("https://")) {
+            return fallback;
+        }
+        return trimmed;
     }
 
 }

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeSupport.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalDomainFacadeSupport.java
@@ -51,7 +51,7 @@ public final class CanonicalDomainFacadeSupport {
         WorkspaceCapabilitiesResponse capabilities = workspaceCapabilityService.snapshot(jwt);
         WorkspaceCapabilityStatusResponse primaryCapability = definition.primaryCapability(capabilities);
         CanonicalMemberState policyState = policyState(primaryCapability);
-        if (policyState == CanonicalMemberState.POLICY_BLOCKED || policyState == CanonicalMemberState.DISABLED) {
+        if (policyState == CanonicalMemberState.POLICY_BLOCKED) {
             return readinessWithoutProviderLookup(primaryCapability, policyState, includeAdminDiagnostics);
         }
 
@@ -166,7 +166,7 @@ public final class CanonicalDomainFacadeSupport {
             return CanonicalMemberState.POLICY_BLOCKED;
         }
         if (capability.policyState() == WorkspaceCapabilityPolicyState.DISABLED || !capability.enabled()) {
-            return CanonicalMemberState.DISABLED;
+            return CanonicalMemberState.POLICY_BLOCKED;
         }
         return CanonicalMemberState.READY;
     }
@@ -179,7 +179,7 @@ public final class CanonicalDomainFacadeSupport {
             return CanonicalMemberState.POLICY_BLOCKED;
         }
         if (primaryCapability.policyState() == WorkspaceCapabilityPolicyState.DISABLED || !primaryCapability.enabled()) {
-            return CanonicalMemberState.DISABLED;
+            return CanonicalMemberState.POLICY_BLOCKED;
         }
         if (maybeSelection.isEmpty()) {
             return CanonicalMemberState.MISCONFIGURED;
@@ -189,7 +189,7 @@ public final class CanonicalDomainFacadeSupport {
         }
         ProviderStatusResponse provider = maybeProvider.get();
         if (!provider.enabled() || provider.state() == ProviderState.DISABLED) {
-            return CanonicalMemberState.DISABLED;
+            return CanonicalMemberState.POLICY_BLOCKED;
         }
         if (!provider.configured() || provider.state() == ProviderState.NOT_CONFIGURED) {
             return CanonicalMemberState.MISCONFIGURED;
@@ -307,7 +307,6 @@ public final class CanonicalDomainFacadeSupport {
             case READY -> capabilityImpact == null || capabilityImpact.isBlank()
                     ? definition.label() + " are available through Weave."
                     : capabilityImpact;
-            case DISABLED -> definition.label() + " are disabled by workspace policy.";
             case DEGRADED -> definition.label() + " are degraded. Ask an admin to review Workspace Health.";
             case POLICY_BLOCKED -> definition.label() + " are blocked by your role or group policy. Ask an admin if you need access.";
             case UNAVAILABLE -> definition.label() + " are unavailable for this workspace right now.";
@@ -330,7 +329,6 @@ public final class CanonicalDomainFacadeSupport {
         return switch (state) {
             case READY -> 0;
             case DEGRADED -> 1;
-            case DISABLED -> 2;
             case MISCONFIGURED -> 3;
             case UNAVAILABLE -> 4;
             case POLICY_BLOCKED -> 5;

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalMemberState.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/CanonicalMemberState.java
@@ -5,13 +5,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Stable member-visible state for canonical Weave domain facades.")
 public enum CanonicalMemberState {
-    READY("ready"),
-    DISABLED("disabled"),
+    READY("available"),
     DEGRADED("degraded"),
-    POLICY_BLOCKED("policy_blocked"),
+    POLICY_BLOCKED("disabled_by_policy"),
     UNAVAILABLE("unavailable"),
-    MISCONFIGURED("misconfigured"),
-    UNSUPPORTED("unsupported");
+    MISCONFIGURED("not_configured"),
+    UNSUPPORTED("coming_later");
 
     private final String value;
 

--- a/server/src/main/java/com/massimotter/weave/backend/domainfacade/NonChatDomainFacadeOperationGuard.java
+++ b/server/src/main/java/com/massimotter/weave/backend/domainfacade/NonChatDomainFacadeOperationGuard.java
@@ -114,7 +114,7 @@ public final class NonChatDomainFacadeOperationGuard {
             case MISCONFIGURED -> SupportSafeFacadeError.NOT_CONFIGURED;
             case DEGRADED -> SupportSafeFacadeError.DEGRADED;
             case POLICY_BLOCKED -> SupportSafeFacadeError.POLICY_BLOCKED;
-            case UNAVAILABLE, DISABLED -> SupportSafeFacadeError.UNAVAILABLE;
+            case UNAVAILABLE -> SupportSafeFacadeError.UNAVAILABLE;
             case UNSUPPORTED -> SupportSafeFacadeError.UNSUPPORTED;
             case READY -> SupportSafeFacadeError.PROVIDER_FAILURE;
         };

--- a/server/src/main/java/com/massimotter/weave/backend/model/ApiErrorResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/ApiErrorResponse.java
@@ -5,12 +5,16 @@ import java.util.Map;
 
 @Schema(description = "Stable JSON error envelope returned by protected API endpoints.")
 public record ApiErrorResponse(
-        @Schema(description = "Stable machine-readable error code.", example = "unauthorized")
+        @Schema(description = "Stable machine-readable error code.", example = "unauthorized", requiredMode = Schema.RequiredMode.REQUIRED)
         String code,
-        @Schema(description = "Operator-facing explanation of what failed.", example = "Bearer authentication is required to access this endpoint.")
+        @Schema(description = "Support-safe explanation of what failed.", example = "Bearer authentication is required to access this endpoint.", requiredMode = Schema.RequiredMode.REQUIRED)
         String message,
-        @Schema(description = "Non-secret diagnostic details for this failure.")
+        @Schema(description = "Non-secret diagnostic details for this failure.", requiredMode = Schema.RequiredMode.REQUIRED)
         Map<String, Object> details,
-        @Schema(description = "Correlation identifier for support and log lookup.", example = "8c2f4d7a-4d5f-4f88-92e8-4fcbb81dd527")
-        String requestId) {
+        @Schema(description = "Correlation identifier for support and log lookup.", example = "8c2f4d7a-4d5f-4f88-92e8-4fcbb81dd527", requiredMode = Schema.RequiredMode.REQUIRED)
+        String requestId,
+        @Schema(description = "Stable reference members can share with support without provider payloads.", example = "support:8c2f4d7a-4d5f-4f88-92e8-4fcbb81dd527", requiredMode = Schema.RequiredMode.REQUIRED)
+        String supportRef,
+        @Schema(description = "Optional member-facing impact state or recovery hint owned by the backend facade.", example = "unavailable")
+        String memberImpact) {
 }

--- a/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatReadinessResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/chat/ChatReadinessResponse.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Schema(description = "Member-safe Weave Chat readiness and policy state.")
 public record ChatReadinessResponse(
-        @Schema(description = "Stable member impact state.", allowableValues = {"usable", "disabled", "degraded", "policy-blocked"}, example = "usable",
+        @Schema(description = "Stable member impact state.", allowableValues = {"available", "disabled_by_policy", "not_configured", "degraded", "unavailable", "coming_later"}, example = "available",
                 requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank
         String impactState,

--- a/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
+++ b/server/src/main/java/com/massimotter/weave/backend/provider/ProviderCapabilityContracts.java
@@ -7,10 +7,12 @@ import java.util.Set;
 public final class ProviderCapabilityContracts {
 
     private static final List<String> STABLE_MEMBER_IMPACT_STATES = List.of(
-            "usable",
-            "disabled",
+            "available",
+            "disabled_by_policy",
+            "not_configured",
             "degraded",
-            "policy-blocked");
+            "unavailable",
+            "coming_later");
 
     private static final Map<String, Definition> DEFINITIONS = Map.ofEntries(
             Map.entry("identity-idm", new Definition(

--- a/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/AdminControlPlaneService.java
@@ -87,10 +87,12 @@ import static com.massimotter.weave.backend.model.IdentityKeyFormat.PRIMARY_IDEN
 public class AdminControlPlaneService {
 
     private static final List<String> STABLE_MEMBER_IMPACT_STATES = List.of(
-            "ready",
-            "disabled",
+            "available",
+            "disabled_by_policy",
+            "not_configured",
             "degraded",
-            "policy-blocked");
+            "unavailable",
+            "coming_later");
     private static final Set<String> SIMULATION_ROLES = Set.of("owner", "admin", "operator", "member", "guest");
     private static final Set<String> SIMULATION_GROUPS = Set.of(
             "weave-calendar-editors",

--- a/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/ChatFacadeService.java
@@ -185,14 +185,14 @@ public class ChatFacadeService {
         WorkspaceCapabilityProperties.Capability chat = workspaceCapabilityProperties.chat();
         if (!chat.enabled()) {
             return new ChatReadinessResponse(
-                    "disabled",
+                    "disabled_by_policy",
                     "Chat is disabled by workspace policy.",
                     granted,
                     true);
         }
         if (jwt != null && !granted.contains("chat.read")) {
             return new ChatReadinessResponse(
-                    "policy-blocked",
+                    "disabled_by_policy",
                     "Chat is blocked by your role or group policy. Ask an admin if you need access.",
                     granted,
                     true);
@@ -200,14 +200,14 @@ public class ChatFacadeService {
         WorkspaceCapabilityReadiness configured = chat.readiness();
         if (configured == WorkspaceCapabilityReadiness.READY || (configured == null && hasText(chat.dependencyUrl()))) {
             return new ChatReadinessResponse(
-                    "usable",
+                    "available",
                     "Weave Chat is available through the workspace Chat domain.",
                     granted,
                     true);
         }
         if (configured == WorkspaceCapabilityReadiness.UNAVAILABLE) {
             return new ChatReadinessResponse(
-                    "disabled",
+                    "unavailable",
                     "Chat is not available in this workspace. Ask an admin to review Workspace Health.",
                     granted,
                     true);
@@ -603,13 +603,13 @@ public class ChatFacadeService {
         workspaceCapabilityService.requireCapability(jwt, capability, DOMAIN, operation);
         WorkspaceCapabilityProperties.Capability chat = workspaceCapabilityProperties.chat();
         if (!chat.enabled()) {
-            throw chatUnavailable("disabled", "Chat is disabled by workspace policy.", operation);
+            throw chatUnavailable("disabled_by_policy", "Chat is disabled by workspace policy.", operation);
         }
         WorkspaceCapabilityReadiness configured = chat.readiness();
         if (configured == WorkspaceCapabilityReadiness.READY || (configured == null && hasText(chat.dependencyUrl()))) {
             return;
         }
-        String impact = configured == WorkspaceCapabilityReadiness.UNAVAILABLE ? "disabled" : "degraded";
+        String impact = configured == WorkspaceCapabilityReadiness.UNAVAILABLE ? "unavailable" : "degraded";
         throw chatUnavailable(impact, "Chat is not ready through the Weave Chat facade.", operation);
     }
 
@@ -629,7 +629,7 @@ public class ChatFacadeService {
                             "module", DOMAIN,
                             "contextId", principal.contextId(),
                             "permission", permission.name().toLowerCase(Locale.ROOT),
-                            "policyState", "policy-blocked",
+                            "policyState", "disabled_by_policy",
                             "reason", decision.reason(),
                             "diagnosticsRedacted", true));
         }

--- a/server/src/test/java/com/massimotter/weave/backend/bdd/ProviderStackReadinessStepDefinitions.java
+++ b/server/src/test/java/com/massimotter/weave/backend/bdd/ProviderStackReadinessStepDefinitions.java
@@ -224,7 +224,13 @@ public class ProviderStackReadinessStepDefinitions {
 
         for (String categoryKey : List.of("identity-idm", "chat", "files", "boards-tasks")) {
             assertThat(stringsFrom(categoryByKey(categoryKey).at("/contract/stableMemberImpactStates")))
-                    .containsExactlyInAnyOrder("usable", "disabled", "degraded", "policy-blocked");
+                    .containsExactlyInAnyOrder(
+                            "available",
+                            "disabled_by_policy",
+                            "not_configured",
+                            "degraded",
+                            "unavailable",
+                            "coming_later");
         }
     }
 
@@ -232,7 +238,13 @@ public class ProviderStackReadinessStepDefinitions {
     public void memberImpactStatesAreStableAcrossProviderAdapters() {
         for (JsonNode category : iterable(lastJson.path("categories"))) {
             assertThat(stringsFrom(category.at("/contract/stableMemberImpactStates")))
-                    .containsExactlyInAnyOrder("usable", "disabled", "degraded", "policy-blocked");
+                    .containsExactlyInAnyOrder(
+                            "available",
+                            "disabled_by_policy",
+                            "not_configured",
+                            "degraded",
+                            "unavailable",
+                            "coming_later");
             assertThat(category.at("/contract/normalMembersConfigureProviders").asBoolean()).isFalse();
             assertThat(category.path("memberImpact").asText()).doesNotContain("secret", "Authorization", "access_token");
         }

--- a/server/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/config/FirstPartyIdentityContractTest.java
@@ -77,7 +77,8 @@ class FirstPartyIdentityContractTest {
                         "Bearer authentication is required and must satisfy the first-party Weave token contract."))
                 .andExpect(jsonPath("$.details.status").value(401))
                 .andExpect(jsonPath("$.details.path").value(endsWith(WORKSPACE_CAPABILITIES_PATH)))
-                .andExpect(jsonPath("$.requestId").value(notNullValue()));
+                .andExpect(jsonPath("$.requestId").value(notNullValue()))
+                .andExpect(jsonPath("$.supportRef").value(startsWith("support:")));
     }
 
     @Test
@@ -90,7 +91,8 @@ class FirstPartyIdentityContractTest {
                         "The bearer token is authenticated but missing the required weave:workspace scope."))
                 .andExpect(jsonPath("$.details.status").value(403))
                 .andExpect(jsonPath("$.details.path").value(endsWith(WORKSPACE_CAPABILITIES_PATH)))
-                .andExpect(jsonPath("$.requestId").value(notNullValue()));
+                .andExpect(jsonPath("$.requestId").value(notNullValue()))
+                .andExpect(jsonPath("$.supportRef").value(startsWith("support:")));
     }
 
     @ParameterizedTest

--- a/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/AdminControlPlaneControllerTest.java
@@ -235,7 +235,8 @@ class AdminControlPlaneControllerTest {
                 .andExpect(jsonPath("$.weaverEligibilityPreview.memberStateWithoutGroup").value("disabled_by_policy"))
                 .andExpect(jsonPath("$.whitelist.denyByDefault").value(true))
                 .andExpect(jsonPath("$.whitelist.normalMembersMayAuthorPolicy").value(false))
-                .andExpect(jsonPath("$.whitelist.stableMemberImpactStates[*]", hasItems("ready", "disabled", "degraded", "policy-blocked")))
+                .andExpect(jsonPath("$.whitelist.stableMemberImpactStates[*]", hasItems(
+                        "available", "disabled_by_policy", "not_configured", "degraded", "unavailable", "coming_later")))
                 .andExpect(jsonPath("$.whitelist.profileCapabilities['guest-deny-default']").isArray())
                 .andExpect(jsonPath("$.identityProviderReadiness.contractVersion").value("identity-provider-readiness-v1"))
                 .andExpect(jsonPath("$.identityProviderReadiness.backendOwnedFacade").value(true))

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ChatControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ChatControllerTest.java
@@ -166,7 +166,7 @@ class ChatControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.contractVersion").value("chat-domain-facade-v1"))
                 .andExpect(jsonPath("$.domain").value("chat"))
-                .andExpect(jsonPath("$.memberState").value("misconfigured"))
+                .andExpect(jsonPath("$.memberState").value("not_configured"))
                 .andExpect(jsonPath("$.memberClientMayConfigureProvider").value(false))
                 .andExpect(jsonPath("$.providerMapping").doesNotExist())
                 .andExpect(content().string(not(containsString("secretref://"))))
@@ -227,7 +227,7 @@ class ChatControllerTest {
                 .andExpect(jsonPath("$.domain").value("chat"))
                 .andExpect(jsonPath("$.releaseStatus").value("canonical-domain-facade"))
                 .andExpect(jsonPath("$.source").value("weave-chat-domain-facade"))
-                .andExpect(jsonPath("$.readiness.impactState").value("usable"))
+                .andExpect(jsonPath("$.readiness.impactState").value("available"))
                 .andExpect(jsonPath("$.readiness.diagnosticsRedacted").value(true))
                 .andExpect(jsonPath("$.readiness.grantedCapabilities[0]").value("chat.read"))
                 .andExpect(jsonPath("$.conversations[0].id").value("channel-general"))
@@ -586,7 +586,7 @@ class ChatControllerTest {
                         false,
                         true,
                         List.of()),
-                Map.of("domain", "chat", "state", "misconfigured", "diagnosticsExposed", false),
+                Map.of("domain", "chat", "state", "not_configured", "diagnosticsExposed", false),
                 Instant.parse("2026-05-25T08:00:00Z"));
     }
 

--- a/server/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/OpenApiDocumentationTest.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -98,6 +99,14 @@ class OpenApiDocumentationTest {
                 .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.code.type").value("string"))
                 .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.message.type").value("string"))
                 .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.requestId.type").value("string"))
+                .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.supportRef.type").value("string"))
+                .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.properties.memberImpact.type").value("string"))
+                .andExpect(jsonPath("$.components.schemas.ApiErrorResponse.required", hasItems(
+                        "code",
+                        "message",
+                        "details",
+                        "requestId",
+                        "supportRef")))
                 .andExpect(jsonPath("$.components.responses.UnauthorizedError.description").value("Missing or invalid bearer token."))
                 .andExpect(jsonPath("$.components.securitySchemes['bearer-jwt'].type").value("http"))
                 .andReturn();

--- a/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/ProviderRegistryControllerTest.java
@@ -207,7 +207,8 @@ class ProviderRegistryControllerTest {
                 .andExpect(jsonPath("$.categories[?(@.category == 'release-evidence')].contract.defaultAdapters[*]", hasItems("release-evidence")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'admin-control-plane')].contract.defaultAdapters[*]", hasItems("weave-health-facade")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'weaver')].readiness", hasItems("disabled")))
-                .andExpect(jsonPath("$.categories[*].contract.stableMemberImpactStates[*]", hasItems("usable", "disabled", "degraded", "policy-blocked")))
+                .andExpect(jsonPath("$.categories[*].contract.stableMemberImpactStates[*]", hasItems(
+                        "available", "disabled_by_policy", "not_configured", "degraded", "unavailable", "coming_later")))
                 .andExpect(jsonPath("$.categories[*].contract.normalMembersConfigureProviders", hasItems(false)))
                 .andExpect(jsonPath("$.categories[?(@.category == 'chat')].contract.defaultAdapters[*]", hasItems("synapse-homeserver")))
                 .andExpect(jsonPath("$.categories[?(@.category == 'chat')].contract.externalAdapters[*]", hasItems("microsoft-teams", "slack")))

--- a/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/provider/DomainAdapterRegistryMapperTest.java
@@ -113,7 +113,13 @@ class DomainAdapterRegistryMapperTest {
     void categoryContractCarriesAntiSiloDomainAdapterFit() {
         var contract = ProviderCapabilityContracts.contract("chat", Set.of(ProviderModule.MATRIX));
 
-        assertThat(contract.stableMemberImpactStates()).containsExactly("usable", "disabled", "degraded", "policy-blocked");
+        assertThat(contract.stableMemberImpactStates()).containsExactly(
+                "available",
+                "disabled_by_policy",
+                "not_configured",
+                "degraded",
+                "unavailable",
+                "coming_later");
         assertThat(contract.canonicalObjects()).contains("WeaveConversation", "WeaveMessage", "WeaveMembership");
         assertThat(contract.externalAdapters()).contains("microsoft-teams", "slack");
         assertThat(contract.lossyMappingRisks()).contains("Slack broadcast/thread semantics", "Teams channel permissions");
@@ -127,7 +133,13 @@ class DomainAdapterRegistryMapperTest {
         CORE_DOMAIN_OBJECTS.forEach((category, canonicalObjects) -> {
             var contract = ProviderCapabilityContracts.contract(category, modulesFor(category));
 
-            assertThat(contract.stableMemberImpactStates()).containsExactly("usable", "disabled", "degraded", "policy-blocked");
+            assertThat(contract.stableMemberImpactStates()).containsExactly(
+                    "available",
+                    "disabled_by_policy",
+                    "not_configured",
+                    "degraded",
+                    "unavailable",
+                    "coming_later");
             assertThat(contract.canonicalObjects()).containsExactlyInAnyOrderElementsOf(canonicalObjects);
             assertThat(contract.sourceOfTruth()).isNotBlank();
             assertThat(contract.lossyMappingRisks()).isNotEmpty();


### PR DESCRIPTION
## Summary

- Harden member-facing Chat/canonical domain state schemas to the server-owned vocabulary: `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, `coming_later`.
- Add required support-safe error metadata (`supportRef`, optional `memberImpact`) to the server-owned `ApiErrorResponse` contract and generated clients.
- Narrow Flutter OpenAPI feature mapping so broad legacy aliases (`ready`, `usable`, `policy_blocked`, `policy-blocked`, `misconfigured`) fail closed instead of becoming product UX state.

## Scope and user impact

- Member-facing facades and generated clients now treat backend/OpenAPI as the state and error contract owner.
- Normal member UX receives Weave-owned state/support references, not provider wiring or raw downstream diagnostics.

## Spec / acceptance link

- Issue: Closes #906; part of #902
- Repo spec / Spec Kit package: pinned Weave spec corpus via `specs/weave-specs.lock.json`; implementation evidence in server/client OpenAPI contracts
- Plan/tasks/traceability: #902 -> #906
- Mapped Gherkin feature/scenario when product behavior changed: provider-stack readiness/member-state contract tests updated
- Evidence mode / reality level: `offline-spec`; contract/schema/client-mapper evidence
- Product-core questions intentionally left unresolved: none

Quality Reset rule: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance before merge. `offline-spec` / `contract_only` fixture evidence must not be described as `live-runtime`, isolated E2E, `release_ready`, or customer-ready evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [ ] none
- [x] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

- Release note: Harden member-facing OpenAPI state and error contracts with support-safe metadata.

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- No screenshots. Generated OpenAPI client/admin artifacts updated.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: support-safe error refs are added; raw provider diagnostics/secrets remain out of member responses.
- Accessibility/localization impact: no UI copy or l10n changes.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: `contracts/openapi/weave-openapi.json`, generated Flutter/Admin OpenAPI artifacts
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: architecture/contract + backend/server + client mapper evidence via PR review path
- If Copilot is unavailable/insufficient, matching reviewer used: internal fallback review requested; Copilot currently unavailable per sprint operating note

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [x] focused `flutter test test/features/chat/data/repositories/backend_chat_repository_test.dart`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [x] Live-stack validation: skipped, contract/schema/client-mapper slice only (`offline-spec`)

Additional gates run:
- `PATH="$HOME/flutter/bin:$PATH" ./gradlew serverCi checkOpenApiContractFresh checkClientOpenApiModelsFresh checkAdminOpenApiTypesFresh contractAuthorityArchitectureCheck clientOpenApiDriftPrevention --console=plain --no-daemon --max-workers=1`
- `PATH="$HOME/flutter/bin:$PATH" ./gradlew generateOpenApiContract generateClientOpenApiModels generateAdminOpenApiTypes --console=plain --no-daemon --max-workers=1`
- focused server tests: `ChatControllerTest`, `ChatDomainFacadeServiceTest`, `CanonicalDomainFacadeServicesTest`, `DomainAdapterRegistryMapperTest`, `ProviderRegistryControllerTest`, `AdminControlPlaneControllerTest`, `AdminControlPlaneServiceTest`

## Notes for reviewers

- Review for claim hygiene first: spec/Gherkin/evidenceMode/realityLevel must match the PR wording.
- Approval semantics must distinguish OpenClaw exec approval states from product user permissions; never treat `allow always` as blanket product permission.
- Keep Massimo's OpenClaw agent hierarchy, allowlists, model routing, personal operator paths, and runtime configuration out of product repo files.