### PR TITLE
feat(client): neutralize member setup handoff

### DIFF
--- a/client/lib/features/app/presentation/providers/workspace_connection_provider.dart
+++ b/client/lib/features/app/presentation/providers/workspace_connection_provider.dart
@@ -76,6 +76,32 @@ final nextcloudIntegrationConnectionProvider =
 final workspaceConnectionStateProvider =
     Provider<AsyncValue<WorkspaceConnectionState>>((ref) {
       final appAuth = ref.watch(appAuthIntegrationConnectionProvider);
+      final backendCapabilities = ref.watch(
+        weaveApiWorkspaceCapabilitySnapshotProvider,
+      );
+
+      if (backendCapabilities case AsyncData(value: final backendSnapshot?)) {
+        if (appAuth.hasError) {
+          return AsyncError(appAuth.error!, appAuth.stackTrace!);
+        }
+        if (appAuth.isLoading) {
+          return const AsyncLoading();
+        }
+
+        return AsyncData(
+          _mapBackendFacadeConnectionState(
+            appAuth: appAuth.requireValue,
+            capabilities: backendSnapshot,
+            matrixInvalidation: ref.watch(
+              integrationInvalidationProvider(WorkspaceIntegration.matrix),
+            ),
+            nextcloudInvalidation: ref.watch(
+              integrationInvalidationProvider(WorkspaceIntegration.nextcloud),
+            ),
+          ),
+        );
+      }
+
       final matrix = ref.watch(matrixIntegrationConnectionProvider);
       final nextcloud = ref.watch(nextcloudIntegrationConnectionProvider);
 
@@ -101,13 +127,76 @@ final workspaceConnectionStateProvider =
       );
     });
 
+WorkspaceConnectionState _mapBackendFacadeConnectionState({
+  required IntegrationConnectionState appAuth,
+  required WorkspaceCapabilitySnapshot capabilities,
+  IntegrationInvalidation? matrixInvalidation,
+  IntegrationInvalidation? nextcloudInvalidation,
+}) {
+  return WorkspaceConnectionState(
+    appAuth: appAuth,
+    matrix: _mapBackendCapabilityConnection(
+      integration: WorkspaceIntegration.matrix,
+      capability: capabilities.chat,
+      invalidation: matrixInvalidation,
+    ),
+    nextcloud: _mapBackendCapabilityConnection(
+      integration: WorkspaceIntegration.nextcloud,
+      capability: capabilities.files,
+      invalidation: nextcloudInvalidation,
+    ),
+  );
+}
+
+IntegrationConnectionState _mapBackendCapabilityConnection({
+  required WorkspaceIntegration integration,
+  required WorkspaceCapabilityState capability,
+  IntegrationInvalidation? invalidation,
+}) {
+  if (invalidation != null) {
+    return IntegrationConnectionState(
+      integration: integration,
+      status: IntegrationConnectionStatus.disconnected,
+      recoveryRequirement: IntegrationRecoveryRequirement.reviewConfiguration,
+      lastInvalidation: invalidation,
+    );
+  }
+
+  return switch (capability.readiness) {
+    WorkspaceCapabilityReadiness.ready ||
+    WorkspaceCapabilityReadiness.degraded ||
+    WorkspaceCapabilityReadiness.unavailable ||
+    WorkspaceCapabilityReadiness.blocked => IntegrationConnectionState(
+      integration: integration,
+      status: IntegrationConnectionStatus.connected,
+    ),
+  };
+}
+
 final workspaceCapabilitySnapshotProvider =
     Provider<AsyncValue<WorkspaceCapabilitySnapshot>>((ref) {
-      final workspace = ref.watch(workspaceConnectionStateProvider);
       final backendCapabilities = ref.watch(
         weaveApiWorkspaceCapabilitySnapshotProvider,
       );
+      final appAuth = ref.watch(appAuthIntegrationConnectionProvider);
 
+      if (backendCapabilities case AsyncData(value: final backendSnapshot?)) {
+        if (appAuth.hasError) {
+          return AsyncError(appAuth.error!, appAuth.stackTrace!);
+        }
+        if (appAuth.isLoading) {
+          return const AsyncLoading();
+        }
+
+        return AsyncData(
+          _mergeWorkspaceCapabilitySnapshots(
+            localSnapshot: _mapBackendFacadeLocalSnapshot(appAuth.requireValue),
+            backendSnapshot: backendSnapshot,
+          ),
+        );
+      }
+
+      final workspace = ref.watch(workspaceConnectionStateProvider);
       if (workspace.hasError) {
         return AsyncError(workspace.error!, workspace.stackTrace!);
       }
@@ -270,6 +359,33 @@ WorkspaceCapabilitySnapshot _mapWorkspaceCapabilitySnapshot(
   );
 }
 
+WorkspaceCapabilitySnapshot _mapBackendFacadeLocalSnapshot(
+  IntegrationConnectionState appAuth,
+) {
+  final shellAccess = _mapShellAccessCapability(appAuth);
+
+  return WorkspaceCapabilitySnapshot(
+    shellAccess: shellAccess,
+    chat: _mapBackendOwnedCapability(
+      capability: WorkspaceCapability.chat,
+      shellAccess: appAuth,
+    ),
+    files: _mapBackendOwnedCapability(
+      capability: WorkspaceCapability.files,
+      shellAccess: appAuth,
+    ),
+    calendar: _mapBackendOwnedCapability(
+      capability: WorkspaceCapability.calendar,
+      shellAccess: appAuth,
+    ),
+    boards: _mapBackendOwnedCapability(
+      capability: WorkspaceCapability.boards,
+      shellAccess: appAuth,
+    ),
+    weaver: _mapDisabledPolicyCapability(WorkspaceCapability.weaver),
+  );
+}
+
 WorkspaceCapabilitySnapshot _mergeWorkspaceCapabilitySnapshots({
   required WorkspaceCapabilitySnapshot localSnapshot,
   required WorkspaceCapabilitySnapshot backendSnapshot,
@@ -414,6 +530,25 @@ WorkspaceCapabilityState _mapFutureCapability({
   return WorkspaceCapabilityState(
     capability: capability,
     readiness: WorkspaceCapabilityReadiness.unavailable,
+  );
+}
+
+WorkspaceCapabilityState _mapBackendOwnedCapability({
+  required WorkspaceCapability capability,
+  required IntegrationConnectionState shellAccess,
+}) {
+  if (shellAccess.status != IntegrationConnectionStatus.connected) {
+    return WorkspaceCapabilityState(
+      capability: capability,
+      readiness: WorkspaceCapabilityReadiness.blocked,
+      recoveryRequirement: shellAccess.recoveryRequirement,
+    );
+  }
+
+  return WorkspaceCapabilityState(
+    capability: capability,
+    readiness: WorkspaceCapabilityReadiness.ready,
+    connectionStatus: IntegrationConnectionStatus.connected,
   );
 }
 

--- a/client/lib/features/server_config/presentation/widgets/server_configuration_form.dart
+++ b/client/lib/features/server_config/presentation/widgets/server_configuration_form.dart
@@ -127,10 +127,13 @@ class _ServerConfigurationFormState
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text('Identity endpoint', style: theme.textTheme.titleMedium),
+        Text(
+          l10n.serverConfigurationIdentityEndpointTitle,
+          style: theme.textTheme.titleMedium,
+        ),
         const SizedBox(height: 8),
         Text(
-          'Provider selection is owned by the Weave Admin Console and backend control plane. This member client stores only canonical Weave endpoints needed to sign in.',
+          l10n.serverConfigurationIdentityEndpointHelper,
           style: theme.textTheme.bodyMedium?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
@@ -183,55 +186,61 @@ class _ServerConfigurationFormState
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Text(
-          l10n.serverConfigurationServicesLabel,
+          widget.layout == ServerConfigurationFormLayout.serviceEndpointsOnly
+              ? l10n.serverConfigurationBackendApiLabel
+              : l10n.serverConfigurationServicesLabel,
           style: theme.textTheme.titleMedium,
         ),
         const SizedBox(height: 8),
         Text(
-          l10n.serverConfigurationServicesHelper,
+          widget.layout == ServerConfigurationFormLayout.serviceEndpointsOnly
+              ? l10n.serverConfigurationBackendApiHelper
+              : l10n.serverConfigurationServicesHelper,
           style: theme.textTheme.bodyMedium?.copyWith(
             color: theme.colorScheme.onSurfaceVariant,
           ),
         ),
         const SizedBox(height: 16),
-        TextField(
-          controller: _matrixController,
-          keyboardType: TextInputType.url,
-          textInputAction: TextInputAction.next,
-          decoration: InputDecoration(
-            labelText: l10n.serverConfigurationMatrixLabel,
-            hintText: 'https://matrix.home.internal',
-            helperText: formState.derivedMatrixHomeserverUrl.isEmpty
-                ? null
-                : l10n.serverConfigurationDerivedHint(
-                    formState.derivedMatrixHomeserverUrl,
-                  ),
-            errorText: formState.matrixError,
+        if (widget.layout == ServerConfigurationFormLayout.full) ...[
+          TextField(
+            controller: _matrixController,
+            keyboardType: TextInputType.url,
+            textInputAction: TextInputAction.next,
+            decoration: InputDecoration(
+              labelText: l10n.serverConfigurationMatrixLabel,
+              hintText: 'https://matrix.home.internal',
+              helperText: formState.derivedMatrixHomeserverUrl.isEmpty
+                  ? null
+                  : l10n.serverConfigurationDerivedHint(
+                      formState.derivedMatrixHomeserverUrl,
+                    ),
+              errorText: formState.matrixError,
+            ),
+            onChanged: ref
+                .read(serverConfigurationFormControllerProvider.notifier)
+                .updateMatrixHomeserverUrl,
           ),
-          onChanged: ref
-              .read(serverConfigurationFormControllerProvider.notifier)
-              .updateMatrixHomeserverUrl,
-        ),
-        const SizedBox(height: 16),
-        TextField(
-          controller: _nextcloudController,
-          keyboardType: TextInputType.url,
-          textInputAction: TextInputAction.next,
-          decoration: InputDecoration(
-            labelText: l10n.serverConfigurationNextcloudLabel,
-            hintText: 'https://files.home.internal',
-            helperText: formState.derivedNextcloudBaseUrl.isEmpty
-                ? null
-                : l10n.serverConfigurationDerivedHint(
-                    formState.derivedNextcloudBaseUrl,
-                  ),
-            errorText: formState.nextcloudError,
+          const SizedBox(height: 16),
+          TextField(
+            controller: _nextcloudController,
+            keyboardType: TextInputType.url,
+            textInputAction: TextInputAction.next,
+            decoration: InputDecoration(
+              labelText: l10n.serverConfigurationNextcloudLabel,
+              hintText: 'https://files.home.internal',
+              helperText: formState.derivedNextcloudBaseUrl.isEmpty
+                  ? null
+                  : l10n.serverConfigurationDerivedHint(
+                      formState.derivedNextcloudBaseUrl,
+                    ),
+              errorText: formState.nextcloudError,
+            ),
+            onChanged: ref
+                .read(serverConfigurationFormControllerProvider.notifier)
+                .updateNextcloudBaseUrl,
           ),
-          onChanged: ref
-              .read(serverConfigurationFormControllerProvider.notifier)
-              .updateNextcloudBaseUrl,
-        ),
-        const SizedBox(height: 16),
+          const SizedBox(height: 16),
+        ],
         TextField(
           controller: _backendApiController,
           keyboardType: TextInputType.url,

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -7,8 +7,8 @@
   "setupTitle": "Weave beitreten",
   "setupProviderStepTitle": "Provider-Kategorien konfigurieren",
   "setupProviderStepDescription": "Die Admin-Einrichtung beginnt mit der Kategorie Identität/IDM und hält Chat, Dateien, Kalender, Boards/Aufgaben, Besprechungen/Anrufe, Dokumente/Zusammenarbeit und Weaver als Provider-Kategorien sichtbar, bevor Mitglieder beitreten.",
-  "setupServicesStepTitle": "Dienstendpunkte prüfen",
-  "setupServicesStepDescription": "Prüfe die aktuellen Dogfood-Service-Endpunkte, die aus dem Identitäts-Issuer abgeleitet wurden. Diese Provider-URLs bleiben Admin-/Operator-Konfiguration, nicht normale Mitglieder-Einrichtung.",
+  "setupServicesStepTitle": "Backend-API prüfen",
+  "setupServicesStepDescription": "Prüfe den Weave-Backend-API-Endpunkt, der aus dem Organisations-Login abgeleitet wurde. Provider-Service-URLs bleiben in Admin-/Support-Diagnosen, nicht in der Mitglieder-Einrichtung.",
   "providerCategorySummaryTitle": "Provider-Kategorien",
   "@providerCategorySummaryTitle": {
     "description": "Titel der Provider-Kategorien-Zusammenfassung für Admins in Einrichtung und Workspace Health"
@@ -804,6 +804,9 @@
   "serverConfigurationClientIdHelper": "Gib die public/native Client-ID ein, die für Weave bei diesem Issuer registriert ist.",
   "serverConfigurationServicesLabel": "Dienstendpunkte",
   "serverConfigurationServicesHelper": "Standardwerte für Matrix, Nextcloud und die Backend-API werden aus dem Issuer-Host abgeleitet. Ändere sie, wenn deine Dienste anderswo liegen.",
+  "serverConfigurationBackendApiHelper": "Der Mitglieder-Client speichert den Weave-Backend-API-Endpunkt für Organisationsfunktionen und Workspace-Status. Provider-Service-URLs bleiben in Admin-/Support-Diagnosen.",
+  "serverConfigurationIdentityEndpointTitle": "Identitätsendpunkt",
+  "serverConfigurationIdentityEndpointHelper": "Provider-Auswahl gehört in die Weave Admin Console und Backend-Control-Plane. Dieser Mitglieder-Client speichert nur kanonische Weave-Endpunkte für die Anmeldung.",
   "serverConfigurationMatrixLabel": "Matrix-Homeserver-URL",
   "serverConfigurationNextcloudLabel": "Nextcloud-Basis-URL",
   "serverConfigurationBackendApiLabel": "Backend-API-Basis-URL",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -28,11 +28,11 @@
   "@setupProviderStepDescription": {
     "description": "Description shown in the setup provider step"
   },
-  "setupServicesStepTitle": "Review Service Endpoints",
+  "setupServicesStepTitle": "Review Backend API",
   "@setupServicesStepTitle": {
     "description": "Title for the setup services step"
   },
-  "setupServicesStepDescription": "Review the current dogfood service endpoints derived from the identity issuer. These provider URLs stay admin/operator configuration, not normal member setup.",
+  "setupServicesStepDescription": "Review the Weave backend API endpoint derived from the organization sign-in issuer. Provider service URLs stay in admin/support diagnostics, not member setup.",
   "@setupServicesStepDescription": {
     "description": "Description shown in the setup services step"
   },
@@ -3098,6 +3098,18 @@
   "serverConfigurationServicesHelper": "Defaults for Matrix, Nextcloud, and the backend API are derived from the issuer host. Edit them if your services live elsewhere.",
   "@serverConfigurationServicesHelper": {
     "description": "Helper text for the service endpoints section"
+  },
+  "serverConfigurationBackendApiHelper": "The member client stores the Weave backend API endpoint for organization capability and workspace state. Provider service URLs stay in admin/support diagnostics.",
+  "@serverConfigurationBackendApiHelper": {
+    "description": "Helper text for backend API-only member handoff/recovery configuration"
+  },
+  "serverConfigurationIdentityEndpointTitle": "Identity endpoint",
+  "@serverConfigurationIdentityEndpointTitle": {
+    "description": "Title for the identity endpoint section in setup and settings"
+  },
+  "serverConfigurationIdentityEndpointHelper": "Provider selection is owned by the Weave Admin Console and backend control plane. This member client stores only canonical Weave endpoints needed to sign in.",
+  "@serverConfigurationIdentityEndpointHelper": {
+    "description": "Helper text for the identity endpoint section in setup and settings"
   },
   "serverConfigurationMatrixLabel": "Matrix Homeserver URL",
   "@serverConfigurationMatrixLabel": {

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -143,13 +143,13 @@ abstract class AppLocalizations {
   /// Title for the setup services step
   ///
   /// In en, this message translates to:
-  /// **'Review Service Endpoints'**
+  /// **'Review Backend API'**
   String get setupServicesStepTitle;
 
   /// Description shown in the setup services step
   ///
   /// In en, this message translates to:
-  /// **'Review the current dogfood service endpoints derived from the identity issuer. These provider URLs stay admin/operator configuration, not normal member setup.'**
+  /// **'Review the Weave backend API endpoint derived from the organization sign-in issuer. Provider service URLs stay in admin/support diagnostics, not member setup.'**
   String get setupServicesStepDescription;
 
   /// Title for the provider category summary shown to admins during setup and workspace health
@@ -4498,6 +4498,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Defaults for Matrix, Nextcloud, and the backend API are derived from the issuer host. Edit them if your services live elsewhere.'**
   String get serverConfigurationServicesHelper;
+
+  /// Helper text for backend API-only member handoff/recovery configuration
+  ///
+  /// In en, this message translates to:
+  /// **'The member client stores the Weave backend API endpoint for organization capability and workspace state. Provider service URLs stay in admin/support diagnostics.'**
+  String get serverConfigurationBackendApiHelper;
+
+  /// Title for the identity endpoint section in setup and settings
+  ///
+  /// In en, this message translates to:
+  /// **'Identity endpoint'**
+  String get serverConfigurationIdentityEndpointTitle;
+
+  /// Helper text for the identity endpoint section in setup and settings
+  ///
+  /// In en, this message translates to:
+  /// **'Provider selection is owned by the Weave Admin Console and backend control plane. This member client stores only canonical Weave endpoints needed to sign in.'**
+  String get serverConfigurationIdentityEndpointHelper;
 
   /// Label for the Matrix homeserver URL field
   ///

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -32,11 +32,11 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die Admin-Einrichtung beginnt mit der Kategorie Identität/IDM und hält Chat, Dateien, Kalender, Boards/Aufgaben, Besprechungen/Anrufe, Dokumente/Zusammenarbeit und Weaver als Provider-Kategorien sichtbar, bevor Mitglieder beitreten.';
 
   @override
-  String get setupServicesStepTitle => 'Dienstendpunkte prüfen';
+  String get setupServicesStepTitle => 'Backend-API prüfen';
 
   @override
   String get setupServicesStepDescription =>
-      'Prüfe die aktuellen Dogfood-Service-Endpunkte, die aus dem Identitäts-Issuer abgeleitet wurden. Diese Provider-URLs bleiben Admin-/Operator-Konfiguration, nicht normale Mitglieder-Einrichtung.';
+      'Prüfe den Weave-Backend-API-Endpunkt, der aus dem Organisations-Login abgeleitet wurde. Provider-Service-URLs bleiben in Admin-/Support-Diagnosen, nicht in der Mitglieder-Einrichtung.';
 
   @override
   String get providerCategorySummaryTitle => 'Provider-Kategorien';
@@ -2721,6 +2721,17 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get serverConfigurationServicesHelper =>
       'Standardwerte für Matrix, Nextcloud und die Backend-API werden aus dem Issuer-Host abgeleitet. Ändere sie, wenn deine Dienste anderswo liegen.';
+
+  @override
+  String get serverConfigurationBackendApiHelper =>
+      'Der Mitglieder-Client speichert den Weave-Backend-API-Endpunkt für Organisationsfunktionen und Workspace-Status. Provider-Service-URLs bleiben in Admin-/Support-Diagnosen.';
+
+  @override
+  String get serverConfigurationIdentityEndpointTitle => 'Identitätsendpunkt';
+
+  @override
+  String get serverConfigurationIdentityEndpointHelper =>
+      'Provider-Auswahl gehört in die Weave Admin Console und Backend-Control-Plane. Dieser Mitglieder-Client speichert nur kanonische Weave-Endpunkte für die Anmeldung.';
 
   @override
   String get serverConfigurationMatrixLabel => 'Matrix-Homeserver-URL';

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -32,11 +32,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'Admin setup starts with the identity/IDM category and keeps chat, files, calendar, boards/tasks, meetings/calls, documents/collaboration, and Weaver visible as provider categories before members join.';
 
   @override
-  String get setupServicesStepTitle => 'Review Service Endpoints';
+  String get setupServicesStepTitle => 'Review Backend API';
 
   @override
   String get setupServicesStepDescription =>
-      'Review the current dogfood service endpoints derived from the identity issuer. These provider URLs stay admin/operator configuration, not normal member setup.';
+      'Review the Weave backend API endpoint derived from the organization sign-in issuer. Provider service URLs stay in admin/support diagnostics, not member setup.';
 
   @override
   String get providerCategorySummaryTitle => 'Provider categories';
@@ -2687,6 +2687,17 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get serverConfigurationServicesHelper =>
       'Defaults for Matrix, Nextcloud, and the backend API are derived from the issuer host. Edit them if your services live elsewhere.';
+
+  @override
+  String get serverConfigurationBackendApiHelper =>
+      'The member client stores the Weave backend API endpoint for organization capability and workspace state. Provider service URLs stay in admin/support diagnostics.';
+
+  @override
+  String get serverConfigurationIdentityEndpointTitle => 'Identity endpoint';
+
+  @override
+  String get serverConfigurationIdentityEndpointHelper =>
+      'Provider selection is owned by the Weave Admin Console and backend control plane. This member client stores only canonical Weave endpoints needed to sign in.';
 
   @override
   String get serverConfigurationMatrixLabel => 'Matrix Homeserver URL';

--- a/client/test/features/app/presentation/providers/workspace_connection_provider_test.dart
+++ b/client/test/features/app/presentation/providers/workspace_connection_provider_test.dart
@@ -267,8 +267,14 @@ void main() {
     );
 
     test(
-      'prefers backend capability readiness when a backend snapshot exists',
+      'prefers backend capability readiness without restoring provider sessions',
       () async {
+        final filesRepository = _FakeFilesRepository(
+          connectionState: FilesConnectionState.connected(
+            baseUrl: Uri.parse('https://files.home.internal'),
+            accountLabel: 'alice',
+          ),
+        );
         final container = ProviderContainer.test(
           overrides: [
             appBootstrapProvider.overrideWith(
@@ -299,14 +305,7 @@ void main() {
                 },
               ),
             ),
-            filesRepositoryProvider.overrideWithValue(
-              _FakeFilesRepository(
-                connectionState: FilesConnectionState.connected(
-                  baseUrl: Uri.parse('https://files.home.internal'),
-                  accountLabel: 'alice',
-                ),
-              ),
-            ),
+            filesRepositoryProvider.overrideWithValue(filesRepository),
             weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
               (ref) async => const WorkspaceCapabilitySnapshot(
                 shellAccess: WorkspaceCapabilityState(
@@ -336,8 +335,6 @@ void main() {
         addTearDown(container.dispose);
 
         await container.read(appBootstrapProvider.future);
-        await container.read(matrixIntegrationConnectionProvider.future);
-        await container.read(nextcloudIntegrationConnectionProvider.future);
         await container.read(
           weaveApiWorkspaceCapabilitySnapshotProvider.future,
         );
@@ -354,6 +351,72 @@ void main() {
           capabilities.requireValue.files.readiness,
           WorkspaceCapabilityReadiness.blocked,
         );
+        expect(filesRepository.restoreConnectionCalls, 0);
+      },
+    );
+
+    test(
+      'workspace connection uses backend readiness without restoring provider sessions',
+      () async {
+        final filesRepository = _FakeFilesRepository(
+          connectionState: FilesConnectionState.connected(
+            baseUrl: Uri.parse('https://files.home.internal'),
+            accountLabel: 'alice',
+          ),
+        );
+        final container = ProviderContainer.test(
+          overrides: [
+            appBootstrapProvider.overrideWith(
+              () => _FakeAppBootstrap(const BootstrapState.ready()),
+            ),
+            savedServerConfigurationProvider.overrideWith(
+              (ref) async => buildTestConfiguration(),
+            ),
+            filesRepositoryProvider.overrideWithValue(filesRepository),
+            weaveApiWorkspaceCapabilitySnapshotProvider.overrideWith(
+              (ref) async => const WorkspaceCapabilitySnapshot(
+                shellAccess: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.shellAccess,
+                  readiness: WorkspaceCapabilityReadiness.ready,
+                ),
+                chat: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.chat,
+                  readiness: WorkspaceCapabilityReadiness.ready,
+                ),
+                files: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.files,
+                  readiness: WorkspaceCapabilityReadiness.degraded,
+                ),
+                calendar: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.calendar,
+                  readiness: WorkspaceCapabilityReadiness.unavailable,
+                ),
+                boards: WorkspaceCapabilityState(
+                  capability: WorkspaceCapability.boards,
+                  readiness: WorkspaceCapabilityReadiness.unavailable,
+                ),
+              ),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(appBootstrapProvider.future);
+        await container.read(
+          weaveApiWorkspaceCapabilitySnapshotProvider.future,
+        );
+
+        final workspace = container.read(workspaceConnectionStateProvider);
+
+        expect(
+          workspace.requireValue.matrix.status,
+          IntegrationConnectionStatus.connected,
+        );
+        expect(
+          workspace.requireValue.nextcloud.status,
+          IntegrationConnectionStatus.connected,
+        );
+        expect(filesRepository.restoreConnectionCalls, 0);
       },
     );
   });

--- a/client/test/features/onboarding/setup_flow_test.dart
+++ b/client/test/features/onboarding/setup_flow_test.dart
@@ -109,7 +109,7 @@ void main() {
       expect(find.text('Nextcloud Base URL'), findsNothing);
     });
 
-    testWidgets('derives service endpoints from the issuer host', (
+    testWidgets('derives backend API handoff from the issuer host', (
       tester,
     ) async {
       await tester.pumpWidget(buildApp());
@@ -130,10 +130,17 @@ void main() {
       await tester.tap(find.text('Next'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Review Service Endpoints'), findsOneWidget);
-      expect(find.text('https://matrix.home.internal'), findsWidgets);
-      expect(find.text('https://files.home.internal'), findsWidgets);
+      expect(find.text('Review Backend API'), findsOneWidget);
+      expect(
+        find.textContaining('The member client stores the Weave backend API'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Defaults for Matrix'), findsNothing);
+      expect(find.text('https://matrix.home.internal'), findsNothing);
+      expect(find.text('https://files.home.internal'), findsNothing);
       expect(find.text('https://api.home.internal/api'), findsWidgets);
+      expect(_textFieldWithLabel('Matrix Homeserver URL'), findsNothing);
+      expect(_textFieldWithLabel('Nextcloud Base URL'), findsNothing);
       expect(find.text('Finish'), findsOneWidget);
     });
 
@@ -154,10 +161,6 @@ void main() {
       await tester.tap(find.text('Next'));
       await tester.pumpAndSettle();
 
-      await tester.enterText(
-        _textFieldWithLabel('Nextcloud Base URL'),
-        'https://files.home.internal',
-      );
       await tester.tap(find.text('Finish'));
       await tester.pumpAndSettle();
 
@@ -166,6 +169,8 @@ void main() {
       final raw = preferencesStore.rawString(serverConfigurationStorageKey);
       final json = jsonDecode(raw!) as Map<String, dynamic>;
       expect(json['oidcClientId'], 'weave-app');
+      expect(json['matrixHomeserverUrl'], 'https://matrix.home.internal');
+      expect(json['nextcloudBaseUrl'], 'https://files.home.internal');
       expect(json['backendApiBaseUrl'], 'https://api.home.internal/api');
     });
 

--- a/client/test/release_1/release_golden_paths_test.dart
+++ b/client/test/release_1/release_golden_paths_test.dart
@@ -123,9 +123,9 @@ void main() {
         await tester.tap(find.text('Next'));
         await tester.pumpAndSettle();
 
-        expect(find.text('Review Service Endpoints'), findsOneWidget);
-        expect(find.text('https://matrix.weave.test'), findsWidgets);
-        expect(find.text('https://files.weave.test'), findsWidgets);
+        expect(find.text('Review Backend API'), findsOneWidget);
+        expect(find.text('https://matrix.weave.test'), findsNothing);
+        expect(find.text('https://files.weave.test'), findsNothing);
         expect(find.text('https://api.weave.test/api'), findsWidgets);
 
         await tester.tap(find.text('Finish'));


### PR DESCRIPTION
## Summary
- Keep onboarding/operator recovery setup focused on organization sign-in plus the Weave backend API endpoint instead of showing Matrix/Nextcloud provider URLs.
- Preserve derived legacy service endpoint fields internally for saved-configuration compatibility.
- Prefer backend facade capability snapshots for member readiness without restoring raw provider sessions when backend capability state is available.

## Replaced approach
Member setup/recovery could review derived Matrix and Nextcloud service URLs, and capability readiness still touched provider-specific local integrations before accepting backend facade capability state.

## Target replacement pattern
Member setup/handoff stays provider-neutral: organization sign-in issuer -> Weave backend API -> backend capability/workspace state. Raw provider endpoints remain admin/operator/support diagnostic concerns, with legacy saved fields derived internally only for compatibility.

## Evidence
- `PATH="$HOME/flutter/bin:$PATH" flutter gen-l10n` PASS
- `PATH="$HOME/flutter/bin:$PATH" flutter test test/features/onboarding/setup_flow_test.dart test/features/app/presentation/providers/workspace_connection_provider_test.dart test/release_1/release_golden_paths_test.dart` PASS
- `PATH="$HOME/flutter/bin:$PATH" ./gradlew clientCi acceptanceContract --console=plain --no-daemon --max-workers=1` PASS
- `git diff --check origin/dev...HEAD` PASS

Closes #905
