### PR TITLE
Fix generated provider selection upload hash

### DIFF
--- a/infra/weave-workspace/01-infrastructure/main.tf
+++ b/infra/weave-workspace/01-infrastructure/main.tf
@@ -535,6 +535,7 @@ module "backend" {
   boards_openproject_base_url                      = var.boards_openproject_base_url
   boards_openproject_api_token                     = var.boards_openproject_api_token
   provider_selections_source                       = local_sensitive_file.generated["provider_selections"].filename
+  provider_selections_source_hash                  = sha256(local.generated_files["provider_selections"].content)
   provider_selections_storage_path                 = "/app/provider-selections.json"
   oidc_issuer_uri                                  = local.keycloak_issuer_url
   oidc_jwk_set_uri                                 = local.keycloak_jwk_set_uri

--- a/infra/weave-workspace/01-infrastructure/modules/backend/main.tf
+++ b/infra/weave-workspace/01-infrastructure/modules/backend/main.tf
@@ -137,7 +137,7 @@ resource "docker_container" "this" {
   upload {
     file        = var.provider_selections_storage_path
     source      = var.provider_selections_source
-    source_hash = filesha256(var.provider_selections_source)
+    source_hash = var.provider_selections_source_hash
   }
 
   networks_advanced {

--- a/infra/weave-workspace/01-infrastructure/modules/backend/variables.tf
+++ b/infra/weave-workspace/01-infrastructure/modules/backend/variables.tf
@@ -267,6 +267,11 @@ variable "provider_selections_source" {
   type        = string
 }
 
+variable "provider_selections_source_hash" {
+  description = "Content hash for the generated support-safe provider selection seed."
+  type        = string
+}
+
 variable "provider_selections_storage_path" {
   description = "Container path used by the backend provider selection repository."
   type        = string


### PR DESCRIPTION
## Summary
- pass the generated provider-selection content hash into the backend Docker upload
- avoid `filesha256()` on a file that OpenTofu has not created yet during planning

## Evidence
- `./gradlew infraStatic --console=plain --no-daemon --max-workers=1`

## Release Notes
- Dogfood readiness fix: provider-selection seed upload now plans correctly in the live stack bootstrap.
