### PR TITLE
Shorten live E2E workspace loop follow-up ref

### DIFF
--- a/client/integration_test/live_stack_app_e2e_test.dart
+++ b/client/integration_test/live_stack_app_e2e_test.dart
@@ -771,7 +771,9 @@ void main() {
                   : 'Calendar write remains blocked by capability policy.',
             ],
             'followUpRefs': <String>[
-              workspaceLoopCalendarRef,
+              calendarManageEventsAllowed
+                  ? 'calendar:e2e-created'
+                  : workspaceLoopCalendarRef,
               'evidence:workspace-loop-live-stack',
             ],
             'references': <Map<String, String>>[


### PR DESCRIPTION
## Summary
- keep the long calendar event id in support-safe marker diagnostics
- send a short server-valid calendar follow-up ref in the workspace-loop decision request

## Evidence
- `PATH="/Users/flotterotter/flutter/bin:$PATH" ./gradlew clientCi --console=plain --no-daemon --max-workers=1`

## Release Notes
- Dogfood readiness fix: live workspace-loop E2E request now satisfies server validation.
