### PR TITLE
fix: make dogfood iOS deeplink discoverable

### DIFF
--- a/client/test/features/onboarding/member_handoff_test.dart
+++ b/client/test/features/onboarding/member_handoff_test.dart
@@ -81,6 +81,21 @@ void main() {
       );
     });
 
+    test('accepts installed iOS custom scheme handoff shape', () {
+      final handoff = const MemberHandoffParser().parse(
+        Uri.parse(
+          'weave://join?handoff_ref=handoff-s32-massimo-dogfood-home&org=massimo-dogfood&workspace=home&profile=local-lan-dogfood&run_id=s32-massimo-dogfood&product_base_url=https://weave.test:44443&platform_config_url=https://api.weave.test:44443/api/platform/config',
+        ),
+      );
+
+      expect(handoff.handoffRef, 'handoff-s32-massimo-dogfood-home');
+      expect(handoff.productBaseUrl.toString(), 'https://weave.test:44443/');
+      expect(
+        handoff.platformConfigUrl.toString(),
+        'https://api.weave.test:44443/api/platform/config',
+      );
+    });
+
     test('generates deterministic QR payload matching the invite contract', () {
       final payload = const MemberHandoffPayloadBuilder().qrPayload(
         productBaseUrl: Uri.parse('https://weave.test:44443'),

--- a/infra/weave-workspace/01-infrastructure/templates/Caddyfile.tpl
+++ b/infra/weave-workspace/01-infrastructure/templates/Caddyfile.tpl
@@ -95,6 +95,7 @@ ${weave_site_addresses} {
     <h2 id="start-app">2. Start or join the app</h2>
     <p>Open the app-start discovery contract at <a href="${client_public_url}/api/platform/config">${client_public_url}/api/platform/config</a> if you need to verify product-gateway app-start, or at <a href="${api_public_url}/api/platform/config">${api_public_url}/api/platform/config</a> for the canonical API host.</p>
     <p>Default Massimo invite/join link: <a href="/join?handoff_ref=handoff-s32-massimo-dogfood-home&amp;org=massimo-dogfood&amp;workspace=home&amp;profile=local-lan-dogfood&amp;run_id=s32-massimo-dogfood">${client_public_url}/join?handoff_ref=handoff-s32-massimo-dogfood-home&amp;org=massimo-dogfood&amp;workspace=home&amp;profile=local-lan-dogfood&amp;run_id=s32-massimo-dogfood</a></p>
+    <p>App custom-scheme link for installed-client handoff testing: <a href="weave://join?handoff_ref=handoff-s32-massimo-dogfood-home&amp;org=massimo-dogfood&amp;workspace=home&amp;profile=local-lan-dogfood&amp;run_id=s32-massimo-dogfood&amp;product_base_url=${client_public_url}&amp;platform_config_url=${api_public_url}/api/platform/config">weave://join?handoff_ref=handoff-s32-massimo-dogfood-home&amp;org=massimo-dogfood&amp;workspace=home&amp;profile=local-lan-dogfood&amp;run_id=s32-massimo-dogfood&amp;product_base_url=${client_public_url}&amp;platform_config_url=${api_public_url}/api/platform/config</a></p>
     <p>The QR payload should be the same DNS-first join URL. The app should fetch platform config, start sign-in, and land in workspace home.</p>
   </section>
 

--- a/infra/weave-workspace/smoke-test.sh
+++ b/infra/weave-workspace/smoke-test.sh
@@ -519,6 +519,9 @@ grep -Fq "${WEAVE_PUBLIC_BASE_URL}/weave-local-ca.pem" <<<"${product_start_page}
 grep -Fq 'Weave Local Development CA' <<<"${product_start_page}" || fail "Smoke check failed: start page should include iPhone CA trust instructions"
 grep -Fq '/api/platform/config' <<<"${product_start_page}" || fail "Smoke check failed: start page should include app-start platform config guidance"
 grep -Fq 'handoff-s32-massimo-dogfood-home' <<<"${product_start_page}" || fail "Smoke check failed: start page should include the default local invite guidance"
+grep -Fq 'weave://join?handoff_ref=handoff-s32-massimo-dogfood-home' <<<"${product_start_page}" || fail "Smoke check failed: start page should include the app custom-scheme handoff link"
+grep -Fq "product_base_url=${WEAVE_PUBLIC_BASE_URL}" <<<"${product_start_page}" || fail "Smoke check failed: custom-scheme handoff should include the product base URL"
+grep -Fq "platform_config_url=${WEAVE_BASE_URL}/api/platform/config" <<<"${product_start_page}" || fail "Smoke check failed: custom-scheme handoff should include the platform config URL"
 grep -Fq 'passwords, tokens, client secrets, or credential URLs' <<<"${product_start_page}" || fail "Smoke check failed: start page should warn that secrets are not embedded"
 [[ "${product_start_page}" != *"127.0.0.1"* && "${product_start_page}" != *"localhost"* && "${product_start_page}" != *"192.168."* ]] || \
   fail "Smoke check failed: Product start page must not expose LAN IP, loopback, or localhost URLs"


### PR DESCRIPTION
## Summary

- Add the installed-client `weave://join` handoff link to the local dogfood product start page.
- Include explicit `product_base_url` and `platform_config_url` parameters so the iOS custom-scheme path can pass the client handoff parser and discover the dogfood stack.
- Cover the exact iOS custom-scheme handoff shape in client tests and require the generated link in the infra smoke test.

## Scope and user impact

- Fixes the dogfood iPhone handoff path so Massimo can open the installed Weave client from the product gateway start page.
- Keeps the HTTPS `/join` link as the QR/browser payload and the `weave://join` link as the installed-app custom-scheme smoke path.
- No secrets or bearer access are added to the handoff; the link carries only support-safe refs plus discovery URLs.

## Spec / acceptance link

- Issue: dogfood readiness follow-up from PR #917 hard Deeplink done-definition.
- Repo spec / Spec Kit package: `specs/weave-specs.lock.json`, `../weave-specs/domains/identity-idm/spec.md`, `../weave-specs/domains/spaces/spec.md`, `../weave-specs/domains/weaver-governed-pa/spec.md`, `../weave-specs/acceptance/features/identity-lifecycle.feature` for the member join boundary.
- Plan/tasks/traceability: dogfood client-bootstrap handoff in `docs/weave-control-bootstrap-to-client-contract.md` and local dogfood topology in `docs/sprint-31-iphone-lan-dogfood-runbook.md`.
- Mapped Gherkin feature/scenario when product behavior changed: existing member join and local dogfood topology scenarios through `e2e/scenario_mappings.json`; no new scenario added for this narrow generated-link repair.
- Evidence mode / reality level: `offline-spec` plus live smoke coverage when deployed to dogfood; reality level `configured` until the dogfood stack serves the updated start page.
- Product-core questions intentionally left unresolved: none.

Quality Reset rule: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance before merge. `offline-spec` / `contract_only` fixture evidence must not be described as `live-runtime`, isolated E2E, `release_ready`, or customer-ready evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

Choose one and explain when needed.

- [x] none
- [ ] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

Use exactly one form.

- Release note: Fixes the local dogfood iOS custom-scheme handoff link so the installed Weave client receives explicit product and platform discovery URLs.
- Release note: none — reason:

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [ ] `release-notes-feature`
- [x] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- No screenshots or docs changed.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: Handoff remains non-secret; no passwords, bearer tokens, client secrets, SecretRefs, CredentialRefs, raw provider payloads, or credential URLs are embedded.
- Accessibility/localization impact: Existing start page copy remains screen-reader readable; no localized app copy changed.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [ ] No public API/auth/topology/spec contract change
- [x] Contract/spec change documented: local dogfood generated handoff link shape now includes explicit product/platform discovery URLs for custom-scheme use.
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: QA/evidence + provider/infra lightweight path for dogfood handoff smoke coverage.
- If Copilot is unavailable/insufficient, matching reviewer used: fallback agent review in this PR body and green focused gates.

## Checks run

- [ ] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [x] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [x] `flutter test test/features/onboarding/member_handoff_test.dart`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [x] Live-stack validation (only when relevant; record run, artifact, or skip reason): local live stack not mutated in this PR; `./gradlew infraStatic` covers the generated smoke-test contract, and dogfood deployment must prove the served page after merge.

Additional focused gate run:

- `PATH="/Users/flotterotter/flutter/bin:$PATH" ./gradlew acceptanceContract infraStatic --console=plain --no-daemon --max-workers=1`

## Notes for reviewers

- Review for claim hygiene first: this PR fixes the generated handoff link and test coverage; it does not by itself claim physical iPhone success.
- The concrete dogfood deeplink this makes available after deployment is `weave://join?handoff_ref=handoff-s32-massimo-dogfood-home&org=massimo-dogfood&workspace=home&profile=local-lan-dogfood&run_id=s32-massimo-dogfood&product_base_url=https://weave.test:44443&platform_config_url=https://api.weave.test:44443/api/platform/config`.
