### PR TITLE
fix: align dogfood platform config smoke assertion

### DIFF
--- a/infra/weave-workspace/smoke-test.sh
+++ b/infra/weave-workspace/smoke-test.sh
@@ -521,7 +521,7 @@ grep -Fq '/api/platform/config' <<<"${product_start_page}" || fail "Smoke check 
 grep -Fq 'handoff-s32-massimo-dogfood-home' <<<"${product_start_page}" || fail "Smoke check failed: start page should include the default local invite guidance"
 grep -Fq 'weave://join?handoff_ref=handoff-s32-massimo-dogfood-home' <<<"${product_start_page}" || fail "Smoke check failed: start page should include the app custom-scheme handoff link"
 grep -Fq "product_base_url=${WEAVE_PUBLIC_BASE_URL}" <<<"${product_start_page}" || fail "Smoke check failed: custom-scheme handoff should include the product base URL"
-grep -Fq "platform_config_url=${WEAVE_BASE_URL}/api/platform/config" <<<"${product_start_page}" || fail "Smoke check failed: custom-scheme handoff should include the platform config URL"
+grep -Fq "platform_config_url=$(public_url "${TF_VAR_api_subdomain:-api}")/api/platform/config" <<<"${product_start_page}" || fail "Smoke check failed: custom-scheme handoff should include the platform config URL"
 grep -Fq 'passwords, tokens, client secrets, or credential URLs' <<<"${product_start_page}" || fail "Smoke check failed: start page should warn that secrets are not embedded"
 [[ "${product_start_page}" != *"127.0.0.1"* && "${product_start_page}" != *"localhost"* && "${product_start_page}" != *"192.168."* ]] || \
   fail "Smoke check failed: Product start page must not expose LAN IP, loopback, or localhost URLs"


### PR DESCRIPTION
## Summary

- Fix the dogfood smoke-test assertion for the custom-scheme `platform_config_url`.
- The generated Caddy start page uses the API host plus `/api/platform/config`; the smoke test was incorrectly appending `/api/platform/config` to `WEAVE_BASE_URL`, which already includes `/api`.

## Scope and user impact

- Unblocks the persistent dogfood deploy after #921 added the iOS custom-scheme handoff link.
- No runtime behavior or user-facing copy changes; this is a readiness/smoke assertion repair.

## Spec / acceptance link

- Issue: dogfood readiness follow-up from PR #917 hard Deeplink done-definition.
- Repo spec / Spec Kit package: `specs/weave-specs.lock.json`; local dogfood topology and member handoff acceptance are already mapped.
- Plan/tasks/traceability: persistent dogfood deploy failure in run `28152310112`, job `83372608943` at “Verify persistent stack readiness”.
- Mapped Gherkin feature/scenario when product behavior changed: no product behavior changed; existing smoke/evidence mapping remains.
- Evidence mode / reality level: `configured`; persistent dogfood deploy must rerun after merge.
- Product-core questions intentionally left unresolved: none.

Quality Reset rule: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance before merge. `offline-spec` / `contract_only` fixture evidence must not be described as `live-runtime`, isolated E2E, `release_ready`, or customer-ready evidence.

## Branch, target lane, and release path

- Target lane: dev
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

Choose one and explain when needed.

- [x] none
- [ ] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

Use exactly one form.

- Release note: Fixes the local dogfood smoke check for the iOS custom-scheme handoff platform config URL.
- Release note: none — reason:

## Release notes label

Choose exactly one before review/merge; CI fails otherwise.

- [ ] `release-notes-feature`
- [x] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- None.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: none; assertion-only change.
- Accessibility/localization impact: none.
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values.

## Contract impact

- [x] No public API/auth/topology/spec contract change
- [ ] Contract/spec change documented:
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [x] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: QA/evidence lightweight path for persistent dogfood smoke.
- If Copilot is unavailable/insufficient, matching reviewer used: fallback agent review plus focused gate.

## Checks run

- [ ] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [ ] `make docs-check` / `make docs-build` (temporary Gradle-delegating aliases for docs or release notes changes)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed)
- [x] Live-stack validation (only when relevant; record run, artifact, or skip reason): persistent dogfood deploy run `28152310112` reached deploy and failed in smoke assertion; rerun required after merge.

Additional focused gate run:

- `PATH="/Users/flotterotter/flutter/bin:$PATH" ./gradlew infraStatic --console=plain --no-daemon --max-workers=1`

## Notes for reviewers

- This repairs the assertion only. The dogfood start page link from #921 remains the target shape for Massimo’s installed iOS client handoff.
