### PR TITLE
promote dev to dogfood deeplink smoke candidate

### DIFF
--- a/infra/weave-workspace/smoke-test.sh
+++ b/infra/weave-workspace/smoke-test.sh
@@ -521,7 +521,7 @@ grep -Fq '/api/platform/config' <<<"${product_start_page}" || fail "Smoke check 
 grep -Fq 'handoff-s32-massimo-dogfood-home' <<<"${product_start_page}" || fail "Smoke check failed: start page should include the default local invite guidance"
 grep -Fq 'weave://join?handoff_ref=handoff-s32-massimo-dogfood-home' <<<"${product_start_page}" || fail "Smoke check failed: start page should include the app custom-scheme handoff link"
 grep -Fq "product_base_url=${WEAVE_PUBLIC_BASE_URL}" <<<"${product_start_page}" || fail "Smoke check failed: custom-scheme handoff should include the product base URL"
-grep -Fq "platform_config_url=${WEAVE_BASE_URL}/api/platform/config" <<<"${product_start_page}" || fail "Smoke check failed: custom-scheme handoff should include the platform config URL"
+grep -Fq "platform_config_url=$(public_url "${TF_VAR_api_subdomain:-api}")/api/platform/config" <<<"${product_start_page}" || fail "Smoke check failed: custom-scheme handoff should include the platform config URL"
 grep -Fq 'passwords, tokens, client secrets, or credential URLs' <<<"${product_start_page}" || fail "Smoke check failed: start page should warn that secrets are not embedded"
 [[ "${product_start_page}" != *"127.0.0.1"* && "${product_start_page}" != *"localhost"* && "${product_start_page}" != *"192.168."* ]] || \
   fail "Smoke check failed: Product start page must not expose LAN IP, loopback, or localhost URLs"


### PR DESCRIPTION
## Summary

- Promote current `dev` to the persistent `dogfood` lane after the iOS deeplink handoff and smoke assertion fixes.
- Candidate SHA: `aae4eee434b7e1d262a72d160391752706f23b6d`.
- Includes #921 and #922 so the dogfood start page serves a usable `weave://join` custom-scheme handoff and the persistent smoke check validates the correct platform config URL.

## Evidence before Live Stack E2E

- #921 CI green: fixes installed-client iOS deeplink handoff shape and adds client/infra coverage.
- #922 CI green: fixes the persistent dogfood smoke assertion root cause from failed deploy run `28152310112`.
- Local focused gates from #921/#922:
  - `PATH="/Users/flotterotter/flutter/bin:$PATH" flutter test test/features/onboarding/member_handoff_test.dart`
  - `PATH="/Users/flotterotter/flutter/bin:$PATH" ./gradlew acceptanceContract infraStatic --console=plain --no-daemon --max-workers=1`
  - `PATH="/Users/flotterotter/flutter/bin:$PATH" ./gradlew infraStatic --console=plain --no-daemon --max-workers=1`

## Promotion note

- This PR must run Live Stack E2E for candidate `aae4eee434b7e1d262a72d160391752706f23b6d`.
- Merging this PR updates the persistent LAN dogfood stack via Test Stack Deploy and is the deployment approval boundary for this readiness slice.
- The concrete iOS custom-scheme handoff expected after deployment is:
  `weave://join?handoff_ref=handoff-s32-massimo-dogfood-home&org=massimo-dogfood&workspace=home&profile=local-lan-dogfood&run_id=s32-massimo-dogfood&product_base_url=https://weave.test:44443&platform_config_url=https://api.weave.test:44443/api/platform/config`

## Release notes

- Lane promotion only; implementation changes retain their original merged PR labels.
