### PR TITLE
fix(dogfood): preflight physical iOS TLS trust

### DIFF
--- a/client/lib/features/onboarding/presentation/member_handoff_screen.dart
+++ b/client/lib/features/onboarding/presentation/member_handoff_screen.dart
@@ -89,15 +89,18 @@ class _MemberHandoffScreenState extends ConsumerState<MemberHandoffScreen> {
     if (failure != null) {
       final errorCode = supportSafeHandoffErrorCode(failure);
       final errorCodeText = l10n.memberHandoffErrorCode(errorCode);
+      final guidance = errorCode == 'WEAVE-APP-START-TLS-FAILED'
+          ? l10n.memberHandoffTlsErrorGuidance
+          : l10n.memberHandoffErrorGuidance;
       _recordVisibleStateOnce('handoff_error', errorCode: errorCode);
       return Scaffold(
         body: SafeArea(
           child: Center(
             child: ErrorState(
               message: l10n.memberHandoffErrorTitle,
-              guidance: '${l10n.memberHandoffErrorGuidance}\n$errorCodeText',
+              guidance: '$guidance\n$errorCodeText',
               semanticLabel:
-                  '${l10n.memberHandoffErrorTitle}. ${l10n.memberHandoffErrorGuidance}. $errorCodeText',
+                  '${l10n.memberHandoffErrorTitle}. $guidance. $errorCodeText',
               retryLabel: l10n.retryButton,
               onRetry: () {
                 setState(() => _failure = null);

--- a/client/lib/l10n/app_de.arb
+++ b/client/lib/l10n/app_de.arb
@@ -1440,6 +1440,10 @@
   "@memberHandoffErrorGuidance": {
     "description": "Support-safe guidance when member handoff consumption fails"
   },
+  "memberHandoffTlsErrorGuidance": "Weave konnte die Startkonfiguration des Workspaces nicht über vertrauenswürdiges TLS erreichen. Für lokales Dogfood installiere die Weave Local Development CA auf diesem iPhone und aktiviere volles Vertrauen, oder bitte deinen Admin um eine öffentlich vertrauenswürdige Organisations-Anmelde-URL.",
+  "@memberHandoffTlsErrorGuidance": {
+    "description": "Support-safe guidance when member handoff consumption fails because platform config TLS trust is missing"
+  },
   "memberHandoffErrorCode": "Fehlercode: {code}",
   "@memberHandoffErrorCode": {
     "description": "Support-safe handoff failure code shown with the member handoff error",

--- a/client/lib/l10n/app_en.arb
+++ b/client/lib/l10n/app_en.arb
@@ -4853,6 +4853,10 @@
   "@memberHandoffErrorGuidance": {
     "description": "Support-safe guidance when member handoff consumption fails"
   },
+  "memberHandoffTlsErrorGuidance": "Weave could not reach the workspace start configuration over trusted TLS. For local dogfood, install and fully trust the Weave Local Development CA on this iPhone, or ask your admin for a publicly trusted organization sign-in link.",
+  "@memberHandoffTlsErrorGuidance": {
+    "description": "Support-safe guidance when member handoff consumption fails because platform config TLS trust is missing"
+  },
   "memberHandoffErrorCode": "Error code: {code}",
   "@memberHandoffErrorCode": {
     "description": "Support-safe handoff failure code shown with the member handoff error",

--- a/client/lib/l10n/generated/app_localizations.dart
+++ b/client/lib/l10n/generated/app_localizations.dart
@@ -6672,6 +6672,12 @@ abstract class AppLocalizations {
   /// **'The invite may be expired, incomplete, or not ready yet. Ask your workspace admin for a fresh invite or organization sign-in link.'**
   String get memberHandoffErrorGuidance;
 
+  /// Support-safe guidance when member handoff consumption fails because platform config TLS trust is missing
+  ///
+  /// In en, this message translates to:
+  /// **'Weave could not reach the workspace start configuration over trusted TLS. For local dogfood, install and fully trust the Weave Local Development CA on this iPhone, or ask your admin for a publicly trusted organization sign-in link.'**
+  String get memberHandoffTlsErrorGuidance;
+
   /// Support-safe handoff failure code shown with the member handoff error
   ///
   /// In en, this message translates to:

--- a/client/lib/l10n/generated/app_localizations_de.dart
+++ b/client/lib/l10n/generated/app_localizations_de.dart
@@ -4151,6 +4151,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Die Einladung ist möglicherweise abgelaufen, unvollständig oder noch nicht bereit. Bitte deinen Workspace-Admin um eine neue Einladung oder Organisations-Anmelde-URL.';
 
   @override
+  String get memberHandoffTlsErrorGuidance =>
+      'Weave konnte die Startkonfiguration des Workspaces nicht über vertrauenswürdiges TLS erreichen. Für lokales Dogfood installiere die Weave Local Development CA auf diesem iPhone und aktiviere volles Vertrauen, oder bitte deinen Admin um eine öffentlich vertrauenswürdige Organisations-Anmelde-URL.';
+
+  @override
   String memberHandoffErrorCode(String code) {
     return 'Fehlercode: $code';
   }

--- a/client/lib/l10n/generated/app_localizations_en.dart
+++ b/client/lib/l10n/generated/app_localizations_en.dart
@@ -4094,6 +4094,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'The invite may be expired, incomplete, or not ready yet. Ask your workspace admin for a fresh invite or organization sign-in link.';
 
   @override
+  String get memberHandoffTlsErrorGuidance =>
+      'Weave could not reach the workspace start configuration over trusted TLS. For local dogfood, install and fully trust the Weave Local Development CA on this iPhone, or ask your admin for a publicly trusted organization sign-in link.';
+
+  @override
   String memberHandoffErrorCode(String code) {
     return 'Error code: $code';
   }

--- a/client/test/features/onboarding/member_handoff_screen_test.dart
+++ b/client/test/features/onboarding/member_handoff_screen_test.dart
@@ -297,6 +297,13 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('We could not open this Weave invite'), findsOneWidget);
+      expect(
+        find.textContaining(
+          'Weave could not reach the workspace start configuration over trusted TLS.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('The invite may be expired'), findsNothing);
       expect(find.textContaining('WEAVE-APP-START-TLS-FAILED'), findsOneWidget);
 
       final rawEvidence = preferencesStore.rawString(

--- a/docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md
+++ b/docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md
@@ -12,6 +12,8 @@ Use this checklist after `weavectl profile apply` emits the run id. Do not paste
 - LAN assumption: iPhone and Mac are on the same LAN, with client isolation disabled.
 - Preflight result: pass / fail with stable code only.
 - Local TLS trust result: `DOGFOOD_TRUST_STABILITY_RESULT` / `DOGFOOD_TRUST_STABILITY_BLOCKED`.
+- Physical iPhone local CA preflight: `WEAVE_IOS_LOCAL_CA_TRUST_STATUS=trusted` / `PHYSICAL_DEVICE_TLS_PENDING`.
+- Platform config fetch boundary: physical iPhone can fetch `/api/platform/config` over trusted TLS / `WEAVE-APP-START-TLS-FAILED`.
 - iOS signing trust result: stable bundle ID / stable provisioning Team ID `KNDHGC2KV6` / stable developer certificate `6RUS2Z848X` / blocked by device policy / not verified.
 - Install transport: Wi-Fi preferred / USB fallback.
 - Install reset mode: update-in-place / trust-preserving app-state reset / explicit destructive uninstall.
@@ -22,12 +24,12 @@ Use this checklist after `weavectl profile apply` emits the run id. Do not paste
 
 1. Install or update Weave on the physical iPhone over Wi-Fi when reachable; use USB only as fallback.
 2. Confirm the install keeps bundle ID `com.massimotter.weave`, provisioning Team ID `KNDHGC2KV6`, developer certificate label `Apple Development: massimo164@me.com (6RUS2Z848X)`, and the same signing/provisioning trust assumptions. A normal update or trust-preserving app-state reset must not require trusting the Developer App again.
-3. Confirm local TLS trust separately: the Weave Local Development CA and leaf certificate match the latest handoff fingerprint baseline unless explicit rotation was requested.
+3. Confirm local TLS trust separately: the Weave Local Development CA and leaf certificate match the latest handoff fingerprint baseline unless explicit rotation was requested, and the iPhone has installed the CA profile and enabled full trust before Weave is launched.
 4. Scan the QR or open the handoff link from the emitted handoff artifact.
 5. Confirm the handoff opens Weave sign-in without asking for OIDC issuer, OIDC client ID, Matrix URL, Nextcloud URL, provider hostname, TLS certificate, provider diagnostics, SecretRef, or credential URL.
 6. Complete SSO.
 7. Confirm Weave workspace/home appears.
-8. If it fails, record only the stable next-action code, for example `WEAVE-LAN-UNREACHABLE`, `WEAVE-HANDOFF-INVALID`, `WEAVE-IOS-DEVELOPER-TRUST-NOT-VERIFIED`, or `WEAVE-SSO-NOT-COMPLETE`.
+8. If it fails, record only the stable next-action code, for example `PHYSICAL_DEVICE_TLS_PENDING`, `WEAVE-APP-START-TLS-FAILED`, `WEAVE-LAN-UNREACHABLE`, `WEAVE-HANDOFF-INVALID`, `WEAVE-IOS-DEVELOPER-TRUST-NOT-VERIFIED`, or `WEAVE-SSO-NOT-COMPLETE`.
 
 ## Result
 
@@ -36,6 +38,7 @@ Use this checklist after `weavectl profile apply` emits the run id. Do not paste
 - SSO result: pass / fail.
 - Workspace/home result: pass / fail.
 - Local TLS trust: stable / rotated by explicit request / blocked.
+- Physical platform-config TLS fetch: pass / `WEAVE-APP-START-TLS-FAILED` / pending manual CA trust.
 - Apple Developer Mode: enabled / not verified.
 - iOS Developer App trust: trusted once / repeated trust prompt / blocked by Apple device policy.
 - iOS app signing/provisioning stability: stable / bundle ID changed / Team ID changed / developer certificate changed / profile hash changed.

--- a/docs/sprint-31-iphone-lan-dogfood-runbook.md
+++ b/docs/sprint-31-iphone-lan-dogfood-runbook.md
@@ -12,8 +12,8 @@ Treat the earlier faulty handoff PR as evidence that local unit/widget and CI ch
 2. Run the onboarding E2E gate in the iOS Simulator from that `dev` state.
 3. Proceed to dogfood promotion/candidate installation only after the simulator gate prints `SIMULATOR_E2E_GREEN`.
 4. Install the dogfood candidate on Massimo's physical iPhone over Wi-Fi when `devicectl` can reach it; if Wi-Fi reachability fails, use USB as the fallback transport after pairing/authorization.
-5. Verify trust stability before handing the build to Massimo: normal stack restart/recreate must preserve the local TLS CA and leaf certificate unless explicit rotation is requested, and normal iOS update/app-state reset must not require Massimo to trust the development team/profile again.
-6. Report `READY_FOR_MASSIMO_TEST` only after the candidate is installable and all relevant onboarding E2E evidence is green, or report `BLOCKED` with the exact failing command/check/device step.
+5. Verify trust stability before handing the build to Massimo: normal stack restart/recreate must preserve the local TLS CA and leaf certificate unless explicit rotation is requested, the physical iPhone must have the Weave Local Development CA installed and fully trusted before platform-config fetch, and normal iOS update/app-state reset must not require Massimo to trust the development team/profile again.
+6. Report `READY_FOR_MASSIMO_TEST` only after the physical iPhone can fetch platform config over trusted TLS and all relevant onboarding E2E evidence is green. If the app shows `WEAVE-APP-START-TLS-FAILED`, report `PHYSICAL_DEVICE_TLS_PENDING`; simulator handoff evidence is not physical-device E2E.
 
 From the repo root, after starting the local stack on a phone-reachable Mac LAN address:
 
@@ -39,6 +39,8 @@ tools/dogfood_handoff_bundle.py
 This writes `build/dogfood/handoff.json` and `build/dogfood/handoff.md` with the current `weave://join` deeplink, web join URL, local CA URLs, CA/leaf fingerprints when local cert files exist, stack commit, and iOS profile/release smoke requirements. Send the generated artifact contents, not a stale chat transcript. If the CA or leaf fingerprint changes between normal reruns, treat that as a trust-stability blocker unless the run explicitly requested certificate rotation.
 
 Installed iOS client smoke must use a profile or release build. Debug builds and raw `devicectl` process launch success are not valid dogfood evidence for iOS custom-scheme launch. Use `tools/dogfood_ios_deeplink_smoke.sh` with `WEAVE_IOS_BUILD_MODE=profile` or `release`; this proves `last_handoff_consumed_v1`, `dogfood_visible_state_v1=handoff_ready`, and `dogfood_auth_state_v1=ready_for_sso` from the app container. It is still only the handoff gate. Full member onboarding evidence additionally requires Sign In, account activation, saved session, workspace entry, restore, reinstall/manual login, and Mailpit capture. Wi-Fi install is preferred, USB is a fallback only, and both install paths use the same stable bundle ID, provisioning Team ID `KNDHGC2KV6`, developer certificate label `Apple Development: massimo164@me.com (6RUS2Z848X)`, signing identity/profile class, and developer-trust assumptions. If a normal update or trust-preserving app-state reset prompts Massimo to trust the development team/profile again, the dogfood path is not ready for Massimo.
+
+For local dogfood HTTPS, the physical smoke has a pre-launch TLS preflight. Set `WEAVE_IOS_LOCAL_CA_TRUST_STATUS=trusted` only after the Weave Local Development CA profile is installed on the iPhone and full trust is enabled in Settings > General > About > Certificate Trust Settings. If that state is not confirmed, the runner exits before install/launch with `PHYSICAL_DEVICE_TLS_PENDING` and writes `build/dogfood/ios-local-tls-preflight.json`. This is a precondition, not E2E success. iOS does not provide a support-safe non-interactive way for this runner to install and fully trust a local root CA; for a no-manual-CA tester flow, use a publicly trusted dogfood endpoint or stable installed configuration instead of relying on local CA setup.
 
 Do not uninstall the physical iPhone app by default. Apple can remove the Developer App trust anchor when the last app signed by a developer is deleted, which turns the next launch into a manual `Apple Development: massimo164@me.com (6RUS2Z848X)` trust step. The physical runner therefore defaults to `WEAVE_IOS_RESET_MODE=update_in_place`. For fresh-install semantics without deleting the app, use `WEAVE_IOS_RESET_MODE=app_state`; the runner appends a dogfood-only reset marker to the handoff so Weave clears saved configuration, handoff evidence, auth session, Nextcloud session, and dogfood evidence before consuming the link. Use `WEAVE_IOS_RESET_MODE=destructive_uninstall` only as an explicit physical-trust-disruptive reset and record that it may require a new Developer App trust approval. If repeated trust remains part of the development-runner path, prefer TestFlight/internal or ad-hoc distribution for professional dogfood handoff instead of asking Massimo to repeat device-management trust.
 
@@ -124,6 +126,7 @@ If the simulator gate is green but the phone is unplugged or Wi-Fi-unreachable, 
 
 ```sh
 WEAVE_IOS_DEVICE_ID=<plugged-iphone-id> \
+WEAVE_IOS_LOCAL_CA_TRUST_STATUS=trusted \
 WEAVE_IOS_RESET_MODE=app_state \
 WEAVE_DOGFOOD_DEEPLINK='<current weave://join... URL>' \
 tools/dogfood_ios_deeplink_smoke.sh

--- a/tools/dogfood_ios_deeplink_smoke.sh
+++ b/tools/dogfood_ios_deeplink_smoke.sh
@@ -13,6 +13,8 @@ INSTALL_TRANSPORT="${WEAVE_IOS_INSTALL_TRANSPORT:-wifi}"
 RESET_MODE="${WEAVE_IOS_RESET_MODE:-update_in_place}"
 EXPECTED_TEAM_ID="${WEAVE_IOS_EXPECTED_TEAM_ID:-KNDHGC2KV6}"
 EXPECTED_DEVELOPER_CERT_TEAM_ID="${WEAVE_IOS_EXPECTED_DEVELOPER_CERT_TEAM_ID:-6RUS2Z848X}"
+LOCAL_CA_TRUST_STATUS="${WEAVE_IOS_LOCAL_CA_TRUST_STATUS:-not_verified}"
+PLATFORM_CONFIG_URL="${WEAVE_DOGFOOD_PLATFORM_CONFIG_URL:-}"
 
 fail() {
   echo "dogfood iOS smoke failed: $*" >&2
@@ -26,6 +28,7 @@ fail() {
 [[ -z "${WEAVE_IOS_RESET_APP_DATA:-}" ]] || fail "WEAVE_IOS_RESET_APP_DATA is deprecated because uninstall can destroy Developer App trust; use WEAVE_IOS_RESET_MODE=update_in_place, app_state, or destructive_uninstall"
 [[ "${INSTALL_TRANSPORT}" == "wifi" || "${INSTALL_TRANSPORT}" == "usb" || "${INSTALL_TRANSPORT}" == "unknown" ]] || fail "WEAVE_IOS_INSTALL_TRANSPORT must be wifi, usb, or unknown"
 [[ "${RESET_MODE}" == "update_in_place" || "${RESET_MODE}" == "app_state" || "${RESET_MODE}" == "destructive_uninstall" ]] || fail "WEAVE_IOS_RESET_MODE must be update_in_place, app_state, or destructive_uninstall"
+[[ "${LOCAL_CA_TRUST_STATUS}" == "trusted" || "${LOCAL_CA_TRUST_STATUS}" == "manual_pending" || "${LOCAL_CA_TRUST_STATUS}" == "publicly_trusted" || "${LOCAL_CA_TRUST_STATUS}" == "not_required" || "${LOCAL_CA_TRUST_STATUS}" == "not_verified" ]] || fail "WEAVE_IOS_LOCAL_CA_TRUST_STATUS must be trusted, manual_pending, publicly_trusted, not_required, or not_verified"
 [[ -x "${FLUTTER_BIN}" ]] || FLUTTER_BIN="$(command -v flutter || true)"
 [[ -n "${FLUTTER_BIN}" && -x "${FLUTTER_BIN}" ]] || fail "flutter was not found; set FLUTTER_BIN"
 
@@ -43,6 +46,63 @@ query["dogfood_reset"] = "app_state"
 print(urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment)))
 PY
 )"
+fi
+
+if [[ -z "${PLATFORM_CONFIG_URL}" ]]; then
+  PLATFORM_CONFIG_URL="$(DEEPLINK="${DEEPLINK}" python3 - <<'PY'
+import os
+from urllib.parse import parse_qs, unquote, urlparse, urlunparse
+
+query = parse_qs(urlparse(os.environ["DEEPLINK"]).query)
+value = query.get("platform_config_url", [""])[0]
+if value:
+    print(unquote(value))
+else:
+    product_base_url = unquote(query.get("product_base_url", [""])[0])
+    parsed = urlparse(product_base_url)
+    print(urlunparse((parsed.scheme, parsed.netloc, "/api/platform/config", "", "", "")) if parsed.scheme and parsed.netloc else "")
+PY
+)"
+fi
+LOCAL_DOGFOOD_TLS_REQUIRED="$(PLATFORM_CONFIG_URL="${PLATFORM_CONFIG_URL}" python3 - <<'PY'
+import os
+from urllib.parse import urlparse
+
+url = os.environ.get("PLATFORM_CONFIG_URL", "")
+parsed = urlparse(url)
+host = parsed.hostname or ""
+requires_local_ca = (
+    parsed.scheme == "https"
+    and (
+        host.endswith("weave.test")
+        or host.endswith(".weave.test")
+        or parsed.port == 44443
+    )
+)
+print("1" if requires_local_ca else "0")
+PY
+)"
+cat > "${EVIDENCE_DIR}/ios-local-tls-preflight.json" <<JSON
+{
+  "schemaVersion": "weave.dogfood.ios-local-tls-preflight.v1",
+  "supportSafe": true,
+  "platformConfigUrl": "${PLATFORM_CONFIG_URL}",
+  "localDogfoodTlsRequired": $([[ "${LOCAL_DOGFOOD_TLS_REQUIRED}" == "1" ]] && echo true || echo false),
+  "iosLocalCaTrustStatus": "${LOCAL_CA_TRUST_STATUS}",
+  "manualPrecondition": "For local dogfood TLS, install the Weave Local Development CA profile on the iPhone and enable full trust before launching Weave.",
+  "failureCodeWhenPending": "PHYSICAL_DEVICE_TLS_PENDING"
+}
+JSON
+if [[ "${LOCAL_DOGFOOD_TLS_REQUIRED}" == "1" ]]; then
+  case "${LOCAL_CA_TRUST_STATUS}" in
+    trusted|publicly_trusted) ;;
+    manual_pending)
+      fail "PHYSICAL_DEVICE_TLS_PENDING: install the Weave Local Development CA profile on the iPhone, enable full trust in Settings > General > About > Certificate Trust Settings, then rerun with WEAVE_IOS_LOCAL_CA_TRUST_STATUS=trusted"
+      ;;
+    *)
+      fail "PHYSICAL_DEVICE_TLS_PENDING: local dogfood platform config uses HTTPS with the Weave local CA; confirm iPhone CA trust first with WEAVE_IOS_LOCAL_CA_TRUST_STATUS=trusted or use a publicly trusted dogfood endpoint"
+      ;;
+  esac
 fi
 
 xcrun devicectl device info details \

--- a/tools/sprint31_lan_dogfood_check.py
+++ b/tools/sprint31_lan_dogfood_check.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -47,8 +48,22 @@ def read(rel: str) -> str:
         fail(f"missing required file: {rel}")
 
 
-def run(args: list[str], expect_success: bool = True) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(args, cwd=ROOT, text=True, capture_output=True, check=False)
+def run(
+    args: list[str],
+    expect_success: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    command_env = os.environ.copy()
+    if env:
+        command_env.update(env)
+    result = subprocess.run(
+        args,
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+        env=command_env,
+    )
     if expect_success and result.returncode != 0:
         fail(f"command failed: {' '.join(args)}\n{result.stdout}\n{result.stderr}")
     if not expect_success and result.returncode == 0:
@@ -146,6 +161,38 @@ def main() -> None:
     android_manifest = read("client/android/app/src/main/AndroidManifest.xml")
     if "weave_member_handoff" not in android_manifest or "android:scheme=\"weave\"" not in android_manifest:
         fail("Android must register a separate Weave member handoff scheme on MainActivity")
+    ios_smoke = read("tools/dogfood_ios_deeplink_smoke.sh")
+    for phrase in [
+        "WEAVE_IOS_LOCAL_CA_TRUST_STATUS",
+        "ios-local-tls-preflight.json",
+        "PHYSICAL_DEVICE_TLS_PENDING",
+    ]:
+        if phrase not in ios_smoke:
+            fail(f"iOS physical smoke missing local TLS preflight guard: {phrase}")
+    with tempfile.TemporaryDirectory() as tmp:
+        result = run(
+            [
+                "bash",
+                "tools/dogfood_ios_deeplink_smoke.sh",
+            ],
+            expect_success=False,
+            env={
+                "WEAVE_IOS_DEVICE_ID": "placeholder-device",
+                "WEAVE_DOGFOOD_DEEPLINK": (
+                    "weave://join?handoff_ref=handoff-s32-massimo-dogfood-home"
+                    "&run_id=s32-massimo-dogfood"
+                    "&platform_config_url=https%3A%2F%2Fweave.test%3A44443%2Fapi%2Fplatform%2Fconfig"
+                ),
+                "WEAVE_IOS_LOCAL_CA_TRUST_STATUS": "manual_pending",
+                "WEAVE_DOGFOOD_EVIDENCE_DIR": tmp,
+                "FLUTTER_BIN": "/usr/bin/true",
+            },
+        )
+        if "PHYSICAL_DEVICE_TLS_PENDING" not in result.stderr:
+            fail("iOS physical smoke must fail before launch when local CA trust is pending")
+        preflight = Path(tmp) / "ios-local-tls-preflight.json"
+        if not preflight.exists():
+            fail("iOS physical smoke must write local TLS preflight evidence before failing")
 
     for rel in [
         "docs/sprint-31-iphone-lan-dogfood-runbook.md",
@@ -157,6 +204,15 @@ def main() -> None:
             if phrase not in text:
                 fail(f"{rel} missing {phrase}")
         assert_no_forbidden(rel)
+    runbook = read("docs/sprint-31-iphone-lan-dogfood-runbook.md")
+    for phrase in [
+        "WEAVE-APP-START-TLS-FAILED",
+        "PHYSICAL_DEVICE_TLS_PENDING",
+        "publicly trusted dogfood endpoint",
+        "simulator handoff evidence is not physical-device E2E",
+    ]:
+        if phrase not in runbook:
+            fail(f"runbook missing physical TLS boundary: {phrase}")
 
     print("sprint31-lan-dogfood-check: ok")
 


### PR DESCRIPTION
## Summary
- add a physical iPhone local TLS preflight to `tools/dogfood_ios_deeplink_smoke.sh` so local dogfood CA trust is confirmed before install/launch
- write support-safe `ios-local-tls-preflight.json` evidence and fail early with `PHYSICAL_DEVICE_TLS_PENDING` when iPhone CA trust is pending
- show TLS-specific member handoff guidance for `WEAVE-APP-START-TLS-FAILED` instead of the generic expired/incomplete invite copy
- update the Sprint 31 runbook/checklist and guard to keep simulator handoff evidence distinct from physical-device E2E

## Evidence
- `${HOME}/flutter/bin/flutter gen-l10n`
- `dart format lib/features/onboarding/presentation/member_handoff_screen.dart test/features/onboarding/member_handoff_screen_test.dart`
- `bash -n tools/dogfood_ios_deeplink_smoke.sh`
- `python3 tools/sprint31_lan_dogfood_check.py`
- `${HOME}/flutter/bin/flutter test test/features/onboarding/member_handoff_screen_test.dart`

## Release notes
Fixed: physical iPhone dogfood runner now fails early when local TLS CA trust is pending and the member app shows platform-config TLS guidance.

## Current status
PHYSICAL_DEVICE_TLS_PENDING: this PR improves the runner and failure messaging, but it does not prove physical iPhone onboarding success. READY requires the physical iPhone to fetch platform config over trusted TLS and continue through auth/workspace evidence.