### PR TITLE
fix(dogfood): prefer public trusted route for physical iPhone

### DIFF
--- a/docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md
+++ b/docs/evidence/sprint-31-physical-iphone-lan-dogfood/physical-iphone-checklist.md
@@ -9,6 +9,8 @@ Use this checklist after `weavectl profile apply` emits the run id. Do not paste
 - Evidence directory:
 - Handoff artifact:
 - Readiness artifact:
+- Dogfood route mode: public trusted HTTPS preferred / local stable CA fallback.
+- Public route acceptance: stable base URL / publicly trusted certificate / support-safe invite links / no secrets in links / no raw provider payloads / Mailpit dogfood mail remains local-safe.
 - LAN assumption: iPhone and Mac are on the same LAN, with client isolation disabled.
 - Preflight result: pass / fail with stable code only.
 - Local TLS trust result: `DOGFOOD_TRUST_STABILITY_RESULT` / `DOGFOOD_TRUST_STABILITY_BLOCKED`.
@@ -24,7 +26,7 @@ Use this checklist after `weavectl profile apply` emits the run id. Do not paste
 
 1. Install or update Weave on the physical iPhone over Wi-Fi when reachable; use USB only as fallback.
 2. Confirm the install keeps bundle ID `com.massimotter.weave`, provisioning Team ID `KNDHGC2KV6`, developer certificate label `Apple Development: massimo164@me.com (6RUS2Z848X)`, and the same signing/provisioning trust assumptions. A normal update or trust-preserving app-state reset must not require trusting the Developer App again.
-3. Confirm local TLS trust separately: the Weave Local Development CA and leaf certificate match the latest handoff fingerprint baseline unless explicit rotation was requested, and the iPhone has installed the CA profile and enabled full trust before Weave is launched.
+3. For public-route dogfood, confirm the generated links use the stable public HTTPS base URL and publicly trusted certificate. For local-route dogfood, confirm the Weave Local Development CA and leaf certificate match the latest handoff fingerprint baseline unless explicit rotation was requested, and the iPhone has installed the CA profile and enabled full trust before Weave is launched.
 4. Scan the QR or open the handoff link from the emitted handoff artifact.
 5. Confirm the handoff opens Weave sign-in without asking for OIDC issuer, OIDC client ID, Matrix URL, Nextcloud URL, provider hostname, TLS certificate, provider diagnostics, SecretRef, or credential URL.
 6. Complete SSO.
@@ -35,6 +37,7 @@ Use this checklist after `weavectl profile apply` emits the run id. Do not paste
 
 - Device: physical iPhone, model/iOS version optional.
 - Handoff type: QR / link / deep link / organization URL.
+- Route type: public trusted HTTPS / local stable CA.
 - SSO result: pass / fail.
 - Workspace/home result: pass / fail.
 - Local TLS trust: stable / rotated by explicit request / blocked.

--- a/docs/sprint-31-iphone-lan-dogfood-runbook.md
+++ b/docs/sprint-31-iphone-lan-dogfood-runbook.md
@@ -9,8 +9,8 @@ Sprint 31 prepares Massimo's first real physical iPhone test on the same LAN as 
 Treat the earlier faulty handoff PR as evidence that local unit/widget and CI checks are not enough. The dogfood/member onboarding delivery order is:
 
 1. Implement and review the change against the `dev` integration state.
-2. Run the onboarding E2E gate in the iOS Simulator from that `dev` state.
-3. Proceed to dogfood promotion/candidate installation only after the simulator gate prints `SIMULATOR_E2E_GREEN`.
+2. Run the onboarding E2E gate in the iOS Simulator from that `dev` state as a fast preflight only; simulator CA injection is not physical dogfood proof.
+3. Proceed to dogfood promotion/candidate installation only after the simulator gate prints `SIMULATOR_E2E_GREEN`, then prove either stable local CA trust on the physical iPhone or a public HTTPS route with a publicly trusted certificate.
 4. Install the dogfood candidate on Massimo's physical iPhone over Wi-Fi when `devicectl` can reach it; if Wi-Fi reachability fails, use USB as the fallback transport after pairing/authorization.
 5. Verify trust stability before handing the build to Massimo: normal stack restart/recreate must preserve the local TLS CA and leaf certificate unless explicit rotation is requested, the physical iPhone must have the Weave Local Development CA installed and fully trusted before platform-config fetch, and normal iOS update/app-state reset must not require Massimo to trust the development team/profile again.
 6. Report `READY_FOR_MASSIMO_TEST` only after the physical iPhone can fetch platform config over trusted TLS and all relevant onboarding E2E evidence is green. If the app shows `WEAVE-APP-START-TLS-FAILED`, report `PHYSICAL_DEVICE_TLS_PENDING`; simulator handoff evidence is not physical-device E2E.
@@ -30,13 +30,15 @@ For dry validation before the stack is listening, use `--preflight-mode validate
 
 The command rejects `localhost`, `127.0.0.1`, `0.0.0.0`, container-only names, and Mac-only `.local` assumptions before handoff output. Handoff evidence stores refs and endpoint classes, not raw secrets or provider diagnostics. The handoff includes one canonical product join URL (`/join`) plus a `weave:/join?...` local-dev fallback. These are non-secret enrollment handoff links, not bearer access. Real access control is the provisioned account, organization/workspace membership, and identity-provider session. Both handoff links point at the public `/api/platform/config` app-start discovery contract; the member client must not derive provider topology from a guessed base URL.
 
+For Massimo-facing dogfood, prefer a public HTTPS route with a publicly trusted certificate when it is available. A public route removes repeated local CA trust friction and makes invite links realistic. Its acceptance contract is: stable base URL, real HTTPS trust, generated support-safe invite links, no secrets in links, no raw provider payloads, and Mailpit/dogfood mail constraints still local/safe as needed. Keep the local `weave.test` route as an acceptable fallback only when the same local CA and leaf certificate persist across normal stack restarts and reruns.
+
 For the persistent `weave.test` dogfood lane, generate the current handoff bundle before sending tester instructions:
 
 ```sh
 tools/dogfood_handoff_bundle.py
 ```
 
-This writes `build/dogfood/handoff.json` and `build/dogfood/handoff.md` with the current `weave://join` deeplink, web join URL, local CA URLs, CA/leaf fingerprints when local cert files exist, stack commit, and iOS profile/release smoke requirements. Send the generated artifact contents, not a stale chat transcript. If the CA or leaf fingerprint changes between normal reruns, treat that as a trust-stability blocker unless the run explicitly requested certificate rotation.
+This writes `build/dogfood/handoff.json` and `build/dogfood/handoff.md` with the current `weave://join` deeplink, web join URL, dogfood route mode, local CA URLs, CA/leaf fingerprints when local cert files exist, stack commit, and iOS profile/release smoke requirements. Send the generated artifact contents, not a stale chat transcript. If the CA or leaf fingerprint changes between normal reruns, treat that as a trust-stability blocker unless the run explicitly requested certificate rotation. For public-route handoffs, run it with `--dogfood-route-mode public-trusted-https --product-base-url https://<stable-public-dogfood-host> --platform-config-url https://<stable-public-dogfood-host>/api/platform/config`; the generated support-safe links must still be non-secret enrollment handoff links.
 
 Installed iOS client smoke must use a profile or release build. Debug builds and raw `devicectl` process launch success are not valid dogfood evidence for iOS custom-scheme launch. Use `tools/dogfood_ios_deeplink_smoke.sh` with `WEAVE_IOS_BUILD_MODE=profile` or `release`; this proves `last_handoff_consumed_v1`, `dogfood_visible_state_v1=handoff_ready`, and `dogfood_auth_state_v1=ready_for_sso` from the app container. It is still only the handoff gate. Full member onboarding evidence additionally requires Sign In, account activation, saved session, workspace entry, restore, reinstall/manual login, and Mailpit capture. Wi-Fi install is preferred, USB is a fallback only, and both install paths use the same stable bundle ID, provisioning Team ID `KNDHGC2KV6`, developer certificate label `Apple Development: massimo164@me.com (6RUS2Z848X)`, signing identity/profile class, and developer-trust assumptions. If a normal update or trust-preserving app-state reset prompts Massimo to trust the development team/profile again, the dogfood path is not ready for Massimo.
 
@@ -71,7 +73,7 @@ When Massimo's physical iPhone is not reachable, run the simulator handoff gate 
 tools/dogfood_ios_simulator_onboarding_smoke.sh
 ```
 
-The simulator smoke boots or reuses an iPhone simulator, installs the local dogfood CA, builds the iOS simulator app, clears app data, installs Weave, injects the same pending native deeplink URL that the iOS URL bridge consumes, and verifies `handoff_ready` plus `ready_for_sso` support-safe preferences. It prints `SIMULATOR_E2E_GREEN` only for that simulator-covered scope. It does not replace physical-device evidence because `simctl openurl` can stop on Apple's "Open in Weave?" consent sheet and simulator runs do not prove the real iPhone trust profile, AppAuth browser handoff, account activation, saved session restore, reinstall/manual login, or Mailpit capture.
+The simulator smoke boots or reuses an iPhone simulator, installs the local dogfood CA, builds the iOS simulator app, clears app data, installs Weave, injects the same pending native deeplink URL that the iOS URL bridge consumes, and verifies `handoff_ready` plus `ready_for_sso` support-safe preferences. It prints `SIMULATOR_E2E_GREEN` only for that simulator-covered scope. It does not replace physical-device evidence because simulator-only certificate injection is repeatable in a way physical iPhone testing is not, `simctl openurl` can stop on Apple's "Open in Weave?" consent sheet, and simulator runs do not prove the real iPhone trust profile, AppAuth browser handoff, account activation, saved session restore, reinstall/manual login, or Mailpit capture.
 
 ## What Massimo should see
 

--- a/release/sprint-31-physical-iphone-lan-dogfood/local-lan-dogfood.profile.json
+++ b/release/sprint-31-physical-iphone-lan-dogfood/local-lan-dogfood.profile.json
@@ -8,6 +8,14 @@
   "memberPhoneAllowed": true,
   "publicDnsRequired": false,
   "trustedInternetTlsRequired": false,
+  "physicalDogfoodRoutePolicy": {
+    "simulatorCertInjectionCountsAsPhysicalProof": false,
+    "preferredMassimoRoute": "public-trusted-https",
+    "localFallback": "persistent-local-ca-and-leaf",
+    "localCaRotationRequiresExplicitRequest": true,
+    "defaultPhysicalReset": "update-in-place",
+    "freshSemantics": "app-state-reset"
+  },
   "rejects": [
     "localhost",
     "127.0.0.1",

--- a/tools/dogfood_handoff_bundle.py
+++ b/tools/dogfood_handoff_bundle.py
@@ -11,7 +11,7 @@ import tempfile
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -103,11 +103,14 @@ def write_markdown(path: Path, payload: dict[str, object]) -> None:
     tester = payload["testerVisible"]  # type: ignore[index]
     certs = payload["certificates"]  # type: ignore[index]
     ios = payload["iosClient"]  # type: ignore[index]
+    route = payload["dogfoodRoute"]  # type: ignore[index]
     lines = [
         "# Weave Dogfood Handoff",
         "",
         f"- Run ID: `{payload['runId']}`",
         f"- Commit: `{payload['stackCommit']}`",
+        f"- Route mode: `{route['mode']}`",
+        f"- Public route recommended: `{route['publicRouteRecommended']}`",
         f"- Web join URL: `{tester['webJoinUrl']}`",
         f"- iOS deeplink: `{tester['deepLink']}`",
         f"- CA URL: `{certs['caUrl']}`",
@@ -117,10 +120,19 @@ def write_markdown(path: Path, payload: dict[str, object]) -> None:
         "",
         "## iPhone Checklist",
         "",
-        "1. Install/trust the Weave Local Development CA.",
-        "2. Update the current Weave iOS profile or release binary in place; use app-state reset for fresh semantics.",
-        "3. Open the deeplink from Safari or Matrix.",
-        "4. Confirm Weave shows the handoff-aware workspace sign-in state.",
+        "1. Prefer a public HTTPS dogfood route with a publicly trusted certificate for Massimo-facing tests.",
+        "2. If using local HTTPS, reuse the same persisted Weave Local Development CA and leaf certificate; do not rotate unless explicitly requested.",
+        "3. Update the current Weave iOS profile or release binary in place; use app-state reset for fresh semantics.",
+        "4. Open the deeplink from Safari or Matrix.",
+        "5. Confirm Weave shows the handoff-aware workspace sign-in state.",
+        "",
+        "## Public Route Acceptance",
+        "",
+        f"- Stable base URL required: `{route['stableBaseUrlRequired']}`",
+        f"- Publicly trusted HTTPS required for public route: `{route['publiclyTrustedHttpsRequired']}`",
+        f"- Support-safe invite links required: `{route['supportSafeInviteLinksRequired']}`",
+        f"- Secrets in links allowed: `{route['secretsInLinksAllowed']}`",
+        f"- Mailpit/local mail safety still required: `{route['mailpitLocalSafetyRequired']}`",
         "",
         "## Build Requirement",
         "",
@@ -154,6 +166,12 @@ def main() -> int:
     parser.add_argument("--ca-url", default="http://weave.test:44080/weave-local-ca.pem")
     parser.add_argument("--ca-lan-fallback-url", default="http://192.168.178.88:44080/weave-local-ca.pem")
     parser.add_argument("--cert-dir", type=Path, default=DEFAULT_CERT_DIR)
+    parser.add_argument(
+        "--dogfood-route-mode",
+        choices=["local-stable-ca", "public-trusted-https"],
+        default=None,
+        help="Evidence mode for Massimo-facing dogfood links.",
+    )
     parser.add_argument("--leaf-host", default="weave.test")
     parser.add_argument("--leaf-connect-host", default="127.0.0.1")
     parser.add_argument("--leaf-port", type=int, default=44443)
@@ -172,6 +190,15 @@ def main() -> int:
     deep_link_query["platform_config_url"] = args.platform_config_url
     web_join_url = f"{args.product_base_url}/join?{urlencode(query)}"
     deep_link = f"weave://join?{urlencode(deep_link_query)}"
+    product_base = urlparse(args.product_base_url)
+    inferred_public_route = (
+        product_base.scheme == "https"
+        and product_base.hostname not in {"weave.test", "api.weave.test"}
+        and not str(product_base.hostname or "").endswith(".weave.test")
+    )
+    route_mode = args.dogfood_route_mode or (
+        "public-trusted-https" if inferred_public_route else "local-stable-ca"
+    )
 
     ca_file = args.cert_dir / "weave-local-ca.pem"
     leaf_file = args.cert_dir / "weave.test.pem"
@@ -198,6 +225,20 @@ def main() -> int:
             "deepLink": deep_link,
             "platformConfigUrl": args.platform_config_url,
         },
+        "dogfoodRoute": {
+            "mode": route_mode,
+            "simulatorCertInjectionIsPhysicalProof": False,
+            "physicalE2eGate": "physical-or-public-route-e2e",
+            "publicRouteRecommended": True,
+            "stableBaseUrlRequired": True,
+            "publiclyTrustedHttpsRequired": route_mode == "public-trusted-https",
+            "localStableCaAllowed": route_mode == "local-stable-ca",
+            "localCaRotationRequiresExplicitRequest": True,
+            "supportSafeInviteLinksRequired": True,
+            "secretsInLinksAllowed": False,
+            "rawProviderPayloadsAllowed": False,
+            "mailpitLocalSafetyRequired": True,
+        },
         "certificates": {
             "caUrl": args.ca_url,
             "caLanFallbackUrl": args.ca_lan_fallback_url,
@@ -205,6 +246,8 @@ def main() -> int:
             "leafSha256Fingerprint": leaf_fingerprint,
             "leafSubject": leaf_subject,
             "persistedHostDirectory": str(args.cert_dir),
+            "rotationPolicy": "never_rotate_unless_explicit",
+            "physicalIphoneMustAlreadyTrustStableCa": route_mode == "local-stable-ca",
             "fingerprintSource": "host-files"
             if ca_file.exists() and leaf_file.exists()
             else "live-endpoints",

--- a/tools/sprint31_lan_dogfood_check.py
+++ b/tools/sprint31_lan_dogfood_check.py
@@ -84,6 +84,20 @@ def main() -> None:
         fail("Sprint 31 profile must use the unified weavectl profile apply pipeline")
     if profile.get("publicDnsRequired") or profile.get("trustedInternetTlsRequired"):
         fail("local-lan-dogfood must not require public DNS or trusted internet TLS")
+    route_policy = profile.get("physicalDogfoodRoutePolicy", {})
+    if not isinstance(route_policy, dict):
+        fail("profile must include physicalDogfoodRoutePolicy")
+    expected_policy = {
+        "simulatorCertInjectionCountsAsPhysicalProof": False,
+        "preferredMassimoRoute": "public-trusted-https",
+        "localFallback": "persistent-local-ca-and-leaf",
+        "localCaRotationRequiresExplicitRequest": True,
+        "defaultPhysicalReset": "update-in-place",
+        "freshSemantics": "app-state-reset",
+    }
+    for key, expected in expected_policy.items():
+        if route_policy.get(key) != expected:
+            fail(f"profile physical dogfood route policy mismatch for {key}: {route_policy.get(key)!r}")
     for item in FORBIDDEN_MEMBER_INPUTS:
         if item not in profile.get("forbiddenMemberInputs", []):
             fail(f"profile must forbid member input: {item}")
@@ -193,6 +207,49 @@ def main() -> None:
         preflight = Path(tmp) / "ios-local-tls-preflight.json"
         if not preflight.exists():
             fail("iOS physical smoke must write local TLS preflight evidence before failing")
+    handoff_bundle = read("tools/dogfood_handoff_bundle.py")
+    for phrase in [
+        "dogfoodRoute",
+        "public-trusted-https",
+        "local-stable-ca",
+        "simulatorCertInjectionIsPhysicalProof",
+        "secretsInLinksAllowed",
+        "mailpitLocalSafetyRequired",
+    ]:
+        if phrase not in handoff_bundle:
+            fail(f"handoff bundle missing dogfood route evidence: {phrase}")
+    with tempfile.TemporaryDirectory() as tmp:
+        run(
+            [
+                "python3",
+                "tools/dogfood_handoff_bundle.py",
+                "--dogfood-route-mode",
+                "public-trusted-https",
+                "--product-base-url",
+                "https://dogfood.example.invalid",
+                "--platform-config-url",
+                "https://dogfood.example.invalid/api/platform/config",
+                "--output-dir",
+                tmp,
+            ],
+        )
+        handoff = json.loads((Path(tmp) / "handoff.json").read_text(encoding="utf-8"))
+        route = handoff.get("dogfoodRoute", {})
+        if not isinstance(route, dict):
+            fail("handoff bundle must emit dogfoodRoute evidence")
+        expected_route = {
+            "mode": "public-trusted-https",
+            "publicRouteRecommended": True,
+            "publiclyTrustedHttpsRequired": True,
+            "supportSafeInviteLinksRequired": True,
+            "secretsInLinksAllowed": False,
+            "rawProviderPayloadsAllowed": False,
+            "mailpitLocalSafetyRequired": True,
+            "simulatorCertInjectionIsPhysicalProof": False,
+        }
+        for key, expected in expected_route.items():
+            if route.get(key) != expected:
+                fail(f"public dogfood route evidence mismatch for {key}: {route.get(key)!r}")
 
     for rel in [
         "docs/sprint-31-iphone-lan-dogfood-runbook.md",
@@ -208,6 +265,8 @@ def main() -> None:
     for phrase in [
         "WEAVE-APP-START-TLS-FAILED",
         "PHYSICAL_DEVICE_TLS_PENDING",
+        "simulator CA injection is not physical dogfood proof",
+        "public HTTPS route with a publicly trusted certificate",
         "publicly trusted dogfood endpoint",
         "simulator handoff evidence is not physical-device E2E",
     ]:


### PR DESCRIPTION
## Summary
- encode Massimo-facing physical dogfood route direction: simulator cert injection is only a preflight, not physical proof
- add handoff-bundle route evidence for `local-stable-ca` vs `public-trusted-https`
- mark public trusted HTTPS as the recommended tester route with stable base URL, support-safe invite links, no secrets in links, no raw provider payloads, and Mailpit/local mail safety
- keep local CA as fallback only when the same CA/leaf persist and rotation is explicit

## Evidence
- `python3 -m py_compile tools/dogfood_handoff_bundle.py tools/sprint31_lan_dogfood_check.py`
- `python3 tools/dogfood_handoff_bundle.py --dogfood-route-mode public-trusted-https --product-base-url https://dogfood.example.invalid --platform-config-url https://dogfood.example.invalid/api/platform/config --output-dir /tmp/weave-public-handoff-check`
- `python3 -m json.tool /tmp/weave-public-handoff-check/handoff.json >/dev/null`
- `python3 tools/sprint31_lan_dogfood_check.py`

## Release notes
Fixed: physical iPhone dogfood evidence now prefers a public trusted HTTPS route and prevents simulator-only certificate injection from counting as physical proof.

## Current status
PROGRESS / PHYSICAL_DEVICE_TLS_PENDING: this clarifies and guards the tester-friendly route policy. It does not claim physical onboarding success.