### PR TITLE
test(dogfood): require onboarding return evidence

### DIFF
--- a/client/lib/features/onboarding/domain/entities/member_auth_onboarding_state.dart
+++ b/client/lib/features/onboarding/domain/entities/member_auth_onboarding_state.dart
@@ -5,6 +5,7 @@ import 'package:weave/features/auth/domain/entities/auth_failure.dart';
 import 'package:weave/features/onboarding/domain/entities/member_handoff.dart';
 
 const dogfoodAuthStateStorageKey = 'dogfood_auth_state_v1';
+const dogfoodAuthStateHistoryStorageKey = 'dogfood_auth_state_history_v1';
 
 enum MemberAuthOnboardingStage {
   handoffReceived('handoff_received'),
@@ -63,15 +64,30 @@ class MemberAuthOnboardingStateRecorder {
     MemberHandoff? handoff,
     String? errorCode,
   }) async {
+    final snapshot = MemberAuthOnboardingSnapshot(
+      stage: stage,
+      handoff: handoff,
+      errorCode: errorCode,
+    ).toSupportSafeJson();
+    await _store.setString(dogfoodAuthStateStorageKey, jsonEncode(snapshot));
+    await _appendHistory(snapshot);
+  }
+
+  Future<void> _appendHistory(Map<String, Object> snapshot) async {
+    final rawHistory = await _store.getString(
+      dogfoodAuthStateHistoryStorageKey,
+    );
+    final history = <Object>[];
+    if (rawHistory != null && rawHistory.isNotEmpty) {
+      final decoded = jsonDecode(rawHistory);
+      if (decoded is List) {
+        history.addAll(decoded.whereType<Map<String, Object?>>());
+      }
+    }
+    history.add(snapshot);
     await _store.setString(
-      dogfoodAuthStateStorageKey,
-      jsonEncode(
-        MemberAuthOnboardingSnapshot(
-          stage: stage,
-          handoff: handoff,
-          errorCode: errorCode,
-        ).toSupportSafeJson(),
-      ),
+      dogfoodAuthStateHistoryStorageKey,
+      jsonEncode(history),
     );
   }
 

--- a/client/test/features/onboarding/member_handoff_screen_test.dart
+++ b/client/test/features/onboarding/member_handoff_screen_test.dart
@@ -4,17 +4,24 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:weave/core/bootstrap/domain/bootstrap_state.dart';
+import 'package:weave/core/router/app_routes.dart';
 import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/core/persistence/shared_preferences_store.dart';
 import 'package:weave/features/app/domain/use_cases/sign_in_with_oidc.dart';
+import 'package:weave/features/app/domain/use_cases/resolve_app_bootstrap.dart';
 import 'package:weave/features/app/presentation/providers/app_application_providers.dart';
 import 'package:weave/features/auth/domain/entities/auth_failure.dart';
 import 'package:weave/features/onboarding/domain/entities/member_auth_onboarding_state.dart';
+import 'package:weave/features/onboarding/domain/entities/first_run_status.dart';
 import 'package:weave/features/onboarding/domain/entities/member_handoff.dart';
 import 'package:weave/features/onboarding/domain/use_cases/consume_member_handoff.dart';
 import 'package:weave/features/onboarding/presentation/member_handoff_screen.dart';
+import 'package:weave/features/onboarding/presentation/providers/first_run_status_provider.dart';
 import 'package:weave/l10n/generated/app_localizations.dart';
 
+import '../../helpers/first_run_status_fixture.dart';
 import '../../helpers/in_memory_stores.dart';
 
 class _ThrowingConsumeMemberHandoff implements ConsumeMemberHandoff {
@@ -61,6 +68,13 @@ class _FailingSignInWithOidc implements SignInWithOidc {
   Future<void> call({required bool isInteractiveSignInSupported}) async {
     throw failure;
   }
+}
+
+class _ReadyResolveAppBootstrap implements ResolveAppBootstrap {
+  const _ReadyResolveAppBootstrap();
+
+  @override
+  Future<BootstrapState> call() async => const BootstrapState.ready();
 }
 
 void main() {
@@ -191,6 +205,108 @@ void main() {
       expect(authState['handoffRef'], 'handoff-s32-massimo-dogfood-home');
       expect(authState['supportSafe'], isTrue);
     });
+
+    testWidgets(
+      'records browser return and workspace-ready evidence after successful sign-in',
+      (tester) async {
+        final preferencesStore = InMemoryPreferencesStore();
+        final signIn = _RecordingSignInWithOidc();
+        final router = GoRouter(
+          initialLocation: '/join',
+          routes: [
+            GoRoute(
+              path: '/join',
+              builder: (context, state) => MemberHandoffScreen(
+                uri: Uri.parse(
+                  'weave://join?handoff_ref=handoff-s32-massimo-dogfood-home&org=massimo-dogfood&workspace=home&profile=local-lan-dogfood&run_id=s32-massimo-dogfood&product_base_url=https%3A%2F%2Fweave.test%3A44443&platform_config_url=https%3A%2F%2Fweave.test%3A44443%2Fapi%2Fplatform%2Fconfig',
+                ),
+              ),
+            ),
+            GoRoute(
+              path: AppRoutes.firstRun,
+              builder: (context, state) =>
+                  const Scaffold(body: Text('First run workspace shell')),
+            ),
+          ],
+        );
+        final container = ProviderContainer.test(
+          overrides: [
+            preferencesStoreProvider.overrideWith((ref) => preferencesStore),
+            consumeMemberHandoffProvider.overrideWithValue(
+              _SuccessfulConsumeMemberHandoff(
+                MemberHandoff(
+                  handoffRef: 'handoff-s32-massimo-dogfood-home',
+                  profile: 'local-lan-dogfood',
+                  runId: 's32-massimo-dogfood',
+                  organizationSlug: 'massimo-dogfood',
+                  workspaceSlug: 'home',
+                  platformConfigUrl: Uri.parse(
+                    'https://weave.test:44443/api/platform/config',
+                  ),
+                  productBaseUrl: Uri.parse('https://weave.test:44443'),
+                ),
+              ),
+            ),
+            signInWithOidcProvider.overrideWithValue(signIn),
+            resolveAppBootstrapProvider.overrideWithValue(
+              const _ReadyResolveAppBootstrap(),
+            ),
+            firstRunStatusProvider.overrideWith(
+              (ref) async =>
+                  FirstRunLoadResult.authenticated(buildTestFirstRunStatus()),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Sign In'));
+        await tester.pump();
+        signIn.completer.complete();
+        await tester.pumpAndSettle();
+
+        expect(find.text('First run workspace shell'), findsOneWidget);
+
+        final rawAuthState = preferencesStore.rawString(
+          dogfoodAuthStateStorageKey,
+        );
+        expect(rawAuthState, isNotNull);
+        final authState = jsonDecode(rawAuthState!) as Map<String, dynamic>;
+        expect(authState['state'], 'workspace_ready');
+        expect(authState['handoffRef'], 'handoff-s32-massimo-dogfood-home');
+        expect(authState['supportSafe'], isTrue);
+
+        final rawHistory = preferencesStore.rawString(
+          dogfoodAuthStateHistoryStorageKey,
+        );
+        expect(rawHistory, isNotNull);
+        final history = jsonDecode(rawHistory!) as List<dynamic>;
+        expect(
+          history
+              .cast<Map<String, dynamic>>()
+              .map((entry) => entry['state'])
+              .toList(),
+          containsAllInOrder([
+            'sso_in_progress',
+            'authenticated',
+            'workspace_bootstrap_loading',
+            'workspace_ready',
+          ]),
+        );
+      },
+    );
 
     testWidgets('localizes sign-in failures on the handoff ready action', (
       tester,

--- a/docs/dogfood-auth-onboarding-plan.md
+++ b/docs/dogfood-auth-onboarding-plan.md
@@ -59,6 +59,7 @@ The ready/prepared screen must not reappear after successful credentials unless 
 - i18n check: no new sign-in/onboarding user-facing strings bypass ARB/localization.
 - Accessibility check: ready/error states are screen-reader reachable, controls keep 48x48 logical touch targets, and retry/back actions have labels.
 - Dogfood Mailpit check: test/reset emails are captured locally, visible to operator, and not sent externally.
+- Return-to-app gate: copied app preferences include `dogfood_auth_state_history_v1` proving `sso_in_progress`, `authenticated`, `workspace_bootstrap_loading`, and `workspace_ready` in order. A lone final `workspace_ready` value without that history is not dogfood completion evidence.
 - Physical iPhone candidate check: install over Wi-Fi when device reachability works; if Wi-Fi install is unavailable, install over USB before asking Massimo to test.
 - Trust stability check: the local TLS CA and leaf certificate fingerprints remain stable across normal stack restart/recreate unless explicit rotation is requested.
 - iOS signing trust check: the dogfood app keeps the same bundle ID `com.massimotter.weave`, provisioning Team ID `KNDHGC2KV6`, developer certificate label `Apple Development: massimo164@me.com (6RUS2Z848X)`, signing identity/profile class, and installed-app trust assumptions across normal update or app-state reset. A normal update/app-state reset must not ask Massimo to trust the developer again.

--- a/docs/sprint-31-iphone-lan-dogfood-runbook.md
+++ b/docs/sprint-31-iphone-lan-dogfood-runbook.md
@@ -138,7 +138,7 @@ python3 tools/dogfood_onboarding_evidence_check.py \
   --expected-run-id s32-massimo-dogfood
 ```
 
-The command emits `DOGFOOD_MEMBER_ONBOARDING_RESULT` only when the copied app state is support-safe and reaches `workspace_ready`. Use `--skip-mailpit` only for a local dry run; it is not sufficient dogfood completion evidence.
+The command emits `DOGFOOD_MEMBER_ONBOARDING_RESULT` only when the copied app state is support-safe, reaches `workspace_ready`, and includes `dogfood_auth_state_history_v1` with `sso_in_progress`, `authenticated`, `workspace_bootstrap_loading`, and `workspace_ready` in order. That ordered history is the support-safe proof that Sign In opened the browser flow, the app returned after successful credentials, and workspace bootstrap completed. Use `--skip-mailpit` only for a local dry run; it is not sufficient dogfood completion evidence.
 
 If the simulator gate is green but the phone is unplugged or Wi-Fi-unreachable, report `SIMULATOR_E2E_GREEN` and `PHYSICAL_DEVICE_E2E_PENDING` separately. The smallest remaining physical command sequence is:
 

--- a/e2e/features/v0_1_dogfood_release.feature
+++ b/e2e/features/v0_1_dogfood_release.feature
@@ -23,7 +23,7 @@ Feature: Weave v0.1 dogfood production release
   @weave-v01-dogfood-member-invite-activation
   Scenario: Dogfood member invite activation reaches the workspace
     Given an admin has provisioned a dogfood member invite without passwords, bearer tokens, provider payloads, or raw secrets
-    When the member opens the current invite deeplink on a fresh iOS install
+    When the member opens the current invite deeplink on an update-in-place or trust-preserving app-state-reset iOS install
     And the member taps Sign In, completes first-login activation, sets their password, and returns to Weave
     Then Weave records support-safe handoff_ready, ready_for_sso, sso_in_progress, authenticated, workspace_bootstrap_loading, and workspace_ready evidence
     And the authenticated session is restored after force-quit and reopen

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -248,6 +248,15 @@
           ]
         },
         {
+          "path": "tools/dogfood_onboarding_evidence_check.py",
+          "fragments": [
+            "dogfood_auth_state_history_v1",
+            "workspace_bootstrap_loading",
+            "auth history does not prove browser return",
+            "DOGFOOD_MEMBER_ONBOARDING_RESULT"
+          ]
+        },
+        {
           "path": "tools/dogfood_ios_simulator_onboarding_smoke.sh",
           "fragments": [
             "SIMULATOR_E2E_GREEN",

--- a/tools/dogfood_onboarding_evidence_check.py
+++ b/tools/dogfood_onboarding_evidence_check.py
@@ -43,10 +43,12 @@ def main() -> int:
     handoff = read_json_pref(prefs, "last_handoff_consumed_v1")
     visible = read_json_pref(prefs, "dogfood_visible_state_v1")
     auth_state = read_json_pref(prefs, "dogfood_auth_state_v1")
+    auth_history = read_json_array_pref(prefs, "dogfood_auth_state_history_v1")
 
     assert_support_safe("last_handoff_consumed_v1", handoff)
     assert_support_safe("dogfood_visible_state_v1", visible)
     assert_support_safe("dogfood_auth_state_v1", auth_state)
+    assert_support_safe("dogfood_auth_state_history_v1", auth_history)
 
     require(handoff.get("result") == "saved_configuration", "handoff was not saved")
     require(visible.get("state") == "handoff_ready", "visible state is not handoff_ready")
@@ -67,6 +69,33 @@ def main() -> int:
         require(payload.get("runId") == args.expected_run_id, f"{name} runId mismatch")
         require(payload.get("supportSafe") is True, f"{name} is not supportSafe=true")
 
+    required_history = [
+        "sso_in_progress",
+        "authenticated",
+        "workspace_bootstrap_loading",
+        args.required_auth_state,
+    ]
+    observed_history = [entry.get("state") for entry in auth_history]
+    require(
+        contains_in_order(observed_history, required_history),
+        "auth history does not prove browser return, workspace bootstrap, "
+        f"and {args.required_auth_state}",
+    )
+    for index, entry in enumerate(auth_history):
+        require(isinstance(entry, dict), f"auth history entry {index} is not an object")
+        require(
+            entry.get("handoffRef") == args.expected_handoff_ref,
+            f"auth history entry {index} handoffRef mismatch",
+        )
+        require(
+            entry.get("runId") == args.expected_run_id,
+            f"auth history entry {index} runId mismatch",
+        )
+        require(
+            entry.get("supportSafe") is True,
+            f"auth history entry {index} is not supportSafe=true",
+        )
+
     mailpit_count = None
     if not args.skip_mailpit:
         mailpit_count = mailpit_message_count(args.mailpit_api)
@@ -78,6 +107,7 @@ def main() -> int:
         "runId": args.expected_run_id,
         "visibleState": visible.get("state"),
         "authState": auth_state.get("state"),
+        "authHistoryStates": observed_history,
         "mailpitMessageCount": mailpit_count,
         "supportSafe": True,
     }
@@ -112,9 +142,35 @@ def read_json_pref(prefs: dict[str, Any], key: str) -> dict[str, Any]:
     return decoded
 
 
-def assert_support_safe(name: str, payload: dict[str, Any]) -> None:
+def read_json_array_pref(prefs: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    raw = prefs.get(key)
+    if not isinstance(raw, str) or not raw:
+        raise SystemExit(f"{key} missing from copied app preferences")
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"{key} is not valid JSON: {exc}") from exc
+    if not isinstance(decoded, list):
+        raise SystemExit(f"{key} must be a JSON array")
+    result = []
+    for index, entry in enumerate(decoded):
+        if not isinstance(entry, dict):
+            raise SystemExit(f"{key}[{index}] must be a JSON object")
+        result.append(entry)
+    return result
+
+
+def assert_support_safe(name: str, payload: Any) -> None:
     serialized = json.dumps(payload, sort_keys=True)
     require(not SECRET_PATTERN.search(serialized), f"{name} contains secret-like text")
+
+
+def contains_in_order(observed: list[Any], required: list[str]) -> bool:
+    position = 0
+    for value in observed:
+        if position < len(required) and value == required[position]:
+            position += 1
+    return position == len(required)
 
 
 def mailpit_message_count(api_url: str) -> int:


### PR DESCRIPTION
## Summary
- record support-safe dogfood auth-state history in the client
- require ordered Sign In/browser-return/workspace bootstrap evidence in the dogfood onboarding gate
- align v0.1 dogfood acceptance, scenario mapping, and runbook docs with update-in-place/app-state-reset policy

## Verification
- flutter test test/features/onboarding/member_handoff_screen_test.dart
- python ast.parse tools/dogfood_onboarding_evidence_check.py
- tools/dogfood_onboarding_evidence_check.py with support-safe plist fixture and --skip-mailpit
- ./gradlew acceptanceContract docsCheck
- git diff --check

Closes #934.
Relates #925, #926, #935.