### PR TITLE
fix(dogfood): align operator no-secrets check

### DIFF
--- a/infra/weave-workspace/operator-check.sh
+++ b/infra/weave-workspace/operator-check.sh
@@ -630,7 +630,7 @@ grep -Fq "http://${TF_VAR_tenant_domain:-weave.test}:${TF_VAR_proxy_http_host_po
 grep -Fq "${WEAVE_PUBLIC_BASE_URL}/weave-local-ca.pem" <<<"${product_start_page}" || fail "Operator check failed: start page is missing the HTTPS local CA link"
 grep -Fq 'Weave Local Development CA' <<<"${product_start_page}" || fail "Operator check failed: start page is missing iPhone trust guidance"
 grep -Fq 'handoff-s32-massimo-dogfood-home' <<<"${product_start_page}" || fail "Operator check failed: start page is missing default invite guidance"
-grep -Fq 'passwords, tokens, client secrets, or credential URLs' <<<"${product_start_page}" || fail "Operator check failed: start page is missing the no-secrets warning"
+grep -Fq 'passwords, tokens, client secrets, credential URLs, or activation action links' <<<"${product_start_page}" || fail "Operator check failed: start page is missing the no-secrets warning"
 [[ "${product_start_page}" != *"127.0.0.1"* && "${product_start_page}" != *"localhost"* && "${product_start_page}" != *"192.168."* ]] || \
   fail "Operator check failed: start page must not expose loopback, localhost, or LAN-IP local truth"
 product_platform_config="$(curl_json "${WEAVE_PUBLIC_BASE_URL}/api/platform/config")"


### PR DESCRIPTION
## Summary
- align operator-check no-secrets assertion with the stricter start page copy already required by smoke-test and the Caddy template contract
- unblocks dev-to-dogfood promotion without changing certificates, app install mode, or local dogfood routes

## Verification
- bash infra/weave-workspace/tests/infra-product-contract-test.sh
- ./gradlew acceptanceContract docsCheck
- git diff --check

Relates #937.