### PR TITLE
fix(dogfood): scope member gate runtime evidence

### DIFF
--- a/client/tool/acceptance_contract.dart
+++ b/client/tool/acceptance_contract.dart
@@ -81,7 +81,11 @@ void main(List<String> args) {
   final mappings = loadScenarioMappings(root, mappingPath);
   final runtimeEvidence = testLogPath == null
       ? RuntimeEvidence.notCollected()
-      : extractRuntimeEvidence(File(_join(root.path, testLogPath)), mappings);
+      : extractRuntimeEvidence(
+          File(_join(root.path, testLogPath)),
+          mappings,
+          source: evidenceSource,
+        );
   final result = validateAcceptanceContract(
     root: root,
     scenarios: scenarios,
@@ -352,7 +356,7 @@ ScenarioMappingResult _validateScenarioMapping(
       );
     }
     if (runtimeEvidence.wasCollected &&
-        mapping.evidenceMode.requiresRuntimeObservation &&
+        mapping.requiresRuntimeObservationFor(runtimeEvidence.source) &&
         !runtimeObserved) {
       findings.add(
         AcceptanceFinding(
@@ -391,7 +395,8 @@ ScenarioMappingResult _validateScenarioMapping(
     }
   }
 
-  final runtimeStatus = !mapping.evidenceMode.requiresRuntimeObservation
+  final runtimeStatus =
+      !mapping.requiresRuntimeObservationFor(runtimeEvidence.source)
       ? RuntimeScenarioStatus.notRequired
       : runtimeEvidence.wasCollected
       ? markerResults.every((marker) => marker.runtimeObserved)
@@ -409,13 +414,14 @@ ScenarioMappingResult _validateScenarioMapping(
 
 RuntimeEvidence extractRuntimeEvidence(
   File logFile,
-  List<ScenarioMapping> mappings,
-) {
+  List<ScenarioMapping> mappings, {
+  String? source,
+}) {
   if (!logFile.existsSync()) {
     return RuntimeEvidence.notCollected();
   }
   final expectedMarkers = mappings
-      .where((mapping) => mapping.evidenceMode.requiresRuntimeObservation)
+      .where((mapping) => mapping.requiresRuntimeObservationFor(source))
       .expand((mapping) => mapping.evidenceMarkers)
       .toSet();
   final markers = <String, SanitizedEvidenceMarker>{};
@@ -433,6 +439,7 @@ RuntimeEvidence extractRuntimeEvidence(
   }
   return RuntimeEvidence(
     wasCollected: true,
+    source: source,
     markers: Map<String, SanitizedEvidenceMarker>.unmodifiable(markers),
   );
 }
@@ -544,6 +551,9 @@ String renderMarkdownSummary(
               .map(
                 (marker) => evidenceMode == EvidenceMode.offlineSpec
                     ? '${marker.marker}:offline-spec'
+                    : scenarioResult.runtimeStatus ==
+                          RuntimeScenarioStatus.notRequired
+                    ? '${marker.marker}:mapped'
                     : runtimeEvidence.wasCollected
                     ? '${marker.marker}:${marker.runtimeObserved ? 'seen' : 'missing'}'
                     : '${marker.marker}:mapped',
@@ -702,6 +712,7 @@ class ScenarioMapping {
     required this.featurePath,
     required this.executableTest,
     required this.evidenceMode,
+    this.runtimeSources = const <String>[],
     required this.evidenceMarkers,
     required this.additionalEvidence,
   });
@@ -716,6 +727,8 @@ class ScenarioMapping {
         json['evidenceMode'] as String?,
         executableTest: json['executableTest']! as String,
       ),
+      runtimeSources: ((json['runtimeSources'] as List?) ?? const <Object>[])
+          .cast<String>(),
       evidenceMarkers: (json['evidenceMarkers']! as List).cast<String>(),
       additionalEvidence:
           ((json['additionalEvidence'] as List?) ?? const <Object>[])
@@ -733,8 +746,14 @@ class ScenarioMapping {
   final String featurePath;
   final String executableTest;
   final EvidenceMode evidenceMode;
+  final List<String> runtimeSources;
   final List<String> evidenceMarkers;
   final List<AdditionalEvidenceMapping> additionalEvidence;
+
+  bool requiresRuntimeObservationFor(String? source) =>
+      evidenceMode.requiresRuntimeObservation &&
+      (runtimeSources.isEmpty ||
+          (source != null && runtimeSources.contains(source)));
 
   Map<String, Object?> toJson() => <String, Object?>{
     'tag': tag,
@@ -742,6 +761,7 @@ class ScenarioMapping {
     'feature': featurePath,
     'executableTest': executableTest,
     'evidenceMode': evidenceMode.jsonValue,
+    if (runtimeSources.isNotEmpty) 'runtimeSources': runtimeSources,
     'evidenceMarkers': evidenceMarkers,
     if (additionalEvidence.isNotEmpty)
       'additionalEvidence': additionalEvidence
@@ -893,20 +913,27 @@ enum RuntimeScenarioStatus {
 }
 
 class RuntimeEvidence {
-  const RuntimeEvidence({required this.wasCollected, required this.markers});
+  const RuntimeEvidence({
+    required this.wasCollected,
+    this.source,
+    required this.markers,
+  });
 
   factory RuntimeEvidence.notCollected() => const RuntimeEvidence(
     wasCollected: false,
+    source: null,
     markers: <String, SanitizedEvidenceMarker>{},
   );
 
   final bool wasCollected;
+  final String? source;
   final Map<String, SanitizedEvidenceMarker> markers;
 
   Set<String> get observedMarkers => markers.keys.toSet();
 
   Map<String, Object?> toJson() => <String, Object?>{
     'wasCollected': wasCollected,
+    'source': source,
     'markers': markers.map((key, value) => MapEntry(key, value.toJson())),
   };
 }

--- a/docs/sprint-31-iphone-lan-dogfood-runbook.md
+++ b/docs/sprint-31-iphone-lan-dogfood-runbook.md
@@ -140,6 +140,8 @@ python3 tools/dogfood_onboarding_evidence_check.py \
 
 The command emits `DOGFOOD_MEMBER_ONBOARDING_RESULT` only when the copied app state is support-safe, reaches `workspace_ready`, and includes `dogfood_auth_state_history_v1` with `sso_in_progress`, `authenticated`, `workspace_bootstrap_loading`, and `workspace_ready` in order. That ordered history is the support-safe proof that Sign In opened the browser flow, the app returned after successful credentials, and workspace bootstrap completed. Use `--skip-mailpit` only for a local dry run; it is not sufficient dogfood completion evidence.
 
+The release acceptance contract records this scenario as live runtime evidence scoped to source `dogfood-member-onboarding`. The generic `live-stack-e2e` lane proves stack login/chat/files/provider/workspace markers, but it must not claim or block on the member invite activation markers unless `tools/dogfood_member_onboarding_gate.sh` produced the dogfood onboarding log.
+
 If the simulator gate is green but the phone is unplugged or Wi-Fi-unreachable, report `SIMULATOR_E2E_GREEN` and `PHYSICAL_DEVICE_E2E_PENDING` separately. The smallest remaining physical command sequence is:
 
 ```sh

--- a/e2e/scenario_mappings.json
+++ b/e2e/scenario_mappings.json
@@ -221,6 +221,9 @@
         "DOGFOOD_TRUST_STABILITY_RESULT"
       ],
       "evidenceMode": "live-runtime",
+      "runtimeSources": [
+        "dogfood-member-onboarding"
+      ],
       "additionalEvidence": [
         {
           "path": "client/test/features/onboarding/consume_member_handoff_test.dart",


### PR DESCRIPTION
## Summary
- scope live runtime marker validation by acceptance evidence source
- bind the dogfood member invite gate to source `dogfood-member-onboarding`
- document that generic live-stack-e2e must not claim or block on the separate dogfood member onboarding gate

## Verification
- `./gradlew e2eStructureCheck acceptanceContract docsCheck`
- `dart run tool/acceptance_contract.dart guard --root .. --features e2e/features --mapping e2e/scenario_mappings.json --test-log /private/tmp/weave-live-stack-e2e.log --source live-stack-e2e --lane dogfood-candidate-live-evidence`
- `git diff --check`

Supports #934 and unblocks #937.