### PR TITLE
fix(client): dogfood locale and calendar feedback

### DIFF
--- a/client/lib/features/calendar/presentation/providers/calendar_provider.dart
+++ b/client/lib/features/calendar/presentation/providers/calendar_provider.dart
@@ -65,44 +65,62 @@ class CalendarNotifier extends _$CalendarNotifier {
 
   Future<void> createEvent(CalendarEventDraft draft) async {
     final repository = ref.read(calendarRepositoryProvider);
+    final previousState = state;
     state = const AsyncLoading<CalendarEventList>();
-    state = await AsyncValue.guard(() async {
+    try {
       await repository.createEvent(draft);
-      return repository.loadEvents(
-        scope: ref.read(selectedCalendarScopeProvider),
+      state = AsyncData(
+        await repository.loadEvents(
+          scope: ref.read(selectedCalendarScopeProvider),
+        ),
       );
-    });
+    } catch (error, stackTrace) {
+      state = previousState;
+      Error.throwWithStackTrace(error, stackTrace);
+    }
   }
 
   Future<void> updateEvent(String id, CalendarEventDraft draft) async {
     final repository = ref.read(calendarRepositoryProvider);
+    final previousState = state;
     state = const AsyncLoading<CalendarEventList>();
-    state = await AsyncValue.guard(() async {
+    try {
       await repository.updateEvent(id, draft);
-      return repository.loadEvents(
-        scope: ref.read(selectedCalendarScopeProvider),
+      state = AsyncData(
+        await repository.loadEvents(
+          scope: ref.read(selectedCalendarScopeProvider),
+        ),
       );
-    });
+    } catch (error, stackTrace) {
+      state = previousState;
+      Error.throwWithStackTrace(error, stackTrace);
+    }
   }
 
   Future<void> deleteEvent(String id) async {
     final repository = ref.read(calendarRepositoryProvider);
-    final previousState = state.asData?.value;
-    if (previousState != null) {
+    final previousState = state;
+    final previousEvents = previousState.asData?.value;
+    if (previousEvents != null) {
       state = AsyncData(
         CalendarEventList(
-          scope: previousState.scope,
-          events: previousState.events
+          scope: previousEvents.scope,
+          events: previousEvents.events
               .where((event) => event.id != id)
               .toList(growable: false),
         ),
       );
     }
-    state = await AsyncValue.guard(() async {
+    try {
       await repository.deleteEvent(id);
-      return repository.loadEvents(
-        scope: ref.read(selectedCalendarScopeProvider),
+      state = AsyncData(
+        await repository.loadEvents(
+          scope: ref.read(selectedCalendarScopeProvider),
+        ),
       );
-    });
+    } catch (error, stackTrace) {
+      state = previousState;
+      Error.throwWithStackTrace(error, stackTrace);
+    }
   }
 }

--- a/client/lib/features/calendar/presentation/providers/calendar_provider.g.dart
+++ b/client/lib/features/calendar/presentation/providers/calendar_provider.g.dart
@@ -340,7 +340,7 @@ final class CalendarNotifierProvider
   CalendarNotifier create() => CalendarNotifier();
 }
 
-String _$calendarNotifierHash() => r'9bfa0be88274e403ad261f18989fd9de9d095486';
+String _$calendarNotifierHash() => r'a3e51fe4f662f370f7d9f906db00414fd89635ad';
 
 abstract class _$CalendarNotifier extends $AsyncNotifier<CalendarEventList> {
   FutureOr<CalendarEventList> build();

--- a/client/lib/features/shell/presentation/shell_recent_activity.dart
+++ b/client/lib/features/shell/presentation/shell_recent_activity.dart
@@ -426,10 +426,14 @@ class _ActivityStatusPill extends StatelessWidget {
           children: [
             Icon(icon, size: 18, color: theme.colorScheme.onSurfaceVariant),
             const SizedBox(width: 6),
-            Text(
-              message,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+            Flexible(
+              child: Text(
+                message,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
             if (actionLabel != null && onAction != null) ...[

--- a/client/lib/main.dart
+++ b/client/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:weave/features/auth/data/repositories/oidc_auth_session_reposito
 import 'package:weave/features/onboarding/domain/entities/member_auth_onboarding_state.dart';
 import 'package:weave/features/onboarding/domain/use_cases/consume_member_handoff.dart';
 import 'package:weave/features/onboarding/presentation/member_handoff_screen.dart';
+import 'package:weave/features/profile/presentation/providers/user_profile_provider.dart';
 import 'package:weave/features/server_config/data/repositories/shared_preferences_server_configuration_repository.dart';
 import 'package:weave/integrations/nextcloud/data/repositories/secure_nextcloud_session_repository.dart';
 import 'package:weave/l10n/generated/app_localizations.dart';
@@ -215,12 +216,18 @@ class _WeaveAppState extends ConsumerState<WeaveApp>
           data: (selection) => selection,
           orElse: () => const AppThemeSelection(),
         );
+    final profileLocale = _profileLocale(
+      ref
+          .watch(userProfileProvider)
+          .maybeWhen(data: (profile) => profile?.locale, orElse: () => null),
+    );
     return MaterialApp.router(
       title: 'Weave',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.lightFor(themeSelection),
       darkTheme: AppTheme.darkFor(themeSelection),
       themeMode: themeSelection.themeMode,
+      locale: profileLocale,
       routerConfig: router,
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
@@ -238,5 +245,20 @@ class _WeaveAppState extends ConsumerState<WeaveApp>
       supportedLocales: AppLocalizations.supportedLocales,
       home: home,
     );
+  }
+
+  Locale? _profileLocale(String? locale) {
+    final normalizedLocale = locale?.trim();
+    if (normalizedLocale == null || normalizedLocale.isEmpty) {
+      return null;
+    }
+    final languageCode = normalizedLocale
+        .split(RegExp('[-_]'))
+        .first
+        .toLowerCase();
+    if (languageCode == 'en' || languageCode == 'de') {
+      return Locale(languageCode);
+    }
+    return null;
   }
 }

--- a/client/test/core/router/app_router_test.dart
+++ b/client/test/core/router/app_router_test.dart
@@ -29,6 +29,7 @@ import 'package:weave/features/onboarding/presentation/first_run_screen.dart';
 import 'package:weave/features/onboarding/presentation/member_handoff_screen.dart';
 import 'package:weave/features/onboarding/presentation/providers/first_run_status_provider.dart';
 import 'package:weave/features/onboarding/presentation/welcome_screen.dart';
+import 'package:weave/features/profile/domain/entities/user_profile.dart';
 import 'package:weave/features/profile/presentation/providers/user_profile_provider.dart';
 import 'package:weave/features/server_config/domain/entities/server_configuration.dart';
 import 'package:weave/features/server_config/domain/repositories/server_configuration_repository.dart';
@@ -219,6 +220,7 @@ void main() {
       InMemoryPreferencesStore? preferencesStore,
       FirstRunStatus? firstRunStatus,
       Future<FirstRunLoadResult> Function()? firstRunStatusLoader,
+      UserProfile? userProfile,
     }) {
       final container = ProviderContainer.test(
         overrides: [
@@ -252,7 +254,7 @@ void main() {
                   ),
                 ),
           ),
-          userProfileProvider.overrideWith((ref) async => null),
+          userProfileProvider.overrideWith((ref) async => userProfile),
           workspaceConnectionStateProvider.overrideWithValue(
             _workspaceConnectionState(),
           ),
@@ -331,6 +333,40 @@ void main() {
 
       expect(find.byType(FirstRunScreen), findsNothing);
       expect(find.byType(NavigationBar), findsOneWidget);
+    });
+
+    testWidgets('uses the saved profile locale for the app language', (
+      tester,
+    ) async {
+      final secureStore = InMemorySecureStore();
+      await secureStore.write(
+        authSessionStorageKey,
+        AuthSessionDto.fromSession(buildTestAuthSession()).encode(),
+      );
+      final container = createContainer(
+        configuration: buildTestConfiguration(),
+        secureStore: secureStore,
+        userProfile: const UserProfile(
+          userId: 'member-1',
+          username: 'member',
+          displayName: 'Member',
+          locale: 'de',
+          timezone: 'Europe/Berlin',
+          emailVerified: true,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const WeaveApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final app = tester.widget<MaterialApp>(find.byType(MaterialApp));
+      expect(app.locale, const Locale('de'));
     });
 
     testWidgets(

--- a/client/test/features/calendar/calendar_screen_test.dart
+++ b/client/test/features/calendar/calendar_screen_test.dart
@@ -11,10 +11,13 @@ import 'package:weave/features/calendar/presentation/providers/calendar_provider
 import '../../helpers/test_app.dart';
 
 class _FakeCalendarRepository implements CalendarRepository {
-  _FakeCalendarRepository({required List<CalendarEvent> events})
-    : events = List<CalendarEvent>.of(events);
+  _FakeCalendarRepository({
+    required List<CalendarEvent> events,
+    this.failCreates = false,
+  }) : events = List<CalendarEvent>.of(events);
 
   final List<CalendarEvent> events;
+  final bool failCreates;
   final List<CalendarEventDraft> createdDrafts = <CalendarEventDraft>[];
   final List<String> deletedIds = <String>[];
 
@@ -65,6 +68,9 @@ class _FakeCalendarRepository implements CalendarRepository {
   @override
   Future<CalendarEvent> createEvent(CalendarEventDraft draft) async {
     createdDrafts.add(draft);
+    if (failCreates) {
+      throw StateError('create failed');
+    }
     final event = CalendarEvent(
       id: 'created-${createdDrafts.length}',
       title: draft.title,
@@ -215,6 +221,52 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(repository.deletedIds.single, 'created-1');
+    });
+
+    testWidgets('keeps the calendar visible when saving an event fails', (
+      tester,
+    ) async {
+      final repository = _FakeCalendarRepository(
+        events: [
+          CalendarEvent(
+            id: 'event-1',
+            title: 'Design review',
+            startTime: DateTime(2026, 6, 27, 10),
+            endTime: DateTime(2026, 6, 27, 11),
+          ),
+        ],
+        failCreates: true,
+      );
+
+      await tester.pumpWidget(
+        createTestApp(
+          const CalendarScreen(),
+          overrides: [
+            workspaceCapabilitySnapshotProvider.overrideWithValue(
+              const AsyncData(_readySnapshot),
+            ),
+            calendarRepositoryProvider.overrideWithValue(repository),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Create event'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).first, 'Planning sync');
+      await tester.tap(find.text('Save event'));
+      await tester.pumpAndSettle();
+
+      expect(repository.createdDrafts.single.title, 'Planning sync');
+      expect(find.text('Design review'), findsOneWidget);
+      expect(
+        find.text('The calendar could not save that change right now.'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Calendar event details are unavailable right now.'),
+        findsNothing,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- apply saved profile locale to the Flutter app locale so the language picker changes the visible app language
- keep the calendar visible when create/update/delete fails and surface the existing failure snackbar instead of replacing the screen with the details error state
- allow localized activity status copy to fit inside the shell status pill

## Verification
- flutter test test/core/router/app_router_test.dart test/features/calendar/calendar_screen_test.dart
- flutter analyze

## Dogfood context
Reported from iOS dogfood smoke on 2026-06-27: language picker selection did not change app language; calendar save failure surfaced as a global details-unavailable state.