### PR TITLE
feat(client): split member settings from admin diagnostics

### DIFF
--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -49,8 +49,12 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context);
-    final savedConfiguration = ref.watch(savedServerConfigurationProvider);
     final authState = ref.watch(authFlowControllerProvider);
+    final profile = ref.watch(userProfileProvider);
+    final canAdministerWorkspace = profile.maybeWhen(
+      data: (user) => user?.canAdministerWorkspace ?? false,
+      orElse: () => false,
+    );
 
     return CustomScrollView(
       slivers: [
@@ -58,79 +62,99 @@ class SettingsScreen extends ConsumerWidget {
         SliverPadding(
           padding: const EdgeInsets.all(24),
           sliver: SliverToBoxAdapter(
-            child: savedConfiguration.when(
-              loading: () => LoadingState(message: l10n.loadingLabel),
-              error: (error, _) => ErrorState(
-                message: l10n.errorStateLabel,
-                retryLabel: l10n.retryButton,
-                onRetry: () => ref.invalidate(savedServerConfigurationProvider),
-              ),
-              data: (configuration) => Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const _SettingsBrandCard(),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const _SettingsBrandCard(),
+                const SizedBox(height: 32),
+                const _ThemePreferenceSection(),
+                const SizedBox(height: 32),
+                const _LanguagePreferenceSection(),
+                const SizedBox(height: 32),
+                const ProfileSummaryCard(),
+                const SizedBox(height: 32),
+                const _WeaverMemberSettingsSection(),
+                const SizedBox(height: 32),
+                const _SettingsHelpCard(),
+                const SizedBox(height: 32),
+                const _ShellModuleVisibilitySettingsSection(),
+                if (canAdministerWorkspace) ...[
                   const SizedBox(height: 32),
-                  const _ThemePreferenceSection(),
-                  const SizedBox(height: 32),
-                  const _LanguagePreferenceSection(),
-                  const SizedBox(height: 32),
-                  const ProfileSummaryCard(),
-                  const SizedBox(height: 32),
-                  const _WorkspaceReadinessCard(),
-                  const SizedBox(height: 32),
-                  const _AgentCapabilityPolicySection(),
-                  const SizedBox(height: 32),
-                  const _WeaverMemberSettingsSection(),
-                  const SizedBox(height: 32),
-                  const _SettingsHelpCard(),
-                  const SizedBox(height: 32),
-                  const _ShellModuleVisibilitySettingsSection(),
-                  if (FeatureFlags.hasFeatureGatedSurfaces) ...[
-                    const SizedBox(height: 32),
-                    const _FeaturePreviewSurfacesSection(),
-                  ],
-                  const SizedBox(height: 32),
-                  _AdminSetupSection(configuration: configuration),
-                  const SizedBox(height: 32),
-                  Text(
-                    l10n.settingsSignOutTitle,
-                    style: Theme.of(context).textTheme.headlineSmall,
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    l10n.settingsSignOutDescription,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  AccessibleButton(
-                    outlined: true,
-                    onPressed: authState.isBusy
-                        ? null
-                        : () => ref
-                              .read(authFlowControllerProvider.notifier)
-                              .signOut(),
-                    semanticLabel: l10n.settingsSignOutButton,
-                    child: Text(
-                      authState.isBusy
-                          ? l10n.settingsSignOutInProgress
-                          : l10n.settingsSignOutButton,
-                    ),
-                  ),
-                  if (authState.failure != null) ...[
-                    const SizedBox(height: 16),
-                    Text(
-                      authState.failure!.message,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.error,
-                      ),
-                    ),
-                  ],
+                  const _AdminOnlySettingsSections(),
                 ],
-              ),
+                const SizedBox(height: 32),
+                Text(
+                  l10n.settingsSignOutTitle,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  l10n.settingsSignOutDescription,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                AccessibleButton(
+                  outlined: true,
+                  onPressed: authState.isBusy
+                      ? null
+                      : () => ref
+                            .read(authFlowControllerProvider.notifier)
+                            .signOut(),
+                  semanticLabel: l10n.settingsSignOutButton,
+                  child: Text(
+                    authState.isBusy
+                        ? l10n.settingsSignOutInProgress
+                        : l10n.settingsSignOutButton,
+                  ),
+                ),
+                if (authState.failure != null) ...[
+                  const SizedBox(height: 16),
+                  Text(
+                    authState.failure!.message,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ],
+              ],
             ),
           ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AdminOnlySettingsSections extends ConsumerWidget {
+  const _AdminOnlySettingsSections();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context);
+    final savedConfiguration = ref.watch(savedServerConfigurationProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const _WorkspaceReadinessCard(),
+        const SizedBox(height: 32),
+        const _AgentCapabilityPolicySection(),
+        if (FeatureFlags.hasFeatureGatedSurfaces) ...[
+          const SizedBox(height: 32),
+          const _FeaturePreviewSurfacesSection(),
+        ],
+        const SizedBox(height: 32),
+        savedConfiguration.when(
+          loading: () => LoadingState(message: l10n.loadingLabel),
+          error: (error, _) => ErrorState(
+            message: l10n.errorStateLabel,
+            retryLabel: l10n.retryButton,
+            onRetry: () => ref.invalidate(savedServerConfigurationProvider),
+          ),
+          data: (configuration) =>
+              _AdminSetupSection(configuration: configuration),
         ),
       ],
     );
@@ -1480,7 +1504,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                 _WorkspaceReadinessRow(
                   label: l10n.settingsWorkspaceCalendarLabel,
                   capability: capabilitySnapshot.calendar,
-                  connection: workspaceState.files,
                 ),
               ],
             ),
@@ -2149,13 +2172,13 @@ class _WorkspaceReadinessRow extends StatelessWidget {
   const _WorkspaceReadinessRow({
     required this.label,
     required this.capability,
-    required this.connection,
+    this.connection,
     this.matrixDiagnostic,
   });
 
   final String label;
   final WorkspaceCapabilityState capability;
-  final IntegrationConnectionState connection;
+  final IntegrationConnectionState? connection;
   final MatrixE2eeDiagnostic? matrixDiagnostic;
 
   @override
@@ -2178,10 +2201,11 @@ class _WorkspaceReadinessRow extends StatelessWidget {
                 label: l10n.settingsWorkspaceCapabilityLabel,
                 value: _capabilityLabel(l10n, capability.readiness),
               ),
-              _StatusPill(
-                label: l10n.settingsWorkspaceConnectionLabel,
-                value: _connectionLabel(l10n, connection.status),
-              ),
+              if (connection case final connection?)
+                _StatusPill(
+                  label: l10n.settingsWorkspaceConnectionLabel,
+                  value: _connectionLabel(l10n, connection.status),
+                ),
               _StatusPill(
                 label: l10n.settingsWorkspacePolicyLabel,
                 value: _policyLabel(l10n, capability.policyState),
@@ -2193,13 +2217,10 @@ class _WorkspaceReadinessRow extends StatelessWidget {
                   value: recovery.recovery,
                 ),
               ),
-              if (connection.lastInvalidation != null)
+              if (connection?.lastInvalidation case final invalidation?)
                 _StatusPill(
                   label: l10n.settingsWorkspaceLastChangeLabel,
-                  value: _invalidationLabel(
-                    l10n,
-                    connection.lastInvalidation!.reason,
-                  ),
+                  value: _invalidationLabel(l10n, invalidation.reason),
                 ),
               if (matrixDiagnostic case final diagnostic?) ...[
                 _StatusPill(

--- a/client/test/features/app/weave_app_backend_capability_flow_test.dart
+++ b/client/test/features/app/weave_app_backend_capability_flow_test.dart
@@ -372,30 +372,30 @@ void main() {
       );
       expect(weaveApiClient.lastAccessToken, 'backend-boundary-token');
 
-      expect(find.text('Workspace Readiness'), findsOneWidget);
+      expect(find.text('Appearance'), findsOneWidget);
+      expect(find.text('Language'), findsOneWidget);
+      expect(find.text('Weave profile'), findsOneWidget);
+      expect(find.text('Shell modules'), findsOneWidget);
+      expect(find.text('Workspace Readiness'), findsNothing);
       expect(
         find.text(
           'Shell access is ready, but one or more services still need attention.',
         ),
-        findsOneWidget,
+        findsNothing,
       );
-      expect(find.text('Workspace setup is admin-only'), findsOneWidget);
+      expect(find.text('Workspace setup is admin-only'), findsNothing);
       expect(find.text('Server Configuration'), findsNothing);
-      expect(
-        find.text('Readiness: Ready', findRichText: true),
-        findsNWidgets(2),
-      );
-      expect(
-        find.text('Readiness: Blocked', findRichText: true),
-        findsOneWidget,
-      );
+      expect(find.text('Provider stack readiness'), findsNothing);
+      expect(find.text('AI agent capability governance'), findsNothing);
+      expect(find.text('Readiness: Ready', findRichText: true), findsNothing);
+      expect(find.text('Readiness: Blocked', findRichText: true), findsNothing);
       expect(
         find.text('Connection: Degraded', findRichText: true),
         findsNothing,
       );
       expect(
         find.text('Connection: Connected', findRichText: true),
-        findsNWidgets(4),
+        findsNothing,
       );
     },
   );

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -494,31 +494,26 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      await tester.scrollUntilVisible(
-        find.text('AI agent capability governance'),
-        300,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(find.text('AI agent capability governance'), findsOneWidget);
+      expect(find.text('Appearance'), findsOneWidget);
+      expect(find.text('Language'), findsOneWidget);
+      expect(find.text('Weave profile'), findsOneWidget);
+      expect(find.text('Help and user handbook'), findsOneWidget);
+      expect(find.text('Shell modules'), findsOneWidget);
+      expect(find.text('AI agent capability governance'), findsNothing);
       expect(
         find.textContaining('AI agent chats are not enabled'),
-        findsOneWidget,
+        findsNothing,
       );
       expect(
         find.textContaining('Ask a workspace owner or admin'),
-        findsOneWidget,
+        findsNothing,
       );
-
-      await tester.scrollUntilVisible(
-        find.text('Workspace setup is admin-only'),
-        300,
-        scrollable: find.byType(Scrollable).first,
-      );
-      expect(find.text('Workspace setup is admin-only'), findsOneWidget);
+      expect(find.text('Workspace setup is admin-only'), findsNothing);
       expect(
         find.textContaining('Normal users can keep using Weave'),
-        findsOneWidget,
+        findsNothing,
       );
+      expect(find.text('Workspace Readiness'), findsNothing);
       expect(find.text('Server Configuration'), findsNothing);
       expect(find.text('Provider categories'), findsNothing);
       expect(find.text('Identity/IDM'), findsNothing);
@@ -807,7 +802,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.text('Workspace Readiness'), findsOneWidget);
+      expect(find.text('Workspace Readiness'), findsNothing);
       expect(find.text('Provider stack readiness'), findsNothing);
       expect(find.text('Admin/operator readiness cockpit'), findsNothing);
       expect(find.textContaining('nextcloud-files'), findsNothing);
@@ -1313,7 +1308,7 @@ void main() {
             weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
               (ref) async => _matrixDiagnostic,
             ),
-            userProfileProvider.overrideWith((ref) async => null),
+            userProfileProvider.overrideWith((ref) async => _ownerProfile),
           ],
         );
         addTearDown(container.dispose);

--- a/client/test/features/shell/app_shell_test.dart
+++ b/client/test/features/shell/app_shell_test.dart
@@ -278,7 +278,12 @@ void main() {
       await tester.tap(find.byIcon(Icons.settings_outlined));
       await tester.pumpAndSettle();
 
-      expect(find.text('Workspace setup is admin-only'), findsOneWidget);
+      expect(find.text('Appearance'), findsOneWidget);
+      expect(find.text('Language'), findsOneWidget);
+      expect(find.text('Weave profile'), findsOneWidget);
+      expect(find.text('Shell modules'), findsOneWidget);
+      expect(find.text('Workspace setup is admin-only'), findsNothing);
+      expect(find.text('Workspace Readiness'), findsNothing);
       expect(find.text('Server Configuration'), findsNothing);
     });
 


### PR DESCRIPTION
## Summary
- keep normal member Settings focused on app preferences, profile, governed Weaver member choices, help, shell modules, and sign-out
- move workspace readiness, agent governance, provider readiness, and server setup behind the admin-only settings section
- stop showing a normal-member admin setup boundary card in Settings
- fix Calendar readiness so it does not reuse Files connection state

## Evidence
- flutter test test/features/settings/settings_screen_test.dart test/architecture/member_client_provider_boundary_contract_test.dart test/architecture/release_scope_contract_test.dart test/release_1/ux_release_copy_contract_test.dart
- flutter analyze --fatal-infos

Refs #963
Refs #951
Refs #956