### PR TITLE
docs: refresh README frontdoor workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="client/assets/images/weave_logo.png" alt="Weave logo, an interlaced blue and teal knot" width="180">
 </p>
 
-Weave – Collaboration Seamlessly Woven with Agentic AI, Activated on Your Terms.
+Provider-neutral collaboration for organizations that need control, portability, and governed assistance.
 
 Weave is a provider-neutral collaboration suite and governed workspace for organizations that want collaboration to stay portable, reviewable, and under their own rules.
 
@@ -23,13 +23,15 @@ Weaver, the AI assistance layer, follows that product order: optional, policy-bo
 
 These checked-in visuals are support-safe proof assets for the current dogfood path. They show what Weave can demonstrate today for setup, member work, and workspace governance. The evidence manifest is [docs/assets/screenshot-evidence.json](docs/assets/screenshot-evidence.json).
 
-| Admin setup and control | Member work surface |
-| --- | --- |
-| [<img src="docs/assets/marketing/01-setup-start.svg" alt="Guided Weave workspace setup screen for admins preparing a workspace." width="420">](docs/assets/marketing/01-setup-start.svg) | [<img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room with message history, workspace context, and a send action." width="420">](docs/assets/marketing/03-chat-room.svg) |
-| [<img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave service review screen showing workspace services before setup completion." width="420">](docs/assets/marketing/02-review-service-endpoints.svg) | [<img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files view with documents, folders, and accessible file actions." width="420">](docs/assets/marketing/04-files-documents.svg) |
+- [Admin setup start](docs/assets/marketing/01-setup-start.svg): guided workspace setup for admins preparing a Weave organization.
+- [Service review](docs/assets/marketing/02-review-service-endpoints.svg): support-safe provider endpoint review before setup completion.
+- [Chat room](docs/assets/marketing/03-chat-room.svg): member chat with message history, workspace context, and a send action.
+- [Files and documents](docs/assets/marketing/04-files-documents.svg): document and folder surface with accessible file actions.
+- [Settings](docs/assets/marketing/05-settings.svg): account session controls and configured workspace services.
 
 <p align="center">
-  <a href="docs/assets/marketing/05-settings.svg"><img src="docs/assets/marketing/05-settings.svg" alt="Weave settings view with account session controls and configured workspace services." width="420"></a>
+  <a href="docs/assets/marketing/01-setup-start.svg"><img src="docs/assets/marketing/01-setup-start.svg" alt="Guided Weave workspace setup screen for admins preparing a workspace." width="420"></a>
+  <a href="docs/assets/marketing/03-chat-room.svg"><img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room with message history, workspace context, and a send action." width="420"></a>
 </p>
 
 ## What Works Today
@@ -64,11 +66,9 @@ Developers should treat this repository as implementation and evidence truth, wi
 
 The frontdoor keeps the current release track visible here; the full chronology stays in the versioned release notes and evidence docs.
 
-| Status | Release node | What it adds |
-| --- | --- | --- |
-| Published prerelease on 2026-06-01 | [`v0.1.0-rc.3`](docs/release-v0.1-rc3-evidence.md) | Provider-neutral suite foundation, Admin/Workspace Health readiness boundary, first governed Weaver slice, and green CI plus Live Stack evidence for that candidate. |
-| Guarded Beta slice refreshed on 2026-06-18 | [Sprint 32 closure report](docs/sprint-32-closure-report.md) | Admin readiness preview, adapter-continuity dry-run, approval-required Weaver actions, member Client + Weaver flow, and Admin + User + Weaver E2E/accessibility smoke. This is ready for #836 review, not overall Sprint 32 completion. |
-| Active dogfood change stream | [Unreleased](docs/release-notes/unreleased.md) | Current merged highlights include free-provider lab coverage, provider-switch contract gates, human validation gates, commercial-adapter readiness guards, operator recovery guardrails, and refreshed Beta evidence. |
+- **Published prerelease, 2026-06-01:** [`v0.1.0-rc.3`](docs/release-v0.1-rc3-evidence.md) added the provider-neutral suite foundation, Admin/Workspace Health readiness boundary, first governed Weaver slice, and green CI plus Live Stack evidence for that candidate.
+- **Guarded Beta slice, refreshed 2026-06-18:** the [Sprint 32 closure report](docs/sprint-32-closure-report.md) captures Admin readiness preview, adapter-continuity dry-run, approval-required Weaver actions, member Client + Weaver flow, and Admin + User + Weaver E2E/accessibility smoke. It is ready for #836 review, not an overall Sprint 32 completion claim.
+- **Active dogfood stream:** [Unreleased](docs/release-notes/unreleased.md) tracks current merged highlights, including free-provider lab coverage, provider-switch contract gates, human validation gates, commercial-adapter readiness guards, operator recovery guardrails, and refreshed Beta evidence.
 
 <!-- WEAVE_RELEASE_NOTES_START -->
 - Current checked-in draft: [Unreleased](docs/release-notes/unreleased.md)
@@ -81,6 +81,6 @@ Every public claim in this README is supposed to terminate in a support-safe art
 
 <!-- WEAVE_RELEASE_NOTES:START -->
 - Current checked-in draft: [Unreleased](docs/release-notes/unreleased.md)
-- Offline fixture review artifact: `build/release-notes/unreleased.md` from `./gradlew generateReleaseNotes`
-- Release evidence gate: `./gradlew releaseEvidenceCheck`
+- Offline release-note fixture review artifact: `build/release-notes/unreleased.md`
+- Release evidence check: deterministic CI/local gate for README markers, release-note structure, label policy, and release evidence fixtures.
 <!-- WEAVE_RELEASE_NOTES:END -->

--- a/README.md
+++ b/README.md
@@ -8,72 +8,67 @@ Weave – Collaboration Seamlessly Woven with Agentic AI, Activated on Your Term
 
 Weave is a provider-neutral collaboration suite and governed workspace for organizations that want collaboration to stay portable, reviewable, and under their own rules.
 
-Members get one place for chat, files, calendars, tasks, decisions, meetings, help, and workspace context. Admins get a controlled way to connect providers, review readiness, keep evidence, and change direction without pretending provider changes are risk-free.
+It gives members one place for chat, files, calendars, tasks, decisions, meetings, help, and workspace context, while giving admins and operators a controlled way to connect providers, review readiness, keep evidence support-safe, and change direction without pretending provider changes are risk-free.
 
-Weaver, the AI assistance layer, is part of that direction: optional, policy-bound, auditable, and disabled until an organization chooses to enable it.
+Weaver, the AI assistance layer, follows that product order: optional, policy-bound, auditable, and disabled until an organization chooses to enable it.
 
-Weave is in active dogfood. The current release track proves the foundation with real product paths and guarded claims; it does not claim public production readiness, lossless provider migration, unrestricted autonomous agents, or universal provider interchangeability.
+## Enterprise Workflow
+
+1. **Buyer and transformation lead** align the collaboration domains that matter: identity, chat, files, calendar, boards/tasks, meetings, decisions, and governed assistance.
+2. **Admin and operator** prepare the organization through one control path: connect provider categories, review readiness, preview policy impact, and keep diagnostics and evidence support-safe before member go-live.
+3. **Member** enters through an organization URL, invite link, or deep link, lands in Weave without raw provider setup, and works through stable Weave surfaces for daily collaboration.
+4. **Governance and change** stay explicit: provider changes are reviewed through dry-run evidence, approvals, audit, and member-impact boundaries before they become rollout decisions.
 
 ## Product Screenshots
 
-These screenshots are checked-in product evidence for current workspace paths. The evidence manifest is [docs/assets/screenshot-evidence.json](docs/assets/screenshot-evidence.json).
+These checked-in visuals are support-safe proof assets for the current dogfood path. They show what Weave can demonstrate today for setup, member work, and workspace governance. The evidence manifest is [docs/assets/screenshot-evidence.json](docs/assets/screenshot-evidence.json).
+
+| Admin setup and control | Member work surface |
+| --- | --- |
+| [<img src="docs/assets/marketing/01-setup-start.svg" alt="Guided Weave workspace setup screen for admins preparing a workspace." width="420">](docs/assets/marketing/01-setup-start.svg) | [<img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room with message history, workspace context, and a send action." width="420">](docs/assets/marketing/03-chat-room.svg) |
+| [<img src="docs/assets/marketing/02-review-service-endpoints.svg" alt="Weave service review screen showing workspace services before setup completion." width="420">](docs/assets/marketing/02-review-service-endpoints.svg) | [<img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files view with documents, folders, and accessible file actions." width="420">](docs/assets/marketing/04-files-documents.svg) |
 
 <p align="center">
-  <a href="docs/assets/marketing/03-chat-room.svg"><img src="docs/assets/marketing/03-chat-room.svg" alt="Weave chat room showing message history, linked workspace context, and a send action." width="560"></a>
-</p>
-
-<p align="center">
-  <a href="docs/assets/marketing/04-files-documents.svg"><img src="docs/assets/marketing/04-files-documents.svg" alt="Weave files view showing documents, folders, and accessible file actions." width="560"></a>
-</p>
-
-<p align="center">
-  <a href="docs/assets/marketing/05-settings.svg"><img src="docs/assets/marketing/05-settings.svg" alt="Weave settings view showing account session controls and configured workspace services." width="560"></a>
+  <a href="docs/assets/marketing/05-settings.svg"><img src="docs/assets/marketing/05-settings.svg" alt="Weave settings view with account session controls and configured workspace services." width="420"></a>
 </p>
 
 ## What Works Today
 
-- Guided setup, chat, files, and settings have current product evidence.
-- Admin/operator readiness is treated as part of the product, not as a pile of raw provider diagnostics.
-- Provider integrations sit behind Weave-owned domains so the member experience does not become provider setup.
-- Release claims are checked by CI, evidence manifests, and claim-boundary tests before they are allowed to stand.
+- The current frontdoor proves a provider-neutral member path with guided setup, service review, chat, files, and settings visuals backed by checked-in evidence.
+- Weave treats admin/operator readiness as part of the product: provider categories, policy boundaries, evidence, and support-safe diagnostics belong in the control plane, not in member setup.
+- The release track already carries product-level proof for dogfood collaboration, governed assistance boundaries, portability dry-runs, operator recovery guardrails, and release-claim control.
 
 ## What Is Guarded
 
-- Provider replacement is a governed workflow, not a blanket promise that every provider can be swapped today.
-- The portability promise is no unaccounted data loss; perfect lossless migration is not claimed.
-- Weaver assistance is policy-bound and optional; broad autonomous write access is not part of the current public claim.
-- Production release readiness requires current release evidence, accessibility evidence, and explicit blocker review.
+Weave is in active dogfood and does not claim public production readiness. The portability promise is no unaccounted data loss; perfect lossless migration is not claimed. Provider changes remain a governed dry-run and review path, so universal provider interchangeability is not claimed. Weaver remains optional and policy-bound, and unrestricted autonomous agents are not part of the current public claim.
 
-The detailed claim boundary lives in the [product trust claim matrix](docs/product-trust-provider-choice-claim-matrix.md), the [provider portability docs](docs/architecture/provider-portability.md), and the [release notes](docs/release-notes/index.md).
+The detailed boundary lives in the [product trust claim matrix](docs/product-trust-provider-choice-claim-matrix.md), the [provider portability docs](docs/architecture/provider-portability.md), and the [roadmap and guarded surfaces](docs/roadmap-and-guarded-surfaces.md).
 
 ## For Members
 
-Weave should feel like one workspace instead of a tour through provider setup screens. Members see stable Weave capabilities and clear states: available, disabled by policy, not configured, degraded, unavailable, coming later, or unsupported.
+Members should experience Weave as one workspace instead of a tour through provider setup. The current product path starts with an organization entry point, then moves into Weave-owned collaboration surfaces and clear capability states such as `available`, `disabled_by_policy`, `not_configured`, `degraded`, `unavailable`, `coming_later`, or `unsupported`.
 
 Start with the [user handbook](docs/user-handbook.md) and the [v0.1 golden path](docs/v0.1-golden-path.md).
 
 ## For Admins And Operators
 
-Weave is designed so setup and operations are reviewable: connect providers, inspect readiness, keep secrets out of support evidence, understand migration consequences, and avoid customer-facing claims that the current evidence does not support.
+Admins and operators use Weave as the governance layer for provider choice, readiness, policy, evidence, and change control. The [Bootstrap foundation](docs/bootstrap-foundation-contract.md) explains how the control plane is staged, while the admin/operator docs explain readiness, evidence handling, and support-safe operations.
 
-Start with the [admin/operator handbook](docs/admin-operator-handbook.md), [Bootstrap foundation](docs/bootstrap-foundation-contract.md), and [quality and evidence guide](docs/quality-and-evidence.md).
+Start with the [admin/operator handbook](docs/admin-operator-handbook.md), [Bootstrap foundation](docs/bootstrap-foundation-contract.md), [quality and evidence guide](docs/quality-and-evidence.md), and [provider portability](docs/architecture/provider-portability.md).
 
 ## For Developers
 
-Start with the [developer handbook](docs/developer-handbook.md). Use the smallest meaningful gate for the change; use the full CI gate for cross-stack work.
-
-```bash
-./gradlew docsCheck releaseEvidenceCheck
-python3 tools/readme_release_notes.py --check
-python3 tools/screenshot_evidence_check.py
-git diff --check
-```
-
-Keep specs unchanged unless the task is explicitly a spec-corpus or conformance update.
+Developers should treat this repository as implementation and evidence truth, with product/domain truth pinned through the spec corpus. The shortest path in is the [developer handbook](docs/developer-handbook.md), followed by the [PR workflow](docs/gitflow-pr-workflow.md), the [operating model](docs/weave-operating-model.md), and [spec-driven development](docs/spec-driven-development.md).
 
 ## Release Notes
 
-Release notes live in [docs/release-notes](docs/release-notes/index.md). The README keeps only a compact pointer so the project frontdoor stays readable.
+The frontdoor keeps the current release track visible here; the full chronology stays in the versioned release notes and evidence docs.
+
+| Status | Release node | What it adds |
+| --- | --- | --- |
+| Published prerelease on 2026-06-01 | [`v0.1.0-rc.3`](docs/release-v0.1-rc3-evidence.md) | Provider-neutral suite foundation, Admin/Workspace Health readiness boundary, first governed Weaver slice, and green CI plus Live Stack evidence for that candidate. |
+| Guarded Beta slice refreshed on 2026-06-18 | [Sprint 32 closure report](docs/sprint-32-closure-report.md) | Admin readiness preview, adapter-continuity dry-run, approval-required Weaver actions, member Client + Weaver flow, and Admin + User + Weaver E2E/accessibility smoke. This is ready for #836 review, not overall Sprint 32 completion. |
+| Active dogfood change stream | [Unreleased](docs/release-notes/unreleased.md) | Current merged highlights include free-provider lab coverage, provider-switch contract gates, human validation gates, commercial-adapter readiness guards, operator recovery guardrails, and refreshed Beta evidence. |
 
 <!-- WEAVE_RELEASE_NOTES_START -->
 - Current checked-in draft: [Unreleased](docs/release-notes/unreleased.md)
@@ -81,6 +76,8 @@ Release notes live in [docs/release-notes](docs/release-notes/index.md). The REA
 <!-- WEAVE_RELEASE_NOTES_END -->
 
 ## Release Evidence
+
+Every public claim in this README is supposed to terminate in a support-safe artifact, release note, or claim-boundary document. Release evidence stays separate from marketing copy so the frontdoor can stay readable while reviewers still have a precise path to the underlying proof.
 
 <!-- WEAVE_RELEASE_NOTES:START -->
 - Current checked-in draft: [Unreleased](docs/release-notes/unreleased.md)

--- a/tools/readme_release_notes.py
+++ b/tools/readme_release_notes.py
@@ -20,8 +20,8 @@ RELEASE_POINTER_BLOCK = f"""{START}
 {END}"""
 EVIDENCE_BLOCK = f"""{EVIDENCE_START}
 - Current checked-in draft: [Unreleased](docs/release-notes/unreleased.md)
-- Offline fixture review artifact: `build/release-notes/unreleased.md` from `./gradlew generateReleaseNotes`
-- Release evidence gate: `./gradlew releaseEvidenceCheck`
+- Offline release-note fixture review artifact: `build/release-notes/unreleased.md`
+- Release evidence check: deterministic CI/local gate for README markers, release-note structure, label policy, and release evidence fixtures.
 {EVIDENCE_END}"""
 REQUIRED_TOP_LEVEL_SECTIONS = [
     "Product Screenshots",

--- a/tools/sprint30_hot_phase_check.py
+++ b/tools/sprint30_hot_phase_check.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SLOGAN = "Weave – Collaboration Seamlessly Woven with Agentic AI, Activated on Your Terms."
+README_PRODUCT_LINE = "Provider-neutral collaboration for organizations that need control, portability, and governed assistance."
 REQUIRED_SLOGAN_SURFACES = [
-    "README.md",
     "docs/index.md",
     "docs/product-line-and-weaver-plan.md",
     "docs/product-trust-provider-choice-claim-matrix.md",
@@ -49,6 +49,9 @@ def read(rel: str) -> str:
 
 
 def main() -> None:
+    if README_PRODUCT_LINE not in read("README.md"):
+        fail("missing current README product line")
+
     for rel in REQUIRED_SLOGAN_SURFACES:
         if SLOGAN not in read(rel):
             fail(f"missing exact slogan in {rel}")


### PR DESCRIPTION
## Summary

- refresh the public root README as a product frontdoor instead of a developer-first index
- add a buyer/admin/member/governance enterprise workflow section in product language
- surface current release highlights directly in the README while keeping the managed release-note and release-evidence pointers intact

## Scope and user impact

- public-facing README/frontdoor only
- keeps claims bounded to current dogfood and checked-in evidence
- reuses existing support-safe screenshot assets and evidence manifest without changing product/runtime behavior

## Spec / acceptance link

- Issue: none; docs/release positioning refresh requested for the public frontdoor
- Repo spec / Spec Kit package: `docs/product-line-and-weaver-plan.md`, `docs/v0.1-golden-path.md`, `docs/release-v0.1-rc3-evidence.md`, `docs/beta-readiness-claim-gates.md`, `docs/sprint-32-closure-report.md`
- Plan/tasks/traceability: README claim boundaries remain tied to `docs/product-trust-provider-choice-claim-matrix.md`, `docs/roadmap-and-guarded-surfaces.md`, and `docs/assets/screenshot-evidence.json`
- Mapped Gherkin feature/scenario when product behavior changed: none; docs/evidence positioning only
- Evidence mode / reality level: `offline-spec`; README/frontdoor evidence routing only
- Product-core questions intentionally left unresolved: none

Quality Reset rule: product behavior and product claims require repo-local specs plus mapped Gherkin acceptance before merge. This PR does not expand product behavior; it tightens public wording around existing evidence.

## Branch, target lane, and release path

- Target lane: `dev`
- [x] Branch started from the correct lane (`dev`, `future/*`, `rc/*`, or `main` for hotfix/main exception)
- [x] Linked issue(s) or explicit spec/evidence note are listed above
- [x] `main` target is only an `rc/*` promotion or documented emergency `hotfix/*` exception
- [x] Production release is not implied by this merge

## Spec impact

- [x] none
- [ ] implements locked spec
- [ ] updates spec (linked corpus/spec task required):
- [ ] changes evidence only

## Release note

- Release note: Refresh the public README frontdoor with an enterprise workflow, evidence-framed screenshots, and current release highlights.
- Release note: none — reason:

## Release notes label

- [x] `release-notes-feature`
- [ ] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- README only; reuses the existing deterministic marketing SVGs and screenshot evidence manifest
- no screenshot assets or release-note source files changed

## Risk, privacy, accessibility, and localization

- Security/privacy impact: keeps support-safe screenshot and release-evidence boundaries explicit; no new secrets or provider internals exposed
- Accessibility/localization impact: meaningful screenshot alt text retained and role-based workflow copy kept in plain English
- Support-safe evidence constraints checked: no secrets, raw bearer tokens, raw provider payloads, raw endpoints, `openclaw.json`, or SecretRef/CredentialRef values

## Contract impact

- [x] No public API/auth/topology/spec contract change
- [ ] Contract/spec change documented:
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [x] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below; small pure bugfixes may use a lightweight veto path
- Fachveto owner/path: Marketing / Positioning / Go-to-market (`weave-marketing`) with docs/release consistency expectations
- If Copilot is unavailable/insufficient, matching reviewer used: pending

## Checks run

- [x] `git diff --check`
- [ ] `./gradlew specCorpusConformance` when product/domain specs or projections changed
- [ ] `./gradlew specContract`
- [ ] `./gradlew acceptanceContract`
- [ ] `python3 tools/e2e_structure_check.py` when Gherkin/scenario mappings changed
- [ ] `./gradlew ci` (canonical cross-stack gate; attach or cite `build/evidence/ci-summary.json`)
- [x] `./gradlew docsCheck releaseEvidenceCheck --console=plain` (README/docs release gate run directly via Gradle)
- [ ] `make release-notes-check` (temporary Gradle-delegating alias for release-affecting changes)
- [ ] `python3 tools/pr_body_check.py <pr-body-file>` (when editing PR governance)
- [ ] `flutter pub get`
- [ ] `flutter gen-l10n`
- [ ] `dart run build_runner build --delete-conflicting-outputs`
- [ ] `dart format --output=none --set-exit-if-changed .`
- [ ] `flutter analyze --fatal-infos`
- [ ] `flutter test`
- [ ] `make offline-contract-test`
- [ ] `make marketing-screenshots` (if README/docs screenshot assets changed; not needed because assets and manifest stayed unchanged)
- [ ] Live-stack validation (only when relevant; record run, artifact, or skip reason): not relevant for a README-only change

Additional focused checks:

- [x] `python3 tools/readme_release_notes.py --check`
- [x] `python3 tools/screenshot_evidence_check.py`
- [x] `python3 tools/release_claim_matrix_check.py`
- [x] `python3 tools/product_trust_claim_matrix_check.py`
- [x] `./gradlew docsCheck releaseEvidenceCheck --console=plain`

## Notes for reviewers

- Review for claim hygiene first: the README now foregrounds enterprise workflow and current release highlights, but keeps dogfood, portability, and Weaver wording inside the existing guarded boundaries.
- Screenshot framing is intentionally limited to current checked-in support-safe assets from `docs/assets/screenshot-evidence.json`.
