### PR TITLE
test: fence member Matrix diagnostics

### DIFF
--- a/client/lib/features/chat/presentation/providers/chat_security_repository_provider.dart
+++ b/client/lib/features/chat/presentation/providers/chat_security_repository_provider.dart
@@ -8,8 +8,8 @@ import 'package:weave/features/server_config/presentation/providers/server_confi
 /// Diagnostic-only Matrix E2EE/security seam.
 ///
 /// Normal member chat/readiness flows must use backend-owned Chat and workspace
-/// capability facades. This provider is kept only for explicit security
-/// diagnostics until #895 replaces/fences the diagnostic with a backend API.
+/// capability facades. This provider is kept only for isolated diagnostics;
+/// normal member routes must not import or mount it.
 final chatSecurityRepositoryProvider = Provider<ChatSecurityRepository>((ref) {
   return MatrixChatSecurityRepository(
     securityService: ref.watch(matrixSecurityServiceProvider),

--- a/client/lib/features/settings/presentation/settings_screen.dart
+++ b/client/lib/features/settings/presentation/settings_screen.dart
@@ -16,7 +16,6 @@ import 'package:weave/core/widgets/error_state.dart';
 import 'package:weave/core/widgets/loading_state.dart';
 import 'package:weave/core/widgets/weave_logo.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
-import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
 import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
@@ -1515,9 +1514,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
           data: (profile) => profile?.canAdministerWorkspace ?? false,
           orElse: () => false,
         );
-    final matrixDiagnostic = canViewWorkspaceHealth
-        ? ref.watch(weaveApiMatrixE2eeDiagnosticProvider).asData?.value
-        : null;
     final providerStackSnapshot = canViewWorkspaceHealth
         ? ref.watch(weaveApiProviderStackSnapshotProvider).asData?.value
         : null;
@@ -1563,7 +1559,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                       ref.invalidate(
                         weaveApiWorkspaceCapabilitySnapshotProvider,
                       );
-                      ref.invalidate(weaveApiMatrixE2eeDiagnosticProvider);
                       ref.invalidate(weaveApiProviderStackSnapshotProvider);
                       ref.invalidate(
                         weaveApiOfficeCapabilitiesSnapshotProvider,
@@ -1594,7 +1589,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
                   label: l10n.settingsWorkspaceChatLabel,
                   capability: capabilitySnapshot.chat,
                   connection: workspaceState.chat,
-                  matrixDiagnostic: matrixDiagnostic,
                 ),
                 const Divider(height: 32),
                 _WorkspaceReadinessRow(
@@ -1618,7 +1612,6 @@ class _WorkspaceReadinessCard extends ConsumerWidget {
               }
               ref.invalidate(appAuthIntegrationConnectionProvider);
               ref.invalidate(weaveApiWorkspaceCapabilitySnapshotProvider);
-              ref.invalidate(weaveApiMatrixE2eeDiagnosticProvider);
               ref.invalidate(weaveApiProviderStackSnapshotProvider);
               ref.invalidate(weaveApiOfficeCapabilitiesSnapshotProvider);
             },
@@ -2275,13 +2268,11 @@ class _WorkspaceReadinessRow extends StatelessWidget {
     required this.label,
     required this.capability,
     this.connection,
-    this.matrixDiagnostic,
   });
 
   final String label;
   final WorkspaceCapabilityState capability;
   final IntegrationConnectionState? connection;
-  final MatrixE2eeDiagnostic? matrixDiagnostic;
 
   @override
   Widget build(BuildContext context) {
@@ -2324,26 +2315,6 @@ class _WorkspaceReadinessRow extends StatelessWidget {
                   label: l10n.settingsWorkspaceLastChangeLabel,
                   value: _invalidationLabel(l10n, invalidation.reason),
                 ),
-              if (matrixDiagnostic case final diagnostic?) ...[
-                _StatusPill(
-                  label: l10n.settingsWorkspaceMatrixE2eeGateLabel,
-                  value: diagnostic.isValidated
-                      ? l10n.settingsWorkspaceMatrixE2eeValidated
-                      : l10n.settingsWorkspaceMatrixE2eeNotValidated,
-                ),
-                _StatusPill(
-                  label: l10n.settingsWorkspaceMatrixServerBodiesLabel,
-                  value: diagnostic.keepsMessageBodiesOpaque
-                      ? l10n.settingsWorkspaceMatrixServerBodiesOpaque
-                      : l10n.settingsWorkspaceMatrixServerBodiesReadable,
-                ),
-                _StatusPill(
-                  label: l10n.settingsWorkspaceMatrixAgentWritesLabel,
-                  value: diagnostic.keepsAgentsAndConnectorsFailClosed
-                      ? l10n.settingsWorkspaceMatrixAgentWritesBlocked
-                      : l10n.settingsWorkspaceMatrixAgentWritesReview,
-                ),
-              ],
             ],
           ),
         ],

--- a/client/test/architecture/backend_facade_contract_test.dart
+++ b/client/test/architecture/backend_facade_contract_test.dart
@@ -180,7 +180,7 @@ void main() {
       securityProvider,
       contains('Diagnostic-only Matrix E2EE/security seam'),
     );
-    expect(securityProvider, contains('until #895'));
+    expect(securityProvider, contains('normal member routes must not import'));
   });
 
   test('member Chat screen stays on Weave-domain readiness language', () async {

--- a/client/test/architecture/member_client_provider_boundary_contract_test.dart
+++ b/client/test/architecture/member_client_provider_boundary_contract_test.dart
@@ -145,4 +145,43 @@ void main() {
     expect(settings, isNot(contains('chatSecurityRepositoryProvider')));
     expect(settings, isNot(contains('MatrixChatSecurityRepository')));
   });
+
+  test('normal member routes cannot mount diagnostic Matrix providers', () {
+    final normalMemberRouteFiles = <String>[
+      'lib/core/router/app_router.dart',
+      'lib/features/home/presentation/home_screen.dart',
+      'lib/features/chat/presentation/chat_screen.dart',
+      'lib/features/chat/presentation/chat_room_screen.dart',
+      'lib/features/files/presentation/files_screen.dart',
+      'lib/features/calendar/presentation/calendar_screen.dart',
+      'lib/features/profile/presentation/profile_screen.dart',
+      'lib/features/help/presentation/help_screen.dart',
+      'lib/features/settings/presentation/settings_screen.dart',
+      'lib/features/shell/presentation/app_shell.dart',
+      'lib/features/shell/presentation/shell_workspace_status.dart',
+    ];
+    final forbiddenFragments = <String>[
+      'ChatSecuritySettingsSection',
+      'chat_security_settings_section.dart',
+      'chatSecurityProvider',
+      'chatSecurityRepositoryProvider',
+      'MatrixChatSecurityRepository',
+      'MatrixE2eeDiagnostic',
+      'weaveApiMatrixE2eeDiagnosticProvider',
+      'fetchMatrixE2eeDiagnostic',
+      'PlatformStatusResponseDto',
+    ];
+
+    for (final path in normalMemberRouteFiles) {
+      final source = File(path).readAsStringSync();
+      for (final fragment in forbiddenFragments) {
+        expect(
+          source,
+          isNot(contains(fragment)),
+          reason:
+              '$path must stay on Weave domain/capability facades and must not mount diagnostic Matrix provider fragment `$fragment`.',
+        );
+      }
+    }
+  });
 }

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -9,7 +9,6 @@ import 'package:weave/core/config/feature_flags.dart';
 import 'package:weave/core/failures/app_failure.dart';
 import 'package:weave/core/persistence/shared_preferences_store.dart';
 import 'package:weave/features/app/domain/entities/integration_invalidation.dart';
-import 'package:weave/features/app/domain/entities/matrix_e2ee_diagnostic.dart';
 import 'package:weave/features/app/domain/entities/provider_stack_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_capability_snapshot.dart';
 import 'package:weave/features/app/domain/entities/workspace_connection_state.dart';
@@ -109,17 +108,6 @@ AsyncValue<WorkspaceConnectionState> _workspaceConnectionState() {
     ),
   );
 }
-
-const _matrixDiagnostic = MatrixE2eeDiagnostic(
-  e2eeEnabled: false,
-  status: 'not_validated',
-  serverReadableMessageContent: false,
-  messageContentPolicy: 'encrypted_message_bodies_are_client_readable_only',
-  agentParticipation:
-      'blocked_until_explicit_consent_audit_and_matrix_device_trust_are_implemented',
-  connectorWritePolicy:
-      'fail_closed_until_audit_consent_and_matrix_e2ee_client_identity_are_implemented',
-);
 
 const _ownerProfile = UserProfile(
   userId: 'owner-1',
@@ -277,9 +265,6 @@ void main() {
           weaveBackendConnectionStateProvider.overrideWithValue(
             WeaveBackendConnectionState.connected,
           ),
-          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-            (ref) async => _matrixDiagnostic,
-          ),
           userProfileProvider.overrideWith((ref) async => _ownerProfile),
         ],
       );
@@ -326,18 +311,9 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(
-        find.text('E2EE gate: Not validated', findRichText: true),
-        findsOneWidget,
-      );
-      expect(
-        find.text('Server-readable bodies: No', findRichText: true),
-        findsOneWidget,
-      );
-      expect(
-        find.text('Agent writes: Blocked/fail-closed', findRichText: true),
-        findsOneWidget,
-      );
+      expect(find.textContaining('E2EE gate'), findsNothing);
+      expect(find.textContaining('Server-readable bodies'), findsNothing);
+      expect(find.textContaining('Agent writes'), findsNothing);
       await tester.drag(find.byType(CustomScrollView), const Offset(0, -900));
       await tester.pumpAndSettle();
       expect(find.text('AI agent capability governance'), findsOneWidget);
@@ -433,9 +409,6 @@ void main() {
           ),
           weaveBackendConnectionStateProvider.overrideWithValue(
             WeaveBackendConnectionState.connected,
-          ),
-          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-            (ref) async => _matrixDiagnostic,
           ),
           userProfileProvider.overrideWith((ref) async => _memberProfile),
         ],
@@ -608,9 +581,6 @@ void main() {
             weaveBackendConnectionStateProvider.overrideWithValue(
               WeaveBackendConnectionState.connected,
             ),
-            weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-              (ref) async => _matrixDiagnostic,
-            ),
             userProfileProvider.overrideWith((ref) async => _memberProfile),
           ],
         );
@@ -711,9 +681,6 @@ void main() {
           weaveBackendConnectionStateProvider.overrideWithValue(
             WeaveBackendConnectionState.connected,
           ),
-          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-            (ref) async => _matrixDiagnostic,
-          ),
           userProfileProvider.overrideWith((ref) async => _memberProfile),
         ],
       );
@@ -760,9 +727,6 @@ void main() {
           ),
           weaveBackendConnectionStateProvider.overrideWithValue(
             WeaveBackendConnectionState.connected,
-          ),
-          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-            (ref) async => _matrixDiagnostic,
           ),
           weaveApiProviderStackSnapshotProvider.overrideWith(
             (ref) async => const ProviderStackSnapshot(
@@ -841,9 +805,6 @@ void main() {
           weaveBackendConnectionStateProvider.overrideWithValue(
             WeaveBackendConnectionState.connected,
           ),
-          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-            (ref) async => _matrixDiagnostic,
-          ),
           userProfileProvider.overrideWith((ref) async => _ownerProfile),
         ],
       );
@@ -888,9 +849,6 @@ void main() {
           ),
           weaveBackendConnectionStateProvider.overrideWithValue(
             WeaveBackendConnectionState.connected,
-          ),
-          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-            (ref) async => _matrixDiagnostic,
           ),
           userProfileProvider.overrideWith((ref) async => null),
         ],
@@ -961,9 +919,6 @@ void main() {
           ),
           weaveBackendConnectionStateProvider.overrideWithValue(
             WeaveBackendConnectionState.connected,
-          ),
-          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-            (ref) async => _matrixDiagnostic,
           ),
           weaveApiProviderStackSnapshotProvider.overrideWith(
             (ref) async => const ProviderStackSnapshot(
@@ -1163,9 +1118,6 @@ void main() {
           weaveBackendConnectionStateProvider.overrideWithValue(
             WeaveBackendConnectionState.connected,
           ),
-          weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-            (ref) async => _matrixDiagnostic,
-          ),
           weaveApiProviderStackSnapshotProvider.overrideWith(
             (ref) async => ProviderStackSnapshot(
               releaseStatus: 'provider-final-coverage',
@@ -1312,9 +1264,6 @@ void main() {
             ),
             weaveBackendConnectionStateProvider.overrideWithValue(
               WeaveBackendConnectionState.connected,
-            ),
-            weaveApiMatrixE2eeDiagnosticProvider.overrideWith(
-              (ref) async => _matrixDiagnostic,
             ),
             userProfileProvider.overrideWith((ref) async => _ownerProfile),
           ],

--- a/client/test/features/settings/settings_screen_test.dart
+++ b/client/test/features/settings/settings_screen_test.dart
@@ -311,9 +311,18 @@ void main() {
         ),
         findsOneWidget,
       );
-      expect(find.textContaining('E2EE gate'), findsNothing);
-      expect(find.textContaining('Server-readable bodies'), findsNothing);
-      expect(find.textContaining('Agent writes'), findsNothing);
+      expect(
+        find.textContaining('E2EE gate', findRichText: true),
+        findsNothing,
+      );
+      expect(
+        find.textContaining('Server-readable bodies', findRichText: true),
+        findsNothing,
+      );
+      expect(
+        find.textContaining('Agent writes', findRichText: true),
+        findsNothing,
+      );
       await tester.drag(find.byType(CustomScrollView), const Offset(0, -900));
       await tester.pumpAndSettle();
       expect(find.text('AI agent capability governance'), findsOneWidget);


### PR DESCRIPTION
## Summary

- Removes the Matrix E2EE diagnostic pills from the Workspace Health readiness presentation so member/admin UI stays on backend capability and provider-stack summaries.
- Keeps the remaining direct Matrix security repository explicitly fenced as an isolated diagnostic seam.
- Adds an architecture guard that normal member routes cannot import or mount Matrix diagnostic providers, platform-status DTOs, or security diagnostic widgets.

## Scope and user impact

- Normal members stay on Weave domain/capability surfaces and cannot reach Matrix diagnostic controls through Settings, Home, Shell, Chat, Files, Calendar, Profile, or Help routes.
- Workspace Health still shows support-safe capability, provider-stack, and office readiness evidence for admins.
- The backend Matrix E2EE diagnostic client remains tested as an integration/backend-status client, but it is not mounted in member presentation.

## Spec / acceptance link

- Fixes #895
- Governing source: pinned corpus plus `docs/product-line-and-weaver-plan.md` provider-neutral member/admin boundary.
- Acceptance criteria set for this slice:
  - normal member routes cannot import or mount Matrix diagnostic providers/widgets;
  - Workspace Health no longer renders Matrix-specific E2EE diagnostic pills;
  - remaining Matrix SDK imports stay constrained to the existing diagnostic/service seam;
  - client gates prove the boundary with architecture and widget tests.
- Evidence mode / reality level: offline client/architecture evidence; no live provider/auth behavior changed.
- Product-core questions intentionally left unresolved: none.

## Branch, target lane, and release path

- Target lane: dev
- Branch: `feat/member-provider-diagnostic-boundary`
- Commit: `d604f5672f`
- Production release is not implied by this merge.

## Spec impact

- [x] none
- [ ] implements locked spec
- [ ] updates spec
- [ ] changes evidence only

## Release note

- Release note: Fixed the member/provider boundary so Matrix security diagnostics remain fenced from normal member routes.

## Release notes label

- [ ] `release-notes-feature`
- [x] `release-notes-bugfix`
- [ ] `release-notes-skip`

## Screenshots or docs impact

- `clientCi` regenerated marketing screenshots during the gate and confirmed no checked-in screenshot drift from the clean commit.

## Risk, privacy, accessibility, and localization

- Security/privacy impact: reduces provider-specific diagnostic exposure in presentation code; no secrets, raw provider payloads, endpoints, or tokens added.
- Accessibility/localization impact: removes Matrix-specific status pills; no new user-facing copy.
- Support-safe evidence constraints checked: architecture tests now fail if normal member route files mount diagnostic Matrix provider fragments.

## Contract impact

- [x] No public API/auth/topology/spec contract change
- [ ] Contract/spec change documented:
- [ ] `./gradlew specContract` run for spec/product-contract changes

## Review readiness and Fachveto

- [ ] Copilot review requested for this review-ready PR, or Copilot exhaustion/unavailability noted
- [ ] Copilot findings addressed or fallback human/agent review evidence documented
- [x] Relevant Fachveto owner/path named below
- Fachveto owner/path: Client architecture + security/privacy provider-boundary review for #895.

## Checks run

- [x] `git diff --check`
- [x] `flutter test test/architecture/member_client_provider_boundary_contract_test.dart test/architecture/backend_facade_contract_test.dart test/features/settings/settings_screen_test.dart`
- [x] Copilot review finding addressed: rich-text matching added to removed-diagnostic negative assertions
- [x] `./gradlew acceptanceContract clientCi --console=plain --no-daemon --max-workers=1`
- [ ] Live-stack validation: not run; no live auth/provider behavior changed.

## Notes for reviewers

- Review the new route-level architecture guard first: normal member route files must stay on Weave capability/provider-stack facades and must not mount Matrix diagnostic fragments.
- The low-level Matrix E2EE diagnostic client remains covered by integration tests, but the presentation route graph no longer renders it.
