### PR TITLE
test: allow supportRef in live stack capability safety

### DIFF
--- a/client/integration_test/live_stack_app_e2e_test.dart
+++ b/client/integration_test/live_stack_app_e2e_test.dart
@@ -1137,6 +1137,7 @@ bool _capabilityStateSupportSafe(Map<String, dynamic> capability) {
     'policyState',
     'profileKey',
     'memberImpact',
+    'supportRef',
     'grantedCapabilities',
   };
   if (capability.isEmpty ||
@@ -1144,10 +1145,11 @@ bool _capabilityStateSupportSafe(Map<String, dynamic> capability) {
     return false;
   }
   final impact = _jsonString(capability['memberImpact']);
+  final supportRef = _jsonString(capability['supportRef']);
   return !RegExp(
     r'(Authorization|Bearer|token|secret|password|https?://|/api/v3/|SecretRef|secretref://)',
     caseSensitive: false,
-  ).hasMatch(impact);
+  ).hasMatch('$impact $supportRef');
 }
 
 bool _availableOrHonestFallback(Map<String, dynamic> capability) {


### PR DESCRIPTION
## Summary

- Allow the Live Stack E2E capability support-safety checker to accept the backend's supportRef field.
- Validate supportRef with the same support-safe token/URL/secret regex used for member impact.

## Scope and user impact

- Keeps PR #995 dogfood promotion blocked only by real support-safety leaks, not by the now-standard supportRef contract field.
- No production release is implied.

## Spec / acceptance link

- Issues/PRs: #995, #944.
- Acceptance: existing Live Stack E2E provider reality gate and e2e/scenario_mappings.json.
- Evidence mode: offline acceptance contract plus remote Live Stack E2E after merge/update.

## Release note

- Release note: none. Test/evidence gate maintenance only.

## Release notes label

- [ ] release-notes-feature
- [ ] release-notes-bugfix
- [x] release-notes-skip

## Risk, privacy, accessibility, and localization

- Security/privacy impact: no app/runtime behavior change; supportRef is still checked for raw token/secret/URL patterns.
- Accessibility/localization impact: none.
- Support-safe evidence constraints checked: supportRef and memberImpact are both scanned for secret/provider leak patterns.

## Review readiness and Fachveto

- Copilot review requested if available.
- Fachveto owner/path: QA/Evidence lightweight veto for Live Stack E2E gate maintenance.

## Checks run

- dart format --output=none --set-exit-if-changed integration_test/live_stack_app_e2e_test.dart
- ./gradlew acceptanceContract --console=plain --no-daemon --max-workers=1
