### PR TITLE
docs: define domain facade protocol projections

### DIFF
--- a/docs/architecture/domain-facade-protocol-projections.md
+++ b/docs/architecture/domain-facade-protocol-projections.md
@@ -1,0 +1,137 @@
+# Domain facade protocol projections
+
+Weave uses domain facades as product truth. Open protocols are exposed as
+projections only when they improve native OS integration, interoperability, or
+federation without leaking provider semantics into member, admin, or MCP
+contracts.
+
+This decision applies to Files, Calendar, and Chat. Calls/Meetings remain a
+separate native-call and media-signaling boundary.
+
+## Decision
+
+Each domain has one Weave-owned core:
+
+- canonical object references such as `file:`, `event:`, `conversation:`, and
+  `message:`;
+- Space/workspace/team/channel bindings;
+- policy, capability, audit, and support-safe error semantics;
+- provider mappings hidden behind adapters;
+- generated OpenAPI member/admin contracts;
+- governed MCP tools generated or validated from the same facade metadata.
+
+OpenAPI is the primary JSON contract for Weave clients, Admin Console, and the
+MCP adapter, but it is not the only valid projection. WebDAV, CalDAV/iCalendar,
+and Matrix are allowed where they are the right open standard for OS integration
+or federation. They must remain Weave projections or provider adapters, never
+the product truth.
+
+## Files
+
+Final shape:
+
+- Product truth: Weave Files facade.
+- JSON/API projection: `/api/files/**` and generated OpenAPI models.
+- Standard projection: optional Weave WebDAV-compatible surface for desktop or
+  admin-approved clients.
+- Native OS adapters: iOS File Provider extension and Android DocumentsProvider
+  / Storage Access Framework, backed by the Weave Files facade or Weave WebDAV
+  projection.
+- Provider adapters: Nextcloud WebDAV first; S3/object storage or other storage
+  adapters later.
+- MCP: semantic tools such as `files.search`, `files.read_metadata`,
+  `files.read_content`, `files.write`, and `files.share_item`, backed by Weave
+  policy and audit.
+
+WebDAV is an open standard and is a strong fit for file/folder interoperability,
+but raw WebDAV is not the member product contract. File Provider and
+DocumentsProvider implementations expose native OS file surfaces while preserving
+Weave IDs, policy, audit, and support-safe errors.
+
+Near-term federation for files should use Weave guest/external sharing policy.
+Provider-native federated shares may become adapter capabilities later.
+
+## Calendar
+
+Final shape:
+
+- Product truth: Weave Calendar facade for workspace, team, and channel events.
+- JSON/API projection: `/api/calendar/**` and generated OpenAPI models.
+- Standard projection: Weave CalDAV/iCalendar for native iOS/macOS Calendar and
+  external calendar clients.
+- Native OS adapters: iOS/macOS CalDAV configuration profile against Weave
+  CalDAV; Android Account + SyncAdapter writing through Calendar Provider /
+  `CalendarContract`, backed by the Weave Calendar facade or Weave CalDAV.
+- Provider adapters: Nextcloud CalDAV first; Graph/Google/generic CalDAV-like
+  adapters later.
+- MCP: semantic tools such as `calendar.search_events`,
+  `calendar.create_event`, `calendar.update_event`, and
+  `calendar.link_meeting_thread`, backed by server policy and audit.
+
+CalDAV/iCalendar are the right standards for native calendar interoperability,
+especially on Apple platforms. Android has no universal CalDAV account install
+path, so Weave needs an Android sync adapter if native Calendar integration is a
+product requirement.
+
+Private personal calendar ingestion is not the current product path. Keep the
+scope on Weave-owned workspace/team/channel calendars and meeting threads.
+External attendee/inter-organization federation can later use iTIP/iMIP or
+provider-specific bridge adapters behind the Calendar facade.
+
+## Chat
+
+Final shape:
+
+- Product truth: Weave Chat facade for conversations, messages, membership,
+  attachments, decisions, meeting threads, policy, readiness, and audit.
+- JSON/API projection: Weave Chat OpenAPI where server-visible metadata,
+  readiness, attachment, decision-ledger, and governed write operations are safe.
+- Backing protocol and federation projection: Matrix Client-Server and
+  Server-Server APIs.
+- Native clients: Weave mobile clients use a Matrix-capable transport layer where
+  encrypted room participation requires it, but product UI exposes Weave
+  conversations/channels rather than raw Matrix IDs.
+- Provider adapters: Matrix first; Slack/Teams imports or bridges later as
+  adapters, not product truth.
+- MCP: semantic tools such as `chat.send_message`,
+  `chat.search_accessible_messages`, `chat.summarize_thread`, and
+  `chat.create_decision_ref`, with explicit consent/audit gates for shared-state
+  writes and decrypted-content access.
+
+Matrix is the strongest open and federated fit for Teams-like chat, but open
+federation should be gated. Tenant isolation, identity mapping, moderation,
+invite policy, retention, and external-room UX must be proven before broad
+inter-organization federation is enabled.
+
+MCP must not receive raw Matrix access by default. E2EE and room history make
+chat the hardest domain for server-side tools; MCP should operate on governed
+Weave projections, consented summaries, decision records, attachment references,
+and user-authorized decrypted indexes.
+
+## MCP projection rule
+
+MCP tools are semantic Weave tools, not raw protocol scripts. Under the hood,
+they may call OpenAPI, WebDAV, CalDAV, Matrix, or provider adapters, but:
+
+- tool names and capability keys stay domain-semantic;
+- server policy, authorization, validation, redaction, and audit remain the hard
+  boundary;
+- raw provider credentials, URLs, diagnostics, and unrestricted protocol methods
+  are not exposed to MCP clients;
+- destructive or shared-state writes require the same approval/audit receipts as
+  product clients.
+
+## Cleanup required
+
+The following drift must be removed as this architecture lands:
+
+- member-facing Nextcloud, CalDAV, WebDAV, or Matrix implementation details in
+  normal Files/Calendar/Chat copy;
+- DTO defaults or error messages that expose provider identifiers as product
+  truth;
+- private personal calendar setup language in release-facing paths while the
+  current product scope is shared workspace/team/channel calendars;
+- duplicate MCP contract logic that is not generated from or validated against
+  the server facade metadata and OpenAPI route allowlist;
+- native setup surfaces that expose provider endpoints instead of Weave
+  projections.

--- a/docs/architecture/provider-portability.md
+++ b/docs/architecture/provider-portability.md
@@ -57,7 +57,14 @@ The first release-quality Nextcloud path uses backend actor adapters. Member-fac
 
 ## Native OS integration boundary
 
-Native OS integrations sit above the provider adapter layer. They use OS contracts but receive only Weave-owned setup/status/provisioning metadata:
+Native OS integrations sit above the provider adapter layer. The governing
+decision is [Domain facade protocol projections](domain-facade-protocol-projections.md):
+Weave domain facades are product truth, while WebDAV, CalDAV/iCalendar, Matrix,
+OpenAPI, native OS extensions/providers, and MCP tools are projections or
+adapters over that truth.
+
+Native integrations use OS contracts but receive only Weave-owned
+setup/status/provisioning metadata:
 
 | Domain | Native OS boundary | Weave facade contract | Availability gate |
 | --- | --- | --- | --- |
@@ -65,7 +72,13 @@ Native OS integrations sit above the provider adapter layer. They use OS contrac
 | Calendar | iOS CalDAV configuration profile semantics; Android Account/SyncAdapter plus Calendar Provider / CalendarContract. | `GET /api/calendar/native-sync-setup` plus setup credential lifecycle and event facade hooks. The response contains Weave API paths only and no raw calendar-provider host. | Full native availability is blocked until signed profile/account setup, event sync, and revoke/fail-closed behavior are proven on physical or instrumentation devices. |
 | Calls/Meetings | iOS CallKit + PushKit/VoIP concerns; Android Telecom / ConnectionService where supported. | `GET /api/calls/native-boundary-setup` describes Weave meeting invitation, policy, and join-grant boundaries. Actual media transport remains separate. | Full native availability is blocked until provider-neutral meetings facade endpoints, native call UI, permissions, audio routing, and revoke/join evidence are proven on devices. |
 
-OpenAPI remains the setup/status/provisioning surface for these native integrations. It does not replace the native OS provider, account, sync, or call UI contracts.
+OpenAPI remains the primary setup/status/provisioning surface for Weave clients,
+Admin Console, and MCP route allowlists. It does not replace native OS provider,
+account, sync, call UI, or protocol projections where standards are the better
+fit. Files may expose a Weave WebDAV-compatible projection; Calendar may expose
+a Weave CalDAV/iCalendar projection; Chat may use Matrix for transport and
+federation. These projections must use Weave facades and never become provider
+pass-throughs.
 
 ## Keycloak desired-state dry-run direction
 

--- a/server/docs/calendar-native-sync-setup.md
+++ b/server/docs/calendar-native-sync-setup.md
@@ -1,6 +1,11 @@
 # Calendar native sync setup
 
 Weave Calendar native integration is additive to the in-app Calendar view. Native OS setup must use Weave-owned setup and sync facades, not raw provider account details.
+The architecture is defined in
+`docs/architecture/domain-facade-protocol-projections.md`: the Calendar domain
+facade is product truth, while OpenAPI, Weave CalDAV/iCalendar, iOS/macOS
+profiles, Android Account/SyncAdapter, and MCP tools are projections over that
+facade.
 
 ## Current executable slice
 
@@ -9,13 +14,17 @@ Weave Calendar native integration is additive to the in-app Calendar view. Nativ
 - iOS boundary: CalDAV configuration profile semantics delivered through a Weave route.
 - Android boundary: Account/SyncAdapter plus Calendar Provider / CalendarContract semantics.
 - Flutter/native bridge role: setup, status, and revoke only.
-- Calendar proof hooks: `GET /api/calendar/scopes`, `GET /api/calendar/events`, `POST /api/calendar/client-setup/credentials`, and the fail-closed Apple profile route.
+- Calendar proof hooks: `GET /api/calendar/scopes`, `GET /api/calendar/events`, `POST /api/calendar/client-setup/credentials`, and the fail-closed Apple profile route. A Weave CalDAV/iCalendar projection is the standards-compatible route for native Apple Calendar and external calendar clients.
 - Support-safe blocked states for the remaining work: signed profile delivery, Android SyncAdapter wiring, scoped credential secret issuance, and physical-device sync/revoke evidence.
 
 The response deliberately contains only Weave-owned API paths. It must not include provider hostnames, provider account URLs, provider credentials, bearer tokens, or raw provider diagnostics.
 
 ## Product boundary
 
-The member app may show native setup status and start or revoke native setup. It must not become a CalDAV/WebDAV client and must not store provider credentials. Calendar rows and sync state belong in the native OS calendar account/provider layer, backed by Weave calendar facade endpoints.
+The member app may show native setup status and start or revoke native setup. It
+must not become a raw provider CalDAV/WebDAV client and must not store provider
+credentials. Calendar rows and sync state belong in the native OS calendar
+account/provider layer, backed by Weave calendar facade endpoints or a Weave
+CalDAV/iCalendar projection.
 
 Full native availability remains blocked until physical-device evidence proves profile/account setup, event sync, and revocation behavior.

--- a/server/docs/calls-native-boundary-setup.md
+++ b/server/docs/calls-native-boundary-setup.md
@@ -1,6 +1,11 @@
 # Calls native boundary setup
 
 Weave Calls and Meetings native integration separates OS call UI from media transport and provider administration. Native call surfaces must be driven by Weave meeting invitations, policy, and join grants.
+Files, Calendar, and Chat use the domain-facade/protocol-projection decision in
+`docs/architecture/domain-facade-protocol-projections.md`. Calls/Meetings share
+the same principle but remain a separate media/signaling boundary: OS call UI is
+a native projection, while media transport and signaling grants are not replaced
+by OpenAPI alone.
 
 ## Current executable slice
 

--- a/server/docs/files-native-provider-setup.md
+++ b/server/docs/files-native-provider-setup.md
@@ -1,6 +1,11 @@
 # Files native provider setup
 
 Weave Files must integrate with native OS file surfaces through Weave-owned facades, not through raw storage-provider setup.
+The architecture is defined in
+`docs/architecture/domain-facade-protocol-projections.md`: the Files domain
+facade is product truth, while OpenAPI, a future Weave WebDAV-compatible
+projection, iOS File Provider, Android DocumentsProvider, and MCP tools are
+thin projections over that facade.
 
 ## Current executable slice
 
@@ -9,14 +14,18 @@ Weave Files must integrate with native OS file surfaces through Weave-owned faca
 - iOS boundary: File Provider extension.
 - Android boundary: DocumentsProvider / Storage Access Framework.
 - Flutter/native bridge role: setup, status, and revoke only.
-- File IO proof hooks: `GET /api/files`, `GET /api/files/{id}/download`, and `POST /api/files/upload`.
+- File IO proof hooks: `GET /api/files`, `GET /api/files/{id}/download`, and `POST /api/files/upload`; a future Weave WebDAV-compatible projection may reuse the same facade for standards-compatible clients.
 - Support-safe blocked states for the remaining work: native extension/provider implementation, per-device token revocation, and physical-device provider proof.
 
 The response deliberately contains only Weave-owned API paths. It must not include provider hostnames, WebDAV URLs, provider credentials, bearer tokens, or provider diagnostics.
 
 ## Product boundary
 
-The member app may show native setup status and let the user start or revoke native setup. It must not become a WebDAV client and must not store storage-provider credentials. Native OS file IO belongs in the iOS File Provider extension or Android DocumentsProvider, backed by Weave file facade endpoints.
+The member app may show native setup status and let the user start or revoke
+native setup. It must not become a raw provider WebDAV client and must not store
+storage-provider credentials. Native OS file IO belongs in the iOS File Provider
+extension or Android DocumentsProvider, backed by Weave file facade endpoints or
+a Weave WebDAV-compatible projection.
 
 ## First dogfood proof
 


### PR DESCRIPTION
## Summary

- Add the final Files/Calendar/Chat facade/protocol projection decision.
- Clarify that Weave domain facades are product truth, while OpenAPI, WebDAV, CalDAV/iCalendar, Matrix, native OS adapters, and MCP tools are projections/adapters.
- Link the decision from provider portability and native setup docs so Sprint 33 does not drift into OpenAPI-only or provider-passthrough architecture.

## Scope

- Documentation/architecture only.
- Follow-up to #999 after Massimo clarified the desired domain-facade criteria: open standards, native iOS/Android usability, optional federation, and MCP semantic tool compatibility.

## Checks run

- git diff --check
- ./gradlew docsCheck --console=plain --no-daemon --max-workers=1

## Release notes label

- [ ] release-notes-feature
- [ ] release-notes-bugfix
- [x] release-notes-skip
