### PR TITLE
feat: add standard protocol access discovery

### DIFF
--- a/client/lib/generated/openapi_models.dart
+++ b/client/lib/generated/openapi_models.dart
@@ -2695,6 +2695,128 @@ class ClaimMapper {
   };
 }
 
+class ClientAccessCredentialLifecycleResponse {
+  const ClientAccessCredentialLifecycleResponse({
+    this.blockedUntil,
+    this.lifecyclePaths,
+    this.secretMaterialReturned,
+    this.status,
+  });
+
+  factory ClientAccessCredentialLifecycleResponse.fromJson(
+    Map<String, dynamic> json,
+  ) => ClientAccessCredentialLifecycleResponse(
+    blockedUntil: (json["blockedUntil"] as List<dynamic>?)
+        ?.map((e) => e as String)
+        .toList(),
+    lifecyclePaths: (json["lifecyclePaths"] as List<dynamic>?)
+        ?.map((e) => e as String)
+        .toList(),
+    secretMaterialReturned: json["secretMaterialReturned"] as bool?,
+    status: json["status"] as String?,
+  );
+
+  final List<String>? blockedUntil;
+  final List<String>? lifecyclePaths;
+  final bool? secretMaterialReturned;
+  final String? status;
+
+  Map<String, dynamic> toJson() => {
+    "blockedUntil": _openApiJsonValue(blockedUntil),
+    "lifecyclePaths": _openApiJsonValue(lifecyclePaths),
+    "secretMaterialReturned": _openApiJsonValue(secretMaterialReturned),
+    "status": _openApiJsonValue(status),
+  };
+}
+
+class ClientAccessDiscoveryResponse {
+  const ClientAccessDiscoveryResponse({
+    this.credentialLifecycle,
+    this.domain,
+    this.openApiTag,
+    this.productApiBasePath,
+    this.providerConfigurationExposed,
+    this.supportSafe,
+    this.surfaces,
+  });
+
+  factory ClientAccessDiscoveryResponse.fromJson(Map<String, dynamic> json) =>
+      ClientAccessDiscoveryResponse(
+        credentialLifecycle: json["credentialLifecycle"] == null
+            ? null
+            : ClientAccessCredentialLifecycleResponse.fromJson(
+                json["credentialLifecycle"] as Map<String, dynamic>,
+              ),
+        domain: json["domain"] as String?,
+        openApiTag: json["openApiTag"] as String?,
+        productApiBasePath: json["productApiBasePath"] as String?,
+        providerConfigurationExposed:
+            json["providerConfigurationExposed"] as bool?,
+        supportSafe: json["supportSafe"] as bool?,
+        surfaces: (json["surfaces"] as List<dynamic>?)
+            ?.map(
+              (e) => ClientAccessProtocolSurfaceResponse.fromJson(
+                e as Map<String, dynamic>,
+              ),
+            )
+            .toList(),
+      );
+
+  final ClientAccessCredentialLifecycleResponse? credentialLifecycle;
+  final String? domain;
+  final String? openApiTag;
+  final String? productApiBasePath;
+  final bool? providerConfigurationExposed;
+  final bool? supportSafe;
+  final List<ClientAccessProtocolSurfaceResponse>? surfaces;
+
+  Map<String, dynamic> toJson() => {
+    "credentialLifecycle": _openApiJsonValue(credentialLifecycle),
+    "domain": _openApiJsonValue(domain),
+    "openApiTag": _openApiJsonValue(openApiTag),
+    "productApiBasePath": _openApiJsonValue(productApiBasePath),
+    "providerConfigurationExposed": _openApiJsonValue(
+      providerConfigurationExposed,
+    ),
+    "supportSafe": _openApiJsonValue(supportSafe),
+    "surfaces": _openApiJsonValue(surfaces),
+  };
+}
+
+class ClientAccessProtocolSurfaceResponse {
+  const ClientAccessProtocolSurfaceResponse({
+    this.kind,
+    this.name,
+    this.notes,
+    this.readiness,
+    this.setupPath,
+  });
+
+  factory ClientAccessProtocolSurfaceResponse.fromJson(
+    Map<String, dynamic> json,
+  ) => ClientAccessProtocolSurfaceResponse(
+    kind: json["kind"] as String?,
+    name: json["name"] as String?,
+    notes: (json["notes"] as List<dynamic>?)?.map((e) => e as String).toList(),
+    readiness: json["readiness"] as String?,
+    setupPath: json["setupPath"] as String?,
+  );
+
+  final String? kind;
+  final String? name;
+  final List<String>? notes;
+  final String? readiness;
+  final String? setupPath;
+
+  Map<String, dynamic> toJson() => {
+    "kind": _openApiJsonValue(kind),
+    "name": _openApiJsonValue(name),
+    "notes": _openApiJsonValue(notes),
+    "readiness": _openApiJsonValue(readiness),
+    "setupPath": _openApiJsonValue(setupPath),
+  };
+}
+
 class ConnectorBoundaryResponse {
   const ConnectorBoundaryResponse({
     this.deferredUntil,
@@ -6651,6 +6773,7 @@ class OrganizationManifestResponse {
   const OrganizationManifestResponse({
     this.adminConsoleResponsibilities,
     this.capabilities,
+    this.clientAccessDiscovery,
     this.clientResponsibilities,
     this.diagnosticsExposed,
     this.displayName,
@@ -6676,6 +6799,9 @@ class OrganizationManifestResponse {
         : WorkspaceCapabilitiesResponse.fromJson(
             json["capabilities"] as Map<String, dynamic>,
           ),
+    clientAccessDiscovery:
+        (json["clientAccessDiscovery"] as Map<String, dynamic>?)
+            ?.cast<String, Object?>(),
     clientResponsibilities: (json["clientResponsibilities"] as List<dynamic>?)
         ?.map((e) => e as String)
         .toList(),
@@ -6695,6 +6821,7 @@ class OrganizationManifestResponse {
 
   final List<String>? adminConsoleResponsibilities;
   final WorkspaceCapabilitiesResponse? capabilities;
+  final Map<String, Object?>? clientAccessDiscovery;
   final List<String>? clientResponsibilities;
   final bool? diagnosticsExposed;
   final String? displayName;
@@ -6712,6 +6839,7 @@ class OrganizationManifestResponse {
       adminConsoleResponsibilities,
     ),
     "capabilities": _openApiJsonValue(capabilities),
+    "clientAccessDiscovery": _openApiJsonValue(clientAccessDiscovery),
     "clientResponsibilities": _openApiJsonValue(clientResponsibilities),
     "diagnosticsExposed": _openApiJsonValue(diagnosticsExposed),
     "displayName": _openApiJsonValue(displayName),

--- a/contracts/openapi/weave-openapi.json
+++ b/contracts/openapi/weave-openapi.json
@@ -2319,6 +2319,110 @@
         },
         "type": "object"
       },
+      "ClientAccessCredentialLifecycleResponse": {
+        "description": "Support-safe credential lifecycle summary for member, native, generic, and MCP clients.",
+        "properties": {
+          "blockedUntil": {
+            "description": "Support-safe blockers before this access surface can be called ready.",
+            "items": {
+              "description": "Support-safe blockers before this access surface can be called ready.",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "lifecyclePaths": {
+            "description": "Weave-owned lifecycle paths or references only; never provider URLs or raw secret refs.",
+            "items": {
+              "description": "Weave-owned lifecycle paths or references only; never provider URLs or raw secret refs.",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "secretMaterialReturned": {
+            "description": "Whether credentials or bearer tokens are returned in this manifest. Must remain false.",
+            "example": false,
+            "type": "boolean"
+          },
+          "status": {
+            "description": "Stable lifecycle posture.",
+            "example": "blocked_until_revocable_device_grants",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ClientAccessDiscoveryResponse": {
+        "description": "Support-safe discovery metadata for a Weave domain access surface.",
+        "properties": {
+          "credentialLifecycle": {
+            "$ref": "#/components/schemas/ClientAccessCredentialLifecycleResponse"
+          },
+          "domain": {
+            "description": "Provider-neutral Weave domain key.",
+            "example": "files",
+            "type": "string"
+          },
+          "openApiTag": {
+            "description": "OpenAPI tag or contract group for generated clients and MCP allowlists.",
+            "example": "Files",
+            "type": "string"
+          },
+          "productApiBasePath": {
+            "description": "Weave-owned product API base path.",
+            "example": "/api/files",
+            "type": "string"
+          },
+          "providerConfigurationExposed": {
+            "description": "False: discovery must not expose raw provider setup or endpoint configuration.",
+            "example": false,
+            "type": "boolean"
+          },
+          "supportSafe": {
+            "description": "True when discovery excludes raw provider URLs, credentials, endpoint rotation data, and diagnostics.",
+            "type": "boolean"
+          },
+          "surfaces": {
+            "description": "Open-standard or native projection surfaces exposed over Weave domain truth.",
+            "items": {
+              "$ref": "#/components/schemas/ClientAccessProtocolSurfaceResponse"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
+      "ClientAccessProtocolSurfaceResponse": {
+        "description": "One Weave-owned client access projection for a domain facade.",
+        "properties": {
+          "kind": {
+            "description": "Surface kind, such as openapi, standard-protocol, native-os, mcp, or provider-adapter.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Surface name in product-neutral terms.",
+            "example": "Weave WebDAV projection",
+            "type": "string"
+          },
+          "notes": {
+            "description": "Support-safe notes for generated clients and admins.",
+            "items": {
+              "description": "Support-safe notes for generated clients and admins.",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "readiness": {
+            "description": "Stable readiness posture for this surface.",
+            "example": "contract_ready",
+            "type": "string"
+          },
+          "setupPath": {
+            "description": "Weave-owned API, setup, status, or lifecycle path when one exists. Null means the surface is documented but not exposed yet.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ConnectorBoundaryResponse": {
         "properties": {
           "deferredUntil": {
@@ -5485,6 +5589,13 @@
           },
           "capabilities": {
             "$ref": "#/components/schemas/WorkspaceCapabilitiesResponse"
+          },
+          "clientAccessDiscovery": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ClientAccessDiscoveryResponse"
+            },
+            "description": "Support-safe domain access discovery for product APIs, standard-protocol projections, native setup, and governed MCP consumers.",
+            "type": "object"
           },
           "clientResponsibilities": {
             "description": "Responsibilities owned by the member Weave Client.",

--- a/docs/architecture/domain-facade-protocol-projections.md
+++ b/docs/architecture/domain-facade-protocol-projections.md
@@ -8,6 +8,26 @@ contracts.
 This decision applies to Files, Calendar, and Chat. Calls/Meetings remain a
 separate native-call and media-signaling boundary.
 
+## Why standards and federation matter
+
+Open standards are not a retreat from Weave product ownership. They reduce
+lock-in and let organizations use generic, native, and federated clients without
+handing those clients raw provider URLs or tokens. A member should be able to
+open files through an operating-system file surface, see workspace events in a
+native calendar, or join a call from a platform call UI while Weave still owns
+domain truth, policy, audit, revocation, readiness, support-safe errors, and
+provider mappings.
+
+The northbound/southbound split is therefore mandatory:
+
+- **Northbound:** Weave exposes product APIs and selected standard protocol
+  projections to Flutter, Web, Admin Console, MCP, native OS integrations, and
+  generic clients.
+- **Southbound:** Weave calls configured domain providers through adapters such
+  as WebDAV, CalDAV, Matrix, Graph, Google, Slack, Teams, LiveKit, or storage
+  APIs. These adapters are interchangeable implementation choices, not member
+  product contracts.
+
 ## Decision
 
 Each domain has one Weave-owned core:
@@ -25,6 +45,55 @@ MCP adapter, but it is not the only valid projection. WebDAV, CalDAV/iCalendar,
 and Matrix are allowed where they are the right open standard for OS integration
 or federation. They must remain Weave projections or provider adapters, never
 the product truth.
+
+## OpenAPI role
+
+OpenAPI remains critical. It is the generated contract for Flutter, Web, Admin
+Console, setup/revoke screens, support-safe readiness cards, MCP route
+allowlists, and generated models. Adding WebDAV, CalDAV/iCalendar, Matrix, or a
+native OS boundary must not displace OpenAPI. Standard protocol surfaces need a
+Weave-owned OpenAPI discovery, setup, status, revoke, and audit path so clients
+can learn whether a projection is enabled and how credentials or grants expire.
+
+## Target server module shape
+
+The server should move toward domain packages with the same internal outline:
+
+| Layer | Responsibility |
+| --- | --- |
+| `server/.../<domain>/facade` | Northbound Weave product API, OpenAPI DTOs, and support-safe errors. |
+| `server/.../<domain>/projection` | Optional WebDAV, CalDAV/iCalendar, Matrix-compatible, native OS, or MCP projection adapters over the facade. |
+| `server/.../<domain>/adapter` | Southbound provider clients and anti-corruption mappers. |
+| `server/.../<domain>/mapping` | Provider object mapping, lossy-field, permission-impact, conflict, portability, and audit evidence. |
+| `server/.../<domain>/policy` | Capability gates, revocation, credential lifecycle, and audit decisions. |
+
+Existing packages can migrate incrementally. Do not rename broad packages or
+move all code in one PR; add the boundary where new contracts or tests need it.
+
+## Client access discovery and credential lifecycle
+
+Member clients discover access from the authenticated organization manifest and
+domain setup endpoints. The manifest may expose Weave-owned paths such as
+`/api/files`, `/api/calendar/native-sync-setup`, or
+`/api/calls/native-boundary-setup`. It must not expose raw provider endpoints,
+provider tenant URLs, app passwords, bearer tokens, static profile secrets,
+endpoint rotation data, or admin diagnostics.
+
+Credential and grant lifecycle is part of the Weave contract:
+
+- Files native access requires revocable per-device Weave grants before member
+  availability can be true.
+- Calendar native/generic access requires scoped revocable CalDAV/iCalendar
+  credentials, signed profile delivery where profiles are used, and revoke
+  evidence.
+- Chat access is session-bound and must not hand raw Matrix, Slack, or Teams
+  credentials to member clients or MCP.
+- Meetings/Calls use short-lived join grants and native call handoff state;
+  media-provider credentials stay behind server/provider adapters.
+
+The first implementation slice records this discovery in the organization
+manifest as support-safe metadata only. It does not claim that native iOS or
+Android integrations are ready.
 
 ## Files
 
@@ -103,10 +172,37 @@ federation should be gated. Tenant isolation, identity mapping, moderation,
 invite policy, retention, and external-room UX must be proven before broad
 inter-organization federation is enabled.
 
+Near-term Chat decision: **Weave Chat API first, Matrix-compatible transport and
+federation later behind governance gates.** Matrix can be the first backing
+adapter and future federation projection, but Matrix is not mandatory domain
+truth and not the member product vocabulary. Slack and Teams remain southbound
+adapter or bridge candidates.
+
 MCP must not receive raw Matrix access by default. E2EE and room history make
 chat the hardest domain for server-side tools; MCP should operate on governed
 Weave projections, consented summaries, decision records, attachment references,
 and user-authorized decrypted indexes.
+
+## Meetings/Calls
+
+Final shape:
+
+- Product truth: Weave Meetings/Calls facade for meeting metadata, invites,
+  participants, policy, join grants, recordings/captions/artifact references,
+  and audit.
+- JSON/API projection: `/api/calls/**` and generated OpenAPI models.
+- Standard/native boundary: calendar invites, meeting links, iOS CallKit /
+  PushKit boundaries, Android Telecom / ConnectionService boundaries, and
+  provider-neutral join grants.
+- Provider adapters: LiveKit first where configured; Teams/Meet/other meeting
+  providers later through adapters.
+- MCP: semantic tools such as `meetings.find`, `meetings.prepare_agenda`,
+  `meetings.create_join_grant`, and `meetings.link_chat_thread`, backed by
+  policy and audit.
+
+Non-goal: WebDAV and CalDAV do not solve calls. Calendar may schedule a meeting
+and Chat may host a meeting thread, but calls need explicit native call UI,
+media, signaling, permissions, join-grant, and revoke boundaries.
 
 ## MCP projection rule
 

--- a/server/src/main/java/com/massimotter/weave/backend/model/ClientAccessCredentialLifecycleResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/ClientAccessCredentialLifecycleResponse.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Support-safe credential lifecycle summary for member, native, generic, and MCP clients.")
+public record ClientAccessCredentialLifecycleResponse(
+        @Schema(description = "Stable lifecycle posture.", example = "blocked_until_revocable_device_grants")
+        String status,
+        @Schema(description = "Whether credentials or bearer tokens are returned in this manifest. Must remain false.",
+                example = "false")
+        boolean secretMaterialReturned,
+        @Schema(description = "Weave-owned lifecycle paths or references only; never provider URLs or raw secret refs.")
+        List<String> lifecyclePaths,
+        @Schema(description = "Support-safe blockers before this access surface can be called ready.")
+        List<String> blockedUntil) {
+
+    public ClientAccessCredentialLifecycleResponse {
+        lifecyclePaths = lifecyclePaths == null ? List.of() : List.copyOf(lifecyclePaths);
+        blockedUntil = blockedUntil == null ? List.of() : List.copyOf(blockedUntil);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/ClientAccessDiscoveryResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/ClientAccessDiscoveryResponse.java
@@ -1,0 +1,28 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "Support-safe discovery metadata for a Weave domain access surface.")
+public record ClientAccessDiscoveryResponse(
+        @Schema(description = "Provider-neutral Weave domain key.", example = "files")
+        String domain,
+        @Schema(description = "Weave-owned product API base path.", example = "/api/files")
+        String productApiBasePath,
+        @Schema(description = "OpenAPI tag or contract group for generated clients and MCP allowlists.",
+                example = "Files")
+        String openApiTag,
+        @Schema(description = "Open-standard or native projection surfaces exposed over Weave domain truth.")
+        List<ClientAccessProtocolSurfaceResponse> surfaces,
+        @Schema(description = "Credential and grant lifecycle posture for this domain.")
+        ClientAccessCredentialLifecycleResponse credentialLifecycle,
+        @Schema(description = "True when discovery excludes raw provider URLs, credentials, endpoint rotation data, and diagnostics.")
+        boolean supportSafe,
+        @Schema(description = "False: discovery must not expose raw provider setup or endpoint configuration.",
+                example = "false")
+        boolean providerConfigurationExposed) {
+
+    public ClientAccessDiscoveryResponse {
+        surfaces = surfaces == null ? List.of() : List.copyOf(surfaces);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/ClientAccessProtocolSurfaceResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/ClientAccessProtocolSurfaceResponse.java
@@ -1,0 +1,22 @@
+package com.massimotter.weave.backend.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "One Weave-owned client access projection for a domain facade.")
+public record ClientAccessProtocolSurfaceResponse(
+        @Schema(description = "Surface kind, such as openapi, standard-protocol, native-os, mcp, or provider-adapter.")
+        String kind,
+        @Schema(description = "Surface name in product-neutral terms.", example = "Weave WebDAV projection")
+        String name,
+        @Schema(description = "Weave-owned API, setup, status, or lifecycle path when one exists. Null means the surface is documented but not exposed yet.")
+        String setupPath,
+        @Schema(description = "Stable readiness posture for this surface.", example = "contract_ready")
+        String readiness,
+        @Schema(description = "Support-safe notes for generated clients and admins.")
+        List<String> notes) {
+
+    public ClientAccessProtocolSurfaceResponse {
+        notes = notes == null ? List.of() : List.copyOf(notes);
+    }
+}

--- a/server/src/main/java/com/massimotter/weave/backend/model/OrganizationManifestResponse.java
+++ b/server/src/main/java/com/massimotter/weave/backend/model/OrganizationManifestResponse.java
@@ -31,6 +31,8 @@ public record OrganizationManifestResponse(
         List<String> adminConsoleResponsibilities,
         @Schema(description = "Stable member-visible capability states keyed by provider-neutral Weave domain. Values are available, disabled_by_policy, not_configured, degraded, unavailable, or coming_later.")
         Map<String, CapabilityManifestState> memberCapabilityStates,
+        @Schema(description = "Support-safe domain access discovery for product APIs, standard-protocol projections, native setup, and governed MCP consumers.")
+        Map<String, ClientAccessDiscoveryResponse> clientAccessDiscovery,
         @Schema(description = "Effective member capability snapshot; provider setup and diagnostics stay out of this contract.")
         WorkspaceCapabilitiesResponse capabilities) {
 
@@ -38,5 +40,6 @@ public record OrganizationManifestResponse(
         clientResponsibilities = clientResponsibilities == null ? List.of() : List.copyOf(clientResponsibilities);
         adminConsoleResponsibilities = adminConsoleResponsibilities == null ? List.of() : List.copyOf(adminConsoleResponsibilities);
         memberCapabilityStates = memberCapabilityStates == null ? Map.of() : Map.copyOf(memberCapabilityStates);
+        clientAccessDiscovery = clientAccessDiscovery == null ? Map.of() : Map.copyOf(clientAccessDiscovery);
     }
 }

--- a/server/src/main/java/com/massimotter/weave/backend/service/OrganizationManifestService.java
+++ b/server/src/main/java/com/massimotter/weave/backend/service/OrganizationManifestService.java
@@ -3,6 +3,9 @@ package com.massimotter.weave.backend.service;
 import com.massimotter.weave.backend.config.ContextAuthorizationProperties;
 import com.massimotter.weave.backend.exception.ApiErrorException;
 import com.massimotter.weave.backend.model.CapabilityManifestState;
+import com.massimotter.weave.backend.model.ClientAccessCredentialLifecycleResponse;
+import com.massimotter.weave.backend.model.ClientAccessDiscoveryResponse;
+import com.massimotter.weave.backend.model.ClientAccessProtocolSurfaceResponse;
 import com.massimotter.weave.backend.model.OrganizationManifestResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilitiesResponse;
 import com.massimotter.weave.backend.model.WorkspaceCapabilityPolicyState;
@@ -73,6 +76,7 @@ public class OrganizationManifestService {
                         "own provider, tool, and agent whitelisting plus privacy/compliance risk notes",
                         "audit organization-wide defaults and administrative changes"),
                 memberStates(capabilities),
+                clientAccessDiscovery(),
                 capabilities);
     }
 
@@ -201,5 +205,116 @@ public class OrganizationManifestService {
             return CapabilityManifestState.NOT_CONFIGURED;
         }
         return CapabilityManifestState.UNAVAILABLE;
+    }
+
+    private Map<String, ClientAccessDiscoveryResponse> clientAccessDiscovery() {
+        Map<String, ClientAccessDiscoveryResponse> access = new LinkedHashMap<>();
+        access.put("files", filesAccess());
+        access.put("calendar", calendarAccess());
+        access.put("chat", chatAccess());
+        access.put("meetings-calls", meetingsCallsAccess());
+        return access;
+    }
+
+    private ClientAccessDiscoveryResponse filesAccess() {
+        return new ClientAccessDiscoveryResponse(
+                "files",
+                "/api/files",
+                "Files",
+                List.of(
+                        surface("openapi", "Weave Files API", "/api/files", "available",
+                                "Primary generated contract for Weave clients, Admin Console setup/status, and MCP route allowlists."),
+                        surface("standard-protocol", "Weave WebDAV projection", null, "planned_contract",
+                                "Targets generic desktop and OS file clients through Weave policy, audit, and file IDs; it is not a raw storage-provider proxy."),
+                        surface("native-os", "iOS File Provider and Android DocumentsProvider setup", "/api/files/native-provider-setup", "contract_ready_implementation_blocked",
+                                "Native providers call Weave file facade paths only and must prove device revocation before availability."),
+                        surface("mcp", "Governed Files MCP tools", null, "planned_allowlist",
+                                "MCP consumes semantic Weave file capabilities, not raw WebDAV methods or provider credentials.")),
+                credentialLifecycle(
+                        "blocked_until_revocable_device_grants",
+                        List.of("/api/files/native-provider-setup"),
+                        List.of("per-device Weave file grants", "revocation evidence", "native device proof")),
+                true,
+                false);
+    }
+
+    private ClientAccessDiscoveryResponse calendarAccess() {
+        return new ClientAccessDiscoveryResponse(
+                "calendar",
+                "/api/calendar",
+                "Calendar",
+                List.of(
+                        surface("openapi", "Weave Calendar API", "/api/calendar", "available",
+                                "Primary generated contract for Weave clients, Admin Console setup/status, and MCP route allowlists."),
+                        surface("standard-protocol", "Weave CalDAV/iCalendar projection", null, "planned_contract",
+                                "Targets native and generic calendar clients through Weave event, policy, audit, and scope boundaries."),
+                        surface("native-os", "iOS CalDAV profile and Android SyncAdapter setup", "/api/calendar/native-sync-setup", "contract_ready_implementation_blocked",
+                                "Native sync stays scoped to workspace, team, and channel calendars until revocable credentials and device proof exist."),
+                        surface("mcp", "Governed Calendar MCP tools", null, "planned_allowlist",
+                                "MCP consumes semantic Weave event capabilities and audit receipts, not raw CalDAV credentials.")),
+                credentialLifecycle(
+                        "blocked_until_revocable_credentials",
+                        List.of(
+                                "/api/calendar/client-setup/credentials",
+                                "/api/calendar/client-setup/apple.mobileconfig"),
+                        List.of("scoped revocable CalDAV credentials", "signed profile delivery", "native sync and revoke evidence")),
+                true,
+                false);
+    }
+
+    private ClientAccessDiscoveryResponse chatAccess() {
+        return new ClientAccessDiscoveryResponse(
+                "chat",
+                "/api/chat",
+                "Chat domain",
+                List.of(
+                        surface("openapi", "Weave Chat API", "/api/chat", "available",
+                                "Primary product API for Weave conversations, messages, membership, readiness, decisions, and governed writes."),
+                        surface("standard-protocol", "Matrix-compatible transport and federation projection", null, "governed_later",
+                                "Matrix may back encrypted rooms and federation, but Weave Chat remains product truth and federation stays policy-gated."),
+                        surface("mcp", "Governed Chat MCP tools", null, "planned_allowlist",
+                                "MCP receives semantic Weave chat operations, consented summaries, and decision references rather than raw Matrix access.")),
+                credentialLifecycle(
+                        "session_bound_no_raw_matrix_credentials",
+                        List.of("/api/chat/readiness"),
+                        List.of("decrypted-content consent gates", "retention and moderation policy proof", "federation isolation evidence")),
+                true,
+                false);
+    }
+
+    private ClientAccessDiscoveryResponse meetingsCallsAccess() {
+        return new ClientAccessDiscoveryResponse(
+                "meetings-calls",
+                "/api/calls",
+                "Calls",
+                List.of(
+                        surface("openapi", "Weave Calls and Meetings API", "/api/calls", "planned_contract",
+                                "Product API owns meeting metadata, policy, and join-grant lifecycle."),
+                        surface("native-os", "CallKit and Android Telecom boundary", "/api/calls/native-boundary-setup", "contract_ready_implementation_blocked",
+                                "Native call UI is driven by Weave invitations and short-lived join grants; media transport remains separate."),
+                        surface("standard-protocol", "Meeting links and calendar/chat thread references", null, "boundary_only",
+                                "WebDAV and CalDAV do not solve calls; calendar invites and chat threads link to Weave meeting grants.")),
+                credentialLifecycle(
+                        "blocked_until_short_lived_join_grants",
+                        List.of("/api/calls/native-boundary-setup"),
+                        List.of("short-lived join grants", "native call UI proof", "revoke and media-policy evidence")),
+                true,
+                false);
+    }
+
+    private ClientAccessProtocolSurfaceResponse surface(
+            String kind,
+            String name,
+            String setupPath,
+            String readiness,
+            String note) {
+        return new ClientAccessProtocolSurfaceResponse(kind, name, setupPath, readiness, List.of(note));
+    }
+
+    private ClientAccessCredentialLifecycleResponse credentialLifecycle(
+            String status,
+            List<String> lifecyclePaths,
+            List<String> blockedUntil) {
+        return new ClientAccessCredentialLifecycleResponse(status, false, lifecyclePaths, blockedUntil);
     }
 }

--- a/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
+++ b/server/src/test/java/com/massimotter/weave/backend/controller/WorkspaceControllerTest.java
@@ -39,6 +39,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
@@ -140,10 +141,41 @@ class WorkspaceControllerTest {
                 .andExpect(jsonPath("$.memberCapabilityStates['boards-tasks']").value("disabled_by_policy"))
                 .andExpect(jsonPath("$.memberCapabilityStates.meetings").value("not_configured"))
                 .andExpect(jsonPath("$.memberCapabilityStates['forms-contacts']").value("coming_later"))
+                .andExpect(jsonPath("$.clientAccessDiscovery.files.productApiBasePath").value("/api/files"))
+                .andExpect(jsonPath("$.clientAccessDiscovery.files.openApiTag").value("Files"))
+                .andExpect(jsonPath("$.clientAccessDiscovery.files.supportSafe").value(true))
+                .andExpect(jsonPath("$.clientAccessDiscovery.files.providerConfigurationExposed").value(false))
+                .andExpect(jsonPath("$.clientAccessDiscovery.files.surfaces[?(@.kind == 'standard-protocol')].name")
+                        .value(hasItem("Weave WebDAV projection")))
+                .andExpect(jsonPath("$.clientAccessDiscovery.files.surfaces[?(@.kind == 'native-os')].setupPath")
+                        .value(hasItem("/api/files/native-provider-setup")))
+                .andExpect(jsonPath("$.clientAccessDiscovery.files.credentialLifecycle.secretMaterialReturned").value(false))
+                .andExpect(jsonPath("$.clientAccessDiscovery.calendar.surfaces[?(@.kind == 'standard-protocol')].name")
+                        .value(hasItem("Weave CalDAV/iCalendar projection")))
+                .andExpect(jsonPath("$.clientAccessDiscovery.calendar.surfaces[?(@.kind == 'native-os')].setupPath")
+                        .value(hasItem("/api/calendar/native-sync-setup")))
+                .andExpect(jsonPath("$.clientAccessDiscovery.calendar.credentialLifecycle.lifecyclePaths", hasItems(
+                        "/api/calendar/client-setup/credentials",
+                        "/api/calendar/client-setup/apple.mobileconfig")))
+                .andExpect(jsonPath("$.clientAccessDiscovery.chat.openApiTag").value("Chat domain"))
+                .andExpect(jsonPath("$.clientAccessDiscovery.chat.surfaces[?(@.kind == 'openapi')].name")
+                        .value(hasItem("Weave Chat API")))
+                .andExpect(jsonPath("$.clientAccessDiscovery.chat.surfaces[?(@.kind == 'standard-protocol')].name")
+                        .value(hasItem("Matrix-compatible transport and federation projection")))
+                .andExpect(jsonPath("$.clientAccessDiscovery.chat.credentialLifecycle.status")
+                        .value("session_bound_no_raw_matrix_credentials"))
+                .andExpect(jsonPath("$.clientAccessDiscovery['meetings-calls'].surfaces[?(@.kind == 'native-os')].setupPath")
+                        .value(hasItem("/api/calls/native-boundary-setup")))
+                .andExpect(jsonPath("$.clientAccessDiscovery['meetings-calls'].surfaces[?(@.kind == 'standard-protocol')].readiness")
+                        .value(hasItem("boundary_only")))
                 .andExpect(jsonPath("$.capabilities.calendar.grantedCapabilities", hasItems("calendar.manage_events")))
                 .andExpect(jsonPath("$.capabilities.weaver.policyState").value("disabled"))
                 .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string(not(containsString("matrix.weave.test"))))
                 .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string(not(containsString("files.weave.test"))))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string(not(containsString("nextcloud"))))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string(not(containsString("provider.example"))))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string(not(containsString("token="))))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string(not(containsString("secretref://"))))
                 .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string(not(containsString("providerDiagnostics"))))
                 .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().string(not(containsString("Authorization: Bearer"))));
     }


### PR DESCRIPTION
## Summary

- Expands the domain facade protocol projection architecture pack with northbound/southbound boundaries, OpenAPI role, module target shape, client access discovery, credential lifecycle, Chat strategy, and Meetings/Calls non-goals.
- Adds support-safe typed client access discovery to the organization manifest for Files, Calendar, Chat, and Meetings/Calls.
- Adds regression coverage that the member manifest exposes only Weave-owned paths and does not leak raw provider URLs, provider credentials, token query strings, diagnostics, or secret refs.
- Addresses Copilot review feedback by aligning the Chat OpenAPI tag and making surface assertions kind-based rather than order-based.

Refs #1002 for the first foundation slice. #1002 remains open as the follow-up lane tracker unless it is explicitly split or closed after issue hygiene.

## Target lane

dev

## Spec impact

Conformance projection for the pinned corpus domains: Files, Calendar, Chat, and Meetings/Calls. Product/domain truth remains in ../weave-specs through specs/weave-specs.lock.json.

## Release notes

Changed: organization manifest now advertises support-safe domain access discovery for standard protocol, native OS, OpenAPI, and governed MCP consumers.

## Checks run

- ./gradlew :server:test --tests com.massimotter.weave.backend.controller.WorkspaceControllerTest --tests com.massimotter.weave.backend.controller.FilesCalendarFacadeControllerTest --tests com.massimotter.weave.backend.controller.OpenApiDocumentationTest
- ./gradlew :server:test --tests com.massimotter.weave.backend.controller.WorkspaceControllerTest
- ./gradlew serverCi
- ./gradlew docsCheck
- ./gradlew releaseEvidenceCheck
- ./gradlew checkOpenApiContractFresh checkClientOpenApiModelsFresh checkAdminOpenApiTypesFresh

## Blocked or not run locally

- ./gradlew specCorpusConformance: blocked because ../weave-specs has pre-existing uncommitted changes.
- ./gradlew acceptanceContract: blocked locally because dart is not on PATH in this session; GitHub CI has Dart and runs the aggregate gate.

## Risk / privacy / supportability

This is a contract/documentation slice. It intentionally does not implement WebDAV, CalDAV, Matrix federation, or native OS readiness. The new server test asserts the manifest stays support-safe and free of provider URL/credential leakage.